### PR TITLE
fix(rpc): GetNetworkInfoResult field names are invalid

### DIFF
--- a/rpc-json/src/lib.rs
+++ b/rpc-json/src/lib.rs
@@ -66,6 +66,7 @@ pub struct GetNetworkInfoResultAddress {
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct GetNetworkInfoResult {
+    // FIXME: validate max value range for version (currently deserializes into usize)
     pub version: usize,
     #[serde(rename = "buildversion")]
     pub build_version: String,
@@ -83,15 +84,15 @@ pub struct GetNetworkInfoResult {
     #[serde(rename = "networkactive")]
     pub network_active: bool,
     pub connections: usize,
-    #[serde(rename = "inboundconnections")]
+    #[serde(rename = "connections_in")]
     pub inbound_connections: usize,
-    #[serde(rename = "outboundconnections")]
+    #[serde(rename = "connections_out")]
     pub outbound_connections: usize,
-    #[serde(rename = "mnconnections")]
+    #[serde(rename = "connections_mn")]
     pub mn_connections: usize,
-    #[serde(rename = "inboundmnconnections")]
+    #[serde(rename = "connections_mn_in")]
     pub inbound_mn_connections: usize,
-    #[serde(rename = "outboundmnconnections")]
+    #[serde(rename = "connections_mn_out")]
     pub outbound_mn_connections: usize,
     #[serde(rename = "socketevents")]
     pub socket_events: String,


### PR DESCRIPTION
This pull request updates the `GetNetworkInfoResult` struct in `rpc-json/src/lib.rs` to align field names with new naming conventions and adds a note regarding version validation. The changes primarily focus on renaming fields to match updated API responses and improving clarity.

Field renaming for consistency:

* Renamed several connection-related fields in `GetNetworkInfoResult` to use the new naming conventions, such as `connections_in`, `connections_out`, `connections_mn`, `connections_mn_in`, and `connections_mn_out`, replacing the previous names (e.g., `inboundconnections`, `outboundconnections`, etc.) to better reflect their purpose and match the updated API schema.

Code documentation and validation:

* Added a FIXME comment to the `version` field in `GetNetworkInfoResult` noting the need to validate the maximum value range, since it currently deserializes into a `usize`.