### PR TITLE
Fix/genesis testnet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["dash", "hashes", "internals", "fuzz", "rpc-client", "rpc-json", "rpc
 resolver = "2"
 
 [workspace.package]
-version = "0.39.4"
+version = "0.39.6"
 
 [patch.crates-io.dashcore_hashes]
 path = "hashes"

--- a/dash/src/consensus/encode.rs
+++ b/dash/src/consensus/encode.rs
@@ -738,6 +738,7 @@ impl_vec!(TxIn);
 impl_vec!(Vec<u8>);
 impl_vec!(u16);
 impl_vec!(u32);
+impl_vec!(i32);
 impl_vec!(u64);
 impl_vec!(TapLeafHash);
 impl_vec!(VarInt);

--- a/dash/src/network/constants.rs
+++ b/dash/src/network/constants.rs
@@ -163,12 +163,7 @@ impl Network {
                     hex::decode("00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c")
                         .expect("expected valid hex");
                 block_hash.reverse();
-                Some(BlockHash::from_byte_array(
-                    hex::decode("00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c")
-                        .expect("expected valid hex")
-                        .try_into()
-                        .expect("expected 32 bytes"),
-                ))
+                Some(BlockHash::from_byte_array(block_hash.try_into().expect("expected 32 bytes")))
             }
             Network::Devnet => None,
             Network::Regtest => None,

--- a/dash/src/network/message_qrinfo.rs
+++ b/dash/src/network/message_qrinfo.rs
@@ -157,7 +157,7 @@ impl Decodable for QRInfo {
 pub struct QuorumSnapshot {
     pub skip_list_mode: MNSkipListMode,
     pub active_quorum_members: Vec<bool>, // Bitset, length = (active_quorum_members_count + 7) / 8
-    pub skip_list: Vec<u32>,              // Array of uint32_t
+    pub skip_list: Vec<i32>,              // Array of uint32_t
 }
 
 impl Display for QuorumSnapshot {


### PR DESCRIPTION
This pull request includes several changes to the `dash` module, focusing on improving type consistency and simplifying code.

### Type Consistency Improvements:
* [`dash/src/consensus/encode.rs`](diffhunk://#diff-0dae2111477f9d9feb269479024c972d0b3d6e0b2643866ea08f6cee478148fcR741): Added `impl_vec!(i32);` to support encoding of `i32` type.
* [`dash/src/network/message_qrinfo.rs`](diffhunk://#diff-16d0784235e7bbadaffea811b1bec71ddce6741428cbebd9850b1f509866192fL160-R160): Changed `skip_list` type from `Vec<u32>` to `Vec<i32>` in the `QuorumSnapshot` struct to align with the intended data type.

### Fix:
* [`dash/src/network/constants.rs`](diffhunk://#diff-f66d95598c19bc8578b24cf88f5834503eff1664cb383b7712f3887e2a06ee84L166-R166):  Testnet genesis block hash should be reversed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for encoding and decoding vectors of 32-bit signed integers.

- **Bug Fixes**
  - Updated the skip list in quorum snapshots to use signed 32-bit integers, improving data representation.

- **Refactor**
  - Streamlined the process for constructing the Testnet genesis block hash for improved efficiency.

- **Chores**
  - Updated the workspace package version to 0.39.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->