### PR TITLE
Fix: Allow Block hash of 0s to represent genesis.

### DIFF
--- a/dash/src/bip32.rs
+++ b/dash/src/bip32.rs
@@ -36,7 +36,13 @@ use serde;
 
 use crate::base58;
 use crate::crypto::key::{self, Keypair, PrivateKey, PublicKey};
-use crate::dip9::{COINJOIN_PATH_MAINNET, COINJOIN_PATH_TESTNET, DASH_BIP44_PATH_MAINNET, DASH_BIP44_PATH_TESTNET, IDENTITY_AUTHENTICATION_PATH_MAINNET, IDENTITY_AUTHENTICATION_PATH_TESTNET, IDENTITY_INVITATION_PATH_MAINNET, IDENTITY_INVITATION_PATH_TESTNET, IDENTITY_REGISTRATION_PATH_MAINNET, IDENTITY_REGISTRATION_PATH_TESTNET, IDENTITY_TOPUP_PATH_MAINNET, IDENTITY_TOPUP_PATH_TESTNET};
+use crate::dip9::{
+    COINJOIN_PATH_MAINNET, COINJOIN_PATH_TESTNET, DASH_BIP44_PATH_MAINNET, DASH_BIP44_PATH_TESTNET,
+    IDENTITY_AUTHENTICATION_PATH_MAINNET, IDENTITY_AUTHENTICATION_PATH_TESTNET,
+    IDENTITY_INVITATION_PATH_MAINNET, IDENTITY_INVITATION_PATH_TESTNET,
+    IDENTITY_REGISTRATION_PATH_MAINNET, IDENTITY_REGISTRATION_PATH_TESTNET,
+    IDENTITY_TOPUP_PATH_MAINNET, IDENTITY_TOPUP_PATH_TESTNET,
+};
 use crate::hash_types::XpubIdentifier;
 use crate::internal_macros::impl_bytes_newtype;
 use crate::io::Write;
@@ -489,16 +495,15 @@ impl DerivationPath {
         ]);
         root_derivation_path
     }
-    pub fn coinjoin_path(
-        network: Network,
-        account: u32,
-    ) -> Self {
+    pub fn coinjoin_path(network: Network, account: u32) -> Self {
         let mut root_derivation_path: DerivationPath = match network {
             Network::Dash => COINJOIN_PATH_MAINNET,
             _ => COINJOIN_PATH_TESTNET,
         }
         .into();
-        root_derivation_path.0.extend(&[ChildNumber::Hardened { index: account }]);
+        root_derivation_path.0.extend(&[ChildNumber::Hardened {
+            index: account,
+        }]);
         root_derivation_path
     }
 

--- a/dash/src/dip9.rs
+++ b/dash/src/dip9.rs
@@ -155,18 +155,30 @@ pub const DASH_BIP44_PATH_TESTNET: IndexConstPath<2> = IndexConstPath {
 
 pub const COINJOIN_PATH_MAINNET: IndexConstPath<3> = IndexConstPath {
     indexes: [
-        ChildNumber::Hardened { index: FEATURE_PURPOSE },
-        ChildNumber::Hardened { index: DASH_COIN_TYPE },
-        ChildNumber::Hardened { index: FEATURE_PURPOSE_COINJOIN },
+        ChildNumber::Hardened {
+            index: FEATURE_PURPOSE,
+        },
+        ChildNumber::Hardened {
+            index: DASH_COIN_TYPE,
+        },
+        ChildNumber::Hardened {
+            index: FEATURE_PURPOSE_COINJOIN,
+        },
     ],
     reference: DerivationPathReference::CoinJoin,
     path_type: DerivationPathType::ANONYMOUS_FUNDS,
 };
 pub const COINJOIN_PATH_TESTNET: IndexConstPath<3> = IndexConstPath {
     indexes: [
-        ChildNumber::Hardened { index: FEATURE_PURPOSE },
-        ChildNumber::Hardened { index: DASH_TESTNET_COIN_TYPE },
-        ChildNumber::Hardened { index: FEATURE_PURPOSE_COINJOIN },
+        ChildNumber::Hardened {
+            index: FEATURE_PURPOSE,
+        },
+        ChildNumber::Hardened {
+            index: DASH_TESTNET_COIN_TYPE,
+        },
+        ChildNumber::Hardened {
+            index: FEATURE_PURPOSE_COINJOIN,
+        },
     ],
     reference: DerivationPathReference::CoinJoin,
     path_type: DerivationPathType::ANONYMOUS_FUNDS,

--- a/dash/src/sml/masternode_list/from_diff.rs
+++ b/dash/src/sml/masternode_list/from_diff.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use crate::bls_sig_utils::BLSSignature;
 use crate::network::message_sml::MnListDiff;
 use crate::sml::error::SmlError;
@@ -11,6 +9,8 @@ use crate::sml::quorum_entry::qualified_quorum_entry::{
     QualifiedQuorumEntry, VerifyingChainLockSignaturesType,
 };
 use crate::{BlockHash, Network};
+use hashes::Hash;
+use std::collections::BTreeMap;
 
 pub trait TryFromWithBlockHashLookup<T>: Sized {
     type Error;
@@ -67,7 +67,9 @@ impl TryFromWithBlockHashLookup<MnListDiff> for MasternodeList {
     {
         if let Some(genesis_block_hash) = network.known_genesis_block_hash() {
             // Check if the base block is the genesis block
-            if diff.base_block_hash != genesis_block_hash {
+            if diff.base_block_hash != genesis_block_hash
+                && diff.base_block_hash.as_byte_array() != &[0; 32]
+            {
                 return Err(SmlError::BaseBlockNotGenesis(diff.base_block_hash));
             }
         }

--- a/dash/src/sml/masternode_list_engine/mod.rs
+++ b/dash/src/sml/masternode_list_engine/mod.rs
@@ -401,14 +401,18 @@ impl MasternodeListEngine {
 
         let can_verify_previous = quorum_snapshot_and_mn_list_diff_at_h_minus_4c.is_some();
 
-        let h_height = self
-            .block_container
-            .get_height(&mn_list_diff_h.block_hash)
-            .ok_or(QuorumValidationError::RequiredBlockNotPresent(mn_list_diff_h.block_hash))?;
-        let tip_height = self
-            .block_container
-            .get_height(&mn_list_diff_tip.block_hash)
-            .ok_or(QuorumValidationError::RequiredBlockNotPresent(mn_list_diff_tip.block_hash))?;
+        let h_height = self.block_container.get_height(&mn_list_diff_h.block_hash).ok_or(
+            QuorumValidationError::RequiredBlockNotPresent(
+                mn_list_diff_h.block_hash,
+                "getting height at diff h".to_string(),
+            ),
+        )?;
+        let tip_height = self.block_container.get_height(&mn_list_diff_tip.block_hash).ok_or(
+            QuorumValidationError::RequiredBlockNotPresent(
+                mn_list_diff_tip.block_hash,
+                "getting height at diff tip".to_string(),
+            ),
+        )?;
         let rotation_quorum_type = last_commitment_per_index
             .first()
             .map(|quorum_entry| quorum_entry.llmq_type)

--- a/dash/src/sml/masternode_list_engine/mod.rs
+++ b/dash/src/sml/masternode_list_engine/mod.rs
@@ -664,7 +664,9 @@ impl MasternodeListEngine {
             .known_genesis_block_hash()
             .or_else(|| self.block_container.get_hash(&0).cloned())
         {
-            if masternode_list_diff.base_block_hash == known_genesis_block_hash {
+            if masternode_list_diff.base_block_hash == known_genesis_block_hash
+                || masternode_list_diff.base_block_hash.as_byte_array() == &[0; 32]
+            {
                 // we are going from the start
                 let block_hash = masternode_list_diff.block_hash;
 

--- a/dash/src/sml/masternode_list_engine/mod.rs
+++ b/dash/src/sml/masternode_list_engine/mod.rs
@@ -357,7 +357,7 @@ impl MasternodeListEngine {
         Ok(())
     }
 
-    pub fn feed_qr_info<FH, FS>(
+    pub fn feed_qr_info<FH>(
         &mut self,
         qr_info: QRInfo,
         verify_tip_non_rotated_quorums: bool,
@@ -366,7 +366,6 @@ impl MasternodeListEngine {
     ) -> Result<(), QuorumValidationError>
     where
         FH: Fn(&BlockHash) -> Result<u32, ClientDataRetrievalError>,
-        FS: Fn(&BlockHash) -> Result<Option<BLSSignature>, ClientDataRetrievalError>,
     {
         // Fetch and process block heights using the provided callback
         if let Some(fetch_height) = fetch_block_height {

--- a/dash/src/sml/masternode_list_engine/non_rotated_quorum_construction.rs
+++ b/dash/src/sml/masternode_list_engine/non_rotated_quorum_construction.rs
@@ -23,7 +23,10 @@ impl MasternodeListEngine {
                 ))
             }
         } else {
-            Err(QuorumValidationError::RequiredBlockNotPresent(*block_hash))
+            Err(QuorumValidationError::RequiredBlockNotPresent(
+                *block_hash,
+                "looking for masternode list and height for block hash 8 blocks ago".to_string(),
+            ))
         }
     }
 

--- a/dash/src/sml/masternode_list_engine/rotated_quorum_construction.rs
+++ b/dash/src/sml/masternode_list_engine/rotated_quorum_construction.rs
@@ -35,6 +35,7 @@ impl MasternodeListEngine {
         else {
             return Err(QuorumValidationError::RequiredBlockNotPresent(
                 quorum.quorum_entry.quorum_hash,
+                "getting height when finding rotated masternodes for quorum".to_string(),
             ));
         };
         let llmq_type = quorum.quorum_entry.llmq_type;
@@ -82,7 +83,7 @@ impl MasternodeListEngine {
                 self.block_container.get_height(&quorum.quorum_entry.quorum_hash)
             else {
                 return Err(QuorumValidationError::RequiredBlockNotPresent(
-                    quorum.quorum_entry.quorum_hash,
+                    quorum.quorum_entry.quorum_hash, "getting height for a quorum hash when trying to find rotated masternodes for quorums".to_string()
                 ));
             };
             let llmq_type = quorum.quorum_entry.llmq_type;
@@ -145,7 +146,10 @@ impl MasternodeListEngine {
         for quorum in &qr_info.last_commitment_per_index {
             let Some(quorum_block_height) = self.block_container.get_height(&quorum.quorum_hash)
             else {
-                return Err(QuorumValidationError::RequiredBlockNotPresent(quorum.quorum_hash));
+                return Err(QuorumValidationError::RequiredBlockNotPresent(
+                    quorum.quorum_hash,
+                    "getting required cl_sig heights".to_string(),
+                ));
             };
             let llmq_params = quorum.llmq_type.params();
             let quorum_index = quorum_block_height % llmq_params.dkg_params.interval;
@@ -164,6 +168,7 @@ impl MasternodeListEngine {
                     else {
                         return Err(QuorumValidationError::RequiredBlockNotPresent(
                             quorum.quorum_hash,
+                            "getting height for quorum hash for diff at h minus 4c".to_string(),
                         ));
                     };
                     let llmq_params = quorum.llmq_type.params();

--- a/dash/src/sml/quorum_entry/qualified_quorum_entry.rs
+++ b/dash/src/sml/quorum_entry/qualified_quorum_entry.rs
@@ -68,7 +68,7 @@ impl QualifiedQuorumEntry {
     /// * `result` - A `Result` containing either success (`Ok`) or a `QuorumValidationError`.
     pub fn update_quorum_status(&mut self, result: Result<(), QuorumValidationError>) {
         match result {
-            Err(QuorumValidationError::RequiredBlockNotPresent(block_hash)) => {
+            Err(QuorumValidationError::RequiredBlockNotPresent(block_hash, _)) => {
                 self.verified = LLMQEntryVerificationStatus::Skipped(
                     LLMQEntryVerificationSkipStatus::UnknownBlock(block_hash),
                 );

--- a/dash/src/sml/quorum_validation_error.rs
+++ b/dash/src/sml/quorum_validation_error.rs
@@ -24,8 +24,8 @@ pub enum ClientDataRetrievalError {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "actual_serde"))]
 pub enum QuorumValidationError {
-    #[error("Required block not present: {0}")]
-    RequiredBlockNotPresent(BlockHash),
+    #[error("Required block not present: {0} ({1})")]
+    RequiredBlockNotPresent(BlockHash, String),
 
     #[error("Required block height not present: {0}")]
     RequiredBlockHeightNotPresent(CoreBlockHeight),


### PR DESCRIPTION
Core has an error where a block hash of 0s would represent the genesis. In this PR I incorporated such behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor & Style**
	- Improved internal code formatting, organization, and method signature consistency.
- **Error Handling**
	- Enhanced validation feedback with more descriptive error messages to provide clearer context when issues arise.

These behind‐the‐scenes improvements aim to support improved maintainability and user-facing error clarity while keeping overall functionality unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->