### PR TITLE
feat: provider registration payload v2

### DIFF
--- a/dash/src/blockdata/transaction/special_transaction/provider_registration.rs
+++ b/dash/src/blockdata/transaction/special_transaction/provider_registration.rs
@@ -38,6 +38,7 @@
 use bincode::{Decode, Encode};
 use hashes::Hash;
 use internals::hex::Case::Lower;
+use std::net::SocketAddr;
 
 use crate::address::Payload;
 use crate::blockdata::transaction::special_transaction::SpecialTransactionBasePayloadEncodable;
@@ -46,6 +47,38 @@ use crate::consensus::{Decodable, Encodable, encode};
 use crate::hash_types::{InputsHash, PubkeyHash, SpecialTransactionPayloadHash};
 use crate::prelude::*;
 use crate::{Address, Network, OutPoint, ScriptBuf, VarInt, io};
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Copy)]
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
+pub enum MasternodeType {
+    Regular = 0,
+    HighPerformance = 1,
+}
+
+impl Encodable for MasternodeType {
+    fn consensus_encode<W: io::Write + ?Sized>(&self, mut w: &mut W) -> Result<usize, io::Error> {
+        let variant = self;
+        let len = (*variant as u16).consensus_encode(&mut w)?;
+        Ok(len)
+    }
+}
+
+impl Decodable for MasternodeType {
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
+        let variant = u16::consensus_decode(r)?;
+        match variant {
+            0 => Ok(MasternodeType::Regular),
+            1 => Ok(MasternodeType::HighPerformance),
+            received => Err(encode::Error::InvalidEnumValue {
+                max: 1,
+                received,
+                msg: "Invalid MasternodeType variant".to_string(),
+            }),
+        }
+    }
+}
 
 /// A Provider Registration Payload used in a Provider Registration Special Transaction.
 /// This is used to register a Masternode on the network.
@@ -65,11 +98,10 @@ use crate::{Address, Network, OutPoint, ScriptBuf, VarInt, io};
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub struct ProviderRegistrationPayload {
     pub version: u16,
-    pub provider_type: u16,
+    pub provider_type: MasternodeType,
     pub provider_mode: u16,
     pub collateral_outpoint: OutPoint,
-    pub ip_address: u128,
-    pub port: u16,
+    pub service_address: SocketAddr,
     pub owner_key_hash: PubkeyHash,
     pub operator_public_key: BLSPublicKey,
     pub voting_key_hash: PubkeyHash,
@@ -77,6 +109,9 @@ pub struct ProviderRegistrationPayload {
     pub script_payout: ScriptBuf,
     pub inputs_hash: InputsHash,
     pub payload_sig: Vec<u8>,
+    pub platform_node_id: Option<PubkeyHash>,
+    pub platform_p2p_port: Option<u16>,
+    pub platform_http_port: Option<u16>,
 }
 
 impl ProviderRegistrationPayload {
@@ -133,18 +168,28 @@ impl ProviderRegistrationPayload {
 impl SpecialTransactionBasePayloadEncodable for ProviderRegistrationPayload {
     fn base_payload_data_encode<W: io::Write>(&self, mut s: W) -> Result<usize, io::Error> {
         let mut len = 0;
+
         len += self.version.consensus_encode(&mut s)?;
         len += self.provider_type.consensus_encode(&mut s)?;
         len += self.provider_mode.consensus_encode(&mut s)?;
         len += self.collateral_outpoint.consensus_encode(&mut s)?;
-        len += self.ip_address.consensus_encode(&mut s)?;
-        len += u16::swap_bytes(self.port).consensus_encode(&mut s)?;
+        len += self.service_address.consensus_encode(&mut s)?;
         len += self.owner_key_hash.consensus_encode(&mut s)?;
         len += self.operator_public_key.consensus_encode(&mut s)?;
         len += self.voting_key_hash.consensus_encode(&mut s)?;
         len += self.operator_reward.consensus_encode(&mut s)?;
         len += self.script_payout.consensus_encode(&mut s)?;
         len += self.inputs_hash.consensus_encode(&mut s)?;
+
+        if self.version >= 2 && self.provider_type == MasternodeType::HighPerformance {
+            len += self
+                .platform_node_id
+                .unwrap_or_else(|| PubkeyHash::all_zeros())
+                .consensus_encode(&mut s)?;
+            len += self.platform_p2p_port.unwrap_or_default().consensus_encode(&mut s)?;
+            len += self.platform_http_port.unwrap_or_default().consensus_encode(&mut s)?;
+        }
+
         Ok(len)
     }
 
@@ -167,17 +212,27 @@ impl Encodable for ProviderRegistrationPayload {
 impl Decodable for ProviderRegistrationPayload {
     fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Self, encode::Error> {
         let version = u16::consensus_decode(r)?;
-        let provider_type = u16::consensus_decode(r)?;
+        let provider_type = MasternodeType::consensus_decode(r)?;
         let provider_mode = u16::consensus_decode(r)?;
         let collateral_outpoint = OutPoint::consensus_decode(r)?;
-        let ip_address = u128::consensus_decode(r)?;
-        let port = u16::swap_bytes(u16::consensus_decode(r)?);
+        let service_address = SocketAddr::consensus_decode(r)?;
         let owner_key_hash = PubkeyHash::consensus_decode(r)?;
         let operator_public_key = BLSPublicKey::consensus_decode(r)?;
         let voting_key_hash = PubkeyHash::consensus_decode(r)?;
         let operator_reward = u16::consensus_decode(r)?;
         let script_payout = ScriptBuf::consensus_decode(r)?;
         let inputs_hash = InputsHash::consensus_decode(r)?;
+
+        let mut platform_node_id = None;
+        let mut platform_p2p_port = None;
+        let mut platform_http_port = None;
+
+        if version >= 2 && provider_type == MasternodeType::HighPerformance {
+            platform_node_id = Some(PubkeyHash::consensus_decode(r)?);
+            platform_p2p_port = Some(u16::consensus_decode(r)?);
+            platform_http_port = Some(u16::consensus_decode(r)?);
+        }
+
         let payload_sig = Vec::<u8>::consensus_decode(r)?;
 
         Ok(ProviderRegistrationPayload {
@@ -185,8 +240,7 @@ impl Decodable for ProviderRegistrationPayload {
             provider_type,
             provider_mode,
             collateral_outpoint,
-            ip_address,
-            port,
+            service_address,
             owner_key_hash,
             operator_public_key,
             voting_key_hash,
@@ -194,362 +248,409 @@ impl Decodable for ProviderRegistrationPayload {
             script_payout,
             inputs_hash,
             payload_sig,
+            platform_node_id,
+            platform_p2p_port,
+            platform_http_port,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
-
     use hashes::Hash;
     use hashes::hex::FromHex;
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
     use crate::bls_sig_utils::BLSPublicKey;
-    use crate::consensus::Encodable;
+    use crate::consensus::{Encodable, deserialize};
     use crate::hash_types::InputsHash;
-    use crate::transaction::special_transaction::provider_registration::ProviderRegistrationPayload;
-    use crate::{OutPoint, PubkeyHash, ScriptBuf, Txid};
+    use crate::internal_macros::hex;
+    use crate::transaction::special_transaction::provider_registration::{
+        MasternodeType, ProviderRegistrationPayload,
+    };
+    use crate::{OutPoint, PubkeyHash, ScriptBuf, Transaction, Txid};
 
-    #[test]
     #[cfg(feature = "signer")]
-    fn test_collateral_provider_registration_transaction() {
-        // This is a test for testnet
-        let network = Network::Testnet;
+    mod signer {
+        use super::*;
+        use crate::Network;
+        use crate::transaction::special_transaction::SpecialTransactionBasePayloadEncodable;
+        use internals::hex::display::DisplayHex;
 
-        let expected_transaction_bytes = hex!(
-            "0300010001ca9a43051750da7c5f858008f2ff7732d15691e48eb7f845c791e5dca78bab58010000006b483045022100fe8fec0b3880bcac29614348887769b0b589908e3f5ec55a6cf478a6652e736502202f30430806a6690524e4dd599ba498e5ff100dea6a872ebb89c2fd651caa71ed012103d85b25d6886f0b3b8ce1eef63b720b518fad0b8e103eba4e85b6980bfdda2dfdffffffff018e37807e090000001976a9144ee1d4e5d61ac40a13b357ac6e368997079678c888ac00000000fd1201010000000000ca9a43051750da7c5f858008f2ff7732d15691e48eb7f845c791e5dca78bab580000000000000000000000000000ffff010205064e1f3dd03f9ec192b5f275a433bfc90f468ee1a3eb4c157b10706659e25eb362b5d902d809f9160b1688e201ee6e94b40f9b5062d7074683ef05a2d5efb7793c47059c878dfad38a30fafe61575db40f05ab0a08d55119b0aad300001976a9144fbc8fb6e11e253d77e5a9c987418e89cf4a63d288ac3477990b757387cb0406168c2720acf55f83603736a314a37d01b135b873a27b411fb37e49c1ff2b8057713939a5513e6e711a71cff2e517e6224df724ed750aef1b7f9ad9ec612b4a7250232e1e400da718a9501e1d9a5565526e4b1ff68c028763"
-        );
+        #[test]
+        fn test_collateral_provider_registration_transaction() {
+            // This is a test for testnet
+            let network = Network::Testnet;
 
-        let expected_transaction: Transaction =
-            deserialize(expected_transaction_bytes.as_slice()).expect("expected a transaction");
+            let expected_transaction_bytes = hex!(
+                "0300010001ca9a43051750da7c5f858008f2ff7732d15691e48eb7f845c791e5dca78bab58010000006b483045022100fe8fec0b3880bcac29614348887769b0b589908e3f5ec55a6cf478a6652e736502202f30430806a6690524e4dd599ba498e5ff100dea6a872ebb89c2fd651caa71ed012103d85b25d6886f0b3b8ce1eef63b720b518fad0b8e103eba4e85b6980bfdda2dfdffffffff018e37807e090000001976a9144ee1d4e5d61ac40a13b357ac6e368997079678c888ac00000000fd1201010000000000ca9a43051750da7c5f858008f2ff7732d15691e48eb7f845c791e5dca78bab580000000000000000000000000000ffff010205064e1f3dd03f9ec192b5f275a433bfc90f468ee1a3eb4c157b10706659e25eb362b5d902d809f9160b1688e201ee6e94b40f9b5062d7074683ef05a2d5efb7793c47059c878dfad38a30fafe61575db40f05ab0a08d55119b0aad300001976a9144fbc8fb6e11e253d77e5a9c987418e89cf4a63d288ac3477990b757387cb0406168c2720acf55f83603736a314a37d01b135b873a27b411fb37e49c1ff2b8057713939a5513e6e711a71cff2e517e6224df724ed750aef1b7f9ad9ec612b4a7250232e1e400da718a9501e1d9a5565526e4b1ff68c028763"
+            );
 
-        let expected_provider_registration_payload = expected_transaction
-            .special_transaction_payload
-            .clone()
-            .unwrap()
-            .to_provider_registration_payload()
-            .expect("expected to get a provider registration payload");
-        //    protx register_prepare
-        //    58ab8ba7dce591c745f8b78ee49156d13277fff20880855f7cda501705439aca
-        //    0
-        //    1.2.5.6:19999
-        //    yRxHYGLf9G4UVYdtAoB2iAzR3sxxVaZB6y
-        //    97762493aef0bcba1925870abf51dc21f4bc2b8c410c79b7589590e6869a0e04
-        //    yfbxyP4ctRJR1rs3A8C3PdXA4Wtcrw7zTi
-        //    0
-        //    ycBFJGv7V95aSs6XvMewFyp1AMngeRHBwy
+            let expected_transaction: Transaction =
+                deserialize(expected_transaction_bytes.as_slice()).expect("expected a transaction");
 
-        let tx_id =
-            Txid::from_hex("e65f550356250100513aa9c260400562ac8ee1b93ae1cc1214cc9f6830227b51")
-                .expect("expected to decode tx id");
-        let output_address0 = Address::from_str("yTWY6DsS4HBGs2JwDtnvVcpykLkbvtjUte")
-            .expect("expected to be able to get output address");
-        let collateral_address = Address::from_str("yeNVS6tFeQNXJVkjv6nm6gb7PtTERV5dGh")
-            .expect("expected to be able to get collateral address");
-        let collateral_private_key =
-            PrivateKey::from_wif("cTVm7EkgzNBPcwAKGYHfvyK8cyrRAC8n3SUUw8qjLqCg2rpcczfo")
-                .expect("expected valid base 58");
-        let collateral_hash =
-            Txid::from_hex("58ab8ba7dce591c745f8b78ee49156d13277fff20880855f7cda501705439aca")
-                .expect("expected to decode collateral hash");
-        let collateral_index = 0;
-        let payout_address = Address::from_str("yTb47qEBpNmgXvYYsHEN4nh8yJwa5iC4Cs")
-            .expect("expected a valid address");
+            let expected_provider_registration_payload = expected_transaction
+                .special_transaction_payload
+                .clone()
+                .unwrap()
+                .to_provider_registration_payload()
+                .expect("expected to get a provider registration payload");
+            //    protx register_prepare
+            //    58ab8ba7dce591c745f8b78ee49156d13277fff20880855f7cda501705439aca
+            //    0
+            //    1.2.5.6:19999
+            //    yRxHYGLf9G4UVYdtAoB2iAzR3sxxVaZB6y
+            //    97762493aef0bcba1925870abf51dc21f4bc2b8c410c79b7589590e6869a0e04
+            //    yfbxyP4ctRJR1rs3A8C3PdXA4Wtcrw7zTi
+            //    0
+            //    ycBFJGv7V95aSs6XvMewFyp1AMngeRHBwy
 
-        let payload_collateral_string = expected_provider_registration_payload
-            .payload_collateral_string(network)
-            .expect("expected to produce a payload collateral string");
-        let message_digest = signed_msg_hash(payload_collateral_string.as_str());
+            let tx_id =
+                Txid::from_hex("e65f550356250100513aa9c260400562ac8ee1b93ae1cc1214cc9f6830227b51")
+                    .expect("expected to decode tx id");
+            let output_address0 = Address::from_str("yTWY6DsS4HBGs2JwDtnvVcpykLkbvtjUte")
+                .expect("expected to be able to get output address");
+            let collateral_address = Address::from_str("yeNVS6tFeQNXJVkjv6nm6gb7PtTERV5dGh")
+                .expect("expected to be able to get collateral address");
+            let collateral_private_key =
+                PrivateKey::from_wif("cTVm7EkgzNBPcwAKGYHfvyK8cyrRAC8n3SUUw8qjLqCg2rpcczfo")
+                    .expect("expected valid base 58");
+            let collateral_hash =
+                Txid::from_hex("58ab8ba7dce591c745f8b78ee49156d13277fff20880855f7cda501705439aca")
+                    .expect("expected to decode collateral hash");
+            let collateral_index = 0;
+            let payout_address = Address::from_str("yTb47qEBpNmgXvYYsHEN4nh8yJwa5iC4Cs")
+                .expect("expected a valid address");
 
-        let provider_registration_payload_version = 1;
-        assert_eq!(
-            expected_provider_registration_payload.version,
-            provider_registration_payload_version
-        );
-        let provider_type = 0;
-        assert_eq!(expected_provider_registration_payload.provider_type, provider_type);
-        let provider_mode = 0;
-        assert_eq!(expected_provider_registration_payload.provider_mode, provider_mode);
+            let payload_collateral_string = expected_provider_registration_payload
+                .payload_collateral_string(network)
+                .expect("expected to produce a payload collateral string");
+            let message_digest = signed_msg_hash(payload_collateral_string.as_str());
 
-        let collateral_outpoint = OutPoint { txid: collateral_hash, vout: collateral_index };
-        assert_eq!(expected_provider_registration_payload.collateral_outpoint, collateral_outpoint);
+            let provider_registration_payload_version = 1;
+            assert_eq!(
+                expected_provider_registration_payload.version,
+                provider_registration_payload_version
+            );
+            let provider_type = 0;
+            assert_eq!(expected_provider_registration_payload.provider_type, provider_type);
+            let provider_mode = 0;
+            assert_eq!(expected_provider_registration_payload.provider_mode, provider_mode);
 
-        let address = Ipv4Addr::from_str("1.2.5.6").expect("expected an ipv4 address");
-        let [a, b, c, d] = address.octets();
-        let ipv6_bytes: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, a, b, c, d];
-        assert_eq!(
-            ipv6_bytes.to_lower_hex_string(),
-            expected_provider_registration_payload.ip_address.to_le_bytes().to_lower_hex_string()
-        );
+            let collateral_outpoint = OutPoint { txid: collateral_hash, vout: collateral_index };
+            assert_eq!(
+                expected_provider_registration_payload.collateral_outpoint,
+                collateral_outpoint
+            );
 
-        let port = 19999;
-        assert_eq!(port, expected_provider_registration_payload.port);
+            let address = Ipv4Addr::from_str("1.2.5.6").expect("expected an ipv4 address");
+            let [a, b, c, d] = address.octets();
+            let ipv6_bytes: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, a, b, c, d];
+            assert_eq!(
+                ipv6_bytes.to_lower_hex_string(),
+                expected_provider_registration_payload
+                    .service_address
+                    .ip()
+                    .to_canonical()
+                    .to_le_bytes()
+                    .to_lower_hex_string()
+            );
 
-        let owner_key_hash_hex = "3dd03f9ec192b5f275a433bfc90f468ee1a3eb4c";
-        assert_eq!(
-            owner_key_hash_hex,
-            expected_provider_registration_payload.owner_key_hash.to_hex()
-        );
+            let port = 19999;
+            assert_eq!(port, expected_provider_registration_payload.service_address.port());
 
-        let operator_key_hex = "157b10706659e25eb362b5d902d809f9160b1688e201ee6e94b40f9b5062d7074683ef05a2d5efb7793c47059c878dfa";
-        assert_eq!(
-            operator_key_hex,
-            expected_provider_registration_payload.operator_public_key.to_hex()
-        );
+            let service_address = SocketAddr::V4(SocketAddrV4::new(address, port));
 
-        let voting_key_hash_hex = "d38a30fafe61575db40f05ab0a08d55119b0aad3";
-        assert_eq!(
-            voting_key_hash_hex,
-            expected_provider_registration_payload.voting_key_hash.to_hex()
-        );
+            let owner_key_hash_hex = "3dd03f9ec192b5f275a433bfc90f468ee1a3eb4c";
+            assert_eq!(
+                owner_key_hash_hex,
+                expected_provider_registration_payload.owner_key_hash.to_hex()
+            );
 
-        let inputs_hash_hex = "7ba273b835b1017da314a3363760835ff5ac20278c160604cb8773750b997734";
-        assert_eq!(
-            inputs_hash_hex,
-            expected_provider_registration_payload.inputs_hash.to_hex(),
-            "inputs hash calculation has issues"
-        );
+            let operator_key_hex = "157b10706659e25eb362b5d902d809f9160b1688e201ee6e94b40f9b5062d7074683ef05a2d5efb7793c47059c878dfa";
+            assert_eq!(
+                operator_key_hex,
+                expected_provider_registration_payload.operator_public_key.to_hex()
+            );
 
-        assert_eq!(
-            expected_provider_registration_payload.base_payload_hash().to_hex(),
-            "71e973f79003accd202b9a2ab2613ac6ced601b26684e82f561f6684fef2f102",
-            "Payload hash calculation has issues"
-        );
+            let voting_key_hash_hex = "d38a30fafe61575db40f05ab0a08d55119b0aad3";
+            assert_eq!(
+                voting_key_hash_hex,
+                expected_provider_registration_payload.voting_key_hash.to_hex()
+            );
 
-        assert_eq!(
-            "yTb47qEBpNmgXvYYsHEN4nh8yJwa5iC4Cs|0|yRxHYGLf9G4UVYdtAoB2iAzR3sxxVaZB6y|yfbxyP4ctRJR1rs3A8C3PdXA4Wtcrw7zTi|71e973f79003accd202b9a2ab2613ac6ced601b26684e82f561f6684fef2f102",
-            payload_collateral_string,
-            "provider transaction collateral string doesn't match"
-        );
+            let inputs_hash_hex =
+                "7ba273b835b1017da314a3363760835ff5ac20278c160604cb8773750b997734";
+            assert_eq!(
+                inputs_hash_hex,
+                expected_provider_registration_payload.inputs_hash.to_hex(),
+                "inputs hash calculation has issues"
+            );
 
-        let operator_reward = 0;
+            assert_eq!(
+                expected_provider_registration_payload.base_payload_hash().to_hex(),
+                "71e973f79003accd202b9a2ab2613ac6ced601b26684e82f561f6684fef2f102",
+                "Payload hash calculation has issues"
+            );
 
-        assert_eq!(operator_reward, expected_provider_registration_payload.operator_reward);
+            assert_eq!(
+                "yTb47qEBpNmgXvYYsHEN4nh8yJwa5iC4Cs|0|yRxHYGLf9G4UVYdtAoB2iAzR3sxxVaZB6y|yfbxyP4ctRJR1rs3A8C3PdXA4Wtcrw7zTi|71e973f79003accd202b9a2ab2613ac6ced601b26684e82f561f6684fef2f102",
+                payload_collateral_string,
+                "provider transaction collateral string doesn't match"
+            );
 
-        // We should verify the script payouts match
-        let script_payout = payout_address.assume_checked().script_pubkey();
-        assert_eq!(script_payout, expected_provider_registration_payload.script_payout);
+            let operator_reward = 0;
 
-        let expected_base64_signature = "H7N+ScH/K4BXcTk5pVE+bnEacc/y5RfmIk33JO11Cu8bf5rZ7GErSnJQIy4eQA2nGKlQHh2aVWVSbksf9owCh2M=";
-        let signature = sign_hash(
-            message_digest.as_byte_array().as_slice(),
-            collateral_private_key.to_bytes().as_slice(),
-        )
-        .expect("expected to sign message digest");
-        let base64_signature = base64::encode(signature.as_slice());
+            assert_eq!(operator_reward, expected_provider_registration_payload.operator_reward);
 
-        assert_eq!(
-            expected_base64_signature, base64_signature,
-            "message digest signatures don't match"
-        );
+            // We should verify the script payouts match
+            let script_payout = payout_address.assume_checked().script_pubkey();
+            assert_eq!(script_payout, expected_provider_registration_payload.script_payout);
 
-        assert_eq!(expected_provider_registration_payload.payload_sig, signature.to_vec());
+            let expected_base64_signature = "H7N+ScH/K4BXcTk5pVE+bnEacc/y5RfmIk33JO11Cu8bf5rZ7GErSnJQIy4eQA2nGKlQHh2aVWVSbksf9owCh2M=";
+            let signature = sign_hash(
+                message_digest.as_byte_array().as_slice(),
+                collateral_private_key.to_bytes().as_slice(),
+            )
+            .expect("expected to sign message digest");
+            let base64_signature = base64::encode(signature.as_slice());
 
-        assert_eq!(expected_transaction.txid(), tx_id);
+            assert_eq!(
+                expected_base64_signature, base64_signature,
+                "message digest signatures don't match"
+            );
 
-        let mut transaction = Transaction {
-            version: 3,
-            lock_time: 0,
-            input: vec![TxIn {
-                previous_output: OutPoint::new(collateral_hash, 1),
-                script_sig: collateral_address.assume_checked().script_pubkey(),
-                sequence: 4294967295,
-                witness: Default::default(),
-            }],
-            output: vec![TxOut::new_from_address(40777037710, &output_address0.assume_checked())],
-            special_transaction_payload: Some(ProviderRegistrationPayloadType(
-                ProviderRegistrationPayload {
-                    version: provider_registration_payload_version,
-                    provider_type,
-                    provider_mode,
-                    collateral_outpoint,
-                    ip_address: u128::from_le_bytes(ipv6_bytes),
-                    port,
-                    owner_key_hash: PubkeyHash::from_hex(owner_key_hash_hex).unwrap(),
-                    operator_public_key: BLSPublicKey::from_hex(operator_key_hex).unwrap(),
-                    voting_key_hash: PubkeyHash::from_hex(voting_key_hash_hex).unwrap(),
-                    operator_reward,
-                    script_payout,
-                    inputs_hash: InputsHash::from_hex(inputs_hash_hex).unwrap(),
-                    payload_sig: signature.to_vec(),
-                },
-            )),
-        };
-        // We are currently not supporting transaction signing
-        // So just assume signature is correct
-        transaction.input = expected_transaction.input.clone();
+            assert_eq!(expected_provider_registration_payload.payload_sig, signature.to_vec());
 
-        assert_eq!(transaction.hash_inputs().to_hex(), inputs_hash_hex);
+            assert_eq!(expected_transaction.txid(), tx_id);
 
-        assert_eq!(transaction, expected_transaction);
+            let mut transaction = Transaction {
+                version: 3,
+                lock_time: 0,
+                input: vec![TxIn {
+                    previous_output: OutPoint::new(collateral_hash, 1),
+                    script_sig: collateral_address.assume_checked().script_pubkey(),
+                    sequence: 4294967295,
+                    witness: Default::default(),
+                }],
+                output: vec![TxOut::new_from_address(
+                    40777037710,
+                    &output_address0.assume_checked(),
+                )],
+                special_transaction_payload: Some(ProviderRegistrationPayloadType(
+                    ProviderRegistrationPayload {
+                        version: provider_registration_payload_version,
+                        provider_type,
+                        provider_mode,
+                        collateral_outpoint,
+                        service_address,
+                        owner_key_hash: PubkeyHash::from_hex(owner_key_hash_hex).unwrap(),
+                        operator_public_key: BLSPublicKey::from_hex(operator_key_hex).unwrap(),
+                        voting_key_hash: PubkeyHash::from_hex(voting_key_hash_hex).unwrap(),
+                        operator_reward,
+                        script_payout,
+                        inputs_hash: InputsHash::from_hex(inputs_hash_hex).unwrap(),
+                        payload_sig: signature.to_vec(),
+                        platform_node_id: None,
+                        platform_p2p_port: None,
+                        platform_http_port: None,
+                    },
+                )),
+            };
+            // We are currently not supporting transaction signing
+            // So just assume signature is correct
+            transaction.input = expected_transaction.input.clone();
 
-        assert_eq!(transaction.txid(), tx_id);
-    }
+            assert_eq!(transaction.hash_inputs().to_hex(), inputs_hash_hex);
 
-    //todo finish this somewhat low value test
-    #[ignore]
-    #[test]
-    #[cfg(feature = "signer")]
-    fn test_no_collateral_provider_registration_transaction() {
-        // This is a test for testnet
-        let network = Network::Testnet;
+            assert_eq!(transaction, expected_transaction);
 
-        let expected_transaction_bytes = Vec::from_hex("030001000379efbe95cba05893d09f4ec51a71171a3852b54aa958ae35ce43276f5f8f1002000000006a473044022015df39c80ca8595cc197a0be692e9d158dc53bdbc8c6abca0d30c086f338c037022063becdb4f891436de3d2fb21cbf294e9dcb5c1a04bc0ba621867479e46d048cc0121030de5cb8989b6902d98017ab4d42b9244912006b0a1561c1d1ba0e2f3117a39adffffffff79efbe95cba05893d09f4ec51a71171a3852b54aa958ae35ce43276f5f8f1002010000006a47304402205c1bae23b459081b060de14133a20378243bebc05c8e2ed9acdabf6717ae7f9702204027ba0abbcce9ba5b2cb563cbff0190ba8f80e5f8fd6beb07c2c449f194c9be01210270b0f0b71472736a397975a84927314261be815d423006d1bcbc00cd693c3d81ffffffff9d925d6cd8e3a408f472e872d1c2849bc664efda8c7f68f1b3a3efde221bc474010000006a47304402203fa23ec33f91efa026b34e90b15a1fd64ff03242a6a92985b16a25b590e5bae002202d1429374b60b1180cd8b9bd0b432158524f5624d6c5d2d6db8c637c9961a21e0121024c0b09e261253dc40ed572c2d63d0b6cda89154583d75a5ab5a14fba81d70089ffffffff0200e87648170000001976a9143795a62df2eb953c1d08bc996d4089ee5d67e28b88ac438ca95a020000001976a91470ed8f5b5cfd4791c15b9d8a7f829cb6a98da18c88ac00000000d101000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffff010101014e1f3dd03f9ec192b5f275a433bfc90f468ee1a3eb4c157b10706659e25eb362b5d902d809f9160b1688e201ee6e94b40f9b5062d7074683ef05a2d5efb7793c47059c878dfad38a30fafe61575db40f05ab0a08d55119b0aad300001976a9143795a62df2eb953c1d08bc996d4089ee5d67e28b88ac14b33f2231f0df567e0dfb12899c893f5d2d05f6dcc7d9c8c27b68a71191c75400").unwrap();
+            assert_eq!(transaction.txid(), tx_id);
+        }
 
-        let expected_transaction: Transaction =
-            deserialize(expected_transaction_bytes.as_slice()).expect("expected a transaction");
+        //todo finish this somewhat low value test
+        #[ignore]
+        #[test]
+        #[cfg(feature = "signer")]
+        fn test_no_collateral_provider_registration_transaction() {
+            // This is a test for testnet
+            let network = Network::Testnet;
 
-        let expected_provider_registration_payload = expected_transaction
-            .special_transaction_payload
-            .clone()
-            .unwrap()
-            .to_provider_registration_payload()
-            .expect("expected to get a provider registration payload");
+            let expected_transaction_bytes = Vec::from_hex("030001000379efbe95cba05893d09f4ec51a71171a3852b54aa958ae35ce43276f5f8f1002000000006a473044022015df39c80ca8595cc197a0be692e9d158dc53bdbc8c6abca0d30c086f338c037022063becdb4f891436de3d2fb21cbf294e9dcb5c1a04bc0ba621867479e46d048cc0121030de5cb8989b6902d98017ab4d42b9244912006b0a1561c1d1ba0e2f3117a39adffffffff79efbe95cba05893d09f4ec51a71171a3852b54aa958ae35ce43276f5f8f1002010000006a47304402205c1bae23b459081b060de14133a20378243bebc05c8e2ed9acdabf6717ae7f9702204027ba0abbcce9ba5b2cb563cbff0190ba8f80e5f8fd6beb07c2c449f194c9be01210270b0f0b71472736a397975a84927314261be815d423006d1bcbc00cd693c3d81ffffffff9d925d6cd8e3a408f472e872d1c2849bc664efda8c7f68f1b3a3efde221bc474010000006a47304402203fa23ec33f91efa026b34e90b15a1fd64ff03242a6a92985b16a25b590e5bae002202d1429374b60b1180cd8b9bd0b432158524f5624d6c5d2d6db8c637c9961a21e0121024c0b09e261253dc40ed572c2d63d0b6cda89154583d75a5ab5a14fba81d70089ffffffff0200e87648170000001976a9143795a62df2eb953c1d08bc996d4089ee5d67e28b88ac438ca95a020000001976a91470ed8f5b5cfd4791c15b9d8a7f829cb6a98da18c88ac00000000d101000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffff010101014e1f3dd03f9ec192b5f275a433bfc90f468ee1a3eb4c157b10706659e25eb362b5d902d809f9160b1688e201ee6e94b40f9b5062d7074683ef05a2d5efb7793c47059c878dfad38a30fafe61575db40f05ab0a08d55119b0aad300001976a9143795a62df2eb953c1d08bc996d4089ee5d67e28b88ac14b33f2231f0df567e0dfb12899c893f5d2d05f6dcc7d9c8c27b68a71191c75400").unwrap();
 
-        let tx_id =
-            Txid::from_hex("717d2d4a7d583da184872f4a07e35d897a1be9dd9875b4c017c81cf772e36694")
-                .unwrap();
+            let expected_transaction: Transaction =
+                deserialize(expected_transaction_bytes.as_slice()).expect("expected a transaction");
 
-        let output_address0 = Address::from_str("yTWY6DsS4HBGs2JwDtnvVcpykLkbvtjUte")
-            .expect("expected to be able to get output address");
-        let collateral_address = Address::from_str("yeNVS6tFeQNXJVkjv6nm6gb7PtTERV5dGh")
-            .expect("expected to be able to get collateral address");
-        let collateral_private_key =
-            PrivateKey::from_wif("cTVm7EkgzNBPcwAKGYHfvyK8cyrRAC8n3SUUw8qjLqCg2rpcczfo")
-                .expect("expected valid base 58");
-        let collateral_hash =
-            Txid::from_hex("58ab8ba7dce591c745f8b78ee49156d13277fff20880855f7cda501705439aca")
-                .expect("expected to decode collateral hash");
-        let payout_address = Address::from_str("yTb47qEBpNmgXvYYsHEN4nh8yJwa5iC4Cs")
-            .expect("expected a valid address");
+            let expected_provider_registration_payload = expected_transaction
+                .special_transaction_payload
+                .clone()
+                .unwrap()
+                .to_provider_registration_payload()
+                .expect("expected to get a provider registration payload");
 
-        let payload_collateral_string = expected_provider_registration_payload
-            .payload_collateral_string(network)
-            .expect("expected to produce a payload collateral string");
+            let tx_id =
+                Txid::from_hex("717d2d4a7d583da184872f4a07e35d897a1be9dd9875b4c017c81cf772e36694")
+                    .unwrap();
 
-        let provider_registration_payload_version = 1;
-        assert_eq!(
-            expected_provider_registration_payload.version,
-            provider_registration_payload_version
-        );
-        let provider_type = 0;
-        assert_eq!(expected_provider_registration_payload.provider_type, provider_type);
-        let provider_mode = 0;
-        assert_eq!(expected_provider_registration_payload.provider_mode, provider_mode);
+            let output_address0 = Address::from_str("yTWY6DsS4HBGs2JwDtnvVcpykLkbvtjUte")
+                .expect("expected to be able to get output address");
+            let collateral_address = Address::from_str("yeNVS6tFeQNXJVkjv6nm6gb7PtTERV5dGh")
+                .expect("expected to be able to get collateral address");
+            let collateral_private_key =
+                PrivateKey::from_wif("cTVm7EkgzNBPcwAKGYHfvyK8cyrRAC8n3SUUw8qjLqCg2rpcczfo")
+                    .expect("expected valid base 58");
+            let collateral_hash =
+                Txid::from_hex("58ab8ba7dce591c745f8b78ee49156d13277fff20880855f7cda501705439aca")
+                    .expect("expected to decode collateral hash");
+            let payout_address = Address::from_str("yTb47qEBpNmgXvYYsHEN4nh8yJwa5iC4Cs")
+                .expect("expected a valid address");
 
-        let collateral_outpoint = OutPoint { txid: collateral_hash, vout: 0 };
-        assert_eq!(expected_provider_registration_payload.collateral_outpoint, collateral_outpoint);
+            let payload_collateral_string = expected_provider_registration_payload
+                .payload_collateral_string(network)
+                .expect("expected to produce a payload collateral string");
 
-        let address = Ipv4Addr::from_str("1.1.1.1").expect("expected an ipv4 address");
-        let [a, b, c, d] = address.octets();
-        let ipv6_bytes: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, a, b, c, d];
-        assert_eq!(
-            ipv6_bytes.to_lower_hex_string(),
-            expected_provider_registration_payload.ip_address.to_le_bytes().to_lower_hex_string()
-        );
+            let provider_registration_payload_version = 1;
+            assert_eq!(
+                expected_provider_registration_payload.version,
+                provider_registration_payload_version
+            );
+            let provider_type = 0;
+            assert_eq!(expected_provider_registration_payload.provider_type, provider_type);
+            let provider_mode = 0;
+            assert_eq!(expected_provider_registration_payload.provider_mode, provider_mode);
 
-        let port = 19999;
-        assert_eq!(port, expected_provider_registration_payload.port);
+            let collateral_outpoint = OutPoint { txid: collateral_hash, vout: 0 };
+            assert_eq!(
+                expected_provider_registration_payload.collateral_outpoint,
+                collateral_outpoint
+            );
 
-        let owner_key_hash_hex = "3dd03f9ec192b5f275a433bfc90f468ee1a3eb4c";
-        assert_eq!(
-            owner_key_hash_hex,
-            expected_provider_registration_payload.owner_key_hash.to_hex()
-        );
+            let address = Ipv4Addr::from_str("1.1.1.1").expect("expected an ipv4 address");
+            let [a, b, c, d] = address.octets();
+            let ipv6_bytes: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, a, b, c, d];
+            assert_eq!(
+                ipv6_bytes.to_lower_hex_string(),
+                expected_provider_registration_payload
+                    .service_address
+                    .ip()
+                    .to_canonical()
+                    .to_le_bytes()
+                    .to_lower_hex_string()
+            );
 
-        let operator_key_hex = "157b10706659e25eb362b5d902d809f9160b1688e201ee6e94b40f9b5062d7074683ef05a2d5efb7793c47059c878dfa";
-        assert_eq!(
-            operator_key_hex,
-            expected_provider_registration_payload.operator_public_key.to_hex()
-        );
+            let port = 19999;
+            assert_eq!(port, expected_provider_registration_payload.service_address.port());
 
-        let voting_key_hash_hex = "d38a30fafe61575db40f05ab0a08d55119b0aad3";
-        assert_eq!(
-            voting_key_hash_hex,
-            expected_provider_registration_payload.voting_key_hash.to_hex()
-        );
+            let service_address = SocketAddr::V4(SocketAddrV4::new(address, port));
 
-        let inputs_hash_hex = "7ba273b835b1017da314a3363760835ff5ac20278c160604cb8773750b997734";
-        assert_eq!(
-            inputs_hash_hex,
-            expected_provider_registration_payload.inputs_hash.to_hex(),
-            "inputs hash calculation has issues"
-        );
+            let owner_key_hash_hex = "3dd03f9ec192b5f275a433bfc90f468ee1a3eb4c";
+            assert_eq!(
+                owner_key_hash_hex,
+                expected_provider_registration_payload.owner_key_hash.to_hex()
+            );
 
-        assert_eq!(
-            expected_provider_registration_payload.base_payload_hash().to_hex(),
-            "71e973f79003accd202b9a2ab2613ac6ced601b26684e82f561f6684fef2f102",
-            "Payload hash calculation has issues"
-        );
+            let operator_key_hex = "157b10706659e25eb362b5d902d809f9160b1688e201ee6e94b40f9b5062d7074683ef05a2d5efb7793c47059c878dfa";
+            assert_eq!(
+                operator_key_hex,
+                expected_provider_registration_payload.operator_public_key.to_hex()
+            );
 
-        assert_eq!(
-            "yTb47qEBpNmgXvYYsHEN4nh8yJwa5iC4Cs|0|yRxHYGLf9G4UVYdtAoB2iAzR3sxxVaZB6y|yfbxyP4ctRJR1rs3A8C3PdXA4Wtcrw7zTi|71e973f79003accd202b9a2ab2613ac6ced601b26684e82f561f6684fef2f102",
-            payload_collateral_string,
-            "provider transaction collateral string doesn't match"
-        );
+            let voting_key_hash_hex = "d38a30fafe61575db40f05ab0a08d55119b0aad3";
+            assert_eq!(
+                voting_key_hash_hex,
+                expected_provider_registration_payload.voting_key_hash.to_hex()
+            );
 
-        let operator_reward = 0;
+            let inputs_hash_hex =
+                "7ba273b835b1017da314a3363760835ff5ac20278c160604cb8773750b997734";
+            assert_eq!(
+                inputs_hash_hex,
+                expected_provider_registration_payload.inputs_hash.to_hex(),
+                "inputs hash calculation has issues"
+            );
 
-        assert_eq!(operator_reward, expected_provider_registration_payload.operator_reward);
+            assert_eq!(
+                expected_provider_registration_payload.base_payload_hash().to_hex(),
+                "71e973f79003accd202b9a2ab2613ac6ced601b26684e82f561f6684fef2f102",
+                "Payload hash calculation has issues"
+            );
 
-        // We should verify the script payouts match
-        let script_payout = payout_address.assume_checked().script_pubkey();
-        assert_eq!(script_payout, expected_provider_registration_payload.script_payout);
+            assert_eq!(
+                "yTb47qEBpNmgXvYYsHEN4nh8yJwa5iC4Cs|0|yRxHYGLf9G4UVYdtAoB2iAzR3sxxVaZB6y|yfbxyP4ctRJR1rs3A8C3PdXA4Wtcrw7zTi|71e973f79003accd202b9a2ab2613ac6ced601b26684e82f561f6684fef2f102",
+                payload_collateral_string,
+                "provider transaction collateral string doesn't match"
+            );
 
-        let expected_base64_signature = "H7N+ScH/K4BXcTk5pVE+bnEacc/y5RfmIk33JO11Cu8bf5rZ7GErSnJQIy4eQA2nGKlQHh2aVWVSbksf9owCh2M=";
-        let signature = sign_hash(
-            base64::decode(&expected_base64_signature).expect("expected valid base64").as_slice(),
-            collateral_private_key.to_bytes().as_slice(),
-        )
-        .expect("expected to sign message digest");
-        let base64_signature = base64::encode(signature.as_slice());
+            let operator_reward = 0;
 
-        assert_eq!(
-            expected_base64_signature, base64_signature,
-            "message digest signatures don't match"
-        );
+            assert_eq!(operator_reward, expected_provider_registration_payload.operator_reward);
 
-        assert_eq!(expected_provider_registration_payload.payload_sig, signature.to_vec());
+            // We should verify the script payouts match
+            let script_payout = payout_address.assume_checked().script_pubkey();
+            assert_eq!(script_payout, expected_provider_registration_payload.script_payout);
 
-        assert_eq!(expected_transaction.txid(), tx_id);
+            let expected_base64_signature = "H7N+ScH/K4BXcTk5pVE+bnEacc/y5RfmIk33JO11Cu8bf5rZ7GErSnJQIy4eQA2nGKlQHh2aVWVSbksf9owCh2M=";
+            let signature = sign_hash(
+                base64::decode(&expected_base64_signature)
+                    .expect("expected valid base64")
+                    .as_slice(),
+                collateral_private_key.to_bytes().as_slice(),
+            )
+            .expect("expected to sign message digest");
+            let base64_signature = base64::encode(signature.as_slice());
 
-        let mut transaction = Transaction {
-            version: 3,
-            lock_time: 0,
-            input: vec![TxIn {
-                previous_output: OutPoint::new(collateral_hash, 1),
-                script_sig: collateral_address.assume_checked().script_pubkey(),
-                sequence: 4294967295,
-                witness: Witness::new(),
-            }],
-            output: vec![TxOut::new_from_address(40777037710, &output_address0.assume_checked())],
-            special_transaction_payload: Some(ProviderRegistrationPayloadType(
-                ProviderRegistrationPayload {
-                    version: provider_registration_payload_version,
-                    provider_type,
-                    provider_mode,
-                    collateral_outpoint,
-                    ip_address: u128::from_le_bytes(ipv6_bytes),
-                    port,
-                    owner_key_hash: PubkeyHash::from_hex(owner_key_hash_hex).unwrap(),
-                    operator_public_key: BLSPublicKey::from_hex(operator_key_hex).unwrap(),
-                    voting_key_hash: PubkeyHash::from_hex(voting_key_hash_hex).unwrap(),
-                    operator_reward,
-                    script_payout,
-                    inputs_hash: InputsHash::from_hex(inputs_hash_hex).unwrap(),
-                    payload_sig: signature.to_vec(),
-                },
-            )),
-        };
-        // We are currently not supporting transaction signing
-        // So just assume signature is correct
-        transaction.input = expected_transaction.input.clone();
+            assert_eq!(
+                expected_base64_signature, base64_signature,
+                "message digest signatures don't match"
+            );
 
-        assert_eq!(transaction.hash_inputs().to_hex(), inputs_hash_hex);
+            assert_eq!(expected_provider_registration_payload.payload_sig, signature.to_vec());
 
-        assert_eq!(transaction, expected_transaction);
+            assert_eq!(expected_transaction.txid(), tx_id);
 
-        assert_eq!(transaction.txid(), tx_id);
+            let mut transaction = Transaction {
+                version: 3,
+                lock_time: 0,
+                input: vec![TxIn {
+                    previous_output: OutPoint::new(collateral_hash, 1),
+                    script_sig: collateral_address.assume_checked().script_pubkey(),
+                    sequence: 4294967295,
+                    witness: Witness::new(),
+                }],
+                output: vec![TxOut::new_from_address(
+                    40777037710,
+                    &output_address0.assume_checked(),
+                )],
+                special_transaction_payload: Some(ProviderRegistrationPayloadType(
+                    ProviderRegistrationPayload {
+                        version: provider_registration_payload_version,
+                        provider_type,
+                        provider_mode,
+                        collateral_outpoint,
+                        service_address,
+                        owner_key_hash: PubkeyHash::from_hex(owner_key_hash_hex).unwrap(),
+                        operator_public_key: BLSPublicKey::from_hex(operator_key_hex).unwrap(),
+                        voting_key_hash: PubkeyHash::from_hex(voting_key_hash_hex).unwrap(),
+                        operator_reward,
+                        script_payout,
+                        inputs_hash: InputsHash::from_hex(inputs_hash_hex).unwrap(),
+                        payload_sig: signature.to_vec(),
+                        platform_node_id: None,
+                        platform_p2p_port: None,
+                        platform_http_port: None,
+                    },
+                )),
+            };
+            // We are currently not supporting transaction signing
+            // So just assume signature is correct
+            transaction.input = expected_transaction.input.clone();
+
+            assert_eq!(transaction.hash_inputs().to_hex(), inputs_hash_hex);
+
+            assert_eq!(transaction, expected_transaction);
+
+            assert_eq!(transaction.txid(), tx_id);
+        }
     }
 
     #[test]
@@ -557,11 +658,10 @@ mod tests {
         let want = 290;
         let payload = ProviderRegistrationPayload {
             version: 0,
-            provider_type: 0,
+            provider_type: MasternodeType::Regular,
             provider_mode: 0,
             collateral_outpoint: OutPoint { txid: Txid::all_zeros(), vout: 0 },
-            ip_address: 0,
-            port: 0,
+            service_address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::from_bits(0), 0)),
             owner_key_hash: PubkeyHash::all_zeros(),
             operator_public_key: BLSPublicKey::from([0; 48]),
             voting_key_hash: PubkeyHash::all_zeros(),
@@ -569,9 +669,27 @@ mod tests {
             script_payout: ScriptBuf::from_hex("00000000000000000000").unwrap(), // 10 bytes
             inputs_hash: InputsHash::all_zeros(),
             payload_sig: vec![0; 96],
+            platform_node_id: None,
+            platform_p2p_port: None,
+            platform_http_port: None,
         };
         assert_eq!(payload.size(), want);
         let actual = payload.consensus_encode(&mut Vec::new()).unwrap();
         assert_eq!(actual, want);
+    }
+
+    #[test]
+    fn test_payload_version_2_encoding_and_decoding() {
+        let payload_bytes = hex!(
+            "02000100000093e740d1640db90b470eacd00a109fd2545604de231339f59d7d6afe1c6fb74e0100000000000000000000000000ffff52d31528270fb76ced2307e84810443d29baada0b3ece85c94dd9492e693537ddcd32edf56a800899c59e64f3e78156a4901072e5b470a21aa7841ad9abbb00cbc0d2c129e82fb4328fdeee23806c51aefc26fec992c30ead6a6410c1c1b00001976a914c4a7f785e341b694425ea2ddebd8e2249eb5664e88acb66b1aa5263c52fbde60b39f21855a4a0893adaea98f7e8195c2005594a7012a4cd2ca50b36e0a2bb1b6b29da140448b47eeb7a12068bb0141202f9d029a3f810d06e1d0001cbe8228af14af79d24ec28f5a5616a23f8b259e100b8533709c3543b4163251f60283d91670cdde5e975887e6a99ce28a001df528"
+        );
+        let payload: ProviderRegistrationPayload =
+            deserialize(&payload_bytes).expect("deserialize payload");
+
+        let mut serialized_payload_bytes = Vec::new();
+
+        payload.consensus_encode(&mut serialized_payload_bytes).expect("serialize payload");
+
+        assert_eq!(serialized_payload_bytes, payload_bytes);
     }
 }

--- a/dash/src/sml/address.rs
+++ b/dash/src/sml/address.rs
@@ -1,26 +1,24 @@
 use std::io;
 use std::io::Write;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 use crate::consensus::{Decodable, Encodable, encode};
 
 impl Encodable for SocketAddr {
     fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        let ip_address = match self.ip() {
+        let ip = match self.ip() {
             IpAddr::V4(v4) => {
-                // Create a 16-byte array for the IP address.
-                let mut ip_address = [0u8; 16];
                 // For IPv4, the previous implementation stored the IPv4 address in the last 4 bytes.
-                ip_address[12..16].copy_from_slice(&v4.octets());
-                ip_address
+                v4.to_ipv6_mapped().to_bits()
             }
-            IpAddr::V6(_) => unimplemented!("ipv6 not supported"),
+            IpAddr::V6(v6) => v6.to_bits(),
         };
 
         let mut len = 0;
 
         // Encode the 16-byte IP address.
-        len += ip_address.consensus_encode(writer)?;
+        len += ip.consensus_encode(writer)?;
+
         // Encode the port: the legacy code swaps the port’s bytes before encoding.
         len += self.port().swap_bytes().consensus_encode(writer)?;
 
@@ -31,18 +29,71 @@ impl Encodable for SocketAddr {
 impl Decodable for SocketAddr {
     fn consensus_decode<R: io::Read + ?Sized>(reader: &mut R) -> Result<Self, encode::Error> {
         // Decode the 16-byte IP address.
-        let ip_address: [u8; 16] = Decodable::consensus_decode(reader)?;
+        let ip = u128::consensus_decode(reader)?;
+
         // Decode the port (which was stored in swapped order).
-        let port: u16 = Decodable::consensus_decode(reader)?;
-        // Swap the port bytes back to native order.
-        let port = port.swap_bytes();
-        // Extract the IPv4 octets from the last 4 bytes.
-        let ipv4_octets: [u8; 4] = ip_address[12..16]
-            .try_into()
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid IPv4 address"))?;
+        let port = u16::consensus_decode(reader)?.swap_bytes();
 
-        let ip = IpAddr::V4(Ipv4Addr::from(ipv4_octets));
+        let ipv6 = Ipv6Addr::from(ip);
 
-        Ok(SocketAddr::new(ip, port))
+        if let Some(ipv4) = ipv6.to_ipv4() {
+            Ok(SocketAddr::V4(SocketAddrV4::new(ipv4, port)))
+        } else {
+            Ok(SocketAddr::V6(SocketAddrV6::new(ipv6, port, 0, 0)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn encode_decode_ipv4() {
+        let ip = Ipv4Addr::new(192, 168, 1, 1);
+        let address = SocketAddr::V4(SocketAddrV4::new(ip, 1234));
+        let mut writer = Vec::new();
+        address.consensus_encode(&mut writer).unwrap();
+
+        let mut reader = &writer[..];
+        let decoded = SocketAddr::consensus_decode(&mut reader).unwrap();
+
+        assert_eq!(address, decoded);
+    }
+
+    #[test]
+    fn encode_decode_ipv4_mapped() {
+        let ip = Ipv4Addr::new(192, 168, 1, 1);
+        let address = SocketAddr::V6(SocketAddrV6::new(ip.to_ipv6_mapped(), 1234, 0, 0));
+        let mut writer = Vec::new();
+        address.consensus_encode(&mut writer).unwrap();
+
+        let mut reader = &writer[..];
+        let decoded = SocketAddr::consensus_decode(&mut reader).unwrap();
+
+        assert!(decoded.is_ipv4());
+        assert_eq!(decoded.ip(), IpAddr::V4(ip));
+
+        let mut decoded_writer = Vec::new();
+        decoded.consensus_encode(&mut decoded_writer).unwrap();
+
+        assert_eq!(writer, decoded_writer);
+    }
+
+    #[test]
+    fn encode_decode_ipv6() {
+        let address = SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::new(0, 10, 20, 30, 40, 50, 60, 70),
+            1234,
+            0,
+            0,
+        ));
+        let mut writer = Vec::new();
+        address.consensus_encode(&mut writer).unwrap();
+        let mut reader = &writer[..];
+        let decoded = SocketAddr::consensus_decode(&mut reader).unwrap();
+
+        assert_eq!(address, decoded);
     }
 }

--- a/dash/src/sml/masternode_list/scores_for_quorum.rs
+++ b/dash/src/sml/masternode_list/scores_for_quorum.rs
@@ -5,7 +5,7 @@ use crate::hash_types::{QuorumModifierHash, ScoreHash};
 use crate::network::message_qrinfo::QuorumSnapshot;
 use crate::sml::llmq_type::LLMQType;
 use crate::sml::masternode_list::MasternodeList;
-use crate::sml::masternode_list_entry::MasternodeType;
+use crate::sml::masternode_list_entry::EntryMasternodeType;
 use crate::sml::masternode_list_entry::qualified_masternode_list_entry::QualifiedMasternodeListEntry;
 use crate::sml::quorum_entry::qualified_quorum_entry::QualifiedQuorumEntry;
 use crate::sml::quorum_entry::quorum_modifier_type::LLMQModifierType;
@@ -61,7 +61,7 @@ impl MasternodeList {
                 if !hpmn_only
                     || matches!(
                         entry.masternode_list_entry.mn_type,
-                        MasternodeType::HighPerformance { .. }
+                        EntryMasternodeType::HighPerformance { .. }
                     )
                 {
                     entry.score(quorum_modifier).map(|score| (score, entry))


### PR DESCRIPTION
- implement version 2 of payload adding high performance masternode type and platform specifics 
- use `SocketAddr` to reduce code duplication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved provider registration by introducing clear provider type differentiation and a unified network address field.
- **Refactor**
	- Enhanced network address processing to robustly support both IPv4 and IPv6 formats.
	- Renamed enum for better clarity in masternode type handling.
- **Tests**
	- Updated test cases to ensure accurate serialization and decoding of the new payload and address handling.

These changes improve clarity and resilience in provider registration and network communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->