### PR TITLE
ci: temp disable integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -329,6 +329,7 @@ jobs:
 
   integrations_tests:
     name: Integration Tests
+    if: ${{ false }} # Temporarily disabled
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -356,4 +357,3 @@ jobs:
         uses: reviewdog/action-actionlint@v1
         with:
           fail_on_error: true
-


### PR DESCRIPTION
One integration test NEVER worked, it's best we disable it until it is recreated for Dash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes in this release.
- Chores
  - Disabled the Integration Tests job in the CI pipeline, preventing those tests from running in automated builds. All other automation remains unchanged.
- Style
  - Minor formatting cleanup in the CI workflow configuration.
- Tests
  - No changes to test logic or coverage; only execution of the disabled integration test job is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->