### PR TITLE
feat(key-wallet): register known addresses api

### DIFF
--- a/key-wallet/src/managed_account/managed_account_collection.rs
+++ b/key-wallet/src/managed_account/managed_account_collection.rs
@@ -525,6 +525,37 @@ impl ManagedAccountCollection {
         None
     }
 
+    /// Get a mutable reference to an account by its [`AccountType`]
+    pub fn get_account_by_type_mut(
+        &mut self,
+        account_type: &AccountType,
+    ) -> Option<&mut ManagedAccount> {
+        use crate::account::StandardAccountType;
+
+        match account_type {
+            AccountType::Standard {
+                index,
+                standard_account_type,
+            } => match standard_account_type {
+                StandardAccountType::BIP44Account => self.standard_bip44_accounts.get_mut(index),
+                StandardAccountType::BIP32Account => self.standard_bip32_accounts.get_mut(index),
+            },
+            AccountType::CoinJoin {
+                index,
+            } => self.coinjoin_accounts.get_mut(index),
+            AccountType::IdentityRegistration => self.identity_registration.as_mut(),
+            AccountType::IdentityTopUp {
+                registration_index,
+            } => self.identity_topup.get_mut(registration_index),
+            AccountType::IdentityTopUpNotBoundToIdentity => self.identity_topup_not_bound.as_mut(),
+            AccountType::IdentityInvitation => self.identity_invitation.as_mut(),
+            AccountType::ProviderVotingKeys => self.provider_voting_keys.as_mut(),
+            AccountType::ProviderOwnerKeys => self.provider_owner_keys.as_mut(),
+            AccountType::ProviderOperatorKeys => self.provider_operator_keys.as_mut(),
+            AccountType::ProviderPlatformKeys => self.provider_platform_keys.as_mut(),
+        }
+    }
+
     /// Remove an account from the collection
     pub fn remove(&mut self, index: u32) -> Option<ManagedAccount> {
         // Try standard BIP44 first

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -134,6 +134,52 @@ impl ManagedAccount {
         Self::new(managed_type, account.network, account.is_watch_only)
     }
 
+    /// Register externally derived addresses for account types that use a single address pool
+    pub fn register_known_addresses(
+        &mut self,
+        addresses: &[Address],
+    ) -> crate::error::Result<usize> {
+        if addresses.is_empty() {
+            return Ok(0);
+        }
+
+        match &mut self.account_type {
+            ManagedAccountType::IdentityRegistration {
+                addresses: pool,
+            }
+            | ManagedAccountType::IdentityTopUp {
+                addresses: pool,
+                ..
+            }
+            | ManagedAccountType::IdentityTopUpNotBoundToIdentity {
+                addresses: pool,
+            }
+            | ManagedAccountType::IdentityInvitation {
+                addresses: pool,
+            }
+            | ManagedAccountType::ProviderVotingKeys {
+                addresses: pool,
+            }
+            | ManagedAccountType::ProviderOwnerKeys {
+                addresses: pool,
+            }
+            | ManagedAccountType::ProviderOperatorKeys {
+                addresses: pool,
+            }
+            | ManagedAccountType::ProviderPlatformKeys {
+                addresses: pool,
+            }
+            | ManagedAccountType::CoinJoin {
+                addresses: pool,
+                ..
+            } => pool.register_known_addresses(addresses),
+            _ => Err(crate::error::Error::InvalidParameter(
+                "Registering known addresses is only supported for single-pool account types"
+                    .to_string(),
+            )),
+        }
+    }
+
     /// Get the account index
     pub fn index(&self) -> Option<u32> {
         self.account_type.index()


### PR DESCRIPTION
Add a `register_known_addresses` function so watch-only wallets can monitor externally derived addresses in SPV.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to register externally derived addresses in your wallet for automatic monitoring and synchronization.

* **Tests**
  * Added comprehensive test coverage for address registration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->