### PR TITLE
fix: prevent FFI event flooding and memory leak in progress callbacks

### DIFF
--- a/dash-spv-ffi/src/client.rs
+++ b/dash-spv-ffi/src/client.rs
@@ -846,8 +846,7 @@ pub unsafe extern "C" fn dash_spv_ffi_client_sync_to_tip_with_progress(
                                                     );
                                                     // Destroy stage_message allocated in FFIDetailedSyncProgress::from
                                                     crate::types::dash_spv_ffi_string_destroy(stage_message);
-                                                    // Prevent Drop from running on the struct to avoid re-freeing
-                                                    std::mem::forget(ffi_progress);
+                                                    // ffi_progress will be dropped normally here; no Drop impl exists
                                                 }
                                             }
                                         }


### PR DESCRIPTION
This commit addresses two critical issues in the FFI layer:

1. Event Throttling: Limit event draining to 500 events per call to prevent UI/main thread flooding. Remaining events stay queued for the next drain.

2. Memory Leak Fix: Properly free heap-allocated stage_message strings in FFIDetailedSyncProgress after each progress callback to avoid per-callback memory leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced UI freezes and responsiveness issues by capping how many events are processed each cycle, preventing the main thread from being overwhelmed.
  * Resolved memory leaks in synchronization progress notifications, improving stability and reliability during sync operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->