### PR TITLE
fix(ffi-cli): do not pre-maturely break out, continue sync

### DIFF
--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -219,9 +219,6 @@ fn main() {
                     break;
                 }
                 dash_spv_ffi_sync_progress_destroy(prog_ptr);
-            } else {
-                // If progress is unavailable, assume sync finished or errored
-                break;
             }
             thread::sleep(Duration::from_millis(300));
         }


### PR DESCRIPTION
Fixes pre-mature exiting from the sync monitoring loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync progress polling in the CLI to avoid exiting when progress data is temporarily unavailable. The tool now waits and resumes reporting once data appears, reducing intermittent stalls or early termination and providing more consistent, reliable progress updates during long-running synchronizations. This enhances overall stability for users monitoring sync status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->