### PR TITLE
fix(json-rpc): change value sat from u32 to u64

### DIFF
--- a/rpc-json/src/lib.rs
+++ b/rpc-json/src/lib.rs
@@ -540,7 +540,7 @@ pub struct GetRawTransactionResultVin {
     #[serde(default, with = "dashcore::amount::serde::as_btc::opt")]
     pub value: Option<Amount>,
     #[serde(default)]
-    pub value_sat: Option<u32>,
+    pub value_sat: Option<u64>,
     pub addresses: Option<Vec<String>>,
     pub sequence: u32,
 }
@@ -579,7 +579,7 @@ pub struct GetRawTransactionResultVout {
     #[serde(with = "dashcore::amount::serde::as_btc")]
     pub value: Amount,
     #[serde(rename = "valueSat")]
-    pub value_sat: u32,
+    pub value_sat: u64,
     pub n: u32,
     #[serde(rename = "scriptPubKey")]
     pub script_pub_key: GetRawTransactionResultVoutScriptPubKey,


### PR DESCRIPTION
In GetRawTransactionResultVin and GetRawTransactionResultVout, value_sat should be u64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of large satoshi values in transaction details to ensure accurate display for higher amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->