### PR TITLE
feat: instant lock request id

### DIFF
--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -69,6 +69,8 @@ hash_newtype!(InputsHash, sha256d::Hash, 32, doc="A hash of all transaction inpu
 hash_newtype!(QuorumHash, sha256d::Hash, 32, doc="A hash used to identify a quorum");
 hash_newtype!(QuorumVVecHash, sha256d::Hash, 32, doc="A hash of a quorum verification vector");
 
+hash_newtype!(QuorumSigningRequestId, sha256d::Hash, 32, doc="A hash used to identify a quorum signing request");
+
 impl_hashencode!(Txid);
 impl_hashencode!(Wtxid);
 impl_hashencode!(BlockHash);
@@ -90,3 +92,5 @@ impl_hashencode!(InputsHash);
 
 impl_hashencode!(QuorumHash);
 impl_hashencode!(QuorumVVecHash);
+
+impl_hashencode!(QuorumSigningRequestId);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,14 @@ extern crate core2;
 extern crate core; // for Rust 1.29 and no-std tests
 
 // Re-exported dependencies.
+
+/// Bitcoin hashes implementation
 #[macro_use] pub extern crate bitcoin_hashes as hashes;
+
+/// Bitcoin secp256k1 bindings
 pub extern crate secp256k1;
+
+/// Rust implementation of the Bech32 encoding format described
 pub extern crate bech32;
 
 #[cfg(feature = "no-std")]

--- a/src/util/hash.rs
+++ b/src/util/hash.rs
@@ -28,7 +28,7 @@ use prelude::*;
 use io;
 use core::cmp::min;
 
-use hashes::Hash;
+use hashes::{Hash, ripemd160, sha256};
 use consensus::encode::Encodable;
 
 /// Calculates the merkle root of a list of *hashes*, inline (in place) in `hashes`.
@@ -109,6 +109,16 @@ where
     let half_len = hashes.len() / 2 + hashes.len() % 2;
 
     merkle_root_r(&mut hashes[0..half_len])
+}
+
+/// calculates double sha256 on data
+pub fn double_sha(payload : impl AsRef<[u8]>) -> Vec<u8>  {
+    sha256::Hash::hash(&sha256::Hash::hash(payload.as_ref())).to_vec()
+}
+
+/// calculates the RIPEMD169(SHA256(data))
+pub fn ripemd160_sha256(data : &[u8]) -> Vec<u8> {
+    ripemd160::Hash::hash(&sha256::Hash::hash(data)).to_vec()
 }
 
 #[cfg(test)]

--- a/src/util/signer.rs
+++ b/src/util/signer.rs
@@ -131,17 +131,6 @@ impl CompactSignature for RecoverableSignature {
     }
 }
 
-
-/// calculates double sha256 on data
-pub fn double_sha(payload : impl AsRef<[u8]>) -> Vec<u8>  {
-    sha256::Hash::hash(&sha256::Hash::hash(payload.as_ref())).to_vec()
-}
-
-/// calculates the RIPEMD169(SHA256(data))
-pub fn ripemd160_sha256(data : &[u8]) -> Vec<u8> {
-    ripemd160::Hash::hash(&sha256::Hash::hash(data)).to_vec()
-}
-
 #[cfg(test)]
 mod test {
     use crate::{assert_error_contains};


### PR DESCRIPTION
For instant lock signature verification we need to calculate request id

This PR adds `InstantLock.request_id` method that returns quorum signing request id

