### PR TITLE
fix: further block deserialization fixes 

### DIFF
--- a/dash/src/blockdata/transaction/mod.rs
+++ b/dash/src/blockdata/transaction/mod.rs
@@ -653,6 +653,9 @@ impl Decodable for Transaction {
         if special_transaction_type == TransactionType::AssetUnlock {
             segwit = false;
         }
+        if special_transaction_type == TransactionType::QuorumCommitment {
+            segwit = false;
+        }
         if segwit {
             let segwit_flag = u8::consensus_decode_from_finite_reader(r)?;
             match segwit_flag {

--- a/dash/src/blockdata/transaction/special_transaction/quorum_commitment.rs
+++ b/dash/src/blockdata/transaction/special_transaction/quorum_commitment.rs
@@ -50,7 +50,7 @@ impl QuorumFinalizationCommitment {
         size += VarInt(self.signers.len() as u64).len() + self.signers.len();
         size += VarInt(self.valid_members.len() as u64).len() + self.valid_members.len();
         if self.version == 2 || self.version == 4 {
-            size += 16;
+            size += 2;
         }
         size
     }

--- a/dash/src/blockdata/transaction/special_transaction/quorum_commitment.rs
+++ b/dash/src/blockdata/transaction/special_transaction/quorum_commitment.rs
@@ -62,8 +62,10 @@ impl Encodable for QuorumFinalizationCommitment {
         len += self.version.consensus_encode(w)?;
         len += self.llmq_type.consensus_encode(w)?;
         len += self.quorum_hash.consensus_encode(w)?;
-        if self.version == 2 || self.version == 4 {
-            len += self.quorum_index.unwrap().consensus_encode(w)?;
+        if let Some(q_index) = self.quorum_index {
+            if self.version == 2 || self.version == 4 {
+                len += q_index.consensus_encode(w)?;
+            }
         }
         len += self.signers.consensus_encode(w)?;
         len += self.valid_members.consensus_encode(w)?;


### PR DESCRIPTION
Further fixes for deserializing blocks correctly:

- qcommitment seqwit is always false
- qcommitment support of quorumIndex field (dip-24)
- qcommitment correct deserialization of signers, validMembers fields as dynamic bitsets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction handling for `TransactionType::QuorumCommitment`, ensuring proper deserialization as non-segwit.
	- Introduced a new field `quorum_index` in the `QuorumFinalizationCommitment` structure for improved functionality.
	- Added utility functions for better handling of variable-length data in transactions.

- **Documentation**
	- Updated documentation comments for clarity on segwit and non-segwit transaction handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->