### PR TITLE
fix: Locking issue after #190

### DIFF
--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -331,6 +331,9 @@ impl PeerNetworkManager {
                         message = peer_guard.receive_message() => {
                             message
                         },
+                        _ = tokio::time::sleep(MESSAGE_RECEIVE_TIMEOUT) => {
+                            Err(NetworkError::Timeout)
+                        },
                         _ = shutdown_token.cancelled() => {
                             log::info!("Breaking peer reader loop for {} - shutdown signal received while reading (iteration {})", addr, loop_iteration);
                             break;


### PR DESCRIPTION
#188 removed the read timeouts of the `Peer::receive_message` which currently leads to a lockup of the peer because the write lock is held while waiting for the message. Needs some more refactoring but this works for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of network communication timeouts between peers with automatic recovery mechanisms to enhance stability.
  * Enhanced error tracking and debug logging for timeout events to support network diagnostics.
  * Refined message reception control flow while maintaining shutdown procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->