### PR TITLE
test: enable `core-block-hash-use-x11` for tests

### DIFF
--- a/dash/Cargo.toml
+++ b/dash/Cargo.toml
@@ -80,6 +80,7 @@ secp256k1 = { features = [ "recovery", "rand", "hashes" ], version="0.30.0" }
 bip39 = "2.0.0"
 bincode_test = {package = "bincode", version= "1.3.3" }
 assert_matches = "1.5.0"
+dashcore = { path = ".", features = ["core-block-hash-use-x11"] }
 
 [[example]]
 name = "bip32"


### PR DESCRIPTION
Test asserts expect x11 hashes so they are faling without the `core-block-hash-use-x11` feature being enabled