### PR TITLE
feat: update DNS resolver to hickory_resolver

### DIFF
--- a/dash-spv/Cargo.toml
+++ b/dash-spv/Cargo.toml
@@ -46,8 +46,8 @@ indexmap = "2.0"
 # Terminal UI
 crossterm = "0.27"
 
-# DNS
-trust-dns-resolver = "0.23"
+# DNS (trust-dns-resolver was renamed to hickory_resolver)
+hickory-resolver = "0.25"
 
 # Also add log to main dependencies for consistency
 log = "0.4"

--- a/dash-spv/src/network/discovery.rs
+++ b/dash-spv/src/network/discovery.rs
@@ -1,10 +1,10 @@
 //! DNS-based peer discovery for Dash network
 
 use dashcore::Network;
-use std::net::{IpAddr, SocketAddr};
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hickory_resolver::name_server::TokioConnectionProvider;
 use hickory_resolver::TokioResolver;
+use std::net::{IpAddr, SocketAddr};
 
 use crate::error::SpvError as Error;
 use crate::network::constants::{MAINNET_DNS_SEEDS, TESTNET_DNS_SEEDS};
@@ -24,7 +24,9 @@ impl DnsDiscovery {
         .with_options(ResolverOpts::default())
         .build();
 
-        Ok(Self { resolver })
+        Ok(Self {
+            resolver,
+        })
     }
 
     /// Discover peers for the given network

--- a/dash-spv/src/network/discovery.rs
+++ b/dash-spv/src/network/discovery.rs
@@ -2,26 +2,29 @@
 
 use dashcore::Network;
 use std::net::{IpAddr, SocketAddr};
-use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
-use trust_dns_resolver::TokioAsyncResolver;
+use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::TokioResolver;
 
 use crate::error::SpvError as Error;
 use crate::network::constants::{MAINNET_DNS_SEEDS, TESTNET_DNS_SEEDS};
 
 /// DNS discovery for finding initial peers
 pub struct DnsDiscovery {
-    resolver: TokioAsyncResolver,
+    resolver: TokioResolver,
 }
 
 impl DnsDiscovery {
     /// Create a new DNS discovery instance
     pub async fn new() -> Result<Self, Error> {
-        let resolver =
-            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default());
+        let resolver = hickory_resolver::Resolver::builder_with_config(
+            ResolverConfig::default(),
+            TokioConnectionProvider::default(),
+        )
+        .with_options(ResolverOpts::default())
+        .build();
 
-        Ok(Self {
-            resolver,
-        })
+        Ok(Self { resolver })
     }
 
     /// Discover peers for the given network


### PR DESCRIPTION
Replaced the deprecated `trust-dns-resolver` with `hickory_resolver` in the project. This change includes updating the dependencies in `Cargo.toml` and modifying the DNS discovery implementation to utilize the new resolver. This update was required because the old dns resolver had a critical security vulnerability in it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Refactor
  * Replaced the DNS resolution backend used by network discovery; behavior and public interfaces remain unchanged so peer discovery continues to work as before.

* Chores
  * Updated resolver dependency to a newer library/version (renamed upstream).
  * Minor formatting cleanup (ensured newline at end of file).

No user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->