### PR TITLE
refactor: `TcpConnection` -> `Peer` and `ConnectionPool` -> `PeerPool`

### DIFF
--- a/dash-spv/ARCHITECTURE.md
+++ b/dash-spv/ARCHITECTURE.md
@@ -680,7 +680,7 @@ The network module handles all P2P communication with the Dash network.
 - Graceful shutdown
 
 **Complex Types Used**:
-- `HashMap<PeerId, Arc<TcpConnection>>` - **JUSTIFIED**: Efficient peer lookup
+- `HashMap<PeerId, Arc<Peer>>` - **JUSTIFIED**: Efficient peer lookup
 - Multiple tokio::sync primitives - **JUSTIFIED**: Complex concurrent operations
 
 **Critical Issues**:

--- a/dash-spv/CLAUDE.md
+++ b/dash-spv/CLAUDE.md
@@ -116,7 +116,7 @@ TCP-based networking with proper Dash protocol implementation:
 - **DNS-first peer discovery**: Automatically uses DNS seeds (`dnsseed.dash.org`, `testnet-seed.dashdot.io`) when no explicit peers are configured
 - **Immediate startup**: No delay for initial peer discovery (10-second delay only for subsequent searches)
 - **Exclusive mode**: When explicit peers are provided, uses only those peers (no DNS discovery)
-- Connection management via `TcpConnection`
+- Connection management via `Peer`
 - Handshake handling via `HandshakeManager`
 - Message routing via `MessageHandler`
 - Peer support via `PeerNetworkManager`

--- a/dash-spv/src/network/handshake.rs
+++ b/dash-spv/src/network/handshake.rs
@@ -12,7 +12,7 @@ use dashcore::Network;
 
 use crate::client::config::MempoolStrategy;
 use crate::error::{NetworkError, NetworkResult};
-use crate::network::connection::TcpConnection;
+use crate::network::peer::Peer;
 
 /// Handshake state.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -65,7 +65,7 @@ impl HandshakeManager {
     }
 
     /// Perform the handshake with a peer.
-    pub async fn perform_handshake(&mut self, connection: &mut TcpConnection) -> NetworkResult<()> {
+    pub async fn perform_handshake(&mut self, connection: &mut Peer) -> NetworkResult<()> {
         use tokio::time::{timeout, Duration};
 
         // Send version message
@@ -145,7 +145,7 @@ impl HandshakeManager {
     /// Handle a handshake message.
     async fn handle_handshake_message(
         &mut self,
-        connection: &mut TcpConnection,
+        connection: &mut Peer,
         message: NetworkMessage,
     ) -> NetworkResult<Option<HandshakeState>> {
         match message {
@@ -238,7 +238,7 @@ impl HandshakeManager {
     }
 
     /// Send version message.
-    async fn send_version(&mut self, connection: &mut TcpConnection) -> NetworkResult<()> {
+    async fn send_version(&mut self, connection: &mut Peer) -> NetworkResult<()> {
         let version_message = self.build_version_message(connection.peer_info().address)?;
         connection.send_message(NetworkMessage::Version(version_message)).await?;
         tracing::debug!("Sent version message");
@@ -309,7 +309,7 @@ impl HandshakeManager {
     }
 
     /// Negotiate headers2 support with the peer after handshake completion.
-    async fn negotiate_headers2(&self, connection: &mut TcpConnection) -> NetworkResult<()> {
+    async fn negotiate_headers2(&self, connection: &mut Peer) -> NetworkResult<()> {
         // Headers2 is currently disabled due to protocol compatibility issues
         // Always send SendHeaders regardless of peer support
         tracing::info!("Headers2 is disabled - sending SendHeaders only");

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -1,11 +1,11 @@
 //! Network layer for the Dash SPV client.
 
 pub mod addrv2;
-pub mod connection;
 pub mod constants;
 pub mod discovery;
 pub mod handshake;
 pub mod manager;
+pub mod peer;
 pub mod persist;
 pub mod pool;
 pub mod reputation;
@@ -23,9 +23,9 @@ use crate::error::NetworkResult;
 use dashcore::network::message::NetworkMessage;
 use dashcore::BlockHash;
 
-pub use connection::TcpConnection;
 pub use handshake::{HandshakeManager, HandshakeState};
 pub use manager::PeerNetworkManager;
+pub use peer::Peer;
 
 /// Network manager trait for abstracting network operations.
 #[async_trait]

--- a/dash-spv/src/network/pool.rs
+++ b/dash-spv/src/network/pool.rs
@@ -1,4 +1,4 @@
-//! Connection pool for managing multiple peer connections
+//! Peer pool for managing multiple peer connections
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
@@ -6,22 +6,22 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::error::{NetworkError, SpvError as Error};
-use crate::network::connection::TcpConnection;
 use crate::network::constants::{MAX_PEERS, MIN_PEERS};
+use crate::network::peer::Peer;
 
-/// Pool for managing multiple TCP connections
-pub struct ConnectionPool {
-    /// Active connections mapped by peer address
-    connections: Arc<RwLock<HashMap<SocketAddr, Arc<RwLock<TcpConnection>>>>>,
+/// Pool for managing multiple peer instances
+pub struct PeerPool {
+    /// Active peers mapped by address
+    peers: Arc<RwLock<HashMap<SocketAddr, Arc<RwLock<Peer>>>>>,
     /// Addresses currently being connected to
     connecting: Arc<RwLock<HashSet<SocketAddr>>>,
 }
 
-impl ConnectionPool {
-    /// Create a new connection pool
+impl PeerPool {
+    /// Create a new peer pool
     pub fn new() -> Self {
         Self {
-            connections: Arc::new(RwLock::new(HashMap::new())),
+            peers: Arc::new(RwLock::new(HashMap::new())),
             connecting: Arc::new(RwLock::new(HashSet::new())),
         }
     }
@@ -32,16 +32,16 @@ impl ConnectionPool {
         connecting.insert(addr)
     }
 
-    /// Add a connection to the pool
-    pub async fn add_connection(&self, addr: SocketAddr, conn: TcpConnection) -> Result<(), Error> {
-        let mut connections = self.connections.write().await;
+    /// Add a peer to the pool
+    pub async fn add_peer(&self, addr: SocketAddr, peer: Peer) -> Result<(), Error> {
+        let mut peers = self.peers.write().await;
         let mut connecting = self.connecting.write().await;
 
         // Remove from connecting set
         connecting.remove(&addr);
 
         // Check if we're at capacity
-        if connections.len() >= MAX_PEERS {
+        if peers.len() >= MAX_PEERS {
             return Err(Error::Network(NetworkError::ConnectionFailed(format!(
                 "Maximum peers ({}) reached",
                 MAX_PEERS
@@ -49,45 +49,45 @@ impl ConnectionPool {
         }
 
         // Check if already connected
-        if connections.contains_key(&addr) {
+        if peers.contains_key(&addr) {
             return Err(Error::Network(NetworkError::ConnectionFailed(format!(
                 "Already connected to {}",
                 addr
             ))));
         }
 
-        connections.insert(addr, Arc::new(RwLock::new(conn)));
-        log::info!("Added connection to {}, total peers: {}", addr, connections.len());
+        peers.insert(addr, Arc::new(RwLock::new(peer)));
+        log::info!("Added peer {}, total peers: {}", addr, peers.len());
         Ok(())
     }
 
-    /// Remove a connection from the pool
-    pub async fn remove_connection(&self, addr: &SocketAddr) -> Option<Arc<RwLock<TcpConnection>>> {
-        let removed = self.connections.write().await.remove(addr);
+    /// Remove a peer from the pool
+    pub async fn remove_peer(&self, addr: &SocketAddr) -> Option<Arc<RwLock<Peer>>> {
+        let removed = self.peers.write().await.remove(addr);
         if removed.is_some() {
-            log::info!("Removed connection to {}", addr);
+            log::info!("Removed peer {}", addr);
         }
         removed
     }
 
-    /// Get all active connections
-    pub async fn get_all_connections(&self) -> Vec<(SocketAddr, Arc<RwLock<TcpConnection>>)> {
-        self.connections.read().await.iter().map(|(addr, conn)| (*addr, conn.clone())).collect()
+    /// Get all active peers
+    pub async fn get_all_peers(&self) -> Vec<(SocketAddr, Arc<RwLock<Peer>>)> {
+        self.peers.read().await.iter().map(|(addr, peer)| (*addr, peer.clone())).collect()
     }
 
-    /// Get a specific connection
-    pub async fn get_connection(&self, addr: &SocketAddr) -> Option<Arc<RwLock<TcpConnection>>> {
-        self.connections.read().await.get(addr).cloned()
+    /// Get a specific peer
+    pub async fn get_peer(&self, addr: &SocketAddr) -> Option<Arc<RwLock<Peer>>> {
+        self.peers.read().await.get(addr).cloned()
     }
 
-    /// Get the number of active connections
-    pub async fn connection_count(&self) -> usize {
-        self.connections.read().await.len()
+    /// Get the number of active peers
+    pub async fn peer_count(&self) -> usize {
+        self.peers.read().await.len()
     }
 
     /// Check if connected to a specific peer
     pub async fn is_connected(&self, addr: &SocketAddr) -> bool {
-        self.connections.read().await.contains_key(addr)
+        self.peers.read().await.contains_key(addr)
     }
 
     /// Check if currently connecting to a peer
@@ -97,41 +97,41 @@ impl ConnectionPool {
 
     /// Get all connected peer addresses
     pub async fn get_connected_addresses(&self) -> Vec<SocketAddr> {
-        self.connections.read().await.keys().copied().collect()
+        self.peers.read().await.keys().copied().collect()
     }
 
-    /// Check if we need more connections
-    pub async fn needs_more_connections(&self) -> bool {
-        self.connection_count().await < MIN_PEERS
+    /// Check if we need more peers
+    pub async fn needs_more_peers(&self) -> bool {
+        self.peer_count().await < MIN_PEERS
     }
 
-    /// Check if we can accept more connections
-    pub async fn can_accept_connections(&self) -> bool {
-        self.connection_count().await < MAX_PEERS
+    /// Check if we can accept more peers
+    pub async fn can_accept_peers(&self) -> bool {
+        self.peer_count().await < MAX_PEERS
     }
 
     /// Clean up disconnected peers
     pub async fn cleanup_disconnected(&self) {
-        let connections = self.connections.read().await;
+        let peers = self.peers.read().await;
         let mut unhealthy = Vec::new();
 
-        // Check each connection's health
-        for (addr, conn) in connections.iter() {
+        // Check each peer's health
+        for (addr, peer) in peers.iter() {
             // Use blocking read to properly check health
-            let conn_guard = conn.read().await;
-            if !conn_guard.is_healthy() {
+            let peer_guard = peer.read().await;
+            if !peer_guard.is_healthy() {
                 unhealthy.push(*addr);
             }
         }
 
         // Release read lock before taking write lock
-        drop(connections);
+        drop(peers);
 
         // Remove unhealthy connections
         if !unhealthy.is_empty() {
-            let mut connections = self.connections.write().await;
+            let mut peers = self.peers.write().await;
             for addr in unhealthy {
-                connections.remove(&addr);
+                peers.remove(&addr);
                 log::warn!(
                     "Cleaned up unhealthy peer: {} (marked unhealthy by health check)",
                     addr
@@ -141,7 +141,7 @@ impl ConnectionPool {
     }
 }
 
-impl Default for ConnectionPool {
+impl Default for PeerPool {
     fn default() -> Self {
         Self::new()
     }
@@ -152,13 +152,13 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_connection_pool_basic() {
-        let pool = ConnectionPool::new();
+    async fn test_peer_pool_basic() {
+        let pool = PeerPool::new();
 
         // Initial state
-        assert_eq!(pool.connection_count().await, 0);
-        assert!(pool.needs_more_connections().await);
-        assert!(pool.can_accept_connections().await);
+        assert_eq!(pool.peer_count().await, 0);
+        assert!(pool.needs_more_peers().await);
+        assert!(pool.can_accept_peers().await);
 
         // Test marking as connecting
         let addr = "127.0.0.1:9999".parse().expect("Failed to parse test address");

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -95,38 +95,38 @@ mod peer_network_manager_tests {
 }
 
 #[cfg(test)]
-mod connection_tests {
-    use crate::network::connection::TcpConnection;
+mod peer_tests {
+    use crate::network::peer::Peer;
     use dashcore::Network;
     use std::time::Duration;
 
     #[test]
-    fn test_tcp_connection_creation() {
+    fn test_peer_creation() {
         let addr = "127.0.0.1:9999".parse().unwrap();
         let timeout = Duration::from_secs(30);
-        let conn = TcpConnection::new(addr, timeout, Network::Dash);
+        let peer = Peer::new(addr, timeout, Network::Dash);
 
-        assert!(!conn.is_connected());
-        assert_eq!(conn.peer_info().address, addr);
+        assert!(!peer.is_connected());
+        assert_eq!(peer.peer_info().address, addr);
     }
 }
 
 #[cfg(test)]
 mod pool_tests {
-    use crate::network::pool::ConnectionPool;
+    use crate::network::pool::PeerPool;
 
     #[tokio::test]
     async fn test_pool_limits() {
-        let pool = ConnectionPool::new();
+        let pool = PeerPool::new();
 
-        // Test needs_more_connections logic
-        assert!(pool.needs_more_connections().await);
+        // Test needs_more_peers logic
+        assert!(pool.needs_more_peers().await);
 
         // Can accept up to MAX_PEERS
-        assert!(pool.can_accept_connections().await);
+        assert!(pool.can_accept_peers().await);
 
-        // Test connection count
-        assert_eq!(pool.connection_count().await, 0);
+        // Test peer count
+        assert_eq!(pool.peer_count().await, 0);
 
         // Verify pool limits indirectly through methods; avoid constant assertions
     }

--- a/dash-spv/tests/error_handling_test.rs
+++ b/dash-spv/tests/error_handling_test.rs
@@ -28,7 +28,7 @@ use dashcore_hashes::Hash;
 use tokio::sync::{mpsc, RwLock};
 
 use dash_spv::error::*;
-use dash_spv::network::{NetworkManager, TcpConnection};
+use dash_spv::network::{NetworkManager, Peer};
 use dash_spv::storage::{DiskStorageManager, StorageManager};
 use dash_spv::sync::sequential::phases::SyncPhase;
 use dash_spv::sync::sequential::recovery::{RecoveryManager, RecoveryStrategy};
@@ -567,7 +567,7 @@ async fn test_network_connection_failure() {
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9999);
 
     // Test connection timeout
-    let result = TcpConnection::connect(addr, 1, Network::Dash).await;
+    let result = Peer::connect(addr, 1, Network::Dash).await;
 
     match result {
         Err(NetworkError::ConnectionFailed(msg)) => {

--- a/dash-spv/tests/handshake_test.rs
+++ b/dash-spv/tests/handshake_test.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use dash_spv::client::config::MempoolStrategy;
-use dash_spv::network::{HandshakeManager, NetworkManager, PeerNetworkManager, TcpConnection};
+use dash_spv::network::{HandshakeManager, NetworkManager, Peer, PeerNetworkManager};
 use dash_spv::{ClientConfig, Network};
 
 #[tokio::test]
@@ -13,7 +13,7 @@ async fn test_handshake_with_mainnet_peer() {
     let _ = env_logger::builder().filter_level(log::LevelFilter::Debug).is_test(true).try_init();
 
     let peer_addr: SocketAddr = "127.0.0.1:9999".parse().expect("Valid peer address");
-    let result = TcpConnection::connect(peer_addr, 10, Network::Dash).await;
+    let result = Peer::connect(peer_addr, 10, Network::Dash).await;
 
     match result {
         Ok(mut connection) => {
@@ -54,7 +54,7 @@ async fn test_handshake_timeout() {
     // Using a non-routable IP that will cause the connection to hang
     let peer_addr: SocketAddr = "10.255.255.1:9999".parse().expect("Valid peer address");
     let start = std::time::Instant::now();
-    let result = TcpConnection::connect(peer_addr, 2, Network::Dash).await;
+    let result = Peer::connect(peer_addr, 2, Network::Dash).await;
     let elapsed = start.elapsed();
 
     assert!(result.is_err(), "Connection should fail for non-routable peer");
@@ -86,7 +86,7 @@ async fn test_network_manager_creation() {
 #[tokio::test]
 async fn test_multiple_connect_disconnect_cycles() {
     let peer_addr: SocketAddr = "127.0.0.1:9999".parse().expect("Valid peer address");
-    let mut connection = TcpConnection::new(peer_addr, Duration::from_secs(10), Network::Dash);
+    let mut connection = Peer::new(peer_addr, Duration::from_secs(10), Network::Dash);
 
     // Try multiple connect/disconnect cycles
     for i in 1..=3 {

--- a/dash-spv/tests/peer_test.rs
+++ b/dash-spv/tests/peer_test.rs
@@ -198,7 +198,7 @@ async fn test_max_peer_limit() {
         DashSpvClient::new(config, network_manager, storage_manager, wallet).await.unwrap();
 
     // The client should never connect to more than MAX_PEERS
-    // This is enforced in the ConnectionPool
+    // This is enforced in the PeerPool
     println!("Maximum peer limit is set to: {}", MAX_PEERS);
     assert_eq!(MAX_PEERS, 3, "Default max peers should be 12");
 }
@@ -208,17 +208,17 @@ mod unit_tests {
     use super::*;
     use dash_spv::network::addrv2::AddrV2Handler;
     use dash_spv::network::discovery::DnsDiscovery;
-    use dash_spv::network::pool::ConnectionPool;
+    use dash_spv::network::pool::PeerPool;
     use dashcore::network::constants::ServiceFlags;
 
     #[tokio::test]
     async fn test_connection_pool_limits() {
-        let pool = ConnectionPool::new();
+        let pool = PeerPool::new();
 
         // Should start empty
-        assert_eq!(pool.connection_count().await, 0);
-        assert!(pool.needs_more_connections().await);
-        assert!(pool.can_accept_connections().await);
+        assert_eq!(pool.peer_count().await, 0);
+        assert!(pool.needs_more_peers().await);
+        assert!(pool.can_accept_peers().await);
 
         // Test marking as connecting
         let addr1: SocketAddr = "127.0.0.1:9999".parse().unwrap();


### PR DESCRIPTION
Just some renaming for readability. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal network architecture for improved peer management and code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->