### PR TITLE
feat: re-export masternode list engine through dash-spv

### DIFF
--- a/dash-spv/src/client/mod.rs
+++ b/dash-spv/src/client/mod.rs
@@ -25,6 +25,7 @@ use crate::sync::SyncManager;
 use crate::types::{AddressBalance, ChainState, SpvStats, SyncProgress, WatchItem};
 use crate::validation::ValidationManager;
 use dashcore::network::constants::NetworkExt;
+use dashcore::sml::masternode_list_engine::MasternodeListEngine;
 
 pub use block_processor::{BlockProcessingTask, BlockProcessor};
 pub use config::ClientConfig;
@@ -1609,6 +1610,12 @@ impl DashSpvClient {
     /// Get the number of connected peers.
     pub async fn get_peer_count(&self) -> usize {
         self.network.peer_count()
+    }
+
+    /// Get a reference to the masternode list engine.
+    /// Returns None if masternode sync is not enabled in config.
+    pub fn masternode_list_engine(&self) -> Option<&MasternodeListEngine> {
+        self.sync_manager.masternode_list_engine()
     }
 
     /// Sync compact filters for recent blocks and check for matches.

--- a/dash-spv/src/lib.rs
+++ b/dash-spv/src/lib.rs
@@ -70,6 +70,13 @@ pub use wallet::{
 // Re-export commonly used dashcore types
 pub use dashcore::{Address, BlockHash, Network, OutPoint, ScriptBuf};
 
+// Re-export MasternodeListEngine and related types
+pub use dashcore::sml::masternode_list_engine::{
+    MasternodeListEngine,
+    MasternodeListEngineBlockContainer,
+    MasternodeListEngineBTreeMapBlockContainer,
+};
+
 /// Current version of the dash-spv library.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/dash-spv/src/sync/mod.rs
+++ b/dash-spv/src/sync/mod.rs
@@ -21,6 +21,7 @@ use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use crate::types::SyncProgress;
 use dashcore::network::constants::NetworkExt;
+use dashcore::sml::masternode_list_engine::MasternodeListEngine;
 
 pub use filters::FilterSyncManager;
 pub use headers::HeaderSyncManager;
@@ -190,6 +191,11 @@ impl SyncManager {
         let _ = self.filter_sync.check_filter_request_timeouts(network, storage).await;
 
         Ok(())
+    }
+
+    /// Get a reference to the masternode list engine.
+    pub fn masternode_list_engine(&self) -> Option<&MasternodeListEngine> {
+        self.masternode_sync.engine()
     }
 
     /// Synchronize all components to the tip.


### PR DESCRIPTION
Need access to MasternodeListEngine in clients that are only using dash-spv as dependency