### PR TITLE
fix: Fix `PeerNetworkManager` cast in `broadcast_transaction`

### DIFF
--- a/dash-spv/src/client/transactions.rs
+++ b/dash-spv/src/client/transactions.rs
@@ -19,7 +19,7 @@ impl<
         let network = self
             .network
             .as_any()
-            .downcast_ref::<crate::network::multi_peer::MultiPeerNetworkManager>()
+            .downcast_ref::<crate::network::manager::PeerNetworkManager>()
             .ok_or_else(|| {
                 SpvError::Config("Network manager does not support broadcasting".to_string())
             })?;


### PR DESCRIPTION
PR #180 used `MultiPeerNetworkManager`, this was renamed in #183 which was merged before #180 but after its CI run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal network transaction broadcasting mechanism with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->