### PR TITLE
refactor: migrate received_filter_heights to tokio::Mutex and add find_available_header_at_or_before helper

### DIFF
--- a/dash-spv-ffi/tests/unit/test_type_conversions.rs
+++ b/dash-spv-ffi/tests/unit/test_type_conversions.rs
@@ -209,7 +209,7 @@ mod tests {
             filters_received: u64::MAX,
             filter_sync_start_time: None,
             last_filter_received_time: None,
-            received_filter_heights: std::sync::Arc::new(std::sync::Mutex::new(
+            received_filter_heights: std::sync::Arc::new(tokio::sync::Mutex::new(
                 std::collections::HashSet::new(),
             )),
             active_filter_requests: 0,

--- a/dash-spv/src/client/status_display.rs
+++ b/dash-spv/src/client/status_display.rs
@@ -76,10 +76,9 @@ impl<'a, S: StorageManager + Send + Sync + 'static> StatusDisplay<'a, S> {
         let stats = self.stats.read().await;
 
         // Calculate last synced filter height from received filter heights
-        let last_synced_filter_height = if let Ok(heights) = stats.received_filter_heights.lock() {
+        let last_synced_filter_height = {
+            let heights = stats.received_filter_heights.lock().await;
             heights.iter().max().copied()
-        } else {
-            None
         };
 
         // Calculate the actual header height considering checkpoint sync

--- a/dash-spv/src/sync/filters.rs
+++ b/dash-spv/src/sync/filters.rs
@@ -602,7 +602,11 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
                                             "This indicates a serious storage inconsistency. Stopping filter header sync."
                                         );
                                         self.syncing_filter_headers = false;
-                                        return Ok(false);
+                                        return Err(SyncError::Storage(format!(
+                                            "No available headers found between {} and {} while selecting next batch stop hash",
+                                            min_height,
+                                            next_batch_end_height
+                                        )));
                                     }
                                 }
                             }

--- a/dash-spv/src/sync/filters.rs
+++ b/dash-spv/src/sync/filters.rs
@@ -2842,7 +2842,9 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
             stats_lock.filter_sync_start_time = Some(std::time::Instant::now());
             stats_lock.last_filter_received_time = None;
             // Clear the received heights tracking for a fresh start
-            let mut heights = stats_lock.received_filter_heights.lock().await;
+            let received_filter_heights = stats_lock.received_filter_heights.clone();
+            drop(stats_lock); // Release the RwLock before awaiting the mutex
+            let mut heights = received_filter_heights.lock().await;
             heights.clear();
             tracing::info!(
                 "📊 Started new filter sync tracking: {} filters requested",

--- a/dash-spv/src/sync/sequential/mod.rs
+++ b/dash-spv/src/sync/sequential/mod.rs
@@ -85,7 +85,7 @@ impl<
     /// Create a new sequential sync manager
     pub fn new(
         config: &ClientConfig,
-        received_filter_heights: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<u32>>>,
+        received_filter_heights: std::sync::Arc<tokio::sync::Mutex<std::collections::HashSet<u32>>>,
         wallet: std::sync::Arc<tokio::sync::RwLock<W>>,
     ) -> SyncResult<Self> {
         // Create reorg config with sensible defaults

--- a/dash-spv/src/sync/sequential/mod.rs
+++ b/dash-spv/src/sync/sequential/mod.rs
@@ -24,7 +24,7 @@ use crate::storage::StorageManager;
 use crate::sync::{
     FilterSyncManager, HeaderSyncManagerWithReorg, MasternodeSyncManager, ReorgConfig,
 };
-use crate::types::{ChainState, SyncProgress};
+use crate::types::{ChainState, SharedFilterHeights, SyncProgress};
 use key_wallet_manager::wallet_interface::WalletInterface;
 
 use phases::{PhaseTransition, SyncPhase};
@@ -85,7 +85,7 @@ impl<
     /// Create a new sequential sync manager
     pub fn new(
         config: &ClientConfig,
-        received_filter_heights: std::sync::Arc<tokio::sync::Mutex<std::collections::HashSet<u32>>>,
+        received_filter_heights: SharedFilterHeights,
         wallet: std::sync::Arc<tokio::sync::RwLock<W>>,
     ) -> SyncResult<Self> {
         // Create reorg config with sensible defaults

--- a/dash-spv/src/types.rs
+++ b/dash-spv/src/types.rs
@@ -550,7 +550,7 @@ pub struct SpvStats {
 
     /// Received filter heights for gap tracking (shared with FilterSyncManager).
     #[serde(skip)]
-    pub received_filter_heights: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<u32>>>,
+    pub received_filter_heights: std::sync::Arc<tokio::sync::Mutex<std::collections::HashSet<u32>>>,
 
     /// Number of filter requests currently active.
     pub active_filter_requests: u32,
@@ -587,7 +587,7 @@ impl Default for SpvStats {
             filters_received: 0,
             filter_sync_start_time: None,
             last_filter_received_time: None,
-            received_filter_heights: std::sync::Arc::new(std::sync::Mutex::new(
+            received_filter_heights: std::sync::Arc::new(tokio::sync::Mutex::new(
                 std::collections::HashSet::new(),
             )),
             active_filter_requests: 0,

--- a/dash-spv/src/types.rs
+++ b/dash-spv/src/types.rs
@@ -9,6 +9,9 @@ use dashcore::{
 };
 use serde::{Deserialize, Serialize};
 
+/// Shared, mutex-protected set of filter heights used across components.
+pub type SharedFilterHeights = std::sync::Arc<tokio::sync::Mutex<std::collections::HashSet<u32>>>;
+
 /// Unique identifier for a peer connection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PeerId(pub u64);
@@ -550,7 +553,7 @@ pub struct SpvStats {
 
     /// Received filter heights for gap tracking (shared with FilterSyncManager).
     #[serde(skip)]
-    pub received_filter_heights: std::sync::Arc<tokio::sync::Mutex<std::collections::HashSet<u32>>>,
+    pub received_filter_heights: SharedFilterHeights,
 
     /// Number of filter requests currently active.
     pub active_filter_requests: u32,

--- a/dash-spv/tests/block_download_test.rs
+++ b/dash-spv/tests/block_download_test.rs
@@ -8,7 +8,8 @@
 //! Tests for block downloading on filter match functionality.
 
 use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 
 use dashcore::{

--- a/dash-spv/tests/cfheader_gap_test.rs
+++ b/dash-spv/tests/cfheader_gap_test.rs
@@ -6,7 +6,8 @@
 //! Tests for CFHeader gap detection and auto-restart functionality.
 
 use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 use dash_spv::{
     client::ClientConfig,

--- a/dash-spv/tests/filter_header_verification_test.rs
+++ b/dash-spv/tests/filter_header_verification_test.rs
@@ -32,7 +32,8 @@ use dashcore::{
 };
 use dashcore_hashes::{sha256d, Hash};
 use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 /// Mock network manager for testing filter sync
 #[derive(Debug)]

--- a/dash-spv/tests/simple_gap_test.rs
+++ b/dash-spv/tests/simple_gap_test.rs
@@ -1,7 +1,8 @@
 //! Basic test for CFHeader gap detection functionality.
 
 use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 use dash_spv::{
     client::ClientConfig,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - More accurate status display for last-synced filter height.

- Bug Fixes
  - Prevented potential deadlocks and stalls in filter synchronization.
  - More reliable failure reporting when headers are missing.

- Refactor
  - Migrated synchronization primitives to async-friendly locks to avoid blocking in async flows.
  - Centralized header-lookup logic with improved diagnostics and clearer error propagation.

- Tests
  - Updated tests and mocks to use awaitable locking and async-aware APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->