### PR TITLE
fix: incorrect interval for LLMQ_100_67

### DIFF
--- a/dash/src/sml/llmq_type/mod.rs
+++ b/dash/src/sml/llmq_type/mod.rs
@@ -78,7 +78,7 @@ pub const DKG_400_85: DKGParams = DKGParams {
     bad_votes_threshold: 300,
 };
 pub const DKG_100_67: DKGParams = DKGParams {
-    interval: 2,
+    interval: 24,
     phase_blocks: 2,
     mining_window_start: 10,
     mining_window_end: 18,


### PR DESCRIPTION
This pull request modifies the `DKGParams` configuration in the `dash/src/sml/llmq_type/mod.rs` file. The most notable change is an update to the `interval` value for the `DKG_100_67` constant.

See: https://github.com/dashpay/dash/blob/702d147488c7d4c1b5f8e4470a0b4da2618e8b17/src/llmq/params.h#L464

Configuration change:

* [`dash/src/sml/llmq_type/mod.rs`](diffhunk://#diff-2b01b79818f7b3c6e079d7dc5a928425a1096f10a6824cbed899f42aa0ba97ebL81-R81): Updated the `interval` value for `DKG_100_67` from `2` to `24`, likely to adjust the frequency of the DKG process.