### PR TITLE
refactor(key-wallet): improve API with standard FromStr trait and bet…

### DIFF
--- a/key-wallet/examples/basic_usage.rs
+++ b/key-wallet/examples/basic_usage.rs
@@ -67,7 +67,7 @@ fn main() -> core::result::Result<(), Box<dyn std::error::Error>> {
     // 8. Address parsing example
     println!("\n8. Address parsing...");
     let test_address = "XyPvhVmhWKDgvMJLwfFfMwhxpxGgd3TBxq";
-    match key_wallet::address::Address::from_str(test_address) {
+    match test_address.parse::<key_wallet::address::Address>() {
         Ok(parsed) => {
             println!("   Parsed address: {}", parsed);
             println!("   Type: {:?}", parsed.address_type);
@@ -84,7 +84,6 @@ fn demonstrate_address_generation() -> core::result::Result<(), Box<dyn std::err
     // This demonstrates bulk address generation
     let seed = [0u8; 64];
     let wallet = HDWallet::from_seed(&seed, Network::Dash)?;
-    let account = wallet.bip44_account(0)?;
     let path = key_wallet::DerivationPath::from(vec![
         key_wallet::ChildNumber::from_hardened_idx(44).unwrap(),
         key_wallet::ChildNumber::from_hardened_idx(5).unwrap(),

--- a/key-wallet/tests/address_tests.rs
+++ b/key-wallet/tests/address_tests.rs
@@ -1,5 +1,6 @@
 //! Address tests
 
+use std::str::FromStr;
 use bitcoin_hashes::{hash160, Hash};
 use key_wallet::address::{Address, AddressGenerator, AddressType};
 use key_wallet::derivation::HDWallet;
@@ -98,7 +99,6 @@ fn test_address_generator() {
     let wallet = HDWallet::from_seed(&seed, Network::Dash).unwrap();
 
     // Get account public key
-    let account = wallet.bip44_account(0).unwrap();
     let path = key_wallet::DerivationPath::from(vec![
         key_wallet::ChildNumber::from_hardened_idx(44).unwrap(),
         key_wallet::ChildNumber::from_hardened_idx(5).unwrap(),

--- a/key-wallet/tests/mnemonic_tests.rs
+++ b/key-wallet/tests/mnemonic_tests.rs
@@ -1,7 +1,7 @@
 //! Mnemonic tests
 
 use key_wallet::mnemonic::{Language, Mnemonic};
-use key_wallet::{ExtendedPrivKey, Network};
+use key_wallet::Network;
 
 #[test]
 fn test_mnemonic_validation() {


### PR DESCRIPTION
…ter error handling

- Implement standard FromStr trait for Address parsing
- Keep explicit to_string() method for backward compatibility
- Add from_string() convenience method
- Improve error handling by using explicit Error::Bip32 wrapping instead of generic Into
- Fix AccountDerivation to derive private keys first, then convert to public
- Update tests to import FromStr trait where needed

These changes make the key-wallet API more idiomatic while maintaining compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved address parsing to use more idiomatic Rust patterns and streamlined script generation for addresses.
  * Standardized error handling for key derivation processes.
  * Simplified and clarified test code by removing unused variables and imports.

* **Bug Fixes**
  * Enhanced reliability of address and key derivation by restructuring error mapping and parsing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->