### PR TITLE
feat: allow localhost on ffi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ cobertura.xml
 # Build scripts artifacts
 *.log
 /dash-spv-ffi/peer_reputation.json
+/dash-spv/peer_reputation.json

--- a/dash-spv-ffi/FFI_API.md
+++ b/dash-spv-ffi/FFI_API.md
@@ -4,7 +4,7 @@ This document provides a comprehensive reference for all FFI (Foreign Function I
 
 **Auto-generated**: This documentation is automatically generated from the source code. Do not edit manually.
 
-**Total Functions**: 63
+**Total Functions**: 64
 
 ## Table of Contents
 
@@ -34,12 +34,12 @@ Functions: 4
 
 ### Configuration
 
-Functions: 25
+Functions: 26
 
 | Function | Description | Module |
 |----------|-------------|--------|
 | `dash_spv_ffi_client_update_config` | Update the running client's configuration | client |
-| `dash_spv_ffi_config_add_peer` | Adds a peer address to the configuration  # Safety - `config` must be a valid... | config |
+| `dash_spv_ffi_config_add_peer` | Adds a peer address to the configuration  Accepts either a full socket addres... | config |
 | `dash_spv_ffi_config_destroy` | Destroys an FFIClientConfig and frees its memory  # Safety - `config` must be... | config |
 | `dash_spv_ffi_config_get_data_dir` | Gets the data directory path from the configuration  # Safety - `config` must... | config |
 | `dash_spv_ffi_config_get_mempool_strategy` | Gets the mempool synchronization strategy  # Safety - `config` must be a vali... | config |
@@ -58,6 +58,7 @@ Functions: 25
 | `dash_spv_ffi_config_set_mempool_tracking` | Enables or disables mempool tracking  # Safety - `config` must be a valid poi... | config |
 | `dash_spv_ffi_config_set_persist_mempool` | Sets whether to persist mempool state to disk  # Safety - `config` must be a ... | config |
 | `dash_spv_ffi_config_set_relay_transactions` | Sets whether to relay transactions (currently a no-op)  # Safety - `config` m... | config |
+| `dash_spv_ffi_config_set_restrict_to_configured_peers` | Restrict connections strictly to configured peers (disable DNS discovery and ... | config |
 | `dash_spv_ffi_config_set_start_from_height` | Sets the starting block height for synchronization  # Safety - `config` must ... | config |
 | `dash_spv_ffi_config_set_user_agent` | Sets the user agent string to advertise in the P2P handshake  # Safety - `con... | config |
 | `dash_spv_ffi_config_set_validation_mode` | Sets the validation mode for the SPV client  # Safety - `config` must be a va... | config |
@@ -247,16 +248,14 @@ dash_spv_ffi_config_add_peer(config: *mut FFIClientConfig, addr: *const c_char,)
 ```
 
 **Description:**
-Adds a peer address to the configuration  # Safety - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet - `addr` must be a valid null-terminated C string containing a socket address (e.g., "192.168.1.1:9999") - The caller must ensure both pointers remain valid for the duration of this call
+Adds a peer address to the configuration  Accepts either a full socket address (e.g., "192.168.1.1:9999" or "[::1]:19999") or an IP-only string (e.g., "127.0.0.1" or "2001:db8::1"). When an IP-only string is given, the default P2P port for the configured network is used.  # Safety - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet - `addr` must be a valid null-terminated C string containing a socket address or IP-only string - The caller must ensure both pointers remain valid for the duration of this call
 
 **Safety:**
-- `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet - `addr` must be a valid null-terminated C string containing a socket address (e.g., "192.168.1.1:9999") - The caller must ensure both pointers remain valid for the duration of this call
+- `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet - `addr` must be a valid null-terminated C string containing a socket address or IP-only string - The caller must ensure both pointers remain valid for the duration of this call
 
 **Module:** `config`
 
 ---
-
-Note: `dash_spv_ffi_config_add_peer` also accepts IP-only strings (e.g., `"127.0.0.1"` or `"2001:db8::1"`). When given, the default P2P port for the selected network is used.
 
 #### `dash_spv_ffi_config_destroy`
 
@@ -529,6 +528,22 @@ Sets whether to relay transactions (currently a no-op)  # Safety - `config` must
 
 **Safety:**
 - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet - The caller must ensure the config pointer remains valid for the duration of this call
+
+**Module:** `config`
+
+---
+
+#### `dash_spv_ffi_config_set_restrict_to_configured_peers`
+
+```c
+dash_spv_ffi_config_set_restrict_to_configured_peers(config: *mut FFIClientConfig, restrict: bool,) -> i32
+```
+
+**Description:**
+Restrict connections strictly to configured peers (disable DNS discovery and peer store)  # Safety - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet
+
+**Safety:**
+- `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet
 
 **Module:** `config`
 

--- a/dash-spv-ffi/FFI_API.md
+++ b/dash-spv-ffi/FFI_API.md
@@ -256,6 +256,8 @@ Adds a peer address to the configuration  # Safety - `config` must be a valid po
 
 ---
 
+Note: `dash_spv_ffi_config_add_peer` also accepts IP-only strings (e.g., `"127.0.0.1"` or `"2001:db8::1"`). When given, the default P2P port for the selected network is used.
+
 #### `dash_spv_ffi_config_destroy`
 
 ```c

--- a/dash-spv-ffi/README.md
+++ b/dash-spv-ffi/README.md
@@ -82,7 +82,7 @@ dash_spv_ffi_config_destroy(config);
 - `dash_spv_ffi_config_set_data_dir(config, path)` - Set data directory
 - `dash_spv_ffi_config_set_validation_mode(config, mode)` - Set validation mode
 - `dash_spv_ffi_config_set_max_peers(config, max)` - Set maximum peers
-- `dash_spv_ffi_config_add_peer(config, addr)` - Add a peer address
+- `dash_spv_ffi_config_add_peer(config, addr)` - Add a peer address. Accepts `"ip:port"`, `[ipv6]:port`, or IP-only (defaults to the network port).
 - `dash_spv_ffi_config_destroy(config)` - Free config memory
 
 ### Client Operations

--- a/dash-spv-ffi/include/dash_spv_ffi.h
+++ b/dash-spv-ffi/include/dash_spv_ffi.h
@@ -509,9 +509,13 @@ int32_t dash_spv_ffi_config_set_max_peers(FFIClientConfig *config,
 /**
  * Adds a peer address to the configuration
  *
+ * Accepts either a full socket address (e.g., "192.168.1.1:9999" or "[::1]:19999")
+ * or an IP-only string (e.g., "127.0.0.1" or "2001:db8::1"). When an IP-only
+ * string is given, the default P2P port for the configured network is used.
+ *
  * # Safety
  * - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet
- * - `addr` must be a valid null-terminated C string containing a socket address (e.g., "192.168.1.1:9999")
+ * - `addr` must be a valid null-terminated C string containing a socket address or IP-only string
  * - The caller must ensure both pointers remain valid for the duration of this call
  */
 int32_t dash_spv_ffi_config_add_peer(FFIClientConfig *config,
@@ -547,6 +551,15 @@ int32_t dash_spv_ffi_config_set_relay_transactions(FFIClientConfig *config,
  */
 int32_t dash_spv_ffi_config_set_filter_load(FFIClientConfig *config,
                                             bool load_filters);
+
+/**
+ * Restrict connections strictly to configured peers (disable DNS discovery and peer store)
+ *
+ * # Safety
+ * - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet
+ */
+int32_t dash_spv_ffi_config_set_restrict_to_configured_peers(FFIClientConfig *config,
+                                                             bool restrict);
 
 /**
  * Enables or disables masternode synchronization

--- a/dash-spv-ffi/src/config.rs
+++ b/dash-spv-ffi/src/config.rs
@@ -2,8 +2,8 @@ use crate::{null_check, set_last_error, FFIErrorCode, FFIMempoolStrategy, FFIStr
 use dash_spv::{ClientConfig, ValidationMode};
 use key_wallet_ffi::FFINetwork;
 use std::ffi::CStr;
-use std::os::raw::c_char;
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+use std::os::raw::c_char;
 
 #[repr(C)]
 pub enum FFIValidationMode {

--- a/dash-spv-ffi/tests/unit/test_configuration.rs
+++ b/dash-spv-ffi/tests/unit/test_configuration.rs
@@ -96,9 +96,6 @@ mod tests {
 
     #[test]
     #[serial]
-    // removed: host_port API tests (consolidated into add_peer behavior)
-    #[test]
-    #[serial]
     fn test_adding_maximum_peers() {
         unsafe {
             let config = dash_spv_ffi_config_testnet();

--- a/dash-spv-ffi/tests/unit/test_configuration.rs
+++ b/dash-spv-ffi/tests/unit/test_configuration.rs
@@ -80,8 +80,8 @@ mod tests {
                 "192.168.1.1:8333",
                 "[::1]:9999",
                 "[2001:db8::1]:8333",
-                "127.0.0.1",        // IP-only v4
-                "2001:db8::1",      // IP-only v6
+                "127.0.0.1",   // IP-only v4
+                "2001:db8::1", // IP-only v6
             ];
 
             for addr in &valid_addrs {
@@ -97,7 +97,6 @@ mod tests {
     #[test]
     #[serial]
     // removed: host_port API tests (consolidated into add_peer behavior)
-
     #[test]
     #[serial]
     fn test_adding_maximum_peers() {

--- a/dash-spv-ffi/tests/unit/test_configuration.rs
+++ b/dash-spv-ffi/tests/unit/test_configuration.rs
@@ -58,7 +58,7 @@ mod tests {
                 "256.256.256.256:9999",
                 "127.0.0.1:99999", // port too high
                 "127.0.0.1:-1",    // negative port
-                "127.0.0.1",       // missing port
+                "localhost",       // hostname without port should be rejected
                 ":9999",           // missing IP
                 ":::",             // invalid IPv6
                 "localhost:abc",   // non-numeric port
@@ -74,9 +74,15 @@ mod tests {
                 assert!(!error_ptr.is_null());
             }
 
-            // Test valid addresses
-            let valid_addrs =
-                ["127.0.0.1:9999", "192.168.1.1:8333", "[::1]:9999", "[2001:db8::1]:8333"];
+            // Test valid addresses including IP-only forms (port inferred from network)
+            let valid_addrs = [
+                "127.0.0.1:9999",
+                "192.168.1.1:8333",
+                "[::1]:9999",
+                "[2001:db8::1]:8333",
+                "127.0.0.1",        // IP-only v4
+                "2001:db8::1",      // IP-only v6
+            ];
 
             for addr in &valid_addrs {
                 let c_addr = CString::new(*addr).unwrap();
@@ -87,6 +93,10 @@ mod tests {
             dash_spv_ffi_config_destroy(config);
         }
     }
+
+    #[test]
+    #[serial]
+    // removed: host_port API tests (consolidated into add_peer behavior)
 
     #[test]
     #[serial]
@@ -195,6 +205,11 @@ mod tests {
 
             assert_eq!(
                 dash_spv_ffi_config_set_filter_load(config, true),
+                FFIErrorCode::Success as i32
+            );
+
+            assert_eq!(
+                dash_spv_ffi_config_set_restrict_to_configured_peers(config, true),
                 FFIErrorCode::Success as i32
             );
 

--- a/dash-spv/src/client/config.rs
+++ b/dash-spv/src/client/config.rs
@@ -30,6 +30,13 @@ pub struct ClientConfig {
     /// List of peer addresses to connect to.
     pub peers: Vec<SocketAddr>,
 
+    /// Restrict connections strictly to the configured peers.
+    ///
+    /// When true, the client will not use DNS discovery or peer persistence and
+    /// will only attempt to connect to addresses provided in `peers`.
+    /// If no peers are configured, no outbound connections will be made.
+    pub restrict_to_configured_peers: bool,
+
     /// Optional path for persistent storage.
     pub storage_path: Option<PathBuf>,
 
@@ -183,6 +190,7 @@ impl Default for ClientConfig {
         Self {
             network: Network::Dash,
             peers: vec![],
+            restrict_to_configured_peers: false,
             storage_path: None,
             validation_mode: ValidationMode::Full,
             filter_checkpoint_interval: 1000,
@@ -243,6 +251,7 @@ impl ClientConfig {
         Self {
             network,
             peers: Self::default_peers_for_network(network),
+            restrict_to_configured_peers: false,
             ..Self::default()
         }
     }
@@ -265,6 +274,12 @@ impl ClientConfig {
     /// Add a peer address.
     pub fn add_peer(&mut self, address: SocketAddr) -> &mut Self {
         self.peers.push(address);
+        self
+    }
+
+    /// Restrict connections to the configured peers only.
+    pub fn with_restrict_to_configured_peers(mut self, restrict: bool) -> Self {
+        self.restrict_to_configured_peers = restrict;
         self
     }
 

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -129,6 +129,7 @@ mod multi_peer_tests {
         ClientConfig {
             network: Network::Regtest,
             peers: vec!["127.0.0.1:19899".parse().unwrap()],
+            restrict_to_configured_peers: false,
             storage_path: Some(temp_dir.path().to_path_buf()),
             validation_mode: crate::types::ValidationMode::Basic,
             filter_checkpoint_interval: 1000,

--- a/dash-spv/src/storage/disk.rs
+++ b/dash-spv/src/storage/disk.rs
@@ -1571,7 +1571,7 @@ impl StorageManager for DiskStorageManager {
                         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                         tokio::fs::remove_dir_all(&self.base_path).await?;
                     } else {
-                        return Err(StorageError::Io(e).into());
+                        return Err(StorageError::Io(e));
                     }
                 }
             }

--- a/swift-dash-core-sdk/Sources/DashSPVFFI/include/dash_spv_ffi.h
+++ b/swift-dash-core-sdk/Sources/DashSPVFFI/include/dash_spv_ffi.h
@@ -3,9 +3,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-// Include shared FFI types (FFINetwork, etc.) from key-wallet-ffi
-#include "key_wallet_ffi.h"
-
 typedef enum FFIMempoolStrategy {
   FetchAll = 0,
   BloomFilter = 1,
@@ -28,10 +25,26 @@ typedef enum FFIValidationMode {
   Full = 2,
 } FFIValidationMode;
 
-/**
- * FFIDashSpvClient structure
- */
 typedef struct FFIDashSpvClient FFIDashSpvClient;
+
+/**
+ * FFI-safe array that transfers ownership of memory to the C caller.
+ *
+ * # Safety
+ *
+ * This struct represents memory that has been allocated by Rust but ownership
+ * has been transferred to the C caller. The caller is responsible for:
+ * - Not accessing the memory after it has been freed
+ * - Calling `dash_spv_ffi_array_destroy` to properly deallocate the memory
+ * - Ensuring the data, len, and capacity fields remain consistent
+ */
+typedef struct FFIArray {
+  void *data;
+  uintptr_t len;
+  uintptr_t capacity;
+  uintptr_t elem_size;
+  uintptr_t elem_align;
+} FFIArray;
 
 typedef ClientConfig FFIClientConfig;
 
@@ -148,25 +161,6 @@ typedef struct FFIResult {
 } FFIResult;
 
 /**
- * FFI-safe array that transfers ownership of memory to the C caller.
- *
- * # Safety
- *
- * This struct represents memory that has been allocated by Rust but ownership
- * has been transferred to the C caller. The caller is responsible for:
- * - Not accessing the memory after it has been freed
- * - Calling `dash_spv_ffi_array_destroy` to properly deallocate the memory
- * - Ensuring the data, len, and capacity fields remain consistent
- */
-typedef struct FFIArray {
-  void *data;
-  uintptr_t len;
-  uintptr_t capacity;
-  uintptr_t elem_size;
-  uintptr_t elem_align;
-} FFIArray;
-
-/**
  * FFI-safe representation of an unconfirmed transaction
  *
  * # Safety
@@ -199,10 +193,83 @@ typedef struct FFIUnconfirmedTransaction {
   uintptr_t addresses_len;
 } FFIUnconfirmedTransaction;
 
+/**
+ * Get the latest checkpoint for the given network.
+ *
+ * # Safety
+ * - `out_height` must be a valid pointer to a `u32`.
+ * - `out_hash` must point to at least 32 writable bytes.
+ */
+int32_t dash_spv_ffi_checkpoint_latest(FFINetwork network, uint32_t *out_height, uint8_t *out_hash);
+
+/**
+ * Get the last checkpoint at or before a given height.
+ *
+ * # Safety
+ * - `out_height` must be a valid pointer to a `u32`.
+ * - `out_hash` must point to at least 32 writable bytes.
+ */
+int32_t dash_spv_ffi_checkpoint_before_height(FFINetwork network,
+                                              uint32_t height,
+                                              uint32_t *out_height,
+                                              uint8_t *out_hash);
+
+/**
+ * Get the last checkpoint at or before a given UNIX timestamp (seconds).
+ *
+ * # Safety
+ * - `out_height` must be a valid pointer to a `u32`.
+ * - `out_hash` must point to at least 32 writable bytes.
+ */
+int32_t dash_spv_ffi_checkpoint_before_timestamp(FFINetwork network,
+                                                 uint32_t timestamp,
+                                                 uint32_t *out_height,
+                                                 uint8_t *out_hash);
+
+/**
+ * Get all checkpoints between two heights (inclusive).
+ *
+ * Returns an `FFIArray` of `FFICheckpoint` items. The caller owns the memory and
+ * must free the array buffer using `dash_spv_ffi_array_destroy` when done.
+ */
+struct FFIArray dash_spv_ffi_checkpoints_between_heights(FFINetwork network,
+                                                         uint32_t start_height,
+                                                         uint32_t end_height);
+
+/**
+ * Create a new SPV client and return an opaque pointer.
+ *
+ * # Safety
+ * - `config` must be a valid, non-null pointer for the duration of the call.
+ * - The returned pointer must be freed with `dash_spv_ffi_client_destroy`.
+ */
 struct FFIDashSpvClient *dash_spv_ffi_client_new(const FFIClientConfig *config);
 
+/**
+ * Update the running client's configuration.
+ *
+ * # Safety
+ * - `client` must be a valid pointer to an `FFIDashSpvClient`.
+ * - `config` must be a valid pointer to an `FFIClientConfig`.
+ * - The network in `config` must match the client's network; changing networks at runtime is not supported.
+ */
+int32_t dash_spv_ffi_client_update_config(struct FFIDashSpvClient *client,
+                                          const FFIClientConfig *config);
+
+/**
+ * Start the SPV client.
+ *
+ * # Safety
+ * - `client` must be a valid, non-null pointer to a created client.
+ */
 int32_t dash_spv_ffi_client_start(struct FFIDashSpvClient *client);
 
+/**
+ * Stop the SPV client.
+ *
+ * # Safety
+ * - `client` must be a valid, non-null pointer to a created client.
+ */
 int32_t dash_spv_ffi_client_stop(struct FFIDashSpvClient *client);
 
 /**
@@ -296,27 +363,87 @@ int32_t dash_spv_ffi_client_sync_to_tip_with_progress(struct FFIDashSpvClient *c
  */
 int32_t dash_spv_ffi_client_cancel_sync(struct FFIDashSpvClient *client);
 
+/**
+ * Get the current sync progress snapshot.
+ *
+ * # Safety
+ * - `client` must be a valid, non-null pointer.
+ */
 struct FFISyncProgress *dash_spv_ffi_client_get_sync_progress(struct FFIDashSpvClient *client);
 
+/**
+ * Get current runtime statistics for the SPV client.
+ *
+ * # Safety
+ * - `client` must be a valid, non-null pointer.
+ */
 struct FFISpvStats *dash_spv_ffi_client_get_stats(struct FFIDashSpvClient *client);
 
+/**
+ * Check if compact filter sync is currently available.
+ *
+ * # Safety
+ * - `client` must be a valid, non-null pointer.
+ */
 bool dash_spv_ffi_client_is_filter_sync_available(struct FFIDashSpvClient *client);
 
+/**
+ * Set event callbacks for the client.
+ *
+ * # Safety
+ * - `client` must be a valid, non-null pointer.
+ */
 int32_t dash_spv_ffi_client_set_event_callbacks(struct FFIDashSpvClient *client,
                                                 struct FFIEventCallbacks callbacks);
 
+/**
+ * Destroy the client and free associated resources.
+ *
+ * # Safety
+ * - `client` must be either null or a pointer obtained from `dash_spv_ffi_client_new`.
+ */
 void dash_spv_ffi_client_destroy(struct FFIDashSpvClient *client);
 
+/**
+ * Destroy a `FFISyncProgress` object returned by this crate.
+ *
+ * # Safety
+ * - `progress` must be a pointer returned from this crate, or null.
+ */
 void dash_spv_ffi_sync_progress_destroy(struct FFISyncProgress *progress);
 
+/**
+ * Destroy an `FFISpvStats` object returned by this crate.
+ *
+ * # Safety
+ * - `stats` must be a pointer returned from this crate, or null.
+ */
 void dash_spv_ffi_spv_stats_destroy(struct FFISpvStats *stats);
 
+/**
+ * Request a rescan of the blockchain from a given height (not yet implemented).
+ *
+ * # Safety
+ * - `client` must be a valid, non-null pointer.
+ */
 int32_t dash_spv_ffi_client_rescan_blockchain(struct FFIDashSpvClient *client,
                                               uint32_t _from_height);
 
+/**
+ * Enable mempool tracking with a given strategy.
+ *
+ * # Safety
+ * - `client` must be a valid, non-null pointer.
+ */
 int32_t dash_spv_ffi_client_enable_mempool_tracking(struct FFIDashSpvClient *client,
                                                     enum FFIMempoolStrategy strategy);
 
+/**
+ * Record that we attempted to send a transaction by its txid.
+ *
+ * # Safety
+ * - `client` and `txid` must be valid, non-null pointers.
+ */
 int32_t dash_spv_ffi_client_record_send(struct FFIDashSpvClient *client, const char *txid);
 
 /**
@@ -329,12 +456,16 @@ int32_t dash_spv_ffi_client_record_send(struct FFIDashSpvClient *client, const c
  *
  * The caller must ensure that:
  * - The client pointer is valid
- * - The returned pointer is freed using wallet_manager_free()
+ * - The returned pointer is freed using `wallet_manager_free` from key-wallet-ffi
  *
  * # Returns
  *
  * An opaque pointer (void*) to the wallet manager, or NULL if the client is not initialized.
  * Swift should treat this as an OpaquePointer.
+ * Get a handle to the wallet manager owned by this client.
+ *
+ * # Safety
+ * - `client` must be a valid, non-null pointer.
  */
 void *dash_spv_ffi_client_get_wallet_manager(struct FFIDashSpvClient *client);
 
@@ -378,9 +509,13 @@ int32_t dash_spv_ffi_config_set_max_peers(FFIClientConfig *config,
 /**
  * Adds a peer address to the configuration
  *
+ * Accepts either a full socket address (e.g., "192.168.1.1:9999" or "[::1]:19999")
+ * or an IP-only string (e.g., "127.0.0.1" or "2001:db8::1"). When an IP-only
+ * string is given, the default P2P port for the configured network is used.
+ *
  * # Safety
  * - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet
- * - `addr` must be a valid null-terminated C string containing a socket address (e.g., "192.168.1.1:9999")
+ * - `addr` must be a valid null-terminated C string containing a socket address or IP-only string
  * - The caller must ensure both pointers remain valid for the duration of this call
  */
 int32_t dash_spv_ffi_config_add_peer(FFIClientConfig *config,
@@ -418,6 +553,25 @@ int32_t dash_spv_ffi_config_set_filter_load(FFIClientConfig *config,
                                             bool load_filters);
 
 /**
+ * Restrict connections strictly to configured peers (disable DNS discovery and peer store)
+ *
+ * # Safety
+ * - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet
+ */
+int32_t dash_spv_ffi_config_set_restrict_to_configured_peers(FFIClientConfig *config,
+                                                             bool restrict);
+
+/**
+ * Enables or disables masternode synchronization
+ *
+ * # Safety
+ * - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet
+ * - The caller must ensure the config pointer remains valid for the duration of this call
+ */
+int32_t dash_spv_ffi_config_set_masternode_sync_enabled(FFIClientConfig *config,
+                                                        bool enable);
+
+/**
  * Gets the network type from the configuration
  *
  * # Safety
@@ -432,7 +586,7 @@ FFINetwork dash_spv_ffi_config_get_network(const FFIClientConfig *config);
  * # Safety
  * - `config` must be a valid pointer to an FFIClientConfig or null
  * - If null or no data directory is set, returns an FFIString with null pointer
- * - The returned FFIString must be freed by the caller using dash_string_free
+ * - The returned FFIString must be freed by the caller using `dash_spv_ffi_string_destroy`
  */
 struct FFIString dash_spv_ffi_config_get_data_dir(const FFIClientConfig *config);
 
@@ -600,8 +754,18 @@ struct FFIResult ffi_dash_spv_get_quorum_public_key(struct FFIDashSpvClient *cli
 struct FFIResult ffi_dash_spv_get_platform_activation_height(struct FFIDashSpvClient *client,
                                                              uint32_t *out_height);
 
+/**
+ * # Safety
+ * - `s.ptr` must be a pointer previously returned by `FFIString::new` or compatible.
+ * - It must not be used after this call.
+ */
 void dash_spv_ffi_string_destroy(struct FFIString s);
 
+/**
+ * # Safety
+ * - `arr` must be either null or a valid pointer to an `FFIArray` previously constructed in Rust.
+ * - The memory referenced by `arr.data` must not be used after this call.
+ */
 void dash_spv_ffi_array_destroy(struct FFIArray *arr);
 
 /**
@@ -611,6 +775,10 @@ void dash_spv_ffi_array_destroy(struct FFIArray *arr);
  * - Iterates the array elements as pointers to FFIString and destroys each via dash_spv_ffi_string_destroy
  * - Frees the underlying vector buffer stored in FFIArray
  * - Does not free the FFIArray struct itself (safe for both stack- and heap-allocated structs)
+ * # Safety
+ * - `arr` must be either null or a valid pointer to an `FFIArray` whose elements are `*mut FFIString`.
+ * - Each element pointer must be valid or null; non-null entries are freed.
+ * - The memory referenced by `arr.data` must not be used after this call.
  */
 void dash_spv_ffi_string_array_destroy(struct FFIArray *arr);
 
@@ -652,6 +820,13 @@ void dash_spv_ffi_unconfirmed_transaction_destroy_addresses(struct FFIString *ad
  */
 void dash_spv_ffi_unconfirmed_transaction_destroy(struct FFIUnconfirmedTransaction *tx);
 
+/**
+ * Initialize logging for the SPV library.
+ *
+ * # Safety
+ * - `level` may be null or point to a valid, NUL-terminated C string.
+ * - If non-null, the pointer must remain valid for the duration of this call.
+ */
 int32_t dash_spv_ffi_init_logging(const char *level);
 
 const char *dash_spv_ffi_version(void);

--- a/swift-dash-core-sdk/Sources/KeyWalletFFI/include/key_wallet_ffi.h
+++ b/swift-dash-core-sdk/Sources/KeyWalletFFI/include/key_wallet_ffi.h
@@ -127,29 +127,6 @@ typedef enum {
 } FFIAddressPoolType;
 
 /*
- Derivation path type for DIP9
- */
-typedef enum {
-    PATH_UNKNOWN = 0,
-    PATH_BIP32 = 1,
-    PATH_BIP44 = 2,
-    PATH_BLOCKCHAIN_IDENTITIES = 3,
-    PATH_PROVIDER_FUNDS = 4,
-    PATH_PROVIDER_VOTING_KEYS = 5,
-    PATH_PROVIDER_OPERATOR_KEYS = 6,
-    PATH_PROVIDER_OWNER_KEYS = 7,
-    PATH_CONTACT_BASED_FUNDS = 8,
-    PATH_CONTACT_BASED_FUNDS_ROOT = 9,
-    PATH_CONTACT_BASED_FUNDS_EXTERNAL = 10,
-    PATH_BLOCKCHAIN_IDENTITY_CREDIT_REGISTRATION_FUNDING = 11,
-    PATH_BLOCKCHAIN_IDENTITY_CREDIT_TOPUP_FUNDING = 12,
-    PATH_BLOCKCHAIN_IDENTITY_CREDIT_INVITATION_FUNDING = 13,
-    PATH_PROVIDER_PLATFORM_NODE_KEYS = 14,
-    PATH_COIN_JOIN = 15,
-    PATH_ROOT = 255,
-} FFIDerivationPathType;
-
-/*
  FFI Error code
  */
 typedef enum {
@@ -639,7 +616,6 @@ typedef struct {
 } FFITxOutput;
 
 /*
- Transaction context for checking
  Transaction check result
  */
 typedef struct {
@@ -1400,6 +1376,224 @@ void account_collection_summary_free(FFIAccountCollectionSummary *summary)
 ;
 
 /*
+ Derive an extended private key from an account at a given index, using the provided master xpriv.
+
+ Returns an opaque FFIExtendedPrivateKey pointer that must be freed with `extended_private_key_free`.
+
+ Notes:
+ - This is chain-agnostic. For accounts with internal/external chains, this returns an error.
+ - For hardened-only account types (e.g., EdDSA), a hardened index is used.
+
+ # Safety
+ - `account` and `master_xpriv` must be valid, non-null pointers allocated by this library.
+ - `error` must be a valid pointer to an FFIError or null.
+ - The caller must free the returned pointer with `extended_private_key_free`.
+ */
+
+FFIExtendedPrivateKey *account_derive_extended_private_key_at(const FFIAccount *account,
+                                                              const FFIExtendedPrivateKey *master_xpriv,
+                                                              unsigned int index,
+                                                              FFIError *error)
+;
+
+/*
+ Derive a BLS private key from a raw seed buffer at the given index.
+
+ Returns a newly allocated hex string of the 32-byte private key. The caller must free
+ it with `string_free`.
+
+ Notes:
+ - Uses the account's network for master key creation.
+ - Chain-agnostic; may return an error for accounts with internal/external chains.
+
+ # Safety
+ - `account` must be a valid, non-null pointer to an `FFIBLSAccount` (only when `bls` feature is enabled).
+ - `seed` must point to a readable buffer of length `seed_len` (1..=64 bytes expected).
+ - `error` must be a valid pointer to an FFIError or null.
+ - Returned string must be freed with `string_free`.
+ */
+
+char *bls_account_derive_private_key_from_seed(const FFIBLSAccount *account,
+                                               const uint8_t *seed,
+                                               size_t seed_len,
+                                               unsigned int index,
+                                               FFIError *error)
+;
+
+/*
+ Derive a BLS private key from a mnemonic + optional passphrase at the given index.
+
+ Returns a newly allocated hex string of the 32-byte private key. The caller must free
+ it with `string_free`.
+
+ Notes:
+ - Uses the English wordlist for parsing the mnemonic.
+ - Chain-agnostic; may return an error for accounts with internal/external chains.
+
+ # Safety
+ - `account` must be a valid, non-null pointer to an `FFIBLSAccount` (only when `bls` feature is enabled).
+ - `mnemonic` must be a valid, null-terminated UTF-8 C string.
+ - `passphrase` may be null; if not null, must be a valid UTF-8 C string.
+ - `error` must be a valid pointer to an FFIError or null.
+ - Returned string must be freed with `string_free`.
+ */
+
+char *bls_account_derive_private_key_from_mnemonic(const FFIBLSAccount *account,
+                                                   const char *mnemonic,
+                                                   const char *passphrase,
+                                                   unsigned int index,
+                                                   FFIError *error)
+;
+
+/*
+ Derive an EdDSA (ed25519) private key from a raw seed buffer at the given index.
+
+ Returns a newly allocated hex string of the 32-byte private key. The caller must free
+ it with `string_free`.
+
+ Notes:
+ - EdDSA only supports hardened derivation; the index will be used accordingly.
+ - Chain-agnostic; EdDSA accounts typically do not have internal/external split.
+
+ # Safety
+ - `account` must be a valid, non-null pointer to an `FFIEdDSAAccount` (only when `eddsa` feature is enabled).
+ - `seed` must point to a readable buffer of length `seed_len` (1..=64 bytes expected).
+ - `error` must be a valid pointer to an FFIError or null.
+ - Returned string must be freed with `string_free`.
+ */
+
+char *eddsa_account_derive_private_key_from_seed(const FFIEdDSAAccount *account,
+                                                 const uint8_t *seed,
+                                                 size_t seed_len,
+                                                 unsigned int index,
+                                                 FFIError *error)
+;
+
+/*
+ Derive an EdDSA (ed25519) private key from a mnemonic + optional passphrase at the given index.
+
+ Returns a newly allocated hex string of the 32-byte private key. The caller must free
+ it with `string_free`.
+
+ Notes:
+ - Uses the English wordlist for parsing the mnemonic.
+
+ # Safety
+ - `account` must be a valid, non-null pointer to an `FFIEdDSAAccount` (only when `eddsa` feature is enabled).
+ - `mnemonic` must be a valid, null-terminated UTF-8 C string.
+ - `passphrase` may be null; if not null, must be a valid UTF-8 C string.
+ - `error` must be a valid pointer to an FFIError or null.
+ - Returned string must be freed with `string_free`.
+ */
+
+char *eddsa_account_derive_private_key_from_mnemonic(const FFIEdDSAAccount *account,
+                                                     const char *mnemonic,
+                                                     const char *passphrase,
+                                                     unsigned int index,
+                                                     FFIError *error)
+;
+
+/*
+ Derive a private key (secp256k1) from an account at a given chain/index, using the provided master xpriv.
+ Returns an opaque FFIPrivateKey pointer that must be freed with `private_key_free`.
+
+ # Safety
+ - `account` and `master_xpriv` must be valid pointers allocated by this library
+ - `error` must be a valid pointer to an FFIError or null
+ */
+
+FFIPrivateKey *account_derive_private_key_at(const FFIAccount *account,
+                                             const FFIExtendedPrivateKey *master_xpriv,
+                                             unsigned int index,
+                                             FFIError *error)
+;
+
+/*
+ Derive a private key from an account at a given chain/index and return as WIF string.
+ Caller must free the returned string with `string_free`.
+
+ # Safety
+ - `account` and `master_xpriv` must be valid pointers allocated by this library
+ - `error` must be a valid pointer to an FFIError or null
+ */
+
+char *account_derive_private_key_as_wif_at(const FFIAccount *account,
+                                           const FFIExtendedPrivateKey *master_xpriv,
+                                           unsigned int index,
+                                           FFIError *error)
+;
+
+/*
+ Derive an extended private key from a raw seed buffer at the given index.
+ Returns an opaque FFIExtendedPrivateKey pointer that must be freed with `extended_private_key_free`.
+
+ # Safety
+ - `account` must be a valid pointer to an FFIAccount
+ - `seed` must point to a valid buffer of length `seed_len`
+ - `error` must be a valid pointer to an FFIError or null
+ */
+
+FFIExtendedPrivateKey *account_derive_extended_private_key_from_seed(const FFIAccount *account,
+                                                                     const uint8_t *seed,
+                                                                     size_t seed_len,
+                                                                     unsigned int index,
+                                                                     FFIError *error)
+;
+
+/*
+ Derive a private key from a raw seed buffer at the given index.
+ Returns an opaque FFIPrivateKey pointer that must be freed with `private_key_free`.
+
+ # Safety
+ - `account` must be a valid pointer to an FFIAccount
+ - `seed` must point to a valid buffer of length `seed_len`
+ - `error` must be a valid pointer to an FFIError or null
+ */
+
+FFIPrivateKey *account_derive_private_key_from_seed(const FFIAccount *account,
+                                                    const uint8_t *seed,
+                                                    size_t seed_len,
+                                                    unsigned int index,
+                                                    FFIError *error)
+;
+
+/*
+ Derive an extended private key from a mnemonic + optional passphrase at the given index.
+ Returns an opaque FFIExtendedPrivateKey pointer that must be freed with `extended_private_key_free`.
+
+ # Safety
+ - `account` must be a valid pointer to an FFIAccount
+ - `mnemonic` must be a valid, null-terminated C string
+ - `passphrase` may be null; if not null, must be a valid C string
+ - `error` must be a valid pointer to an FFIError or null
+ */
+
+FFIExtendedPrivateKey *account_derive_extended_private_key_from_mnemonic(const FFIAccount *account,
+                                                                         const char *mnemonic,
+                                                                         const char *passphrase,
+                                                                         unsigned int index,
+                                                                         FFIError *error)
+;
+
+/*
+ Derive a private key from a mnemonic + optional passphrase at the given index.
+ Returns an opaque FFIPrivateKey pointer that must be freed with `private_key_free`.
+
+ # Safety
+ - `account` must be a valid pointer to an FFIAccount
+ - `mnemonic` must be a valid, null-terminated C string
+ - `passphrase` may be null; if not null, must be a valid C string
+ - `error` must be a valid pointer to an FFIError or null
+ */
+
+FFIPrivateKey *account_derive_private_key_from_mnemonic(const FFIAccount *account,
+                                                        const char *mnemonic,
+                                                        const char *passphrase,
+                                                        unsigned int index,
+                                                        FFIError *error)
+;
+
+/*
  Free address string
 
  # Safety
@@ -1791,25 +1985,6 @@ bool derivation_xpub_fingerprint(const FFIExtendedPubKey *xpub,
  - This function must only be called once per allocation
  */
  void derivation_string_free(char *s) ;
-
-/*
- Derive key using DIP9 path constants for identity
-
- # Safety
-
- - `seed` must be a valid pointer to a byte array of `seed_len` length
- - `error` must be a valid pointer to an FFIError structure or null
- - The caller must ensure the seed pointer remains valid for the duration of this call
- */
-
-FFIExtendedPrivKey *dip9_derive_identity_key(const uint8_t *seed,
-                                             size_t seed_len,
-                                             FFINetwork network,
-                                             unsigned int identity_index,
-                                             unsigned int key_index,
-                                             FFIDerivationPathType key_type,
-                                             FFIError *error)
-;
 
 /*
  Derive an address from a private key

--- a/swift-dash-core-sdk/Sources/SwiftDashCoreSDK/Models/Network.swift
+++ b/swift-dash-core-sdk/Sources/SwiftDashCoreSDK/Models/Network.swift
@@ -16,7 +16,7 @@ public enum DashNetwork: String, Codable, CaseIterable, Sendable {
         case .regtest:
             return 19899
         case .devnet:
-            return 19799
+            return 29999
         }
     }
     

--- a/swift-dash-core-sdk/Tests/SwiftDashCoreSDKTests/DashSDKTests.swift
+++ b/swift-dash-core-sdk/Tests/SwiftDashCoreSDKTests/DashSDKTests.swift
@@ -49,7 +49,7 @@ final class DashSDKTests: XCTestCase {
         XCTAssertEqual(DashNetwork.mainnet.defaultPort, 9999)
         XCTAssertEqual(DashNetwork.testnet.defaultPort, 19999)
         XCTAssertEqual(DashNetwork.regtest.defaultPort, 19899)
-        XCTAssertEqual(DashNetwork.devnet.defaultPort, 19799)
+        XCTAssertEqual(DashNetwork.devnet.defaultPort, 29999)
     }
     
     func testBalanceCalculations() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Option to restrict connections to configured peers only.
  - Peer address input accepts IP-only forms (defaults to network port).
  - Background disk I/O worker and new store_headers_from_height API for checkpoint-style header storage.
  - Expanded FFI/SDK: opaque client type, FFIArray, client lifecycle, checkpoint queries, mempool controls, wallet access, memory destructors, and broad key-derivation helpers (standard, BLS, EdDSA).

- **Refactor**
  - Devnet default P2P port changed to 29999.
  - DIP9-specific derivation removed in favor of index-based derivation APIs.

- **Documentation**
  - Clarified address formats, safety/memory semantics, and required destroy/cleanup calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->