### PR TITLE
refactor(key-wallet): improve code quality with clippy fixes and formatting

### DIFF
--- a/key-wallet/examples/basic_usage.rs
+++ b/key-wallet/examples/basic_usage.rs
@@ -36,7 +36,7 @@ fn main() -> core::result::Result<(), Box<dyn std::error::Error>> {
 
     // 5. Create account derivation
     println!("\n5. Deriving addresses...");
-    let account_derivation = AccountDerivation::new(account.clone());
+    let account_derivation = AccountDerivation::new(account);
 
     // Derive first 5 receive addresses
     println!("   Receive addresses:");

--- a/key-wallet/src/bip32.rs
+++ b/key-wallet/src/bip32.rs
@@ -774,9 +774,9 @@ pub enum KeyDerivationType {
     BLS = 1,
 }
 
-impl Into<u32> for KeyDerivationType {
-    fn into(self) -> u32 {
-        match self {
+impl From<KeyDerivationType> for u32 {
+    fn from(val: KeyDerivationType) -> Self {
+        match val {
             KeyDerivationType::ECDSA => 0,
             KeyDerivationType::BLS => 1,
         }
@@ -985,7 +985,7 @@ impl IntoDerivationPath for String {
     }
 }
 
-impl<'a> IntoDerivationPath for &'a str {
+impl IntoDerivationPath for &str {
     fn into_derivation_path(self) -> Result<DerivationPath, Error> {
         self.parse()
     }
@@ -1443,10 +1443,7 @@ impl ExtendedPrivKey {
         let parent_fingerprint = data[5..9].try_into().expect("4 bytes for fingerprint");
 
         let hardening_byte = data[9];
-        let is_hardened = match hardening_byte {
-            0x00 => false,
-            _ => true,
-        };
+        let is_hardened = !matches!(hardening_byte, 0x00);
 
         let child_number_bytes = data[10..42].try_into().expect("32 bytes for child number");
         let child_number = if is_hardened {
@@ -1778,10 +1775,7 @@ impl ExtendedPubKey {
         let parent_fingerprint = data[5..9].try_into().expect("4 bytes for fingerprint");
 
         let hardening_byte = data[9];
-        let is_hardened = match hardening_byte {
-            0x00 => false,
-            _ => true,
-        };
+        let is_hardened = !matches!(hardening_byte, 0x00);
 
         let child_number_bytes = data[10..42].try_into().expect("32 bytes for child number");
         let child_number = if is_hardened {

--- a/key-wallet/src/derivation.rs
+++ b/key-wallet/src/derivation.rs
@@ -158,8 +158,7 @@ impl AccountDerivation {
         let path = format!("m/0/{}", index)
             .parse::<DerivationPath>()
             .map_err(|e| Error::InvalidDerivationPath(e.to_string()))?;
-        let priv_key = self.account_key.derive_priv(&self.secp, &path)
-            .map_err(Error::Bip32)?;
+        let priv_key = self.account_key.derive_priv(&self.secp, &path).map_err(Error::Bip32)?;
         Ok(ExtendedPubKey::from_priv(&self.secp, &priv_key))
     }
 
@@ -168,8 +167,7 @@ impl AccountDerivation {
         let path = format!("m/1/{}", index)
             .parse::<DerivationPath>()
             .map_err(|e| Error::InvalidDerivationPath(e.to_string()))?;
-        let priv_key = self.account_key.derive_priv(&self.secp, &path)
-            .map_err(Error::Bip32)?;
+        let priv_key = self.account_key.derive_priv(&self.secp, &path).map_err(Error::Bip32)?;
         Ok(ExtendedPubKey::from_priv(&self.secp, &priv_key))
     }
 }

--- a/key-wallet/src/dip9.rs
+++ b/key-wallet/src/dip9.rs
@@ -75,7 +75,7 @@ impl<const N: usize> IndexConstPath<N> {
 
     pub fn append(&self, child_number: ChildNumber) -> DerivationPath {
         let root_derivation_path = DerivationPath::from(self.indexes.as_ref());
-        root_derivation_path.extend(&[child_number]);
+        root_derivation_path.extend([child_number]);
         root_derivation_path
     }
 

--- a/key-wallet/tests/address_tests.rs
+++ b/key-wallet/tests/address_tests.rs
@@ -1,11 +1,11 @@
 //! Address tests
 
-use std::str::FromStr;
 use bitcoin_hashes::{hash160, Hash};
 use key_wallet::address::{Address, AddressGenerator, AddressType};
 use key_wallet::derivation::HDWallet;
 use key_wallet::Network;
 use secp256k1::{PublicKey, Secp256k1};
+use std::str::FromStr;
 
 #[test]
 fn test_p2pkh_address_creation() {


### PR DESCRIPTION
## Summary
This PR improves the key-wallet code quality by applying clippy recommendations and formatting fixes.

## Changes
- Remove unnecessary `clone()` in basic_usage.rs example
- Change `Into<u32>` to `From<KeyDerivationType>` for more idiomatic Rust
- Remove unnecessary lifetime annotation on `&str` IntoDerivationPath impl
- Use `matches\!` macro instead of match for boolean checks
- Fix `extend()` call to not need a reference
- Apply cargo fmt to improve code formatting consistency

## Impact
These changes follow Rust best practices and improve code maintainability without affecting functionality. All changes are purely stylistic/idiomatic improvements.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified and modernized internal logic for key derivation and decoding, improving code readability without affecting functionality.
  * Updated trait implementations for type conversions to align with current best practices.
  * Streamlined error handling in account derivation methods for cleaner code.

* **Style**
  * Minor reordering of import statements for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->