### PR TITLE
fix: clean up ffi methods

### DIFF
--- a/hashes/src/util.rs
+++ b/hashes/src/util.rs
@@ -584,7 +584,7 @@ macro_rules! hash_newtype_known_attrs {
 #[cfg(feature = "schemars")]
 pub mod json_hex_string {
     use schemars::SchemaGenerator;
-    use schemars::{Schema, json_schema};
+    use schemars::{json_schema, Schema};
     macro_rules! define_custom_hex {
         ($name:ident, $len:expr) => {
             pub fn $name(_generator: &mut SchemaGenerator) -> Schema {

--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -198,7 +198,7 @@ typedef enum {
     REGTEST = 4,
     DEVNET = 8,
     ALL_NETWORKS = 15,
-} FFINetwork;
+} FFINetworks;
 
 /*
  Provider key type
@@ -794,7 +794,7 @@ extern "C" {
  */
 
 FFIAccountResult wallet_get_account(const FFIWallet *wallet,
-                                    FFINetwork network,
+                                    FFINetworks network,
                                     unsigned int account_index,
                                     FFIAccountType account_type)
 ;
@@ -811,7 +811,7 @@ FFIAccountResult wallet_get_account(const FFIWallet *wallet,
  */
 
 FFIAccountResult wallet_get_top_up_account_with_registration_index(const FFIWallet *wallet,
-                                                                   FFINetwork network,
+                                                                   FFINetworks network,
                                                                    unsigned int registration_index)
 ;
 
@@ -879,7 +879,7 @@ FFIAccountResult wallet_get_top_up_account_with_registration_index(const FFIWall
  - `account` must be a valid pointer to an FFIAccount instance
  - Returns FFINetwork::NoNetworks if the account is null
  */
- FFINetwork account_get_network(const FFIAccount *account) ;
+ FFINetworks account_get_network(const FFIAccount *account) ;
 
 /*
  Get the parent wallet ID of an account
@@ -933,7 +933,7 @@ FFIAccountResult wallet_get_top_up_account_with_registration_index(const FFIWall
  - `account` must be a valid pointer to an FFIBLSAccount instance
  - Returns FFINetwork::NoNetworks if the account is null
  */
- FFINetwork bls_account_get_network(const FFIBLSAccount *account) ;
+ FFINetworks bls_account_get_network(const FFIBLSAccount *account) ;
 
 /*
  Get the parent wallet ID of a BLS account
@@ -990,7 +990,7 @@ FFIAccountType bls_account_get_account_type(const FFIBLSAccount *account,
  - `account` must be a valid pointer to an FFIEdDSAAccount instance
  - Returns FFINetwork::NoNetworks if the account is null
  */
- FFINetwork eddsa_account_get_network(const FFIEdDSAAccount *account) ;
+ FFINetworks eddsa_account_get_network(const FFIEdDSAAccount *account) ;
 
 /*
  Get the parent wallet ID of an EdDSA account
@@ -1039,7 +1039,7 @@ FFIAccountType eddsa_account_get_account_type(const FFIEdDSAAccount *account,
  */
 
 unsigned int wallet_get_account_count(const FFIWallet *wallet,
-                                      FFINetwork network,
+                                      FFINetworks network,
                                       FFIError *error)
 ;
 
@@ -1054,7 +1054,7 @@ unsigned int wallet_get_account_count(const FFIWallet *wallet,
  */
 
 FFIAccountCollection *wallet_get_account_collection(const FFIWallet *wallet,
-                                                    FFINetwork network,
+                                                    FFINetworks network,
                                                     FFIError *error)
 ;
 
@@ -1427,7 +1427,7 @@ void account_collection_summary_free(FFIAccountCollectionSummary *summary)
  - `address` must be a valid null-terminated C string
  - `error` must be a valid pointer to an FFIError
  */
- bool address_validate(const char *address, FFINetwork network, FFIError *error) ;
+ bool address_validate(const char *address, FFINetworks network, FFIError *error) ;
 
 /*
  Get address type
@@ -1443,7 +1443,7 @@ void account_collection_summary_free(FFIAccountCollectionSummary *summary)
  - `address` must be a valid null-terminated C string
  - `error` must be a valid pointer to an FFIError
  */
- unsigned char address_get_type(const char *address, FFINetwork network, FFIError *error) ;
+ unsigned char address_get_type(const char *address, FFINetworks network, FFIError *error) ;
 
 /*
  Free an address pool handle
@@ -1467,7 +1467,7 @@ void account_collection_summary_free(FFIAccountCollectionSummary *summary)
  */
 
 bool managed_wallet_get_address_pool_info(const FFIManagedWallet *managed_wallet,
-                                          FFINetwork network,
+                                          FFINetworks network,
                                           FFIAccountType account_type,
                                           unsigned int account_index,
                                           FFIAddressPoolType pool_type,
@@ -1488,7 +1488,7 @@ bool managed_wallet_get_address_pool_info(const FFIManagedWallet *managed_wallet
  */
 
 bool managed_wallet_set_gap_limit(FFIManagedWallet *managed_wallet,
-                                  FFINetwork network,
+                                  FFINetworks network,
                                   FFIAccountType account_type,
                                   unsigned int account_index,
                                   FFIAddressPoolType pool_type,
@@ -1512,7 +1512,7 @@ bool managed_wallet_set_gap_limit(FFIManagedWallet *managed_wallet,
 
 bool managed_wallet_generate_addresses_to_index(FFIManagedWallet *managed_wallet,
                                                 const FFIWallet *wallet,
-                                                FFINetwork network,
+                                                FFINetworks network,
                                                 FFIAccountType account_type,
                                                 unsigned int account_index,
                                                 FFIAddressPoolType pool_type,
@@ -1534,7 +1534,7 @@ bool managed_wallet_generate_addresses_to_index(FFIManagedWallet *managed_wallet
  */
 
 bool managed_wallet_mark_address_used(FFIManagedWallet *managed_wallet,
-                                      FFINetwork network,
+                                      FFINetworks network,
                                       const char *address,
                                       FFIError *error)
 ;
@@ -1617,7 +1617,7 @@ void address_info_array_free(FFIAddressInfo **infos,
 
 FFIExtendedPrivKey *derivation_new_master_key(const uint8_t *seed,
                                               size_t seed_len,
-                                              FFINetwork network,
+                                              FFINetworks network,
                                               FFIError *error)
 ;
 
@@ -1625,7 +1625,7 @@ FFIExtendedPrivKey *derivation_new_master_key(const uint8_t *seed,
  Derive a BIP44 account path (m/44'/5'/account')
  */
 
-bool derivation_bip44_account_path(FFINetwork network,
+bool derivation_bip44_account_path(FFINetworks network,
                                    unsigned int account_index,
                                    char *path_out,
                                    size_t path_max_len,
@@ -1636,7 +1636,7 @@ bool derivation_bip44_account_path(FFINetwork network,
  Derive a BIP44 payment path (m/44'/5'/account'/change/index)
  */
 
-bool derivation_bip44_payment_path(FFINetwork network,
+bool derivation_bip44_payment_path(FFINetworks network,
                                    unsigned int account_index,
                                    bool is_change,
                                    unsigned int address_index,
@@ -1649,7 +1649,7 @@ bool derivation_bip44_payment_path(FFINetwork network,
  Derive CoinJoin path (m/9'/5'/4'/account')
  */
 
-bool derivation_coinjoin_path(FFINetwork network,
+bool derivation_coinjoin_path(FFINetworks network,
                               unsigned int account_index,
                               char *path_out,
                               size_t path_max_len,
@@ -1660,7 +1660,7 @@ bool derivation_coinjoin_path(FFINetwork network,
  Derive identity registration path (m/9'/5'/5'/1'/index')
  */
 
-bool derivation_identity_registration_path(FFINetwork network,
+bool derivation_identity_registration_path(FFINetworks network,
                                            unsigned int identity_index,
                                            char *path_out,
                                            size_t path_max_len,
@@ -1671,7 +1671,7 @@ bool derivation_identity_registration_path(FFINetwork network,
  Derive identity top-up path (m/9'/5'/5'/2'/identity_index'/top_up_index')
  */
 
-bool derivation_identity_topup_path(FFINetwork network,
+bool derivation_identity_topup_path(FFINetworks network,
                                     unsigned int identity_index,
                                     unsigned int topup_index,
                                     char *path_out,
@@ -1683,7 +1683,7 @@ bool derivation_identity_topup_path(FFINetwork network,
  Derive identity authentication path (m/9'/5'/5'/0'/identity_index'/key_index')
  */
 
-bool derivation_identity_authentication_path(FFINetwork network,
+bool derivation_identity_authentication_path(FFINetworks network,
                                              unsigned int identity_index,
                                              unsigned int key_index,
                                              char *path_out,
@@ -1705,7 +1705,7 @@ bool derivation_identity_authentication_path(FFINetwork network,
 FFIExtendedPrivKey *derivation_derive_private_key_from_seed(const uint8_t *seed,
                                                             size_t seed_len,
                                                             const char *path,
-                                                            FFINetwork network,
+                                                            FFINetworks network,
                                                             FFIError *error)
 ;
 
@@ -1802,7 +1802,7 @@ bool derivation_xpub_fingerprint(const FFIExtendedPubKey *xpub,
 
 FFIExtendedPrivKey *dip9_derive_identity_key(const uint8_t *seed,
                                              size_t seed_len,
-                                             FFINetwork network,
+                                             FFINetworks network,
                                              unsigned int identity_index,
                                              unsigned int key_index,
                                              FFIDerivationPathType key_type,
@@ -1831,7 +1831,7 @@ FFIExtendedPrivKey *dip9_derive_identity_key(const uint8_t *seed,
  */
 
 char *wallet_get_account_xpriv(const FFIWallet *wallet,
-                               FFINetwork network,
+                               FFINetworks network,
                                unsigned int account_index,
                                FFIError *error)
 ;
@@ -1847,7 +1847,7 @@ char *wallet_get_account_xpriv(const FFIWallet *wallet,
  */
 
 char *wallet_get_account_xpub(const FFIWallet *wallet,
-                              FFINetwork network,
+                              FFINetworks network,
                               unsigned int account_index,
                               FFIError *error)
 ;
@@ -1865,7 +1865,7 @@ char *wallet_get_account_xpub(const FFIWallet *wallet,
  */
 
 FFIPrivateKey *wallet_derive_private_key(const FFIWallet *wallet,
-                                         FFINetwork network,
+                                         FFINetworks network,
                                          const char *derivation_path,
                                          FFIError *error)
 ;
@@ -1883,7 +1883,7 @@ FFIPrivateKey *wallet_derive_private_key(const FFIWallet *wallet,
  */
 
 FFIExtendedPrivateKey *wallet_derive_extended_private_key(const FFIWallet *wallet,
-                                                          FFINetwork network,
+                                                          FFINetworks network,
                                                           const char *derivation_path,
                                                           FFIError *error)
 ;
@@ -1900,7 +1900,7 @@ FFIExtendedPrivateKey *wallet_derive_extended_private_key(const FFIWallet *walle
  */
 
 char *wallet_derive_private_key_as_wif(const FFIWallet *wallet,
-                                       FFINetwork network,
+                                       FFINetworks network,
                                        const char *derivation_path,
                                        FFIError *error)
 ;
@@ -1939,7 +1939,7 @@ char *wallet_derive_private_key_as_wif(const FFIWallet *wallet,
  */
 
 char *extended_private_key_to_string(const FFIExtendedPrivateKey *key,
-                                     FFINetwork network,
+                                     FFINetworks network,
                                      FFIError *error)
 ;
 
@@ -1968,7 +1968,7 @@ FFIPrivateKey *extended_private_key_get_private_key(const FFIExtendedPrivateKey 
  - `error` must be a valid pointer to an FFIError
  - The returned string must be freed with `string_free`
  */
- char *private_key_to_wif(const FFIPrivateKey *key, FFINetwork network, FFIError *error) ;
+ char *private_key_to_wif(const FFIPrivateKey *key, FFINetworks network, FFIError *error) ;
 
 /*
  Derive public key at a specific path
@@ -1983,7 +1983,7 @@ FFIPrivateKey *extended_private_key_get_private_key(const FFIExtendedPrivateKey 
  */
 
 FFIPublicKey *wallet_derive_public_key(const FFIWallet *wallet,
-                                       FFINetwork network,
+                                       FFINetworks network,
                                        const char *derivation_path,
                                        FFIError *error)
 ;
@@ -2001,7 +2001,7 @@ FFIPublicKey *wallet_derive_public_key(const FFIWallet *wallet,
  */
 
 FFIExtendedPublicKey *wallet_derive_extended_public_key(const FFIWallet *wallet,
-                                                        FFINetwork network,
+                                                        FFINetworks network,
                                                         const char *derivation_path,
                                                         FFIError *error)
 ;
@@ -2018,7 +2018,7 @@ FFIExtendedPublicKey *wallet_derive_extended_public_key(const FFIWallet *wallet,
  */
 
 char *wallet_derive_public_key_as_hex(const FFIWallet *wallet,
-                                      FFINetwork network,
+                                      FFINetworks network,
                                       const char *derivation_path,
                                       FFIError *error)
 ;
@@ -2057,7 +2057,7 @@ char *wallet_derive_public_key_as_hex(const FFIWallet *wallet,
  */
 
 char *extended_public_key_to_string(const FFIExtendedPublicKey *key,
-                                    FFINetwork network,
+                                    FFINetworks network,
                                     FFIError *error)
 ;
 
@@ -2138,7 +2138,7 @@ bool derivation_path_parse(const char *path,
 
 FFIManagedAccountResult managed_wallet_get_account(const FFIWalletManager *manager,
                                                    const uint8_t *wallet_id,
-                                                   FFINetwork network,
+                                                   FFINetworks network,
                                                    unsigned int account_index,
                                                    FFIAccountType account_type)
 ;
@@ -2160,7 +2160,7 @@ FFIManagedAccountResult managed_wallet_get_account(const FFIWalletManager *manag
 
 FFIManagedAccountResult managed_wallet_get_top_up_account_with_registration_index(const FFIWalletManager *manager,
                                                                                   const uint8_t *wallet_id,
-                                                                                  FFINetwork network,
+                                                                                  FFINetworks network,
                                                                                   unsigned int registration_index)
 ;
 
@@ -2171,7 +2171,7 @@ FFIManagedAccountResult managed_wallet_get_top_up_account_with_registration_inde
 
  - `account` must be a valid pointer to an FFIManagedAccount instance
  */
- FFINetwork managed_account_get_network(const FFIManagedAccount *account) ;
+ FFINetworks managed_account_get_network(const FFIManagedAccount *account) ;
 
 /*
  Get the parent wallet ID of a managed account
@@ -2276,7 +2276,7 @@ FFIAccountType managed_account_get_account_type(const FFIManagedAccount *account
 
 unsigned int managed_wallet_get_account_count(const FFIWalletManager *manager,
                                               const uint8_t *wallet_id,
-                                              FFINetwork network,
+                                              FFINetworks network,
                                               FFIError *error)
 ;
 
@@ -2350,7 +2350,7 @@ FFIAddressPool *managed_account_get_address_pool(const FFIManagedAccount *accoun
 
 FFIManagedAccountCollection *managed_wallet_get_account_collection(const FFIWalletManager *manager,
                                                                    const uint8_t *wallet_id,
-                                                                   FFINetwork network,
+                                                                   FFINetworks network,
                                                                    FFIError *error)
 ;
 
@@ -2727,7 +2727,7 @@ void managed_account_collection_summary_free(FFIManagedAccountCollectionSummary 
 
 char *managed_wallet_get_next_bip44_receive_address(FFIManagedWalletInfo *managed_wallet,
                                                     const FFIWallet *wallet,
-                                                    FFINetwork network,
+                                                    FFINetworks network,
                                                     unsigned int account_index,
                                                     FFIError *error)
 ;
@@ -2748,7 +2748,7 @@ char *managed_wallet_get_next_bip44_receive_address(FFIManagedWalletInfo *manage
 
 char *managed_wallet_get_next_bip44_change_address(FFIManagedWalletInfo *managed_wallet,
                                                    const FFIWallet *wallet,
-                                                   FFINetwork network,
+                                                   FFINetworks network,
                                                    unsigned int account_index,
                                                    FFIError *error)
 ;
@@ -2771,7 +2771,7 @@ char *managed_wallet_get_next_bip44_change_address(FFIManagedWalletInfo *managed
 
 bool managed_wallet_get_bip_44_external_address_range(FFIManagedWalletInfo *managed_wallet,
                                                       const FFIWallet *wallet,
-                                                      FFINetwork network,
+                                                      FFINetworks network,
                                                       unsigned int account_index,
                                                       unsigned int start_index,
                                                       unsigned int end_index,
@@ -2798,7 +2798,7 @@ bool managed_wallet_get_bip_44_external_address_range(FFIManagedWalletInfo *mana
 
 bool managed_wallet_get_bip_44_internal_address_range(FFIManagedWalletInfo *managed_wallet,
                                                       const FFIWallet *wallet,
-                                                      FFINetwork network,
+                                                      FFINetworks network,
                                                       unsigned int account_index,
                                                       unsigned int start_index,
                                                       unsigned int end_index,
@@ -2929,7 +2929,7 @@ bool mnemonic_to_seed(const char *mnemonic,
  */
 
 bool wallet_generate_provider_key(const FFIWallet *wallet,
-                                  FFINetwork network,
+                                  FFINetworks network,
                                   FFIProviderKeyType key_type,
                                   unsigned int key_index,
                                   bool include_private,
@@ -2965,7 +2965,7 @@ bool wallet_generate_provider_key(const FFIWallet *wallet,
  */
 
 bool wallet_sign_with_provider_key(const FFIWallet *wallet,
-                                   FFINetwork network,
+                                   FFINetworks network,
                                    FFIProviderKeyType key_type,
                                    unsigned int _key_index,
                                    const uint8_t *data,
@@ -2989,7 +2989,7 @@ bool wallet_sign_with_provider_key(const FFIWallet *wallet,
  */
 
 bool wallet_build_transaction(FFIWallet *wallet,
-                              FFINetwork _network,
+                              FFINetworks _network,
                               unsigned int account_index,
                               const FFITxOutput *outputs,
                               size_t outputs_count,
@@ -3013,7 +3013,7 @@ bool wallet_build_transaction(FFIWallet *wallet,
  */
 
 bool wallet_sign_transaction(const FFIWallet *wallet,
-                             FFINetwork _network,
+                             FFINetworks _network,
                              const uint8_t *tx_bytes,
                              size_t tx_len,
                              uint8_t **signed_tx_out,
@@ -3037,7 +3037,7 @@ bool wallet_sign_transaction(const FFIWallet *wallet,
  */
 
 bool wallet_check_transaction(FFIWallet *wallet,
-                              FFINetwork network,
+                              FFINetworks network,
                               const uint8_t *tx_bytes,
                               size_t tx_len,
                               FFITransactionContext context_type,
@@ -3091,7 +3091,7 @@ bool wallet_check_transaction(FFIWallet *wallet,
 
 bool managed_wallet_check_transaction(FFIManagedWallet *managed_wallet,
                                       const FFIWallet *wallet,
-                                      FFINetwork network,
+                                      FFINetworks network,
                                       const uint8_t *tx_bytes,
                                       size_t tx_len,
                                       FFITransactionContext context_type,
@@ -3161,7 +3161,7 @@ bool managed_wallet_check_transaction(FFIManagedWallet *managed_wallet,
  */
 
 bool managed_wallet_get_utxos(const FFIManagedWalletInfo *managed_info,
-                              FFINetwork network,
+                              FFINetworks network,
                               FFIUTXO **utxos_out,
                               size_t *count_out,
                               FFIError *error)
@@ -3177,7 +3177,7 @@ bool managed_wallet_get_utxos(const FFIManagedWalletInfo *managed_info,
  */
 
 bool wallet_get_utxos(const FFIWallet *_wallet,
-                      FFINetwork _network,
+                      FFINetworks _network,
                       FFIUTXO **utxos_out,
                       size_t *count_out,
                       FFIError *error)
@@ -3210,7 +3210,7 @@ bool wallet_get_utxos(const FFIWallet *_wallet,
 
 FFIWallet *wallet_create_from_mnemonic_with_options(const char *mnemonic,
                                                     const char *passphrase,
-                                                    FFINetwork networks,
+                                                    FFINetworks networks,
                                                     const FFIWalletAccountCreationOptions *account_options,
                                                     FFIError *error)
 ;
@@ -3229,7 +3229,7 @@ FFIWallet *wallet_create_from_mnemonic_with_options(const char *mnemonic,
 
 FFIWallet *wallet_create_from_mnemonic(const char *mnemonic,
                                        const char *passphrase,
-                                       FFINetwork network,
+                                       FFINetworks network,
                                        FFIError *error)
 ;
 
@@ -3246,7 +3246,7 @@ FFIWallet *wallet_create_from_mnemonic(const char *mnemonic,
 
 FFIWallet *wallet_create_from_seed_with_options(const uint8_t *seed,
                                                 size_t seed_len,
-                                                FFINetwork networks,
+                                                FFINetworks networks,
                                                 const FFIWalletAccountCreationOptions *account_options,
                                                 FFIError *error)
 ;
@@ -3263,7 +3263,7 @@ FFIWallet *wallet_create_from_seed_with_options(const uint8_t *seed,
 
 FFIWallet *wallet_create_from_seed(const uint8_t *seed,
                                    size_t seed_len,
-                                   FFINetwork network,
+                                   FFINetworks network,
                                    FFIError *error)
 ;
 
@@ -3277,7 +3277,7 @@ FFIWallet *wallet_create_from_seed(const uint8_t *seed,
  - The caller must ensure all pointers remain valid for the duration of this call
  */
 
-FFIWallet *wallet_create_random_with_options(FFINetwork networks,
+FFIWallet *wallet_create_random_with_options(FFINetworks networks,
                                              const FFIWalletAccountCreationOptions *account_options,
                                              FFIError *error)
 ;
@@ -3290,7 +3290,7 @@ FFIWallet *wallet_create_random_with_options(FFINetwork networks,
  - `error` must be a valid pointer to an FFIError structure or null
  - The caller must ensure the pointer remains valid for the duration of this call
  */
- FFIWallet *wallet_create_random(FFINetwork network, FFIError *error) ;
+ FFIWallet *wallet_create_random(FFINetworks network, FFIError *error) ;
 
 /*
  Get wallet ID (32-byte hash)
@@ -3338,7 +3338,7 @@ FFIWallet *wallet_create_random_with_options(FFINetwork networks,
  */
 
 char *wallet_get_xpub(const FFIWallet *wallet,
-                      FFINetwork network,
+                      FFINetworks network,
                       unsigned int account_index,
                       FFIError *error)
 ;
@@ -3382,7 +3382,7 @@ char *wallet_get_xpub(const FFIWallet *wallet,
  */
 
 FFIAccountResult wallet_add_account(FFIWallet *wallet,
-                                    FFINetwork network,
+                                    FFINetworks network,
                                     FFIAccountType account_type,
                                     unsigned int account_index)
 ;
@@ -3400,7 +3400,7 @@ FFIAccountResult wallet_add_account(FFIWallet *wallet,
  */
 
 FFIAccountResult wallet_add_account_with_xpub_bytes(FFIWallet *wallet,
-                                                    FFINetwork network,
+                                                    FFINetworks network,
                                                     FFIAccountType account_type,
                                                     unsigned int account_index,
                                                     const uint8_t *xpub_bytes,
@@ -3420,7 +3420,7 @@ FFIAccountResult wallet_add_account_with_xpub_bytes(FFIWallet *wallet,
  */
 
 FFIAccountResult wallet_add_account_with_string_xpub(FFIWallet *wallet,
-                                                     FFINetwork network,
+                                                     FFINetworks network,
                                                      FFIAccountType account_type,
                                                      unsigned int account_index,
                                                      const char *xpub_string)
@@ -3447,7 +3447,7 @@ FFIAccountResult wallet_add_account_with_string_xpub(FFIWallet *wallet,
 bool wallet_manager_add_wallet_from_mnemonic_with_options(FFIWalletManager *manager,
                                                           const char *mnemonic,
                                                           const char *passphrase,
-                                                          FFINetwork network,
+                                                          FFINetworks network,
                                                           const FFIWalletAccountCreationOptions *account_options,
                                                           FFIError *error)
 ;
@@ -3467,7 +3467,7 @@ bool wallet_manager_add_wallet_from_mnemonic_with_options(FFIWalletManager *mana
 bool wallet_manager_add_wallet_from_mnemonic(FFIWalletManager *manager,
                                              const char *mnemonic,
                                              const char *passphrase,
-                                             FFINetwork network,
+                                             FFINetworks network,
                                              FFIError *error)
 ;
 
@@ -3497,7 +3497,7 @@ bool wallet_manager_add_wallet_from_mnemonic(FFIWalletManager *manager,
 bool wallet_manager_add_wallet_from_mnemonic_return_serialized_bytes(FFIWalletManager *manager,
                                                                      const char *mnemonic,
                                                                      const char *passphrase,
-                                                                     FFINetwork network,
+                                                                     FFINetworks network,
                                                                      unsigned int birth_height,
                                                                      const FFIWalletAccountCreationOptions *account_options,
                                                                      bool downgrade_to_pubkey_wallet,
@@ -3615,7 +3615,7 @@ FFIManagedWalletInfo *wallet_manager_get_managed_wallet_info(const FFIWalletMana
 
 char *wallet_manager_get_receive_address(FFIWalletManager *manager,
                                          const uint8_t *wallet_id,
-                                         FFINetwork network,
+                                         FFINetworks network,
                                          unsigned int account_index,
                                          FFIError *error)
 ;
@@ -3633,7 +3633,7 @@ char *wallet_manager_get_receive_address(FFIWalletManager *manager,
 
 char *wallet_manager_get_change_address(FFIWalletManager *manager,
                                         const uint8_t *wallet_id,
-                                        FFINetwork network,
+                                        FFINetworks network,
                                         unsigned int account_index,
                                         FFIError *error)
 ;
@@ -3681,7 +3681,7 @@ bool wallet_manager_get_wallet_balance(const FFIWalletManager *manager,
 bool wallet_manager_process_transaction(FFIWalletManager *manager,
                                         const uint8_t *tx_bytes,
                                         size_t tx_len,
-                                        FFINetwork network,
+                                        FFINetworks network,
                                         const FFITransactionContextDetails *context,
                                         bool update_state_if_found,
                                         FFIError *error)
@@ -3700,7 +3700,7 @@ bool wallet_manager_process_transaction(FFIWalletManager *manager,
  */
 
 bool wallet_manager_get_monitored_addresses(const FFIWalletManager *manager,
-                                            FFINetwork network,
+                                            FFINetworks network,
                                             char ***addresses_out,
                                             size_t *count_out,
                                             FFIError *error)
@@ -3717,7 +3717,7 @@ bool wallet_manager_get_monitored_addresses(const FFIWalletManager *manager,
  */
 
 bool wallet_manager_update_height(FFIWalletManager *manager,
-                                  FFINetwork network,
+                                  FFINetworks network,
                                   unsigned int height,
                                   FFIError *error)
 ;
@@ -3733,7 +3733,7 @@ bool wallet_manager_update_height(FFIWalletManager *manager,
  */
 
 unsigned int wallet_manager_current_height(const FFIWalletManager *manager,
-                                           FFINetwork network,
+                                           FFINetworks network,
                                            FFIError *error)
 ;
 
@@ -3800,7 +3800,7 @@ void wallet_manager_free_addresses(char **addresses,
 
 char *bip38_encrypt_private_key(const char *private_key,
                                 const char *passphrase,
-                                FFINetwork _network,
+                                FFINetworks _network,
                                 FFIError *error)
 ;
 

--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -1283,21 +1283,16 @@ FFIAccount *account_collection_get_identity_topup_not_bound(const FFIAccountColl
 
 /*
  Get the provider operator keys account if it exists
- Note: This function is only available when the `bls` feature is enabled
+ Note: Returns null if the `bls` feature is not enabled
 
  # Safety
 
  - `collection` must be a valid pointer to an FFIAccountCollection
- - The returned pointer must be freed with `bls_account_free` when no longer needed
+ - The returned pointer must be freed with `bls_account_free` when no longer needed (when BLS is enabled)
  */
 
-FFIBLSAccount *account_collection_get_provider_operator_keys(const FFIAccountCollection *collection)
+void *account_collection_get_provider_operator_keys(const FFIAccountCollection *collection)
 ;
-
-/*
- Get the provider operator keys account if it exists (stub when BLS is disabled)
- */
- void *account_collection_get_provider_operator_keys(const FFIAccountCollection *_collection) ;
 
 /*
  Check if provider operator keys account exists
@@ -1310,21 +1305,16 @@ FFIBLSAccount *account_collection_get_provider_operator_keys(const FFIAccountCol
 
 /*
  Get the provider platform keys account if it exists
- Note: This function is only available when the `eddsa` feature is enabled
+ Note: Returns null if the `eddsa` feature is not enabled
 
  # Safety
 
  - `collection` must be a valid pointer to an FFIAccountCollection
- - The returned pointer must be freed with `eddsa_account_free` when no longer needed
+ - The returned pointer must be freed with `eddsa_account_free` when no longer needed (when EdDSA is enabled)
  */
 
-FFIEdDSAAccount *account_collection_get_provider_platform_keys(const FFIAccountCollection *collection)
+void *account_collection_get_provider_platform_keys(const FFIAccountCollection *collection)
 ;
-
-/*
- Get the provider platform keys account if it exists (stub when EdDSA is disabled)
- */
- void *account_collection_get_provider_platform_keys(const FFIAccountCollection *_collection) ;
 
 /*
  Check if provider platform keys account exists
@@ -2598,22 +2588,15 @@ bool managed_account_collection_has_provider_owner_keys(const FFIManagedAccountC
 
 /*
  Get the provider operator keys account if it exists in managed collection
- Note: This function is only available when the `bls` feature is enabled
+ Note: Returns null if the `bls` feature is not enabled
 
  # Safety
 
  - `collection` must be a valid pointer to an FFIManagedAccountCollection
- - The returned pointer must be freed with `managed_account_free` when no longer needed
+ - The returned pointer must be freed with `managed_account_free` when no longer needed (when BLS is enabled)
  */
 
-FFIManagedAccount *managed_account_collection_get_provider_operator_keys(const FFIManagedAccountCollection *collection)
-;
-
-/*
- Get the provider operator keys account if it exists (stub when BLS is disabled)
- */
-
-FFIManagedAccount *managed_account_collection_get_provider_operator_keys(const FFIManagedAccountCollection *_collection)
+void *managed_account_collection_get_provider_operator_keys(const FFIManagedAccountCollection *collection)
 ;
 
 /*
@@ -2629,23 +2612,15 @@ bool managed_account_collection_has_provider_operator_keys(const FFIManagedAccou
 
 /*
  Get the provider platform keys account if it exists in managed collection
- Note: This function is only available when the `eddsa` feature is enabled
+ Note: Returns null if the `eddsa` feature is not enabled
 
  # Safety
 
  - `collection` must be a valid pointer to an FFIManagedAccountCollection
- - `manager` must be a valid pointer to an FFIWalletManager
- - The returned pointer must be freed with `managed_account_free` when no longer needed
+ - The returned pointer must be freed with `managed_account_free` when no longer needed (when EdDSA is enabled)
  */
 
-FFIManagedAccount *managed_account_collection_get_provider_platform_keys(const FFIManagedAccountCollection *collection)
-;
-
-/*
- Get the provider platform keys account if it exists (stub when EdDSA is disabled)
- */
-
-FFIManagedAccount *managed_account_collection_get_provider_platform_keys(const FFIManagedAccountCollection *_collection)
+void *managed_account_collection_get_provider_platform_keys(const FFIManagedAccountCollection *collection)
 ;
 
 /*

--- a/key-wallet-ffi/src/account.rs
+++ b/key-wallet-ffi/src/account.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_uint;
 use std::sync::Arc;
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFIAccountResult, FFIAccountType, FFINetwork, FFIWallet};
+use crate::types::{FFIAccountResult, FFIAccountType, FFINetworks, FFIWallet};
 #[cfg(feature = "bls")]
 use key_wallet::account::BLSAccount;
 #[cfg(feature = "eddsa")]
@@ -81,7 +81,7 @@ impl FFIEdDSAAccount {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_account(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: c_uint,
     account_type: FFIAccountType,
 ) -> FFIAccountResult {
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn wallet_get_account(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_top_up_account_with_registration_index(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     registration_index: c_uint,
 ) -> FFIAccountResult {
     if wallet.is_null() {
@@ -262,9 +262,9 @@ pub unsafe extern "C" fn account_get_extended_public_key_as_string(
 /// - `account` must be a valid pointer to an FFIAccount instance
 /// - Returns FFINetwork::NoNetworks if the account is null
 #[no_mangle]
-pub unsafe extern "C" fn account_get_network(account: *const FFIAccount) -> FFINetwork {
+pub unsafe extern "C" fn account_get_network(account: *const FFIAccount) -> FFINetworks {
     if account.is_null() {
-        return FFINetwork::NoNetworks;
+        return FFINetworks::NoNetworks;
     }
 
     let account = &*account;
@@ -374,9 +374,9 @@ pub unsafe extern "C" fn bls_account_get_extended_public_key_as_string(
 /// - Returns FFINetwork::NoNetworks if the account is null
 #[cfg(feature = "bls")]
 #[no_mangle]
-pub unsafe extern "C" fn bls_account_get_network(account: *const FFIBLSAccount) -> FFINetwork {
+pub unsafe extern "C" fn bls_account_get_network(account: *const FFIBLSAccount) -> FFINetworks {
     if account.is_null() {
-        return FFINetwork::NoNetworks;
+        return FFINetworks::NoNetworks;
     }
 
     let account = &*account;
@@ -491,9 +491,9 @@ pub unsafe extern "C" fn eddsa_account_get_extended_public_key_as_string(
 /// - Returns FFINetwork::NoNetworks if the account is null
 #[cfg(feature = "eddsa")]
 #[no_mangle]
-pub unsafe extern "C" fn eddsa_account_get_network(account: *const FFIEdDSAAccount) -> FFINetwork {
+pub unsafe extern "C" fn eddsa_account_get_network(account: *const FFIEdDSAAccount) -> FFINetworks {
     if account.is_null() {
-        return FFINetwork::NoNetworks;
+        return FFINetworks::NoNetworks;
     }
 
     let account = &*account;
@@ -581,7 +581,7 @@ pub unsafe extern "C" fn eddsa_account_get_is_watch_only(account: *const FFIEdDS
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_account_count(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> c_uint {
     if wallet.is_null() {

--- a/key-wallet-ffi/src/account_collection.rs
+++ b/key-wallet-ffi/src/account_collection.rs
@@ -9,7 +9,7 @@ use std::ptr;
 
 use crate::account::FFIAccount;
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFINetwork, FFIWallet};
+use crate::types::{FFINetworks, FFIWallet};
 
 /// Opaque handle to an account collection
 pub struct FFIAccountCollection {
@@ -83,7 +83,7 @@ pub struct FFIAccountCollectionSummary {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_account_collection(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> *mut FFIAccountCollection {
     if wallet.is_null() {
@@ -1100,7 +1100,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 ptr::null(),
                 ptr::null_mut(),
             );
@@ -1109,7 +1109,7 @@ mod tests {
             // Get account collection
             let collection = wallet_get_account_collection(
                 wallet,
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 ptr::null_mut(),
             );
             assert!(!collection.is_null());
@@ -1158,7 +1158,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 &options,
                 ptr::null_mut(),
             );
@@ -1167,7 +1167,7 @@ mod tests {
             // Get account collection
             let collection = wallet_get_account_collection(
                 wallet,
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 ptr::null_mut(),
             );
             assert!(!collection.is_null());
@@ -1206,7 +1206,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 &options,
                 ptr::null_mut(),
             );
@@ -1215,7 +1215,7 @@ mod tests {
             // Get account collection
             let collection = wallet_get_account_collection(
                 wallet,
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 ptr::null_mut(),
             );
             assert!(!collection.is_null());
@@ -1278,7 +1278,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 &options,
                 ptr::null_mut(),
             );
@@ -1287,7 +1287,7 @@ mod tests {
             // Get account collection
             let collection = wallet_get_account_collection(
                 wallet,
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 ptr::null_mut(),
             );
             assert!(!collection.is_null());
@@ -1334,7 +1334,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 &options,
                 ptr::null_mut(),
             );
@@ -1343,7 +1343,7 @@ mod tests {
             // Get account collection
             let collection = wallet_get_account_collection(
                 wallet,
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 ptr::null_mut(),
             );
 
@@ -1422,7 +1422,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 &options,
                 ptr::null_mut(),
             );
@@ -1431,7 +1431,7 @@ mod tests {
             // Get account collection
             let collection = wallet_get_account_collection(
                 wallet,
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 ptr::null_mut(),
             );
             assert!(!collection.is_null());
@@ -1512,7 +1512,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 &options,
                 ptr::null_mut(),
             );
@@ -1521,7 +1521,7 @@ mod tests {
             // Get account collection
             let collection = wallet_get_account_collection(
                 wallet,
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 ptr::null_mut(),
             );
 
@@ -1586,7 +1586,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 ptr::null(),
                 ptr::null_mut(),
             );
@@ -1595,7 +1595,7 @@ mod tests {
             // Get account collection
             let collection = wallet_get_account_collection(
                 wallet,
-                crate::types::FFINetwork::Testnet,
+                crate::types::FFINetworks::Testnet,
                 ptr::null_mut(),
             );
             assert!(!collection.is_null());

--- a/key-wallet-ffi/src/account_tests.rs
+++ b/key-wallet-ffi/src/account_tests.rs
@@ -3,7 +3,7 @@
 mod tests {
     use super::super::*;
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::{FFIAccountType, FFINetwork};
+    use crate::types::{FFIAccountType, FFINetworks};
     use crate::wallet;
     use std::ffi::CString;
     use std::ptr;
@@ -11,7 +11,7 @@ mod tests {
     #[test]
     fn test_wallet_get_account_null_wallet() {
         let result = unsafe {
-            wallet_get_account(ptr::null(), FFINetwork::Testnet, 0, FFIAccountType::StandardBIP44)
+            wallet_get_account(ptr::null(), FFINetworks::Testnet, 0, FFIAccountType::StandardBIP44)
         };
 
         assert!(result.account.is_null());
@@ -38,14 +38,14 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
 
         // Try to get the default account (should exist)
         let result = unsafe {
-            wallet_get_account(wallet, FFINetwork::Testnet, 0, FFIAccountType::StandardBIP44)
+            wallet_get_account(wallet, FFINetworks::Testnet, 0, FFIAccountType::StandardBIP44)
         };
 
         // Note: Since the account may not exist yet (depends on wallet creation logic),
@@ -77,7 +77,7 @@ mod tests {
         let mut error = FFIError::success();
 
         let count =
-            unsafe { wallet_get_account_count(ptr::null(), FFINetwork::Testnet, &mut error) };
+            unsafe { wallet_get_account_count(ptr::null(), FFINetworks::Testnet, &mut error) };
 
         assert_eq!(count, 0);
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
@@ -95,12 +95,12 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
 
-        let count = unsafe { wallet_get_account_count(wallet, FFINetwork::Testnet, &mut error) };
+        let count = unsafe { wallet_get_account_count(wallet, FFINetworks::Testnet, &mut error) };
 
         // Should have at least one default account
         assert!(count >= 1);
@@ -124,7 +124,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -133,7 +133,7 @@ mod tests {
         let count = unsafe {
             wallet_get_account_count(
                 wallet,
-                FFINetwork::Dash, // Different network
+                FFINetworks::Dash, // Different network
                 &mut error,
             )
         };
@@ -176,7 +176,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -186,7 +186,7 @@ mod tests {
 
         // Get an account
         let result = unsafe {
-            wallet_get_account(wallet, FFINetwork::Testnet, 0, FFIAccountType::StandardBIP44)
+            wallet_get_account(wallet, FFINetworks::Testnet, 0, FFIAccountType::StandardBIP44)
         };
 
         if !result.account.is_null() {
@@ -201,7 +201,7 @@ mod tests {
 
                 // Test get network
                 let network = account_get_network(result.account);
-                assert_eq!(network as u32, FFINetwork::Testnet as u32);
+                assert_eq!(network as u32, FFINetworks::Testnet as u32);
 
                 // Test get parent wallet id (may be null)
                 let _wallet_id = account_get_parent_wallet_id(result.account);
@@ -243,7 +243,7 @@ mod tests {
             assert!(xpub.is_null());
 
             let network = account_get_network(ptr::null());
-            assert_eq!(network as u32, FFINetwork::NoNetworks as u32);
+            assert_eq!(network as u32, FFINetworks::NoNetworks as u32);
 
             let wallet_id = account_get_parent_wallet_id(ptr::null());
             assert!(wallet_id.is_null());

--- a/key-wallet-ffi/src/address.rs
+++ b/key-wallet-ffi/src/address.rs
@@ -8,7 +8,7 @@ use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_uchar};
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::FFINetwork;
+use crate::types::FFINetworks;
 
 /// Free address string
 ///
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn address_array_free(addresses: *mut *mut c_char, count: 
 #[no_mangle]
 pub unsafe extern "C" fn address_validate(
     address: *const c_char,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> bool {
     if address.is_null() {
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn address_validate(
 #[no_mangle]
 pub unsafe extern "C" fn address_get_type(
     address: *const c_char,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> c_uchar {
     if address.is_null() {

--- a/key-wallet-ffi/src/address_pool.rs
+++ b/key-wallet-ffi/src/address_pool.rs
@@ -8,7 +8,7 @@ use std::os::raw::{c_char, c_uint};
 
 use crate::error::{FFIError, FFIErrorCode};
 use crate::transaction_checking::FFIManagedWallet;
-use crate::types::{FFIAccountType, FFINetwork, FFIWallet};
+use crate::types::{FFIAccountType, FFINetworks, FFIWallet};
 use crate::utils::rust_string_to_c;
 use key_wallet::account::ManagedAccountCollection;
 use key_wallet::managed_account::address_pool::{
@@ -246,7 +246,7 @@ pub struct FFIAddressPoolInfo {
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_get_address_pool_info(
     managed_wallet: *const FFIManagedWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_type: FFIAccountType,
     account_index: c_uint,
     pool_type: FFIAddressPoolType,
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn managed_wallet_get_address_pool_info(
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_set_gap_limit(
     managed_wallet: *mut FFIManagedWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_type: FFIAccountType,
     account_index: c_uint,
     pool_type: FFIAddressPoolType,
@@ -496,7 +496,7 @@ pub unsafe extern "C" fn managed_wallet_set_gap_limit(
 pub unsafe extern "C" fn managed_wallet_generate_addresses_to_index(
     managed_wallet: *mut FFIManagedWallet,
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_type: FFIAccountType,
     account_index: c_uint,
     pool_type: FFIAddressPoolType,
@@ -671,7 +671,7 @@ pub unsafe extern "C" fn managed_wallet_generate_addresses_to_index(
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_mark_address_used(
     managed_wallet: *mut FFIManagedWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     address: *const c_char,
     error: *mut FFIError,
 ) -> bool {
@@ -1105,7 +1105,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1130,7 +1130,7 @@ mod tests {
             let result = crate::managed_account::managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 FFIAccountType::StandardBIP44,
             );
@@ -1206,7 +1206,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1231,7 +1231,7 @@ mod tests {
             let result = crate::managed_account::managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 FFIAccountType::StandardBIP44,
             );

--- a/key-wallet-ffi/src/address_tests.rs
+++ b/key-wallet-ffi/src/address_tests.rs
@@ -15,7 +15,8 @@ mod address_tests {
 
         // Test valid testnet address (generated from test mnemonic)
         let valid_addr = CString::new("yRd4FhXfVGHXpsuZXPNkMrfD9GVj46pnjt").unwrap();
-        let is_valid = unsafe { address_validate(valid_addr.as_ptr(), FFINetworks::Testnet, error) };
+        let is_valid =
+            unsafe { address_validate(valid_addr.as_ptr(), FFINetworks::Testnet, error) };
         assert!(is_valid);
 
         // Test invalid address
@@ -174,7 +175,8 @@ mod address_tests {
         unsafe {
             for invalid_addr in invalid_addresses.iter() {
                 let addr_str = CString::new(*invalid_addr).unwrap();
-                let is_valid = address_validate(addr_str.as_ptr(), FFINetworks::Testnet, &mut error);
+                let is_valid =
+                    address_validate(addr_str.as_ptr(), FFINetworks::Testnet, &mut error);
                 assert!(!is_valid);
             }
         }

--- a/key-wallet-ffi/src/address_tests.rs
+++ b/key-wallet-ffi/src/address_tests.rs
@@ -4,7 +4,7 @@
 mod address_tests {
     use crate::address::{address_array_free, address_free, address_get_type, address_validate};
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::FFINetwork;
+    use crate::types::FFINetworks;
     use std::ffi::CString;
     use std::ptr;
 
@@ -15,18 +15,18 @@ mod address_tests {
 
         // Test valid testnet address (generated from test mnemonic)
         let valid_addr = CString::new("yRd4FhXfVGHXpsuZXPNkMrfD9GVj46pnjt").unwrap();
-        let is_valid = unsafe { address_validate(valid_addr.as_ptr(), FFINetwork::Testnet, error) };
+        let is_valid = unsafe { address_validate(valid_addr.as_ptr(), FFINetworks::Testnet, error) };
         assert!(is_valid);
 
         // Test invalid address
         let invalid_addr = CString::new("invalid_address").unwrap();
         let is_valid =
-            unsafe { address_validate(invalid_addr.as_ptr(), FFINetwork::Testnet, error) };
+            unsafe { address_validate(invalid_addr.as_ptr(), FFINetworks::Testnet, error) };
         assert!(!is_valid);
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidAddress);
 
         // Test null address
-        let is_valid = unsafe { address_validate(ptr::null(), FFINetwork::Testnet, error) };
+        let is_valid = unsafe { address_validate(ptr::null(), FFINetworks::Testnet, error) };
         assert!(!is_valid);
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidInput);
     }
@@ -39,7 +39,7 @@ mod address_tests {
         // Test P2PKH address (generated from test mnemonic)
         let p2pkh_addr = CString::new("yRd4FhXfVGHXpsuZXPNkMrfD9GVj46pnjt").unwrap();
         let addr_type =
-            unsafe { address_get_type(p2pkh_addr.as_ptr(), FFINetwork::Testnet, error) };
+            unsafe { address_get_type(p2pkh_addr.as_ptr(), FFINetworks::Testnet, error) };
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::Success);
         // Returns 0 for P2PKH
         assert_eq!(addr_type, 0);
@@ -52,7 +52,7 @@ mod address_tests {
         // Test with valid testnet address - may fail due to library version differences
         let addr_str = CString::new("yeRZBWYfeNE4yVUHV4ZLs83Ppn9aMRH57A").unwrap();
         let is_valid =
-            unsafe { address_validate(addr_str.as_ptr(), FFINetwork::Testnet, &mut error) };
+            unsafe { address_validate(addr_str.as_ptr(), FFINetworks::Testnet, &mut error) };
 
         assert!(is_valid);
     }
@@ -64,7 +64,7 @@ mod address_tests {
         // Test with invalid address
         let addr_str = CString::new("invalid_address").unwrap();
         let is_valid =
-            unsafe { address_validate(addr_str.as_ptr(), FFINetwork::Testnet, &mut error) };
+            unsafe { address_validate(addr_str.as_ptr(), FFINetworks::Testnet, &mut error) };
 
         assert!(!is_valid);
         assert_eq!(error.code, FFIErrorCode::InvalidAddress);
@@ -74,7 +74,7 @@ mod address_tests {
     fn test_address_validate_null() {
         let mut error = FFIError::success();
 
-        let is_valid = unsafe { address_validate(ptr::null(), FFINetwork::Testnet, &mut error) };
+        let is_valid = unsafe { address_validate(ptr::null(), FFINetworks::Testnet, &mut error) };
 
         assert!(!is_valid);
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
@@ -87,7 +87,7 @@ mod address_tests {
         // Test P2PKH address type (use same known-valid address from other tests)
         let addr_str = CString::new("yRd4FhXfVGHXpsuZXPNkMrfD9GVj46pnjt").unwrap();
         let addr_type =
-            unsafe { address_get_type(addr_str.as_ptr(), FFINetwork::Testnet, &mut error) };
+            unsafe { address_get_type(addr_str.as_ptr(), FFINetworks::Testnet, &mut error) };
 
         // Type should be 0, 1, or 2 for valid addresses
         // If it's invalid (255), the address might not be valid for testnet
@@ -105,7 +105,7 @@ mod address_tests {
 
         let addr_str = CString::new("invalid_address").unwrap();
         let addr_type =
-            unsafe { address_get_type(addr_str.as_ptr(), FFINetwork::Testnet, &mut error) };
+            unsafe { address_get_type(addr_str.as_ptr(), FFINetworks::Testnet, &mut error) };
 
         // Should return 255 (u8::MAX) for invalid
         assert_eq!(addr_type, 255);
@@ -116,7 +116,7 @@ mod address_tests {
     fn test_address_get_type_null() {
         let mut error = FFIError::success();
 
-        let addr_type = unsafe { address_get_type(ptr::null(), FFINetwork::Testnet, &mut error) };
+        let addr_type = unsafe { address_get_type(ptr::null(), FFINetworks::Testnet, &mut error) };
 
         // Should return 255 (u8::MAX) for null input
         assert_eq!(addr_type, 255);
@@ -174,7 +174,7 @@ mod address_tests {
         unsafe {
             for invalid_addr in invalid_addresses.iter() {
                 let addr_str = CString::new(*invalid_addr).unwrap();
-                let is_valid = address_validate(addr_str.as_ptr(), FFINetwork::Testnet, &mut error);
+                let is_valid = address_validate(addr_str.as_ptr(), FFINetworks::Testnet, &mut error);
                 assert!(!is_valid);
             }
         }
@@ -195,7 +195,7 @@ mod address_tests {
             for addr in test_addresses.iter() {
                 let addr_str = CString::new(*addr).unwrap();
                 let addr_type =
-                    address_get_type(addr_str.as_ptr(), FFINetwork::Testnet, &mut error);
+                    address_get_type(addr_str.as_ptr(), FFINetworks::Testnet, &mut error);
 
                 // Should return a valid type (0, 1, 2) or 255 for error
                 assert!(addr_type <= 2 || addr_type == 255);

--- a/key-wallet-ffi/src/bip38.rs
+++ b/key-wallet-ffi/src/bip38.rs
@@ -5,7 +5,7 @@ use std::os::raw::c_char;
 use std::ptr;
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::FFINetwork;
+use crate::types::FFINetworks;
 
 /// Encrypt a private key with BIP38
 ///
@@ -19,7 +19,7 @@ use crate::types::FFINetwork;
 pub unsafe extern "C" fn bip38_encrypt_private_key(
     private_key: *const c_char,
     passphrase: *const c_char,
-    _network: FFINetwork,
+    _network: FFINetworks,
     error: *mut FFIError,
 ) -> *mut c_char {
     #[cfg(feature = "bip38")]

--- a/key-wallet-ffi/src/derivation.rs
+++ b/key-wallet-ffi/src/derivation.rs
@@ -1,7 +1,7 @@
 //! BIP32 and DIP9 derivation path functions
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::FFINetwork;
+use crate::types::FFINetworks;
 use dash_network::Network;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_uint};
@@ -52,7 +52,7 @@ pub struct FFIExtendedPubKey {
 pub unsafe extern "C" fn derivation_new_master_key(
     seed: *const u8,
     seed_len: usize,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> *mut FFIExtendedPrivKey {
     if seed.is_null() {
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn derivation_new_master_key(
 /// Derive a BIP44 account path (m/44'/5'/account')
 #[no_mangle]
 pub extern "C" fn derivation_bip44_account_path(
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: c_uint,
     path_out: *mut c_char,
     path_max_len: usize,
@@ -159,7 +159,7 @@ pub extern "C" fn derivation_bip44_account_path(
 /// Derive a BIP44 payment path (m/44'/5'/account'/change/index)
 #[no_mangle]
 pub extern "C" fn derivation_bip44_payment_path(
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: c_uint,
     is_change: bool,
     address_index: c_uint,
@@ -227,7 +227,7 @@ pub extern "C" fn derivation_bip44_payment_path(
 /// Derive CoinJoin path (m/9'/5'/4'/account')
 #[no_mangle]
 pub extern "C" fn derivation_coinjoin_path(
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: c_uint,
     path_out: *mut c_char,
     path_max_len: usize,
@@ -292,7 +292,7 @@ pub extern "C" fn derivation_coinjoin_path(
 /// Derive identity registration path (m/9'/5'/5'/1'/index')
 #[no_mangle]
 pub extern "C" fn derivation_identity_registration_path(
-    network: FFINetwork,
+    network: FFINetworks,
     identity_index: c_uint,
     path_out: *mut c_char,
     path_max_len: usize,
@@ -357,7 +357,7 @@ pub extern "C" fn derivation_identity_registration_path(
 /// Derive identity top-up path (m/9'/5'/5'/2'/identity_index'/top_up_index')
 #[no_mangle]
 pub extern "C" fn derivation_identity_topup_path(
-    network: FFINetwork,
+    network: FFINetworks,
     identity_index: c_uint,
     topup_index: c_uint,
     path_out: *mut c_char,
@@ -424,7 +424,7 @@ pub extern "C" fn derivation_identity_topup_path(
 /// Derive identity authentication path (m/9'/5'/5'/0'/identity_index'/key_index')
 #[no_mangle]
 pub extern "C" fn derivation_identity_authentication_path(
-    network: FFINetwork,
+    network: FFINetworks,
     identity_index: c_uint,
     key_index: c_uint,
     path_out: *mut c_char,
@@ -505,7 +505,7 @@ pub unsafe extern "C" fn derivation_derive_private_key_from_seed(
     seed: *const u8,
     seed_len: usize,
     path: *const c_char,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> *mut FFIExtendedPrivKey {
     if seed.is_null() || path.is_null() {
@@ -778,7 +778,7 @@ pub unsafe extern "C" fn derivation_string_free(s: *mut c_char) {
 pub unsafe extern "C" fn dip9_derive_identity_key(
     seed: *const u8,
     seed_len: usize,
-    network: FFINetwork,
+    network: FFINetworks,
     identity_index: c_uint,
     key_index: c_uint,
     key_type: FFIDerivationPathType,

--- a/key-wallet-ffi/src/derivation_tests.rs
+++ b/key-wallet-ffi/src/derivation_tests.rs
@@ -529,8 +529,13 @@ mod tests {
         let mut error = FFIError::success();
 
         // Test BIP44 account path with null buffer
-        let success =
-            derivation_bip44_account_path(FFINetworks::Testnet, 0, ptr::null_mut(), 256, &mut error);
+        let success = derivation_bip44_account_path(
+            FFINetworks::Testnet,
+            0,
+            ptr::null_mut(),
+            256,
+            &mut error,
+        );
         assert!(!success);
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
 

--- a/key-wallet-ffi/src/derivation_tests.rs
+++ b/key-wallet-ffi/src/derivation_tests.rs
@@ -6,7 +6,7 @@ mod tests {
     use crate::derivation::*;
     use crate::error::{FFIError, FFIErrorCode};
     use crate::mnemonic;
-    use crate::types::FFINetwork;
+    use crate::types::FFINetworks;
     use std::ffi::{CStr, CString};
     use std::ptr;
 
@@ -34,7 +34,7 @@ mod tests {
 
         // Create master key from seed
         let xprv = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Testnet, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetworks::Testnet, &mut error)
         };
 
         assert!(!xprv.is_null());
@@ -56,7 +56,7 @@ mod tests {
         }
 
         let xprv = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Testnet, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetworks::Testnet, &mut error)
         };
 
         // Get public key
@@ -84,7 +84,7 @@ mod tests {
         }
 
         let xprv = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Testnet, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetworks::Testnet, &mut error)
         };
 
         // Convert to string
@@ -114,7 +114,7 @@ mod tests {
         }
 
         let xprv = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Testnet, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetworks::Testnet, &mut error)
         };
 
         let xpub = unsafe { derivation_xpriv_to_xpub(xprv, &mut error) };
@@ -149,7 +149,7 @@ mod tests {
         }
 
         let xprv = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Testnet, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetworks::Testnet, &mut error)
         };
 
         let xpub = unsafe { derivation_xpriv_to_xpub(xprv, &mut error) };
@@ -179,7 +179,7 @@ mod tests {
         // Test BIP44 account path
         let mut account_path = vec![0u8; 256];
         let success = derivation_bip44_account_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             account_path.as_mut_ptr() as *mut i8,
             account_path.len(),
@@ -194,7 +194,7 @@ mod tests {
         // Test BIP44 payment path
         let mut payment_path = vec![0u8; 256];
         let success = derivation_bip44_payment_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,     // account_index
             false, // is_change
             0,     // address_index
@@ -216,7 +216,7 @@ mod tests {
         // Test CoinJoin path
         let mut coinjoin_path = vec![0u8; 256];
         let success = derivation_coinjoin_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0, // account_index
             coinjoin_path.as_mut_ptr() as *mut i8,
             coinjoin_path.len(),
@@ -227,7 +227,7 @@ mod tests {
         // Test identity registration path - takes 2 args: network and identity_index
         let mut id_reg_path = vec![0u8; 256];
         let success = derivation_identity_registration_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0, // identity_index
             id_reg_path.as_mut_ptr() as *mut i8,
             id_reg_path.len(),
@@ -238,7 +238,7 @@ mod tests {
         // Test identity topup path - takes 3 args: network, identity_index, topup_index
         let mut id_topup_path = vec![0u8; 256];
         let success = derivation_identity_topup_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0, // identity_index
             2, // topup_index
             id_topup_path.as_mut_ptr() as *mut i8,
@@ -250,7 +250,7 @@ mod tests {
         // Test identity authentication path - takes 3 args: network, identity_index, key_index
         let mut id_auth_path = vec![0u8; 256];
         let success = derivation_identity_authentication_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0, // identity_index
             3, // key_index
             id_auth_path.as_mut_ptr() as *mut i8,
@@ -279,7 +279,7 @@ mod tests {
                 seed.as_ptr(),
                 seed.len(),
                 path.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -307,7 +307,7 @@ mod tests {
             dip9_derive_identity_key(
                 seed.as_ptr(),
                 seed.len(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,                                               // identity index
                 0,                                               // key index
                 FFIDerivationPathType::PathBlockchainIdentities, // key_type
@@ -329,7 +329,7 @@ mod tests {
 
         // Test with null seed
         let xprv =
-            unsafe { derivation_new_master_key(ptr::null(), 64, FFINetwork::Testnet, &mut error) };
+            unsafe { derivation_new_master_key(ptr::null(), 64, FFINetworks::Testnet, &mut error) };
         assert!(xprv.is_null());
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
 
@@ -348,7 +348,7 @@ mod tests {
         }
 
         let master_key = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Testnet, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetworks::Testnet, &mut error)
         };
 
         let xpub = unsafe { derivation_xpriv_to_xpub(master_key, &mut error) };
@@ -380,7 +380,7 @@ mod tests {
         }
 
         let master_key = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Testnet, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetworks::Testnet, &mut error)
         };
 
         let xpriv_string = unsafe { derivation_xpriv_to_string(master_key, &mut error) };
@@ -411,7 +411,7 @@ mod tests {
         }
 
         let master_key = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Testnet, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetworks::Testnet, &mut error)
         };
 
         let xpub = unsafe { derivation_xpriv_to_xpub(master_key, &mut error) };
@@ -440,7 +440,7 @@ mod tests {
         // Test identity registration path
         let mut buffer = vec![0u8; 256];
         let success = derivation_identity_registration_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0, // identity_index
             buffer.as_mut_ptr() as *mut i8,
             buffer.len(),
@@ -454,7 +454,7 @@ mod tests {
         // Test identity topup path
         let mut buffer = vec![0u8; 256];
         let success = derivation_identity_topup_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0, // identity_index
             0, // topup_index
             buffer.as_mut_ptr() as *mut i8,
@@ -469,7 +469,7 @@ mod tests {
         // Test identity authentication path
         let mut buffer = vec![0u8; 256];
         let success = derivation_identity_authentication_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0, // identity_index
             0, // key_index
             buffer.as_mut_ptr() as *mut i8,
@@ -502,7 +502,7 @@ mod tests {
 
         // Test with null seed
         let xprv =
-            unsafe { derivation_new_master_key(ptr::null(), 64, FFINetwork::Testnet, &mut error) };
+            unsafe { derivation_new_master_key(ptr::null(), 64, FFINetworks::Testnet, &mut error) };
         assert!(xprv.is_null());
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
 
@@ -512,7 +512,7 @@ mod tests {
             derivation_new_master_key(
                 seed.as_ptr(),
                 seed.len(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 ptr::null_mut(),
             )
         };
@@ -530,13 +530,13 @@ mod tests {
 
         // Test BIP44 account path with null buffer
         let success =
-            derivation_bip44_account_path(FFINetwork::Testnet, 0, ptr::null_mut(), 256, &mut error);
+            derivation_bip44_account_path(FFINetworks::Testnet, 0, ptr::null_mut(), 256, &mut error);
         assert!(!success);
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
 
         // Test BIP44 payment path with null buffer
         let success = derivation_bip44_payment_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             false,
             0,
@@ -549,7 +549,7 @@ mod tests {
 
         // Test CoinJoin path with null buffer
         let success =
-            derivation_coinjoin_path(FFINetwork::Testnet, 0, ptr::null_mut(), 256, &mut error);
+            derivation_coinjoin_path(FFINetworks::Testnet, 0, ptr::null_mut(), 256, &mut error);
         assert!(!success);
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
     }
@@ -561,7 +561,7 @@ mod tests {
         // Test with very small buffer (should fail)
         let mut small_buffer = [0i8; 5];
         let success = derivation_bip44_account_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             small_buffer.as_mut_ptr(),
             small_buffer.len(),
@@ -572,7 +572,7 @@ mod tests {
 
         // Test BIP44 payment path with small buffer
         let success = derivation_bip44_payment_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             false,
             0,
@@ -594,14 +594,14 @@ mod tests {
 
         // Test with Mainnet
         let xprv_main = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Dash, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetworks::Dash, &mut error)
         };
         assert!(!xprv_main.is_null());
         assert_eq!(error.code, FFIErrorCode::Success);
 
         // Test with Testnet
         let xprv_test = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Testnet, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetworks::Testnet, &mut error)
         };
         assert!(!xprv_test.is_null());
         assert_eq!(error.code, FFIErrorCode::Success);
@@ -680,7 +680,7 @@ mod tests {
         }
 
         let xprv = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Testnet, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetworks::Testnet, &mut error)
         };
 
         let xpub = unsafe { derivation_xpriv_to_xpub(xprv, &mut error) };
@@ -710,7 +710,7 @@ mod tests {
                 ptr::null(),
                 64,
                 path.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -723,7 +723,7 @@ mod tests {
                 seed.as_ptr(),
                 seed.len(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -746,7 +746,7 @@ mod tests {
                 seed.as_ptr(),
                 seed.len(),
                 invalid_path.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -768,7 +768,7 @@ mod tests {
             dip9_derive_identity_key(
                 ptr::null(),
                 64,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 0,
                 FFIDerivationPathType::PathBlockchainIdentities,
@@ -792,7 +792,7 @@ mod tests {
             dip9_derive_identity_key(
                 seed.as_ptr(),
                 seed.len(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 0,
                 FFIDerivationPathType::PathBlockchainIdentities,
@@ -813,7 +813,7 @@ mod tests {
 
         // Test identity registration with null buffer
         let success = derivation_identity_registration_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             ptr::null_mut(),
             256,
@@ -824,7 +824,7 @@ mod tests {
 
         // Test identity topup with null buffer
         let success = derivation_identity_topup_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             0,
             ptr::null_mut(),
@@ -836,7 +836,7 @@ mod tests {
 
         // Test identity authentication with null buffer
         let success = derivation_identity_authentication_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             0,
             ptr::null_mut(),
@@ -854,7 +854,7 @@ mod tests {
 
         // Test identity registration with small buffer
         let success = derivation_identity_registration_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             small_buffer.as_mut_ptr(),
             small_buffer.len(),
@@ -865,7 +865,7 @@ mod tests {
 
         // Test identity topup with small buffer
         let success = derivation_identity_topup_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             0,
             small_buffer.as_mut_ptr(),
@@ -877,7 +877,7 @@ mod tests {
 
         // Test identity authentication with small buffer
         let success = derivation_identity_authentication_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             0,
             small_buffer.as_mut_ptr(),
@@ -896,7 +896,7 @@ mod tests {
 
         // Test BIP44 account path with different account indices
         let success1 = derivation_bip44_account_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             buffer1.as_mut_ptr() as *mut i8,
             buffer1.len(),
@@ -905,7 +905,7 @@ mod tests {
         assert!(success1);
 
         let success2 = derivation_bip44_account_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             5,
             buffer2.as_mut_ptr() as *mut i8,
             buffer2.len(),
@@ -928,7 +928,7 @@ mod tests {
         // Test receive address path
         let mut buffer = vec![0u8; 256];
         let success = derivation_bip44_payment_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,     // account_index
             false, // is_change (receive)
             5,     // address_index
@@ -943,7 +943,7 @@ mod tests {
         // Test change address path
         let mut buffer = vec![0u8; 256];
         let success = derivation_bip44_payment_path(
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,    // account_index
             true, // is_change
             3,    // address_index
@@ -968,7 +968,7 @@ mod tests {
 
         // Create master key
         let master_xprv = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Testnet, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetworks::Testnet, &mut error)
         };
         assert!(!master_xprv.is_null());
 
@@ -990,7 +990,7 @@ mod tests {
                 seed.as_ptr(),
                 seed.len(),
                 path.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };

--- a/key-wallet-ffi/src/keys.rs
+++ b/key-wallet-ffi/src/keys.rs
@@ -1,7 +1,7 @@
 //! Key derivation and management
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFINetwork, FFIWallet};
+use crate::types::{FFINetworks, FFIWallet};
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_uint};
 use std::ptr;
@@ -36,7 +36,7 @@ pub struct FFIExtendedPublicKey {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_account_xpriv(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: c_uint,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -96,7 +96,7 @@ pub unsafe extern "C" fn wallet_get_account_xpriv(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_account_xpub(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: c_uint,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -153,7 +153,7 @@ pub unsafe extern "C" fn wallet_get_account_xpub(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_derive_private_key(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     derivation_path: *const c_char,
     error: *mut FFIError,
 ) -> *mut FFIPrivateKey {
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn wallet_derive_private_key(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_derive_extended_private_key(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     derivation_path: *const c_char,
     error: *mut FFIError,
 ) -> *mut FFIExtendedPrivateKey {
@@ -312,7 +312,7 @@ pub unsafe extern "C" fn wallet_derive_extended_private_key(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_derive_private_key_as_wif(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     derivation_path: *const c_char,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -427,7 +427,7 @@ pub unsafe extern "C" fn extended_private_key_free(key: *mut FFIExtendedPrivateK
 #[no_mangle]
 pub unsafe extern "C" fn extended_private_key_to_string(
     key: *const FFIExtendedPrivateKey,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> *mut c_char {
     if key.is_null() {
@@ -503,7 +503,7 @@ pub unsafe extern "C" fn extended_private_key_get_private_key(
 #[no_mangle]
 pub unsafe extern "C" fn private_key_to_wif(
     key: *const FFIPrivateKey,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> *mut c_char {
     if key.is_null() {
@@ -559,7 +559,7 @@ pub unsafe extern "C" fn private_key_to_wif(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_derive_public_key(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     derivation_path: *const c_char,
     error: *mut FFIError,
 ) -> *mut FFIPublicKey {
@@ -641,7 +641,7 @@ pub unsafe extern "C" fn wallet_derive_public_key(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_derive_extended_public_key(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     derivation_path: *const c_char,
     error: *mut FFIError,
 ) -> *mut FFIExtendedPublicKey {
@@ -722,7 +722,7 @@ pub unsafe extern "C" fn wallet_derive_extended_public_key(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_derive_public_key_as_hex(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     derivation_path: *const c_char,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -843,7 +843,7 @@ pub unsafe extern "C" fn extended_public_key_free(key: *mut FFIExtendedPublicKey
 #[no_mangle]
 pub unsafe extern "C" fn extended_public_key_to_string(
     key: *const FFIExtendedPublicKey,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> *mut c_char {
     if key.is_null() {

--- a/key-wallet-ffi/src/keys_tests.rs
+++ b/key-wallet-ffi/src/keys_tests.rs
@@ -5,7 +5,7 @@
 mod tests {
     use crate::error::{FFIError, FFIErrorCode};
     use crate::keys::*;
-    use crate::types::FFINetwork;
+    use crate::types::FFINetworks;
     use crate::wallet;
     use std::ffi::{CStr, CString};
     use std::ptr;
@@ -21,7 +21,7 @@ mod tests {
             let wallet = wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             );
             assert!(!wallet.is_null());
@@ -31,7 +31,7 @@ mod tests {
             let path = CString::new("m/44'/1'/0'").unwrap();
             let ext_priv = wallet_derive_extended_private_key(
                 wallet,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 path.as_ptr(),
                 &mut error,
             );
@@ -40,7 +40,7 @@ mod tests {
 
             // Test extended_private_key_to_string
             let xprv_str =
-                extended_private_key_to_string(ext_priv, FFINetwork::Testnet, &mut error);
+                extended_private_key_to_string(ext_priv, FFINetworks::Testnet, &mut error);
             assert!(!xprv_str.is_null());
             assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -54,7 +54,7 @@ mod tests {
             assert_eq!(error.code, FFIErrorCode::Success);
 
             // Get WIF from the extracted private key
-            let wif = private_key_to_wif(priv_key, FFINetwork::Testnet, &mut error);
+            let wif = private_key_to_wif(priv_key, FFINetworks::Testnet, &mut error);
             assert!(!wif.is_null());
             assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -70,7 +70,7 @@ mod tests {
             // Now test extended public key
             let ext_pub = wallet_derive_extended_public_key(
                 wallet,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 path.as_ptr(),
                 &mut error,
             );
@@ -78,7 +78,7 @@ mod tests {
             assert_eq!(error.code, FFIErrorCode::Success);
 
             // Test extended_public_key_to_string
-            let xpub_str = extended_public_key_to_string(ext_pub, FFINetwork::Testnet, &mut error);
+            let xpub_str = extended_public_key_to_string(ext_pub, FFINetworks::Testnet, &mut error);
             assert!(!xpub_str.is_null());
             assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -121,7 +121,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -129,7 +129,7 @@ mod tests {
 
         // Try to get account xpriv - should fail
         let xpriv_str =
-            unsafe { wallet_get_account_xpriv(wallet, FFINetwork::Testnet, 0, &mut error) };
+            unsafe { wallet_get_account_xpriv(wallet, FFINetworks::Testnet, 0, &mut error) };
 
         // Should return null (not implemented for security)
         assert!(xpriv_str.is_null());
@@ -153,7 +153,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -161,7 +161,7 @@ mod tests {
 
         // Get account xpub
         let xpub_str =
-            unsafe { wallet_get_account_xpub(wallet, FFINetwork::Testnet, 0, &mut error) };
+            unsafe { wallet_get_account_xpub(wallet, FFINetworks::Testnet, 0, &mut error) };
 
         assert!(!xpub_str.is_null());
 
@@ -189,7 +189,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -197,7 +197,7 @@ mod tests {
         // Try to derive private key - should now succeed (44'/1'/0'/0/0 for Dash)
         let path = CString::new("m/44'/1'/0'/0/0").unwrap();
         let privkey_ptr = unsafe {
-            wallet_derive_private_key(wallet, FFINetwork::Testnet, path.as_ptr(), &mut error)
+            wallet_derive_private_key(wallet, FFINetworks::Testnet, path.as_ptr(), &mut error)
         };
 
         // Should succeed and return a valid pointer
@@ -205,7 +205,7 @@ mod tests {
         assert_eq!(error.code, FFIErrorCode::Success);
 
         // Convert to WIF to verify it's valid
-        let wif_str = unsafe { private_key_to_wif(privkey_ptr, FFINetwork::Testnet, &mut error) };
+        let wif_str = unsafe { private_key_to_wif(privkey_ptr, FFINetworks::Testnet, &mut error) };
         assert!(!wif_str.is_null());
         assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -239,7 +239,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -251,7 +251,7 @@ mod tests {
         // Derive public key using derivation path (44'/1'/0'/0/0 for Dash)
         let path = CString::new("m/44'/1'/0'/0/0").unwrap();
         let pubkey_ptr = unsafe {
-            wallet_derive_public_key(wallet, FFINetwork::Testnet, path.as_ptr(), &mut error)
+            wallet_derive_public_key(wallet, FFINetworks::Testnet, path.as_ptr(), &mut error)
         };
 
         if pubkey_ptr.is_null() {
@@ -295,7 +295,7 @@ mod tests {
             let wallet = wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             );
             assert!(!wallet.is_null());
@@ -305,7 +305,7 @@ mod tests {
             let path = CString::new("m/44'/1'/0'/0/0").unwrap();
             let hex_str = wallet_derive_public_key_as_hex(
                 wallet,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 path.as_ptr(),
                 &mut error,
             );
@@ -406,7 +406,7 @@ mod tests {
 
         // Test with null wallet
         let xpriv =
-            unsafe { wallet_get_account_xpriv(ptr::null(), FFINetwork::Testnet, 0, &mut error) };
+            unsafe { wallet_get_account_xpriv(ptr::null(), FFINetworks::Testnet, 0, &mut error) };
         assert!(xpriv.is_null());
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
 
@@ -436,7 +436,7 @@ mod tests {
         // Test with null wallet (44'/1'/0'/0/0 for Dash)
         let path = CString::new("m/44'/1'/0'/0/0").unwrap();
         let pubkey_ptr = unsafe {
-            wallet_derive_public_key(ptr::null(), FFINetwork::Testnet, path.as_ptr(), &mut error)
+            wallet_derive_public_key(ptr::null(), FFINetworks::Testnet, path.as_ptr(), &mut error)
         };
 
         assert!(pubkey_ptr.is_null());
@@ -450,14 +450,14 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
 
         // Test with null path
         let pubkey_ptr = unsafe {
-            wallet_derive_public_key(wallet, FFINetwork::Testnet, ptr::null(), &mut error)
+            wallet_derive_public_key(wallet, FFINetworks::Testnet, ptr::null(), &mut error)
         };
 
         assert!(pubkey_ptr.is_null());
@@ -586,7 +586,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -595,7 +595,7 @@ mod tests {
         // Test different account indices
         for account_index in 0..3 {
             let xpub_str = unsafe {
-                wallet_get_account_xpub(wallet, FFINetwork::Testnet, account_index, &mut error)
+                wallet_get_account_xpub(wallet, FFINetworks::Testnet, account_index, &mut error)
             };
 
             if !xpub_str.is_null() {
@@ -611,7 +611,7 @@ mod tests {
 
         // Test with null wallet
         let xpub_str =
-            unsafe { wallet_get_account_xpub(ptr::null(), FFINetwork::Testnet, 0, &mut error) };
+            unsafe { wallet_get_account_xpub(ptr::null(), FFINetworks::Testnet, 0, &mut error) };
 
         assert!(xpub_str.is_null());
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
@@ -634,7 +634,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -651,7 +651,7 @@ mod tests {
             let path = CString::new(*path_str).unwrap();
 
             let pubkey_ptr = unsafe {
-                wallet_derive_public_key(wallet, FFINetwork::Testnet, path.as_ptr(), &mut error)
+                wallet_derive_public_key(wallet, FFINetworks::Testnet, path.as_ptr(), &mut error)
             };
 
             if !pubkey_ptr.is_null() {

--- a/key-wallet-ffi/src/lib.rs
+++ b/key-wallet-ffi/src/lib.rs
@@ -31,7 +31,7 @@ pub mod bip38;
 
 // Re-export main types for convenience
 pub use error::{FFIError, FFIErrorCode};
-pub use types::{FFIBalance, FFINetwork, FFIWallet};
+pub use types::{FFIBalance, FFINetworks, FFIWallet};
 pub use utxo::FFIUTXO;
 
 // ============================================================================

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use crate::address_pool::{FFIAddressPool, FFIAddressPoolType};
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFIAccountType, FFINetwork};
+use crate::types::{FFIAccountType, FFINetworks};
 use crate::wallet_manager::FFIWalletManager;
 use key_wallet::managed_account::address_pool::AddressPool;
 use key_wallet::managed_account::ManagedAccount;
@@ -86,7 +86,7 @@ impl FFIManagedAccountResult {
 pub unsafe extern "C" fn managed_wallet_get_account(
     manager: *const FFIWalletManager,
     wallet_id: *const u8,
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: c_uint,
     account_type: FFIAccountType,
 ) -> FFIManagedAccountResult {
@@ -218,7 +218,7 @@ pub unsafe extern "C" fn managed_wallet_get_account(
 pub unsafe extern "C" fn managed_wallet_get_top_up_account_with_registration_index(
     manager: *const FFIWalletManager,
     wallet_id: *const u8,
-    network: FFINetwork,
+    network: FFINetworks,
     registration_index: c_uint,
 ) -> FFIManagedAccountResult {
     if manager.is_null() {
@@ -306,9 +306,9 @@ pub unsafe extern "C" fn managed_wallet_get_top_up_account_with_registration_ind
 #[no_mangle]
 pub unsafe extern "C" fn managed_account_get_network(
     account: *const FFIManagedAccount,
-) -> FFINetwork {
+) -> FFINetworks {
     if account.is_null() {
-        return FFINetwork::NoNetworks;
+        return FFINetworks::NoNetworks;
     }
 
     let account = &*account;
@@ -511,7 +511,7 @@ pub unsafe extern "C" fn managed_account_result_free_error(result: *mut FFIManag
 pub unsafe extern "C" fn managed_wallet_get_account_count(
     manager: *const FFIWalletManager,
     wallet_id: *const u8,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> c_uint {
     if manager.is_null() || wallet_id.is_null() {
@@ -795,7 +795,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -820,7 +820,7 @@ mod tests {
             let result = managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 FFIAccountType::StandardBIP44,
             );
@@ -864,7 +864,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &options,
                 &mut error,
             );
@@ -887,7 +887,7 @@ mod tests {
             let mut result = managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 FFIAccountType::CoinJoin,
             );
@@ -944,7 +944,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &options,
                 &mut error,
             );
@@ -966,7 +966,7 @@ mod tests {
             let count = managed_wallet_get_account_count(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             );
 
@@ -998,7 +998,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1023,7 +1023,7 @@ mod tests {
             let result = managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 FFIAccountType::StandardBIP44,
             );
@@ -1036,7 +1036,7 @@ mod tests {
 
             // Test get_network
             let network = managed_account_get_network(account);
-            assert_eq!(network, FFINetwork::Testnet);
+            assert_eq!(network, FFINetworks::Testnet);
 
             // Test get_account_type
             let mut index_out: c_uint = 999; // Initialize with unexpected value
@@ -1087,7 +1087,7 @@ mod tests {
         unsafe {
             // Test null account
             let network = managed_account_get_network(ptr::null());
-            assert_eq!(network, FFINetwork::NoNetworks);
+            assert_eq!(network, FFINetworks::NoNetworks);
 
             let mut index_out: c_uint = 0;
             let account_type = managed_account_get_account_type(ptr::null(), &mut index_out);
@@ -1119,7 +1119,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1141,7 +1141,7 @@ mod tests {
             let result = managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 FFIAccountType::StandardBIP44,
             );
@@ -1176,7 +1176,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1201,7 +1201,7 @@ mod tests {
             let result = managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 FFIAccountType::StandardBIP44,
             );
@@ -1271,7 +1271,7 @@ mod tests {
                 manager,
                 mnemonic2.as_ptr(),
                 passphrase2.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &options,
                 &mut error,
             );
@@ -1291,7 +1291,7 @@ mod tests {
             let cj_result = managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 FFIAccountType::CoinJoin,
             );

--- a/key-wallet-ffi/src/managed_account_collection.rs
+++ b/key-wallet-ffi/src/managed_account_collection.rs
@@ -11,7 +11,7 @@ use std::ptr;
 
 use crate::error::{FFIError, FFIErrorCode};
 use crate::managed_account::FFIManagedAccount;
-use crate::types::FFINetwork;
+use crate::types::FFINetworks;
 use crate::wallet_manager::FFIWalletManager;
 
 /// Opaque handle to a managed account collection
@@ -90,7 +90,7 @@ pub struct FFIManagedAccountCollectionSummary {
 pub unsafe extern "C" fn managed_wallet_get_account_collection(
     manager: *const FFIWalletManager,
     wallet_id: *const u8,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> *mut FFIManagedAccountCollection {
     if manager.is_null() || wallet_id.is_null() {

--- a/key-wallet-ffi/src/managed_account_collection.rs
+++ b/key-wallet-ffi/src/managed_account_collection.rs
@@ -634,39 +634,38 @@ pub unsafe extern "C" fn managed_account_collection_has_provider_owner_keys(
 }
 
 /// Get the provider operator keys account if it exists in managed collection
-/// Note: This function is only available when the `bls` feature is enabled
+/// Note: Returns null if the `bls` feature is not enabled
 ///
 /// # Safety
 ///
 /// - `collection` must be a valid pointer to an FFIManagedAccountCollection
-/// - The returned pointer must be freed with `managed_account_free` when no longer needed
-#[cfg(feature = "bls")]
+/// - The returned pointer must be freed with `managed_account_free` when no longer needed (when BLS is enabled)
 #[no_mangle]
 pub unsafe extern "C" fn managed_account_collection_get_provider_operator_keys(
     collection: *const FFIManagedAccountCollection,
-) -> *mut FFIManagedAccount {
-    if collection.is_null() {
-        return ptr::null_mut();
-    }
-
-    let collection = &*collection;
-    match &collection.collection.provider_operator_keys {
-        Some(account) => {
-            let ffi_account = FFIManagedAccount::new(account);
-            Box::into_raw(Box::new(ffi_account))
+) -> *mut std::os::raw::c_void {
+    #[cfg(feature = "bls")]
+    {
+        if collection.is_null() {
+            return ptr::null_mut();
         }
-        None => ptr::null_mut(),
-    }
-}
 
-/// Get the provider operator keys account if it exists (stub when BLS is disabled)
-#[cfg(not(feature = "bls"))]
-#[no_mangle]
-pub unsafe extern "C" fn managed_account_collection_get_provider_operator_keys(
-    _collection: *const FFIManagedAccountCollection,
-) -> *mut FFIManagedAccount {
-    // BLS feature not enabled, always return null
-    ptr::null_mut()
+        let collection = &*collection;
+        match &collection.collection.provider_operator_keys {
+            Some(account) => {
+                let ffi_account = FFIManagedAccount::new(account);
+                Box::into_raw(Box::new(ffi_account)) as *mut std::os::raw::c_void
+            }
+            None => ptr::null_mut(),
+        }
+    }
+
+    #[cfg(not(feature = "bls"))]
+    {
+        // BLS feature not enabled, always return null
+        let _ = collection; // Avoid unused parameter warning
+        ptr::null_mut()
+    }
 }
 
 /// Check if provider operator keys account exists in managed collection
@@ -695,40 +694,38 @@ pub unsafe extern "C" fn managed_account_collection_has_provider_operator_keys(
 }
 
 /// Get the provider platform keys account if it exists in managed collection
-/// Note: This function is only available when the `eddsa` feature is enabled
+/// Note: Returns null if the `eddsa` feature is not enabled
 ///
 /// # Safety
 ///
 /// - `collection` must be a valid pointer to an FFIManagedAccountCollection
-/// - `manager` must be a valid pointer to an FFIWalletManager
-/// - The returned pointer must be freed with `managed_account_free` when no longer needed
-#[cfg(feature = "eddsa")]
+/// - The returned pointer must be freed with `managed_account_free` when no longer needed (when EdDSA is enabled)
 #[no_mangle]
 pub unsafe extern "C" fn managed_account_collection_get_provider_platform_keys(
     collection: *const FFIManagedAccountCollection,
-) -> *mut FFIManagedAccount {
-    if collection.is_null() {
-        return ptr::null_mut();
-    }
-
-    let collection = &*collection;
-    match &collection.collection.provider_platform_keys {
-        Some(account) => {
-            let ffi_account = FFIManagedAccount::new(account);
-            Box::into_raw(Box::new(ffi_account))
+) -> *mut std::os::raw::c_void {
+    #[cfg(feature = "eddsa")]
+    {
+        if collection.is_null() {
+            return ptr::null_mut();
         }
-        None => ptr::null_mut(),
-    }
-}
 
-/// Get the provider platform keys account if it exists (stub when EdDSA is disabled)
-#[cfg(not(feature = "eddsa"))]
-#[no_mangle]
-pub unsafe extern "C" fn managed_account_collection_get_provider_platform_keys(
-    _collection: *const FFIManagedAccountCollection,
-) -> *mut FFIManagedAccount {
-    // EdDSA feature not enabled, always return null
-    ptr::null_mut()
+        let collection = &*collection;
+        match &collection.collection.provider_platform_keys {
+            Some(account) => {
+                let ffi_account = FFIManagedAccount::new(account);
+                Box::into_raw(Box::new(ffi_account)) as *mut std::os::raw::c_void
+            }
+            None => ptr::null_mut(),
+        }
+    }
+
+    #[cfg(not(feature = "eddsa"))]
+    {
+        // EdDSA feature not enabled, always return null
+        let _ = collection; // Avoid unused parameter warning
+        ptr::null_mut()
+    }
 }
 
 /// Check if provider platform keys account exists in managed collection

--- a/key-wallet-ffi/src/managed_wallet.rs
+++ b/key-wallet-ffi/src/managed_wallet.rs
@@ -9,7 +9,7 @@ use std::os::raw::c_char;
 use std::ptr;
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFINetwork, FFIWallet};
+use crate::types::{FFINetworks, FFIWallet};
 use key_wallet::managed_account::address_pool::KeySource;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 
@@ -50,7 +50,7 @@ impl FFIManagedWalletInfo {
 pub unsafe extern "C" fn managed_wallet_get_next_bip44_receive_address(
     managed_wallet: *mut FFIManagedWalletInfo,
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: std::os::raw::c_uint,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -180,7 +180,7 @@ pub unsafe extern "C" fn managed_wallet_get_next_bip44_receive_address(
 pub unsafe extern "C" fn managed_wallet_get_next_bip44_change_address(
     managed_wallet: *mut FFIManagedWalletInfo,
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: std::os::raw::c_uint,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -312,7 +312,7 @@ pub unsafe extern "C" fn managed_wallet_get_next_bip44_change_address(
 pub unsafe extern "C" fn managed_wallet_get_bip_44_external_address_range(
     managed_wallet: *mut FFIManagedWalletInfo,
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: std::os::raw::c_uint,
     start_index: std::os::raw::c_uint,
     end_index: std::os::raw::c_uint,
@@ -506,7 +506,7 @@ pub unsafe extern "C" fn managed_wallet_get_bip_44_external_address_range(
 pub unsafe extern "C" fn managed_wallet_get_bip_44_internal_address_range(
     managed_wallet: *mut FFIManagedWalletInfo,
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: std::os::raw::c_uint,
     start_index: std::os::raw::c_uint,
     end_index: std::os::raw::c_uint,
@@ -774,7 +774,7 @@ pub unsafe extern "C" fn managed_wallet_info_free(wallet_info: *mut FFIManagedWa
 mod tests {
     use crate::error::{FFIError, FFIErrorCode};
     use crate::managed_wallet::*;
-    use crate::types::FFINetwork;
+    use crate::types::FFINetworks;
     use crate::wallet;
     use key_wallet::managed_account::managed_account_type::ManagedAccountType;
     use std::ffi::{CStr, CString};
@@ -802,7 +802,7 @@ mod tests {
             managed_wallet_get_next_bip44_receive_address(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 &mut error,
             )
@@ -821,7 +821,7 @@ mod tests {
             managed_wallet_get_next_bip44_change_address(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 &mut error,
             )
@@ -842,7 +842,7 @@ mod tests {
             managed_wallet_get_bip_44_external_address_range(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 0,
                 10,
@@ -869,7 +869,7 @@ mod tests {
             managed_wallet_get_bip_44_internal_address_range(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 0,
                 10,
@@ -897,7 +897,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -914,7 +914,7 @@ mod tests {
             managed_wallet_get_next_bip44_receive_address(
                 &mut ffi_managed,
                 wallet,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 &mut error,
             )
@@ -941,7 +941,7 @@ mod tests {
             managed_wallet_get_next_bip44_change_address(
                 &mut ffi_managed,
                 wallet,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 &mut error,
             )
@@ -983,7 +983,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -1047,7 +1047,7 @@ mod tests {
             managed_wallet_get_next_bip44_receive_address(
                 &mut ffi_managed,
                 ffi_wallet_ptr,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 &mut error,
             )
@@ -1066,7 +1066,7 @@ mod tests {
             managed_wallet_get_next_bip44_change_address(
                 &mut ffi_managed,
                 ffi_wallet_ptr,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 &mut error,
             )
@@ -1088,7 +1088,7 @@ mod tests {
             managed_wallet_get_bip_44_external_address_range(
                 &mut ffi_managed,
                 ffi_wallet_ptr,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 0,
                 5,
@@ -1122,7 +1122,7 @@ mod tests {
             managed_wallet_get_bip_44_internal_address_range(
                 &mut ffi_managed,
                 ffi_wallet_ptr,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 0,
                 3,
@@ -1169,7 +1169,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -1259,7 +1259,7 @@ mod tests {
             managed_wallet_get_bip_44_external_address_range(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 0,
                 10,
@@ -1278,7 +1278,7 @@ mod tests {
             managed_wallet_get_bip_44_internal_address_range(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 0,
                 10,

--- a/key-wallet-ffi/src/provider_keys.rs
+++ b/key-wallet-ffi/src/provider_keys.rs
@@ -10,7 +10,7 @@ use std::ptr;
 use std::slice;
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFINetwork, FFIWallet};
+use crate::types::{FFINetworks, FFIWallet};
 use key_wallet::AccountType;
 
 /// Provider key type
@@ -58,7 +58,7 @@ pub struct FFIProviderKeyInfo {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_generate_provider_key(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     key_type: FFIProviderKeyType,
     key_index: c_uint,
     include_private: bool,
@@ -265,7 +265,7 @@ pub unsafe extern "C" fn provider_key_info_free(info: *mut FFIProviderKeyInfo) {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_sign_with_provider_key(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     key_type: FFIProviderKeyType,
     _key_index: c_uint,
     data: *const u8,

--- a/key-wallet-ffi/src/transaction.rs
+++ b/key-wallet-ffi/src/transaction.rs
@@ -4,7 +4,7 @@ use std::os::raw::{c_char, c_uint};
 use std::slice;
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFINetwork, FFIWallet};
+use crate::types::{FFINetworks, FFIWallet};
 
 /// Transaction output for building
 #[repr(C)]
@@ -26,7 +26,7 @@ pub struct FFITxOutput {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_build_transaction(
     wallet: *mut FFIWallet,
-    _network: FFINetwork,
+    _network: FFINetworks,
     account_index: c_uint,
     outputs: *const FFITxOutput,
     outputs_count: usize,
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn wallet_build_transaction(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_sign_transaction(
     wallet: *const FFIWallet,
-    _network: FFINetwork,
+    _network: FFINetworks,
     tx_bytes: *const u8,
     tx_len: usize,
     signed_tx_out: *mut *mut u8,
@@ -136,7 +136,7 @@ pub struct FFITransactionCheckResult {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_check_transaction(
     wallet: *mut FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     tx_bytes: *const u8,
     tx_len: usize,
     context_type: FFITransactionContext,

--- a/key-wallet-ffi/src/transaction_checking.rs
+++ b/key-wallet-ffi/src/transaction_checking.rs
@@ -9,7 +9,7 @@ use std::os::raw::{c_char, c_uint};
 use std::slice;
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFINetwork, FFIWallet};
+use crate::types::{FFINetworks, FFIWallet};
 use dashcore::consensus::Decodable;
 use dashcore::Transaction;
 use key_wallet::transaction_checking::{
@@ -125,7 +125,7 @@ pub unsafe extern "C" fn wallet_create_managed_wallet(
 pub unsafe extern "C" fn managed_wallet_check_transaction(
     managed_wallet: *mut FFIManagedWallet,
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     tx_bytes: *const u8,
     tx_len: usize,
     context_type: FFITransactionContext,

--- a/key-wallet-ffi/src/transaction_tests.rs
+++ b/key-wallet-ffi/src/transaction_tests.rs
@@ -3,7 +3,7 @@
 mod transaction_tests {
     use super::super::*;
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::FFINetwork;
+    use crate::types::FFINetworks;
     use crate::wallet;
     use std::ffi::CString;
     use std::ptr;
@@ -23,7 +23,7 @@ mod transaction_tests {
         let success = unsafe {
             wallet_build_transaction(
                 ptr::null_mut(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 &output,
                 1,
@@ -55,7 +55,7 @@ mod transaction_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -66,7 +66,7 @@ mod transaction_tests {
         let success = unsafe {
             wallet_build_transaction(
                 wallet,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 ptr::null(),
                 0,
@@ -97,7 +97,7 @@ mod transaction_tests {
         let success = unsafe {
             wallet_sign_transaction(
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 tx_bytes.as_ptr(),
                 tx_bytes.len(),
                 &mut signed_tx_out,
@@ -122,7 +122,7 @@ mod transaction_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -133,7 +133,7 @@ mod transaction_tests {
         let success = unsafe {
             wallet_sign_transaction(
                 wallet,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 ptr::null(),
                 0,
                 &mut signed_tx_out,
@@ -171,7 +171,7 @@ mod transaction_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -187,7 +187,7 @@ mod transaction_tests {
         let success = unsafe {
             wallet_build_transaction(
                 wallet,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 &output,
                 1,
@@ -221,7 +221,7 @@ mod transaction_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut error,
             )
         };
@@ -233,7 +233,7 @@ mod transaction_tests {
         let success = unsafe {
             wallet_sign_transaction(
                 wallet,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 tx_bytes.as_ptr(),
                 tx_bytes.len(),
                 &mut signed_tx_out,

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 /// FFI Network type (bit flags for multiple networks)
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum FFINetwork {
+pub enum FFINetworks {
     NoNetworks = 0,
     Dash = 1,
     Testnet = 2,
@@ -16,11 +16,11 @@ pub enum FFINetwork {
     AllNetworks = 15, // Dash | Testnet | Regtest | Devnet
 }
 
-impl FFINetwork {
+impl FFINetworks {
     /// Parse bit flags into a vector of networks
     pub fn parse_networks(&self) -> Vec<Network> {
         // Handle special cases
-        if self == &FFINetwork::NoNetworks {
+        if self == &FFINetworks::NoNetworks {
             return vec![];
         }
 
@@ -28,16 +28,16 @@ impl FFINetwork {
 
         let mut networks = Vec::new();
 
-        if flags & (FFINetwork::Dash as c_uint) != 0 {
+        if flags & (FFINetworks::Dash as c_uint) != 0 {
             networks.push(Network::Dash);
         }
-        if flags & (FFINetwork::Testnet as c_uint) != 0 {
+        if flags & (FFINetworks::Testnet as c_uint) != 0 {
             networks.push(Network::Testnet);
         }
-        if flags & (FFINetwork::Regtest as c_uint) != 0 {
+        if flags & (FFINetworks::Regtest as c_uint) != 0 {
             networks.push(Network::Regtest);
         }
-        if flags & (FFINetwork::Devnet as c_uint) != 0 {
+        if flags & (FFINetworks::Devnet as c_uint) != 0 {
             networks.push(Network::Devnet);
         }
 
@@ -45,7 +45,7 @@ impl FFINetwork {
     }
 }
 
-impl FFINetwork {
+impl FFINetworks {
     /// Try to convert to a single Network
     /// Returns None if multiple networks are set or if NoNetworks is set
     pub fn try_into_single_network(&self) -> Option<Network> {
@@ -53,10 +53,10 @@ impl FFINetwork {
 
         // Check if it's a single network
         match flags {
-            x if x == FFINetwork::Dash as c_uint => Some(Network::Dash),
-            x if x == FFINetwork::Testnet as c_uint => Some(Network::Testnet),
-            x if x == FFINetwork::Regtest as c_uint => Some(Network::Regtest),
-            x if x == FFINetwork::Devnet as c_uint => Some(Network::Devnet),
+            x if x == FFINetworks::Dash as c_uint => Some(Network::Dash),
+            x if x == FFINetworks::Testnet as c_uint => Some(Network::Testnet),
+            x if x == FFINetworks::Regtest as c_uint => Some(Network::Regtest),
+            x if x == FFINetworks::Devnet as c_uint => Some(Network::Devnet),
             _ => None, // Multiple networks or NoNetworks
         }
     }
@@ -64,10 +64,10 @@ impl FFINetwork {
 
 use std::convert::TryFrom;
 
-impl TryFrom<FFINetwork> for Network {
+impl TryFrom<FFINetworks> for Network {
     type Error = &'static str;
 
-    fn try_from(value: FFINetwork) -> Result<Self, Self::Error> {
+    fn try_from(value: FFINetworks) -> Result<Self, Self::Error> {
         match value.try_into_single_network() {
             Some(network) => Ok(network),
             None => Err("FFINetwork must represent exactly one network"),
@@ -75,14 +75,14 @@ impl TryFrom<FFINetwork> for Network {
     }
 }
 
-impl From<Network> for FFINetwork {
+impl From<Network> for FFINetworks {
     fn from(n: Network) -> Self {
         match n {
-            Network::Dash => FFINetwork::Dash,
-            Network::Testnet => FFINetwork::Testnet,
-            Network::Regtest => FFINetwork::Regtest,
-            Network::Devnet => FFINetwork::Devnet,
-            _ => FFINetwork::Dash, // Default to Dash for unknown networks
+            Network::Dash => FFINetworks::Dash,
+            Network::Testnet => FFINetworks::Testnet,
+            Network::Regtest => FFINetworks::Regtest,
+            Network::Devnet => FFINetworks::Devnet,
+            _ => FFINetworks::Dash, // Default to Dash for unknown networks
         }
     }
 }

--- a/key-wallet-ffi/src/utxo.rs
+++ b/key-wallet-ffi/src/utxo.rs
@@ -6,7 +6,7 @@ use std::ptr;
 
 use crate::error::{FFIError, FFIErrorCode};
 use crate::managed_wallet::FFIManagedWalletInfo;
-use crate::types::FFINetwork;
+use crate::types::FFINetworks;
 
 /// UTXO structure for FFI
 #[repr(C)]
@@ -88,7 +88,7 @@ impl FFIUTXO {
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_get_utxos(
     managed_info: *const FFIManagedWalletInfo,
-    network: FFINetwork,
+    network: FFINetworks,
     utxos_out: *mut *mut FFIUTXO,
     count_out: *mut usize,
     error: *mut FFIError,
@@ -175,7 +175,7 @@ pub unsafe extern "C" fn managed_wallet_get_utxos(
 #[deprecated(note = "Use managed_wallet_get_utxos with ManagedWalletInfo instead")]
 pub unsafe extern "C" fn wallet_get_utxos(
     _wallet: *const crate::types::FFIWallet,
-    _network: FFINetwork,
+    _network: FFINetworks,
     utxos_out: *mut *mut FFIUTXO,
     count_out: *mut usize,
     error: *mut FFIError,

--- a/key-wallet-ffi/src/utxo_tests.rs
+++ b/key-wallet-ffi/src/utxo_tests.rs
@@ -2,7 +2,7 @@
 mod utxo_tests {
     use super::super::*;
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::FFINetwork;
+    use crate::types::FFINetworks;
     use key_wallet::managed_account::managed_account_type::ManagedAccountType;
     use std::ffi::CStr;
     use std::ptr;
@@ -83,7 +83,7 @@ mod utxo_tests {
             #[allow(deprecated)]
             super::super::wallet_get_utxos(
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut utxos_out,
                 &mut count_out,
                 error,
@@ -106,7 +106,7 @@ mod utxo_tests {
         let result = unsafe {
             super::super::managed_wallet_get_utxos(
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut utxos_out,
                 &mut count_out,
                 error,
@@ -133,7 +133,7 @@ mod utxo_tests {
         let result = unsafe {
             super::super::managed_wallet_get_utxos(
                 &ffi_managed_info,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut utxos_out,
                 &mut count_out,
                 error,
@@ -256,7 +256,7 @@ mod utxo_tests {
         let result = unsafe {
             super::super::managed_wallet_get_utxos(
                 &ffi_managed_info,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut utxos_out,
                 &mut count_out,
                 error,
@@ -429,7 +429,7 @@ mod utxo_tests {
         let result = unsafe {
             super::super::managed_wallet_get_utxos(
                 &ffi_managed_info,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut utxos_out,
                 &mut count_out,
                 error,
@@ -547,7 +547,7 @@ mod utxo_tests {
         let result = unsafe {
             super::super::managed_wallet_get_utxos(
                 &ffi_managed_info,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut utxos_out,
                 &mut count_out,
                 error,
@@ -563,7 +563,7 @@ mod utxo_tests {
         let result = unsafe {
             super::super::managed_wallet_get_utxos(
                 &ffi_managed_info,
-                FFINetwork::Dash,
+                FFINetworks::Dash,
                 &mut utxos_out,
                 &mut count_out,
                 error,
@@ -579,7 +579,7 @@ mod utxo_tests {
         let result = unsafe {
             super::super::managed_wallet_get_utxos(
                 &ffi_managed_info,
-                FFINetwork::Regtest,
+                FFINetworks::Regtest,
                 &mut utxos_out,
                 &mut count_out,
                 error,
@@ -691,7 +691,7 @@ mod utxo_tests {
         let result = unsafe {
             super::super::managed_wallet_get_utxos(
                 &ffi_managed_info,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 ptr::null_mut(),
                 &mut count_out,
                 error,
@@ -705,7 +705,7 @@ mod utxo_tests {
         let result = unsafe {
             super::super::managed_wallet_get_utxos(
                 &ffi_managed_info,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut utxos_out,
                 ptr::null_mut(),
                 error,

--- a/key-wallet-ffi/src/wallet.rs
+++ b/key-wallet-ffi/src/wallet.rs
@@ -13,7 +13,7 @@ use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::{Mnemonic, Network, Seed, Wallet};
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFINetwork, FFIWallet, FFIWalletAccountCreationOptions};
+use crate::types::{FFINetworks, FFIWallet, FFIWalletAccountCreationOptions};
 
 /// Create a new wallet from mnemonic with options
 ///
@@ -29,7 +29,7 @@ use crate::types::{FFINetwork, FFIWallet, FFIWalletAccountCreationOptions};
 pub unsafe extern "C" fn wallet_create_from_mnemonic_with_options(
     mnemonic: *const c_char,
     passphrase: *const c_char,
-    networks: FFINetwork,
+    networks: FFINetworks,
     account_options: *const FFIWalletAccountCreationOptions,
     error: *mut FFIError,
 ) -> *mut FFIWallet {
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn wallet_create_from_mnemonic_with_options(
 pub unsafe extern "C" fn wallet_create_from_mnemonic(
     mnemonic: *const c_char,
     passphrase: *const c_char,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> *mut FFIWallet {
     wallet_create_from_mnemonic_with_options(
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn wallet_create_from_mnemonic(
 pub unsafe extern "C" fn wallet_create_from_seed_with_options(
     seed: *const u8,
     seed_len: usize,
-    networks: FFINetwork,
+    networks: FFINetworks,
     account_options: *const FFIWalletAccountCreationOptions,
     error: *mut FFIError,
 ) -> *mut FFIWallet {
@@ -227,7 +227,7 @@ pub unsafe extern "C" fn wallet_create_from_seed_with_options(
 pub unsafe extern "C" fn wallet_create_from_seed(
     seed: *const u8,
     seed_len: usize,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> *mut FFIWallet {
     wallet_create_from_seed_with_options(
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn wallet_create_from_seed(
 /// - The caller must ensure all pointers remain valid for the duration of this call
 #[no_mangle]
 pub unsafe extern "C" fn wallet_create_random_with_options(
-    networks: FFINetwork,
+    networks: FFINetworks,
     account_options: *const FFIWalletAccountCreationOptions,
     error: *mut FFIError,
 ) -> *mut FFIWallet {
@@ -286,7 +286,7 @@ pub unsafe extern "C" fn wallet_create_random_with_options(
 /// - The caller must ensure the pointer remains valid for the duration of this call
 #[no_mangle]
 pub unsafe extern "C" fn wallet_create_random(
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> *mut FFIWallet {
     wallet_create_random_with_options(
@@ -382,7 +382,7 @@ pub unsafe extern "C" fn wallet_is_watch_only(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_xpub(
     wallet: *const FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: c_uint,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -482,7 +482,7 @@ pub unsafe extern "C" fn wallet_free_const(wallet: *const FFIWallet) {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_add_account(
     wallet: *mut FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_type: crate::types::FFIAccountType,
     account_index: c_uint,
 ) -> crate::types::FFIAccountResult {
@@ -551,7 +551,7 @@ pub unsafe extern "C" fn wallet_add_account(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_add_account_with_xpub_bytes(
     wallet: *mut FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_type: crate::types::FFIAccountType,
     account_index: c_uint,
     xpub_bytes: *const u8,
@@ -649,7 +649,7 @@ pub unsafe extern "C" fn wallet_add_account_with_xpub_bytes(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_add_account_with_string_xpub(
     wallet: *mut FFIWallet,
-    network: FFINetwork,
+    network: FFINetworks,
     account_type: crate::types::FFIAccountType,
     account_index: c_uint,
     xpub_string: *const c_char,

--- a/key-wallet-ffi/src/wallet_manager.rs
+++ b/key-wallet-ffi/src/wallet_manager.rs
@@ -14,7 +14,7 @@ use std::ptr;
 use std::sync::Mutex;
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::FFINetwork;
+use crate::types::FFINetworks;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet::Network;
 use key_wallet_manager::wallet_manager::{WalletId, WalletManager};
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic_with_options(
     manager: *mut FFIWalletManager,
     mnemonic: *const c_char,
     passphrase: *const c_char,
-    network: FFINetwork,
+    network: FFINetworks,
     account_options: *const crate::types::FFIWalletAccountCreationOptions,
     error: *mut FFIError,
 ) -> bool {
@@ -168,7 +168,7 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic(
     manager: *mut FFIWalletManager,
     mnemonic: *const c_char,
     passphrase: *const c_char,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> bool {
     wallet_manager_add_wallet_from_mnemonic_with_options(
@@ -207,7 +207,7 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic_return_serializ
     manager: *mut FFIWalletManager,
     mnemonic: *const c_char,
     passphrase: *const c_char,
-    network: FFINetwork,
+    network: FFINetworks,
     birth_height: c_uint,
     account_options: *const crate::types::FFIWalletAccountCreationOptions,
     downgrade_to_pubkey_wallet: bool,
@@ -656,7 +656,7 @@ pub unsafe extern "C" fn wallet_manager_get_managed_wallet_info(
 pub unsafe extern "C" fn wallet_manager_get_receive_address(
     manager: *mut FFIWalletManager,
     wallet_id: *const u8,
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: c_uint,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -749,7 +749,7 @@ pub unsafe extern "C" fn wallet_manager_get_receive_address(
 pub unsafe extern "C" fn wallet_manager_get_change_address(
     manager: *mut FFIWalletManager,
     wallet_id: *const u8,
-    network: FFINetwork,
+    network: FFINetworks,
     account_index: c_uint,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -922,7 +922,7 @@ pub unsafe extern "C" fn wallet_manager_process_transaction(
     manager: *mut FFIWalletManager,
     tx_bytes: *const u8,
     tx_len: usize,
-    network: FFINetwork,
+    network: FFINetworks,
     context: *const crate::types::FFITransactionContextDetails,
     update_state_if_found: bool,
     error: *mut FFIError,
@@ -1011,7 +1011,7 @@ pub unsafe extern "C" fn wallet_manager_process_transaction(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_manager_get_monitored_addresses(
     manager: *const FFIWalletManager,
-    network: FFINetwork,
+    network: FFINetworks,
     addresses_out: *mut *mut *mut c_char,
     count_out: *mut usize,
     error: *mut FFIError,
@@ -1108,7 +1108,7 @@ pub unsafe extern "C" fn wallet_manager_get_monitored_addresses(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_manager_update_height(
     manager: *mut FFIWalletManager,
-    network: FFINetwork,
+    network: FFINetworks,
     height: c_uint,
     error: *mut FFIError,
 ) -> bool {
@@ -1157,7 +1157,7 @@ pub unsafe extern "C" fn wallet_manager_update_height(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_manager_current_height(
     manager: *const FFIWalletManager,
-    network: FFINetwork,
+    network: FFINetworks,
     error: *mut FFIError,
 ) -> c_uint {
     if manager.is_null() {

--- a/key-wallet-ffi/src/wallet_manager_serialization_tests.rs
+++ b/key-wallet-ffi/src/wallet_manager_serialization_tests.rs
@@ -3,7 +3,7 @@
 #[cfg(all(test, feature = "bincode"))]
 mod tests {
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::{FFINetwork, FFIWalletAccountCreationOptions};
+    use crate::types::{FFINetworks, FFIWalletAccountCreationOptions};
     use crate::wallet_manager;
     use std::ffi::CString;
     use std::ptr;
@@ -32,7 +32,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,           // birth_height
                 ptr::null(), // default account options
                 false,       // don't downgrade to pubkey wallet
@@ -84,7 +84,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 ptr::null(),
                 true,  // downgrade to pubkey wallet
@@ -133,7 +133,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 ptr::null(),
                 true, // downgrade to pubkey wallet
@@ -182,7 +182,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -231,7 +231,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -298,7 +298,7 @@ mod tests {
                 manager,
                 invalid_mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -334,7 +334,7 @@ mod tests {
                 manager,
                 ptr::null(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -390,7 +390,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 &account_options,
                 false,

--- a/key-wallet-ffi/src/wallet_manager_tests.rs
+++ b/key-wallet-ffi/src/wallet_manager_tests.rs
@@ -4,7 +4,7 @@
 #[allow(clippy::module_inception)]
 mod tests {
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::FFINetwork;
+    use crate::types::FFINetworks;
     use crate::{wallet, wallet_manager};
     use std::ffi::{CStr, CString};
     use std::os::raw::c_char;
@@ -54,7 +54,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet, // Create 3 accounts
+                FFINetworks::Testnet, // Create 3 accounts
                 error,
             )
         };
@@ -92,7 +92,7 @@ mod tests {
                     manager,
                     mnemonic.as_ptr(),
                     ptr::null(), // No passphrase
-                    FFINetwork::Testnet,
+                    FFINetworks::Testnet,
                     error,
                 );
                 if !success {
@@ -167,7 +167,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -193,7 +193,7 @@ mod tests {
             wallet_manager::wallet_manager_get_receive_address(
                 manager,
                 wallet_ids,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0, // account_index
                 error,
             )
@@ -209,7 +209,7 @@ mod tests {
             wallet_manager::wallet_manager_get_receive_address(
                 manager,
                 wallet_ids,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 error,
             )
@@ -249,7 +249,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -274,7 +274,7 @@ mod tests {
             wallet_manager::wallet_manager_get_change_address(
                 manager,
                 wallet_ids,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 error,
             )
@@ -305,7 +305,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -367,7 +367,7 @@ mod tests {
         let success = unsafe {
             wallet_manager::wallet_manager_get_monitored_addresses(
                 manager,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut addresses as *mut *mut *mut c_char,
                 &mut count,
                 error,
@@ -385,7 +385,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -412,7 +412,7 @@ mod tests {
                 let addr = wallet_manager::wallet_manager_get_receive_address(
                     manager,
                     wallet_ids,
-                    FFINetwork::Testnet,
+                    FFINetworks::Testnet,
                     0,
                     error,
                 );
@@ -426,7 +426,7 @@ mod tests {
         let success = unsafe {
             wallet_manager::wallet_manager_get_monitored_addresses(
                 manager,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mut addresses as *mut *mut *mut c_char,
                 &mut count,
                 error,
@@ -463,7 +463,7 @@ mod tests {
 
         // Get initial height
         let height = unsafe {
-            wallet_manager::wallet_manager_current_height(manager, FFINetwork::Testnet, error)
+            wallet_manager::wallet_manager_current_height(manager, FFINetworks::Testnet, error)
         };
         assert_eq!(height, 0);
 
@@ -471,7 +471,7 @@ mod tests {
         let success = unsafe {
             wallet_manager::wallet_manager_update_height(
                 manager,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 100000,
                 error,
             )
@@ -480,7 +480,7 @@ mod tests {
 
         // Verify height was updated
         let height = unsafe {
-            wallet_manager::wallet_manager_current_height(manager, FFINetwork::Testnet, error)
+            wallet_manager::wallet_manager_current_height(manager, FFINetworks::Testnet, error)
         };
         assert_eq!(height, 100000);
 
@@ -510,7 +510,7 @@ mod tests {
                 manager,
                 invalid_mnemonic.as_ptr(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -545,7 +545,7 @@ mod tests {
                     manager,
                     mnemonic.as_ptr(),
                     ptr::null(),         // No passphrase
-                    FFINetwork::Testnet, // 2 accounts per wallet
+                    FFINetworks::Testnet, // 2 accounts per wallet
                     error,
                 );
                 assert!(success);
@@ -579,7 +579,7 @@ mod tests {
                 let addr = wallet_manager::wallet_manager_get_receive_address(
                     manager,
                     wallet_id,
-                    FFINetwork::Testnet,
+                    FFINetworks::Testnet,
                     0,
                     error,
                 );
@@ -616,7 +616,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet, // account_count
+                FFINetworks::Testnet, // account_count
                 error,
             )
         };
@@ -648,7 +648,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -703,7 +703,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -727,7 +727,7 @@ mod tests {
             wallet_manager::wallet_manager_get_change_address(
                 manager,
                 wallet_ids,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0, // address_index
                 error,
             )
@@ -767,7 +767,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -848,7 +848,7 @@ mod tests {
                 ptr::null_mut(),
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet, // account_count
+                FFINetworks::Testnet, // account_count
                 error,
             )
         };
@@ -873,7 +873,7 @@ mod tests {
 
         // Get initial height
         let _height = unsafe {
-            wallet_manager::wallet_manager_current_height(manager, FFINetwork::Testnet, error)
+            wallet_manager::wallet_manager_current_height(manager, FFINetworks::Testnet, error)
         };
 
         // Update height
@@ -881,7 +881,7 @@ mod tests {
         unsafe {
             wallet_manager::wallet_manager_update_height(
                 manager,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 new_height,
                 error,
             );
@@ -889,7 +889,7 @@ mod tests {
 
         // Get updated height
         let current_height = unsafe {
-            wallet_manager::wallet_manager_current_height(manager, FFINetwork::Testnet, error)
+            wallet_manager::wallet_manager_current_height(manager, FFINetworks::Testnet, error)
         };
         assert_eq!(current_height, new_height);
 
@@ -916,7 +916,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -1036,7 +1036,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -1072,7 +1072,7 @@ mod tests {
                 manager,
                 tx_bytes.as_ptr(),
                 tx_bytes.len(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mempool_context,
                 false,
                 error,
@@ -1089,7 +1089,7 @@ mod tests {
                 manager,
                 tx_bytes.as_ptr(),
                 tx_bytes.len(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &block_context,
                 false,
                 error,
@@ -1110,7 +1110,7 @@ mod tests {
                 manager,
                 tx_bytes.as_ptr(),
                 tx_bytes.len(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &chain_locked_context,
                 true,
                 error,
@@ -1125,7 +1125,7 @@ mod tests {
                 ptr::null_mut(),
                 tx_bytes.as_ptr(),
                 tx_bytes.len(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mempool_context,
                 false,
                 error,
@@ -1140,7 +1140,7 @@ mod tests {
                 manager,
                 ptr::null(),
                 10,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mempool_context,
                 false,
                 error,
@@ -1155,7 +1155,7 @@ mod tests {
                 manager,
                 tx_bytes.as_ptr(),
                 0,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mempool_context,
                 false,
                 error,
@@ -1171,7 +1171,7 @@ mod tests {
                 manager,
                 invalid_tx.as_ptr(),
                 invalid_tx.len(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 &mempool_context,
                 false,
                 error,
@@ -1203,7 +1203,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -1318,7 +1318,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,           // birth_height
                 ptr::null(), // default account options
                 false,       // don't downgrade to pubkey wallet
@@ -1360,7 +1360,7 @@ mod tests {
                 manager2,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 ptr::null(),
                 true,  // downgrade to pubkey wallet
@@ -1431,7 +1431,7 @@ mod tests {
                 manager4,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 ptr::null(),
                 true, // downgrade to pubkey wallet
@@ -1471,7 +1471,7 @@ mod tests {
                 manager5,
                 invalid_mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -1519,7 +1519,7 @@ mod tests {
                 manager1,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 100,         // birth_height
                 ptr::null(), // default account options
                 false,       // don't downgrade to pubkey wallet

--- a/key-wallet-ffi/src/wallet_manager_tests.rs
+++ b/key-wallet-ffi/src/wallet_manager_tests.rs
@@ -544,7 +544,7 @@ mod tests {
                 let success = wallet_manager::wallet_manager_add_wallet_from_mnemonic(
                     manager,
                     mnemonic.as_ptr(),
-                    ptr::null(),         // No passphrase
+                    ptr::null(),          // No passphrase
                     FFINetworks::Testnet, // 2 accounts per wallet
                     error,
                 );

--- a/key-wallet-ffi/src/wallet_tests.rs
+++ b/key-wallet-ffi/src/wallet_tests.rs
@@ -4,7 +4,7 @@
 mod wallet_tests {
     use crate::account::account_free;
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::{FFIAccountType, FFINetwork};
+    use crate::types::{FFIAccountType, FFINetworks};
     use crate::wallet;
     use std::ffi::CString;
     use std::ptr;
@@ -23,7 +23,7 @@ mod wallet_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -45,7 +45,7 @@ mod wallet_tests {
         let seed = [0x01u8; 64];
 
         let wallet = unsafe {
-            wallet::wallet_create_from_seed(seed.as_ptr(), seed.len(), FFINetwork::Testnet, error)
+            wallet::wallet_create_from_seed(seed.as_ptr(), seed.len(), FFINetworks::Testnet, error)
         };
 
         assert!(!wallet.is_null());
@@ -63,7 +63,7 @@ mod wallet_tests {
         let error = &mut error as *mut FFIError;
 
         // Test random wallet creation
-        let random_wallet = unsafe { wallet::wallet_create_random(FFINetwork::Testnet, error) };
+        let random_wallet = unsafe { wallet::wallet_create_random(FFINetworks::Testnet, error) };
         assert!(!random_wallet.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::Success);
 
@@ -90,7 +90,7 @@ mod wallet_tests {
                 let wallet = wallet::wallet_create_from_seed(
                     seed.as_ptr(),
                     seed.len(),
-                    FFINetwork::Testnet,
+                    FFINetworks::Testnet,
                     error,
                 );
 
@@ -115,7 +115,7 @@ mod wallet_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -139,7 +139,7 @@ mod wallet_tests {
             wallet::wallet_create_from_mnemonic(
                 ptr::null(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -152,7 +152,7 @@ mod wallet_tests {
             wallet::wallet_create_from_mnemonic(
                 invalid_mnemonic.as_ptr(),
                 ptr::null(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -161,7 +161,7 @@ mod wallet_tests {
 
         // Test with null seed
         let wallet =
-            unsafe { wallet::wallet_create_from_seed(ptr::null(), 64, FFINetwork::Testnet, error) };
+            unsafe { wallet::wallet_create_from_seed(ptr::null(), 64, FFINetworks::Testnet, error) };
         assert!(wallet.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidInput);
     }
@@ -171,7 +171,7 @@ mod wallet_tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let wallet = unsafe { wallet::wallet_create_random(FFINetwork::Testnet, error) };
+        let wallet = unsafe { wallet::wallet_create_random(FFINetworks::Testnet, error) };
         assert!(!wallet.is_null());
 
         // Get wallet ID
@@ -205,7 +205,7 @@ mod wallet_tests {
             wallet::wallet_create_from_seed(
                 seed_bytes.as_ptr(),
                 seed_bytes.len(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -226,7 +226,7 @@ mod wallet_tests {
 
         // Test with null seed bytes
         let wallet =
-            unsafe { wallet::wallet_create_from_seed(ptr::null(), 64, FFINetwork::Testnet, error) };
+            unsafe { wallet::wallet_create_from_seed(ptr::null(), 64, FFINetworks::Testnet, error) };
 
         assert!(wallet.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidInput);
@@ -245,7 +245,7 @@ mod wallet_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -278,14 +278,14 @@ mod wallet_tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let wallet = unsafe { wallet::wallet_create_random(FFINetwork::Testnet, error) };
+        let wallet = unsafe { wallet::wallet_create_random(FFINetworks::Testnet, error) };
         assert!(!wallet.is_null());
 
         // Test adding account - check if it succeeds or fails gracefully
         let result = unsafe {
             wallet::wallet_add_account(
                 wallet,
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 FFIAccountType::StandardBIP44,
                 1,
             )
@@ -320,7 +320,7 @@ mod wallet_tests {
         let result = unsafe {
             wallet::wallet_add_account(
                 ptr::null_mut(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 FFIAccountType::StandardBIP44,
                 0,
             )
@@ -347,7 +347,7 @@ mod wallet_tests {
             wallet::wallet_create_from_seed(
                 normal_seed.as_ptr(),
                 normal_seed.len(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -362,7 +362,7 @@ mod wallet_tests {
             wallet::wallet_create_from_seed(
                 large_seed.as_ptr(),
                 large_seed.len(),
-                FFINetwork::Testnet,
+                FFINetworks::Testnet,
                 error,
             )
         };
@@ -379,11 +379,11 @@ mod wallet_tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let wallet = unsafe { wallet::wallet_create_random(FFINetwork::Testnet, error) };
+        let wallet = unsafe { wallet::wallet_create_random(FFINetworks::Testnet, error) };
         assert!(!wallet.is_null());
 
         // Get xpub for account 0
-        let xpub = unsafe { wallet::wallet_get_xpub(wallet, FFINetwork::Testnet, 0, error) };
+        let xpub = unsafe { wallet::wallet_get_xpub(wallet, FFINetworks::Testnet, 0, error) };
         assert!(!xpub.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::Success);
 
@@ -404,7 +404,7 @@ mod wallet_tests {
         let error = &mut error as *mut FFIError;
 
         // Test with null wallet
-        let xpub = unsafe { wallet::wallet_get_xpub(ptr::null(), FFINetwork::Testnet, 0, error) };
+        let xpub = unsafe { wallet::wallet_get_xpub(ptr::null(), FFINetworks::Testnet, 0, error) };
         assert!(xpub.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidInput);
     }

--- a/key-wallet-ffi/src/wallet_tests.rs
+++ b/key-wallet-ffi/src/wallet_tests.rs
@@ -160,8 +160,9 @@ mod wallet_tests {
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidMnemonic);
 
         // Test with null seed
-        let wallet =
-            unsafe { wallet::wallet_create_from_seed(ptr::null(), 64, FFINetworks::Testnet, error) };
+        let wallet = unsafe {
+            wallet::wallet_create_from_seed(ptr::null(), 64, FFINetworks::Testnet, error)
+        };
         assert!(wallet.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidInput);
     }
@@ -225,8 +226,9 @@ mod wallet_tests {
         let error = &mut error as *mut FFIError;
 
         // Test with null seed bytes
-        let wallet =
-            unsafe { wallet::wallet_create_from_seed(ptr::null(), 64, FFINetworks::Testnet, error) };
+        let wallet = unsafe {
+            wallet::wallet_create_from_seed(ptr::null(), 64, FFINetworks::Testnet, error)
+        };
 
         assert!(wallet.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidInput);

--- a/key-wallet-ffi/tests/debug_wallet_add.rs
+++ b/key-wallet-ffi/tests/debug_wallet_add.rs
@@ -1,7 +1,7 @@
 #[test]
 fn test_debug_wallet_add() {
     use key_wallet_ffi::error::FFIError;
-    use key_wallet_ffi::types::FFINetwork;
+    use key_wallet_ffi::types::FFINetworks;
     use key_wallet_ffi::wallet_manager;
     use std::ffi::CString;
 
@@ -21,7 +21,7 @@ fn test_debug_wallet_add() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };

--- a/key-wallet-ffi/tests/integration_test.rs
+++ b/key-wallet-ffi/tests/integration_test.rs
@@ -3,7 +3,7 @@
 //! These tests verify the interaction between different FFI modules
 
 use key_wallet_ffi::error::{FFIError, FFIErrorCode};
-use key_wallet_ffi::types::FFINetwork;
+use key_wallet_ffi::types::FFINetworks;
 use std::ffi::CString;
 use std::ptr;
 
@@ -35,7 +35,7 @@ fn test_full_wallet_workflow() {
             manager,
             mnemonic,
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };
@@ -62,7 +62,7 @@ fn test_full_wallet_workflow() {
         key_wallet_ffi::wallet_manager::wallet_manager_get_receive_address(
             manager,
             wallet_id,
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             error,
         )
@@ -73,7 +73,7 @@ fn test_full_wallet_workflow() {
         key_wallet_ffi::wallet_manager::wallet_manager_get_change_address(
             manager,
             wallet_id,
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0,
             error,
         )
@@ -135,7 +135,7 @@ fn test_seed_to_wallet_workflow() {
         key_wallet_ffi::wallet::wallet_create_from_seed(
             seed.as_ptr(),
             seed_len,
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };
@@ -157,7 +157,7 @@ fn test_derivation_paths() {
 
     // Account path
     let success = key_wallet_ffi::derivation::derivation_bip44_account_path(
-        FFINetwork::Dash,
+        FFINetworks::Dash,
         0,
         path_buffer.as_mut_ptr() as *mut std::os::raw::c_char,
         path_buffer.len(),
@@ -175,7 +175,7 @@ fn test_derivation_paths() {
     // Payment path
     path_buffer.fill(0);
     let success = key_wallet_ffi::derivation::derivation_bip44_payment_path(
-        FFINetwork::Dash,
+        FFINetworks::Dash,
         0,
         false,
         5,
@@ -206,7 +206,7 @@ fn test_error_handling() {
         key_wallet_ffi::wallet::wallet_create_from_mnemonic(
             invalid_mnemonic.as_ptr(),
             ptr::null(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };
@@ -218,7 +218,7 @@ fn test_error_handling() {
         key_wallet_ffi::wallet::wallet_create_from_mnemonic(
             ptr::null(),
             ptr::null(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };
@@ -231,7 +231,7 @@ fn test_error_handling() {
         key_wallet_ffi::wallet::wallet_create_from_seed(
             invalid_seed.as_ptr(),
             invalid_seed.len(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };

--- a/key-wallet-ffi/tests/test_account_collection.rs
+++ b/key-wallet-ffi/tests/test_account_collection.rs
@@ -3,7 +3,7 @@
 use key_wallet_ffi::account::account_free;
 use key_wallet_ffi::account_collection::*;
 use key_wallet_ffi::types::{
-    FFIAccountCreationOptionType, FFINetwork, FFIWalletAccountCreationOptions,
+    FFIAccountCreationOptionType, FFINetworks, FFIWalletAccountCreationOptions,
 };
 use key_wallet_ffi::wallet::{wallet_create_from_mnemonic_with_options, wallet_free};
 use std::ffi::CString;
@@ -35,7 +35,7 @@ fn test_account_collection_comprehensive() {
         let wallet = wallet_create_from_mnemonic_with_options(
             mnemonic.as_ptr(),
             ptr::null(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             &account_options,
             ptr::null_mut(),
         );
@@ -43,7 +43,7 @@ fn test_account_collection_comprehensive() {
 
         // Get account collection for testnet
         let collection =
-            wallet_get_account_collection(wallet, FFINetwork::Testnet, ptr::null_mut());
+            wallet_get_account_collection(wallet, FFINetworks::Testnet, ptr::null_mut());
         assert!(!collection.is_null());
 
         // Test account count
@@ -153,7 +153,7 @@ fn test_account_collection_minimal() {
         let wallet = wallet_create_from_mnemonic_with_options(
             mnemonic.as_ptr(),
             ptr::null(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             ptr::null(), // Use default options
             ptr::null_mut(),
         );
@@ -161,7 +161,7 @@ fn test_account_collection_minimal() {
 
         // Get account collection
         let collection =
-            wallet_get_account_collection(wallet, FFINetwork::Testnet, ptr::null_mut());
+            wallet_get_account_collection(wallet, FFINetworks::Testnet, ptr::null_mut());
         assert!(!collection.is_null());
 
         // Should have at least some default accounts

--- a/key-wallet-ffi/tests/test_addr_simple.rs
+++ b/key-wallet-ffi/tests/test_addr_simple.rs
@@ -1,7 +1,7 @@
 #[test]
 fn test_address_simple() {
     use key_wallet_ffi::error::FFIError;
-    use key_wallet_ffi::types::FFINetwork;
+    use key_wallet_ffi::types::FFINetworks;
 
     let mut error = FFIError::success();
     let error = &mut error as *mut FFIError;
@@ -12,7 +12,7 @@ fn test_address_simple() {
         key_wallet_ffi::wallet::wallet_create_from_seed(
             seed.as_ptr(),
             seed.len(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };

--- a/key-wallet-ffi/tests/test_import_wallet.rs
+++ b/key-wallet-ffi/tests/test_import_wallet.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 mod tests {
     use key_wallet_ffi::error::{FFIError, FFIErrorCode};
-    use key_wallet_ffi::types::FFINetwork;
+    use key_wallet_ffi::types::FFINetworks;
     use key_wallet_ffi::wallet_manager::*;
     use std::ptr;
 
@@ -25,7 +25,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr() as *const i8,
                 passphrase.as_ptr() as *const i8,
-                FFINetwork::Dash,
+                FFINetworks::Dash,
                 &mut error,
             );
             assert!(success);

--- a/key-wallet-ffi/tests/test_managed_account_collection.rs
+++ b/key-wallet-ffi/tests/test_managed_account_collection.rs
@@ -3,7 +3,7 @@
 use key_wallet_ffi::error::{FFIError, FFIErrorCode};
 use key_wallet_ffi::managed_account_collection::*;
 use key_wallet_ffi::types::{
-    FFIAccountCreationOptionType, FFINetwork, FFIWalletAccountCreationOptions,
+    FFIAccountCreationOptionType, FFINetworks, FFIWalletAccountCreationOptions,
 };
 use key_wallet_ffi::wallet_manager::{
     wallet_manager_add_wallet_from_mnemonic_with_options, wallet_manager_create,
@@ -33,7 +33,7 @@ fn test_managed_account_collection_basic() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             ptr::null(), // Use default options
             &mut error,
         );
@@ -54,7 +54,7 @@ fn test_managed_account_collection_basic() {
         let collection = managed_wallet_get_account_collection(
             manager,
             wallet_ids_out,
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             &mut error,
         );
         assert!(!collection.is_null());
@@ -138,7 +138,7 @@ fn test_managed_account_collection_with_special_accounts() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             &options,
             &mut error,
         );
@@ -157,7 +157,7 @@ fn test_managed_account_collection_with_special_accounts() {
         let collection = managed_wallet_get_account_collection(
             manager,
             wallet_ids_out,
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             &mut error,
         );
         assert!(!collection.is_null());
@@ -263,7 +263,7 @@ fn test_managed_account_collection_summary() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             &options,
             &mut error,
         );
@@ -282,7 +282,7 @@ fn test_managed_account_collection_summary() {
         let collection = managed_wallet_get_account_collection(
             manager,
             wallet_ids_out,
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             &mut error,
         );
         assert!(!collection.is_null());
@@ -357,7 +357,7 @@ fn test_managed_account_collection_summary_data() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             &options,
             &mut error,
         );
@@ -376,7 +376,7 @@ fn test_managed_account_collection_summary_data() {
         let collection = managed_wallet_get_account_collection(
             manager,
             wallet_ids_out,
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             &mut error,
         );
         assert!(!collection.is_null());
@@ -427,7 +427,7 @@ fn test_managed_account_collection_null_safety() {
         let collection = managed_wallet_get_account_collection(
             ptr::null(),
             ptr::null(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             &mut error,
         );
         assert!(collection.is_null());
@@ -463,7 +463,7 @@ fn test_managed_account_collection_nonexistent_accounts() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             ptr::null(), // Default options
             &mut error,
         );
@@ -482,7 +482,7 @@ fn test_managed_account_collection_nonexistent_accounts() {
         let collection = managed_wallet_get_account_collection(
             manager,
             wallet_ids_out,
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             &mut error,
         );
         assert!(!collection.is_null());
@@ -524,7 +524,7 @@ fn test_managed_account_collection_wrong_network() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             ptr::null(),
             &mut error,
         );
@@ -543,7 +543,7 @@ fn test_managed_account_collection_wrong_network() {
         let collection = managed_wallet_get_account_collection(
             manager,
             wallet_ids_out,
-            FFINetwork::Dash, // Wrong network (mainnet)
+            FFINetworks::Dash, // Wrong network (mainnet)
             &mut error,
         );
 

--- a/key-wallet-ffi/tests/test_passphrase_wallets.rs
+++ b/key-wallet-ffi/tests/test_passphrase_wallets.rs
@@ -2,7 +2,7 @@
 //! These tests demonstrate current issues with passphrase handling in the FFI layer
 
 use key_wallet_ffi::error::{FFIError, FFIErrorCode};
-use key_wallet_ffi::types::FFINetwork;
+use key_wallet_ffi::types::FFINetworks;
 use std::ffi::{CStr, CString};
 
 #[test]
@@ -20,7 +20,7 @@ fn test_ffi_wallet_create_from_mnemonic_with_passphrase() {
         key_wallet_ffi::wallet::wallet_create_from_mnemonic(
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };
@@ -69,7 +69,7 @@ fn test_ffi_wallet_manager_add_wallet_with_passphrase() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet, // account_count (ignored)
+            FFINetworks::Testnet, // account_count (ignored)
             error,
         )
     };
@@ -99,7 +99,7 @@ fn test_ffi_wallet_manager_add_wallet_with_passphrase() {
         key_wallet_ffi::wallet_manager::wallet_manager_get_receive_address(
             manager,
             wallet_ids_ptr, // First wallet ID
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             0, // account_index
             error,
         )
@@ -146,7 +146,7 @@ fn test_ffi_wallet_with_passphrase_ideal_workflow() {
         key_wallet_ffi::wallet::wallet_create_from_mnemonic(
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };
@@ -185,7 +185,7 @@ fn test_demonstrate_passphrase_issue_with_account_creation() {
         key_wallet_ffi::wallet::wallet_create_from_mnemonic(
             mnemonic.as_ptr(),
             empty_passphrase.as_ptr(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };
@@ -196,7 +196,7 @@ fn test_demonstrate_passphrase_issue_with_account_creation() {
         key_wallet_ffi::wallet::wallet_create_from_mnemonic(
             mnemonic.as_ptr(),
             actual_passphrase.as_ptr(),
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };
@@ -206,7 +206,7 @@ fn test_demonstrate_passphrase_issue_with_account_creation() {
     let count_no_pass = unsafe {
         key_wallet_ffi::account::wallet_get_account_count(
             wallet_no_pass,
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };
@@ -214,7 +214,7 @@ fn test_demonstrate_passphrase_issue_with_account_creation() {
     let count_with_pass = unsafe {
         key_wallet_ffi::account::wallet_get_account_count(
             wallet_with_pass,
-            FFINetwork::Testnet,
+            FFINetworks::Testnet,
             error,
         )
     };

--- a/swift-dash-core-sdk/Sources/DashSPVFFI/include/dash_spv_ffi.h
+++ b/swift-dash-core-sdk/Sources/DashSPVFFI/include/dash_spv_ffi.h
@@ -32,12 +32,12 @@ typedef enum FFIValidationMode {
   Full = 2,
 } FFIValidationMode;
 
-typedef struct FFIClientConfig FFIClientConfig;
-
 /**
  * FFIDashSpvClient structure
  */
 typedef struct FFIDashSpvClient FFIDashSpvClient;
+
+typedef ClientConfig FFIClientConfig;
 
 typedef struct FFIString {
   char *ptr;
@@ -100,6 +100,8 @@ typedef struct FFIArray {
   void *data;
   uintptr_t len;
   uintptr_t capacity;
+  uintptr_t elem_size;
+  uintptr_t elem_align;
 } FFIArray;
 
 typedef void (*BlockCallback)(uint32_t height, const uint8_t (*hash)[32], void *user_data);
@@ -209,7 +211,7 @@ typedef struct FFIUnconfirmedTransaction {
   uintptr_t addresses_len;
 } FFIUnconfirmedTransaction;
 
-struct FFIDashSpvClient *dash_spv_ffi_client_new(const struct FFIClientConfig *config);
+struct FFIDashSpvClient *dash_spv_ffi_client_new(const FFIClientConfig *config);
 
 int32_t dash_spv_ffi_client_start(struct FFIDashSpvClient *client);
 
@@ -318,7 +320,7 @@ FFIBalance *dash_spv_ffi_client_get_address_balance(struct FFIDashSpvClient *cli
 struct FFIArray *dash_spv_ffi_client_get_utxos(struct FFIDashSpvClient *client);
 
 struct FFIArray *dash_spv_ffi_client_get_utxos_for_address(struct FFIDashSpvClient *client,
-                                                          const char *address);
+                                                           const char *address);
 
 int32_t dash_spv_ffi_client_set_event_callbacks(struct FFIDashSpvClient *client,
                                                 struct FFIEventCallbacks callbacks);
@@ -338,7 +340,7 @@ int32_t dash_spv_ffi_client_watch_script(struct FFIDashSpvClient *client, const 
 int32_t dash_spv_ffi_client_unwatch_script(struct FFIDashSpvClient *client, const char *script_hex);
 
 struct FFIArray *dash_spv_ffi_client_get_address_history(struct FFIDashSpvClient *client,
-                                                        const char *address);
+                                                         const char *address);
 
 struct FFITransaction *dash_spv_ffi_client_get_transaction(struct FFIDashSpvClient *client,
                                                            const char *txid);
@@ -364,7 +366,7 @@ int32_t dash_spv_ffi_client_is_transaction_confirmed(struct FFIDashSpvClient *cl
 void dash_spv_ffi_transaction_destroy(struct FFITransaction *tx);
 
 struct FFIArray *dash_spv_ffi_client_get_address_utxos(struct FFIDashSpvClient *client,
-                                                      const char *address);
+                                                       const char *address);
 
 int32_t dash_spv_ffi_client_enable_mempool_tracking(struct FFIDashSpvClient *client,
                                                     enum FFIMempoolStrategy strategy);
@@ -378,57 +380,54 @@ int32_t dash_spv_ffi_client_record_send(struct FFIDashSpvClient *client, const c
 FFIBalance *dash_spv_ffi_client_get_mempool_balance(struct FFIDashSpvClient *client,
                                                     const char *address);
 
-struct FFIClientConfig *dash_spv_ffi_config_new(enum FFINetwork network);
+FFIClientConfig *dash_spv_ffi_config_new(enum FFINetwork network);
 
-struct FFIClientConfig *dash_spv_ffi_config_mainnet(void);
+FFIClientConfig *dash_spv_ffi_config_mainnet(void);
 
-struct FFIClientConfig *dash_spv_ffi_config_testnet(void);
+FFIClientConfig *dash_spv_ffi_config_testnet(void);
 
-int32_t dash_spv_ffi_config_set_data_dir(struct FFIClientConfig *config, const char *path);
+int32_t dash_spv_ffi_config_set_data_dir(FFIClientConfig *config, const char *path);
 
-int32_t dash_spv_ffi_config_set_validation_mode(struct FFIClientConfig *config,
+int32_t dash_spv_ffi_config_set_validation_mode(FFIClientConfig *config,
                                                 enum FFIValidationMode mode);
 
-int32_t dash_spv_ffi_config_set_max_peers(struct FFIClientConfig *config, uint32_t max_peers);
+int32_t dash_spv_ffi_config_set_max_peers(FFIClientConfig *config, uint32_t max_peers);
 
-int32_t dash_spv_ffi_config_add_peer(struct FFIClientConfig *config, const char *addr);
+int32_t dash_spv_ffi_config_add_peer(FFIClientConfig *config, const char *addr);
 
-int32_t dash_spv_ffi_config_set_user_agent(struct FFIClientConfig *config, const char *user_agent);
+int32_t dash_spv_ffi_config_set_user_agent(FFIClientConfig *config, const char *user_agent);
 
-int32_t dash_spv_ffi_config_set_relay_transactions(struct FFIClientConfig *config, bool _relay);
+int32_t dash_spv_ffi_config_set_relay_transactions(FFIClientConfig *config, bool _relay);
 
-int32_t dash_spv_ffi_config_set_filter_load(struct FFIClientConfig *config, bool load_filters);
+int32_t dash_spv_ffi_config_set_filter_load(FFIClientConfig *config, bool load_filters);
 
-enum FFINetwork dash_spv_ffi_config_get_network(const struct FFIClientConfig *config);
+enum FFINetwork dash_spv_ffi_config_get_network(const FFIClientConfig *config);
 
-struct FFIString dash_spv_ffi_config_get_data_dir(const struct FFIClientConfig *config);
+struct FFIString dash_spv_ffi_config_get_data_dir(const FFIClientConfig *config);
 
-void dash_spv_ffi_config_destroy(struct FFIClientConfig *config);
+void dash_spv_ffi_config_destroy(FFIClientConfig *config);
 
-int32_t dash_spv_ffi_config_set_mempool_tracking(struct FFIClientConfig *config, bool enable);
+int32_t dash_spv_ffi_config_set_mempool_tracking(FFIClientConfig *config, bool enable);
 
-int32_t dash_spv_ffi_config_set_mempool_strategy(struct FFIClientConfig *config,
+int32_t dash_spv_ffi_config_set_mempool_strategy(FFIClientConfig *config,
                                                  enum FFIMempoolStrategy strategy);
 
-int32_t dash_spv_ffi_config_set_max_mempool_transactions(struct FFIClientConfig *config,
+int32_t dash_spv_ffi_config_set_max_mempool_transactions(FFIClientConfig *config,
                                                          uint32_t max_transactions);
 
-int32_t dash_spv_ffi_config_set_mempool_timeout(struct FFIClientConfig *config,
-                                                uint64_t timeout_secs);
+int32_t dash_spv_ffi_config_set_mempool_timeout(FFIClientConfig *config, uint64_t timeout_secs);
 
-int32_t dash_spv_ffi_config_set_fetch_mempool_transactions(struct FFIClientConfig *config,
-                                                           bool fetch);
+int32_t dash_spv_ffi_config_set_fetch_mempool_transactions(FFIClientConfig *config, bool fetch);
 
-int32_t dash_spv_ffi_config_set_persist_mempool(struct FFIClientConfig *config, bool persist);
+int32_t dash_spv_ffi_config_set_persist_mempool(FFIClientConfig *config, bool persist);
 
-bool dash_spv_ffi_config_get_mempool_tracking(const struct FFIClientConfig *config);
+bool dash_spv_ffi_config_get_mempool_tracking(const FFIClientConfig *config);
 
-enum FFIMempoolStrategy dash_spv_ffi_config_get_mempool_strategy(const struct FFIClientConfig *config);
+enum FFIMempoolStrategy dash_spv_ffi_config_get_mempool_strategy(const FFIClientConfig *config);
 
-int32_t dash_spv_ffi_config_set_start_from_height(struct FFIClientConfig *config, uint32_t height);
+int32_t dash_spv_ffi_config_set_start_from_height(FFIClientConfig *config, uint32_t height);
 
-int32_t dash_spv_ffi_config_set_wallet_creation_time(struct FFIClientConfig *config,
-                                                     uint32_t timestamp);
+int32_t dash_spv_ffi_config_set_wallet_creation_time(FFIClientConfig *config, uint32_t timestamp);
 
 const char *dash_spv_ffi_get_last_error(void);
 
@@ -489,6 +488,16 @@ struct FFIResult ffi_dash_spv_get_platform_activation_height(struct FFIDashSpvCl
 void dash_spv_ffi_string_destroy(struct FFIString s);
 
 void dash_spv_ffi_array_destroy(struct FFIArray *arr);
+
+/**
+ * Destroy an array of FFIString pointers (Vec<*mut FFIString>) and their contents.
+ *
+ * This function:
+ * - Iterates the array elements as pointers to FFIString and destroys each via dash_spv_ffi_string_destroy
+ * - Frees the underlying vector buffer stored in FFIArray
+ * - Does not free the FFIArray struct itself (safe for both stack- and heap-allocated structs)
+ */
+void dash_spv_ffi_string_array_destroy(struct FFIArray *arr);
 
 /**
  * Destroys the raw transaction bytes allocated for an FFIUnconfirmedTransaction


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Multi-network (bit-flag) support across wallet, manager, address, derivation, transaction, and UTXO APIs.
  - Added utilities to clear the last error and destroy string arrays.
  - Enhanced array metadata with element size and alignment.
  - Simplified Swift FFI config type via a new alias.
  - Provider key getters now return a nullable opaque handle consistently.

- Refactor
  - Renamed the public network enum and updated all affected API signatures.
  - Standardized behavior to return null when optional features are disabled.

- Tests
  - Updated test suites to align with the new API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->