### PR TITLE
Fix workspace build and test compilation errors

### DIFF
--- a/dash-spv-ffi/tests/test_platform_integration_safety.rs
+++ b/dash-spv-ffi/tests/test_platform_integration_safety.rs
@@ -357,10 +357,11 @@ fn test_error_string_lifecycle() {
 fn test_handle_lifecycle() {
     unsafe {
         // Test null handle operations
-        let null_handle = ptr::null_mut();
+        let null_client: *mut FFIDashSpvClient = ptr::null_mut();
+        let null_handle: *mut CoreSDKHandle = ptr::null_mut();
 
         // Getting core handle from null client
-        let handle = ffi_dash_spv_get_core_handle(null_handle);
+        let handle = ffi_dash_spv_get_core_handle(null_client);
         assert!(handle.is_null());
 
         // Releasing null handle should be safe

--- a/dash-spv-ffi/tests/unit/test_type_conversions.rs
+++ b/dash-spv-ffi/tests/unit/test_type_conversions.rs
@@ -172,6 +172,8 @@ mod tests {
             current_filter_tip: None,
             masternode_engine: None,
             last_masternode_diff_height: None,
+            sync_base_height: 0,
+            synced_from_checkpoint: false,
         };
 
         let ffi_state = FFIChainState::from(state);
@@ -213,6 +215,10 @@ mod tests {
             pending_filter_requests: 0,
             filter_request_timeouts: u64::MAX,
             filter_requests_retried: u64::MAX,
+            connected_peers: 0,
+            total_peers: 0,
+            header_height: 0,
+            filter_height: 0,
         };
 
         let ffi_stats = FFISpvStats::from(stats);

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 [dependencies]
 honggfuzz = { version = "0.5", default-features = false }
 dashcore = { path = "../dash", features = [ "serde" ] }
+key-wallet = { path = "../key-wallet" }
 
 serde = { version = "1.0.219", features = [ "derive" ] }
 serde_json = "1.0"

--- a/fuzz/fuzz_targets/dash/deserialize_psbt.rs
+++ b/fuzz/fuzz_targets/dash/deserialize_psbt.rs
@@ -1,15 +1,15 @@
 use honggfuzz::fuzz;
 
 fn do_test(data: &[u8]) {
-    let psbt: Result<dashcore::psbt::PartiallySignedTransaction, _> =
-        dashcore::psbt::Psbt::deserialize(data);
+    let psbt: Result<key_wallet::psbt::PartiallySignedTransaction, _> =
+        key_wallet::psbt::Psbt::deserialize(data);
     match psbt {
         Err(_) => {}
         Ok(psbt) => {
-            let ser = dashcore::psbt::Psbt::serialize(&psbt);
-            let deser = dashcore::psbt::Psbt::deserialize(&ser).unwrap();
+            let ser = key_wallet::psbt::Psbt::serialize(&psbt);
+            let deser = key_wallet::psbt::Psbt::deserialize(&ser).unwrap();
             // Since the fuzz data could order psbt fields differently, we compare to our deser/ser instead of data
-            assert_eq!(ser, dashcore::psbt::Psbt::serialize(&deser));
+            assert_eq!(ser, key_wallet::psbt::Psbt::serialize(&deser));
         }
     }
 }

--- a/key-wallet-ffi/src/lib.rs
+++ b/key-wallet-ffi/src/lib.rs
@@ -4,9 +4,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use key_wallet::{
-    self as kw, derivation::HDWallet as KwHDWallet, mnemonic as kw_mnemonic,
-    DerivationPath as KwDerivationPath, ExtendedPrivKey, ExtendedPubKey, Network as KwNetwork,
-    Address as KwAddress, AddressType as KwAddressType,
+    self as kw, derivation::HDWallet as KwHDWallet, mnemonic as kw_mnemonic, Address as KwAddress,
+    AddressType as KwAddressType, DerivationPath as KwDerivationPath, ExtendedPrivKey,
+    ExtendedPubKey, Network as KwNetwork,
 };
 use secp256k1::{PublicKey, Secp256k1};
 
@@ -467,8 +467,10 @@ impl Address {
 
         // Convert to expected network and require it
         let expected_network: KwNetwork = network.into();
-        let inner = unchecked_addr.require_network(expected_network).map_err(|e| KeyWalletError::AddressError {
-            message: format!("Address network validation failed: {}", e),
+        let inner = unchecked_addr.require_network(expected_network).map_err(|e| {
+            KeyWalletError::AddressError {
+                message: format!("Address network validation failed: {}", e),
+            }
         })?;
 
         Ok(Self {
@@ -538,19 +540,35 @@ impl AddressGenerator {
         let secp = Secp256k1::new();
 
         // Derive child key: 0 for external (receiving), 1 for internal (change)
-        let chain_code = if external { 0 } else { 1 };
-        let child_chain = xpub.ckd_pub(&secp, kw::ChildNumber::from_normal_idx(chain_code)
-            .map_err(|e| KeyWalletError::InvalidDerivationPath {
-                message: e.to_string(),
-            })?).map_err(|e| KeyWalletError::KeyError {
+        let chain_code = if external {
+            0
+        } else {
+            1
+        };
+        let child_chain = xpub
+            .ckd_pub(
+                &secp,
+                kw::ChildNumber::from_normal_idx(chain_code).map_err(|e| {
+                    KeyWalletError::InvalidDerivationPath {
+                        message: e.to_string(),
+                    }
+                })?,
+            )
+            .map_err(|e| KeyWalletError::KeyError {
                 message: e.to_string(),
             })?;
 
         // Derive specific index
-        let child = child_chain.ckd_pub(&secp, kw::ChildNumber::from_normal_idx(index)
-            .map_err(|e| KeyWalletError::InvalidDerivationPath {
-                message: e.to_string(),
-            })?).map_err(|e| KeyWalletError::KeyError {
+        let child = child_chain
+            .ckd_pub(
+                &secp,
+                kw::ChildNumber::from_normal_idx(index).map_err(|e| {
+                    KeyWalletError::InvalidDerivationPath {
+                        message: e.to_string(),
+                    }
+                })?,
+            )
+            .map_err(|e| KeyWalletError::KeyError {
                 message: e.to_string(),
             })?;
 


### PR DESCRIPTION
## Summary
This PR resolves multiple compilation errors across the rust-dashcore workspace that were preventing successful builds and test compilation.

## Build Fixes
- **PSBT module**: Fixed import paths from `dashcore::psbt` to `key_wallet::psbt` in fuzz targets
- **Dependencies**: Added missing `key-wallet` dependency to `fuzz/Cargo.toml`
- **Address handling**: Fixed non-existent address module imports in `key-wallet-ffi`
- **Error patterns**: Added missing error pattern matches for `CoinJoinNotEnabled`, `Serialization`, and `InvalidParameter`
- **Type conversions**: Fixed mismatches between `secp256k1::PublicKey` and `dashcore::PublicKey`
- **Address validation**: Proper handling of `Address<NetworkUnchecked>` vs `Address<NetworkChecked>`
- **AddressGenerator**: Implemented using BIP44 derivation since the original struct was missing

## Test Fixes
- **Platform integration**: Fixed type mismatches in safety tests with proper null pointer handling
- **ChainState**: Added missing fields `sync_base_height` and `synced_from_checkpoint`
- **SpvStats**: Added missing fields `connected_peers`, `total_peers`, `header_height`, and `filter_height`

## Verification
- ✅ `cargo build` - All workspace crates compile successfully
- ✅ `cargo test --no-run` - All tests compile successfully
- ✅ `cargo fmt` - Code formatting applied
