### PR TITLE
fix: Use non-blocking `TcpStream` in `dash-spv::network::TcpConnection`

### DIFF
--- a/dash-spv/src/client/config.rs
+++ b/dash-spv/src/client/config.rs
@@ -56,9 +56,6 @@ pub struct ClientConfig {
     /// Sync timeout.
     pub sync_timeout: Duration,
 
-    /// Read timeout for TCP socket operations.
-    pub read_timeout: Duration,
-
     /// Whether to enable filter syncing.
     pub enable_filters: bool,
 
@@ -206,7 +203,6 @@ impl Default for ClientConfig {
             connection_timeout: Duration::from_secs(30),
             message_timeout: Duration::from_secs(60),
             sync_timeout: Duration::from_secs(300),
-            read_timeout: Duration::from_millis(100),
             enable_filters: true,
             enable_masternodes: true,
             max_peers: 8,
@@ -323,12 +319,6 @@ impl ClientConfig {
     /// Set connection timeout.
     pub fn with_connection_timeout(mut self, timeout: Duration) -> Self {
         self.connection_timeout = timeout;
-        self
-    }
-
-    /// Set read timeout for TCP socket operations.
-    pub fn with_read_timeout(mut self, timeout: Duration) -> Self {
-        self.read_timeout = timeout;
         self
     }
 

--- a/dash-spv/src/client/config_test.rs
+++ b/dash-spv/src/client/config_test.rs
@@ -22,7 +22,6 @@ mod tests {
         assert_eq!(config.connection_timeout, Duration::from_secs(30));
         assert_eq!(config.message_timeout, Duration::from_secs(60));
         assert_eq!(config.sync_timeout, Duration::from_secs(300));
-        assert_eq!(config.read_timeout, Duration::from_millis(100));
         assert!(config.enable_filters);
         assert!(config.enable_masternodes);
         assert_eq!(config.max_peers, 8);
@@ -65,7 +64,6 @@ mod tests {
             .with_storage_path(path.clone())
             .with_validation_mode(ValidationMode::Basic)
             .with_connection_timeout(Duration::from_secs(10))
-            .with_read_timeout(Duration::from_secs(5))
             .with_log_level("debug")
             .with_max_concurrent_filter_requests(32)
             .with_filter_flow_control(false)
@@ -80,7 +78,6 @@ mod tests {
         assert!(config.enable_persistence);
         assert_eq!(config.validation_mode, ValidationMode::Basic);
         assert_eq!(config.connection_timeout, Duration::from_secs(10));
-        assert_eq!(config.read_timeout, Duration::from_secs(5));
         assert_eq!(config.log_level, "debug");
         assert_eq!(config.max_concurrent_filter_requests, 32);
         assert!(!config.enable_filter_flow_control);

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -22,7 +22,6 @@ mod peer_network_manager_tests {
             connection_timeout: Duration::from_secs(5),
             message_timeout: Duration::from_secs(30),
             sync_timeout: Duration::from_secs(60),
-            read_timeout: Duration::from_millis(15),
             enable_filters: false,
             enable_masternodes: false,
             max_peers: 3,
@@ -105,8 +104,7 @@ mod connection_tests {
     fn test_tcp_connection_creation() {
         let addr = "127.0.0.1:9999".parse().unwrap();
         let timeout = Duration::from_secs(30);
-        let read_timeout = Duration::from_millis(100);
-        let conn = TcpConnection::new(addr, timeout, read_timeout, Network::Dash);
+        let conn = TcpConnection::new(addr, timeout, Network::Dash);
 
         assert!(!conn.is_connected());
         assert_eq!(conn.peer_info().address, addr);

--- a/dash-spv/tests/error_handling_test.rs
+++ b/dash-spv/tests/error_handling_test.rs
@@ -17,7 +17,6 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
-use std::time::Duration;
 
 use dashcore::{
     block::{Header as BlockHeader, Version},
@@ -568,7 +567,7 @@ async fn test_network_connection_failure() {
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9999);
 
     // Test connection timeout
-    let result = TcpConnection::connect(addr, 1, Duration::from_millis(100), Network::Dash).await;
+    let result = TcpConnection::connect(addr, 1, Network::Dash).await;
 
     match result {
         Err(NetworkError::ConnectionFailed(msg)) => {

--- a/dash-spv/tests/handshake_test.rs
+++ b/dash-spv/tests/handshake_test.rs
@@ -13,8 +13,7 @@ async fn test_handshake_with_mainnet_peer() {
     let _ = env_logger::builder().filter_level(log::LevelFilter::Debug).is_test(true).try_init();
 
     let peer_addr: SocketAddr = "127.0.0.1:9999".parse().expect("Valid peer address");
-    let result =
-        TcpConnection::connect(peer_addr, 10, Duration::from_secs(10), Network::Dash).await;
+    let result = TcpConnection::connect(peer_addr, 10, Network::Dash).await;
 
     match result {
         Ok(mut connection) => {
@@ -55,7 +54,7 @@ async fn test_handshake_timeout() {
     // Using a non-routable IP that will cause the connection to hang
     let peer_addr: SocketAddr = "10.255.255.1:9999".parse().expect("Valid peer address");
     let start = std::time::Instant::now();
-    let result = TcpConnection::connect(peer_addr, 2, Duration::from_secs(2), Network::Dash).await;
+    let result = TcpConnection::connect(peer_addr, 2, Network::Dash).await;
     let elapsed = start.elapsed();
 
     assert!(result.is_err(), "Connection should fail for non-routable peer");
@@ -87,12 +86,7 @@ async fn test_network_manager_creation() {
 #[tokio::test]
 async fn test_multiple_connect_disconnect_cycles() {
     let peer_addr: SocketAddr = "127.0.0.1:9999".parse().expect("Valid peer address");
-    let mut connection = TcpConnection::new(
-        peer_addr,
-        Duration::from_secs(10),
-        Duration::from_secs(10),
-        Network::Dash,
-    );
+    let mut connection = TcpConnection::new(peer_addr, Duration::from_secs(10), Network::Dash);
 
     // Try multiple connect/disconnect cycles
     for i in 1..=3 {


### PR DESCRIPTION
`TCPConnection` currently uses the blocking/sync `std::net::TcpStream` which means every connect/read/write attempt blocks the tokio runtime from executing other tasks while the operation waits to succeed or time out which might be a lot if we are talking about connection timeout seconds being 10s and even just the read polling probably creates a lot blocking. Its inefficient and probably created/creates all sorts of issues including the issue which lead to https://github.com/dashpay/rust-dashcore/blob/86fdc9e/dash-spv/src/network/connection.rs#L104-L111.

So this PR:
- Refactors `TCPConnection` to use the async `tokio::net::TcpStream` instead of `std::net::TcpStream`
- Drops the `read_timeout` all over the place since its not longer needed. 

Requires #187 to make tests run reliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified network connection API by removing per-connection read timeout parameters, resulting in cleaner method signatures.
  * Upgraded network I/O handling to async-first architecture for improved performance and responsiveness.
  * Consolidated timeout handling at the application level rather than per-connection, reducing configuration complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->