### PR TITLE
refactor: Drop unused code in `dash-spv::network`

### DIFF
--- a/dash-spv/src/client/message_handler.rs
+++ b/dash-spv/src/client/message_handler.rs
@@ -332,17 +332,9 @@ impl<
             }
             NetworkMessage::Ping(nonce) => {
                 tracing::debug!("Received ping with nonce {}", nonce);
-                // Automatically respond with pong
-                if let Err(e) = self.network.handle_ping(nonce).await {
-                    tracing::error!("Failed to send pong response: {}", e);
-                }
             }
             NetworkMessage::Pong(nonce) => {
                 tracing::debug!("Received pong with nonce {}", nonce);
-                // Validate the pong nonce
-                if let Err(e) = self.network.handle_pong(nonce) {
-                    tracing::warn!("Invalid pong received: {}", e);
-                }
             }
             NetworkMessage::CFilter(cfilter) => {
                 tracing::debug!("Received CFilter for block {}", cfilter.block_hash);

--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -127,21 +127,6 @@ impl<
             }
             drop(running);
 
-            // Check if we need to send a ping
-            if self.network.should_ping() {
-                match self.network.send_ping().await {
-                    Ok(nonce) => {
-                        tracing::trace!("Sent periodic ping with nonce {}", nonce);
-                    }
-                    Err(e) => {
-                        tracing::error!("Failed to send periodic ping: {}", e);
-                    }
-                }
-            }
-
-            // Clean up old pending pings
-            self.network.cleanup_old_pings();
-
             // Check if we have connected peers and start initial sync operations (once)
             if !initial_sync_started && self.network.peer_count() > 0 {
                 tracing::info!("🚀 Peers connected, starting initial sync operations...");

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -17,7 +17,6 @@ mod tests;
 pub mod mock;
 
 use async_trait::async_trait;
-use tokio::sync::mpsc;
 
 use crate::error::NetworkResult;
 use dashcore::network::message::NetworkMessage;
@@ -54,24 +53,6 @@ pub trait NetworkManager: Send + Sync {
     /// Get peer information.
     fn peer_info(&self) -> Vec<crate::types::PeerInfo>;
 
-    /// Send a ping message.
-    async fn send_ping(&mut self) -> NetworkResult<u64>;
-
-    /// Handle a received ping message by sending a pong.
-    async fn handle_ping(&mut self, nonce: u64) -> NetworkResult<()>;
-
-    /// Handle a received pong message.
-    fn handle_pong(&mut self, nonce: u64) -> NetworkResult<()>;
-
-    /// Check if we should send a ping (2 minute timeout).
-    fn should_ping(&self) -> bool;
-
-    /// Clean up old pending pings.
-    fn cleanup_old_pings(&mut self);
-
-    /// Get a message sender channel for sending messages from other components.
-    fn get_message_sender(&self) -> mpsc::Sender<NetworkMessage>;
-
     /// Get the best block height reported by connected peers.
     async fn get_peer_best_height(&self) -> NetworkResult<Option<u32>>;
 
@@ -80,12 +61,6 @@ pub trait NetworkManager: Send + Sync {
         &self,
         service_flags: dashcore::network::constants::ServiceFlags,
     ) -> bool;
-
-    /// Get peers that support a specific service.
-    async fn get_peers_with_service(
-        &self,
-        service_flags: dashcore::network::constants::ServiceFlags,
-    ) -> Vec<crate::types::PeerInfo>;
 
     /// Check if any connected peer supports headers2 compression.
     async fn has_headers2_peer(&self) -> bool {

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -71,17 +71,6 @@ mod peer_network_manager_tests {
     }
 
     #[tokio::test]
-    async fn test_peer_network_manager_creation() {
-        let config = create_test_config();
-        let manager = PeerNetworkManager::new(&config).await.unwrap();
-
-        // Should start with zero peers
-        assert_eq!(manager.peer_count_async().await, 0);
-        // Note: is_connected() still uses sync approach, so we'll check async
-        assert_eq!(manager.peer_count_async().await, 0);
-    }
-
-    #[tokio::test]
     async fn test_as_any_downcast() {
         let config = create_test_config();
         let manager = PeerNetworkManager::new(&config).await.unwrap();

--- a/dash-spv/tests/block_download_test.rs
+++ b/dash-spv/tests/block_download_test.rs
@@ -97,29 +97,6 @@ impl NetworkManager for MockNetworkManager {
         vec![]
     }
 
-    async fn send_ping(&mut self) -> dash_spv::error::NetworkResult<u64> {
-        Ok(12345)
-    }
-
-    async fn handle_ping(&mut self, _nonce: u64) -> dash_spv::error::NetworkResult<()> {
-        Ok(())
-    }
-
-    fn handle_pong(&mut self, _nonce: u64) -> dash_spv::error::NetworkResult<()> {
-        Ok(())
-    }
-
-    fn should_ping(&self) -> bool {
-        false
-    }
-
-    fn cleanup_old_pings(&mut self) {}
-
-    fn get_message_sender(&self) -> tokio::sync::mpsc::Sender<NetworkMessage> {
-        let (tx, _rx) = tokio::sync::mpsc::channel(1);
-        tx
-    }
-
     async fn get_peer_best_height(&self) -> dash_spv::error::NetworkResult<Option<u32>> {
         Ok(Some(100))
     }
@@ -129,13 +106,6 @@ impl NetworkManager for MockNetworkManager {
         _service_flags: dashcore::network::constants::ServiceFlags,
     ) -> bool {
         true
-    }
-
-    async fn get_peers_with_service(
-        &self,
-        _service_flags: dashcore::network::constants::ServiceFlags,
-    ) -> Vec<dash_spv::types::PeerInfo> {
-        vec![]
     }
 
     async fn get_last_message_peer_id(&self) -> dash_spv::types::PeerId {

--- a/dash-spv/tests/cfheader_gap_test.rs
+++ b/dash-spv/tests/cfheader_gap_test.rs
@@ -208,29 +208,6 @@ async fn test_cfheader_restart_cooldown() {
             Vec::new()
         }
 
-        async fn send_ping(&mut self) -> NetworkResult<u64> {
-            Ok(0)
-        }
-
-        async fn handle_ping(&mut self, _nonce: u64) -> NetworkResult<()> {
-            Ok(())
-        }
-
-        fn handle_pong(&mut self, _nonce: u64) -> NetworkResult<()> {
-            Ok(())
-        }
-
-        fn should_ping(&self) -> bool {
-            false
-        }
-
-        fn cleanup_old_pings(&mut self) {}
-
-        fn get_message_sender(&self) -> tokio::sync::mpsc::Sender<NetworkMessage> {
-            let (tx, _rx) = tokio::sync::mpsc::channel(1);
-            tx
-        }
-
         async fn get_peer_best_height(&self) -> dash_spv::error::NetworkResult<Option<u32>> {
             Ok(Some(100))
         }
@@ -240,13 +217,6 @@ async fn test_cfheader_restart_cooldown() {
             _service_flags: dashcore::network::constants::ServiceFlags,
         ) -> bool {
             true
-        }
-
-        async fn get_peers_with_service(
-            &self,
-            _service_flags: dashcore::network::constants::ServiceFlags,
-        ) -> Vec<dash_spv::types::PeerInfo> {
-            vec![]
         }
 
         async fn get_last_message_peer_id(&self) -> dash_spv::types::PeerId {

--- a/dash-spv/tests/chainlock_validation_test.rs
+++ b/dash-spv/tests/chainlock_validation_test.rs
@@ -99,30 +99,6 @@ impl NetworkManager for MockNetworkManager {
         }]
     }
 
-    async fn send_ping(&mut self) -> dash_spv::error::NetworkResult<u64> {
-        Ok(12345) // Return a dummy nonce
-    }
-
-    async fn handle_ping(&mut self, _nonce: u64) -> dash_spv::error::NetworkResult<()> {
-        Ok(())
-    }
-
-    fn should_ping(&self) -> bool {
-        false // Mock doesn't need pinging
-    }
-
-    fn cleanup_old_pings(&mut self) {
-        // No-op for mock
-    }
-
-    fn get_message_sender(
-        &self,
-    ) -> tokio::sync::mpsc::Sender<dashcore::network::message::NetworkMessage> {
-        // Create a dummy sender that drops messages
-        let (tx, _rx) = tokio::sync::mpsc::channel(1);
-        tx
-    }
-
     async fn get_peer_best_height(&self) -> dash_spv::error::NetworkResult<Option<u32>> {
         Ok(Some(0)) // Return dummy height
     }
@@ -132,17 +108,6 @@ impl NetworkManager for MockNetworkManager {
         _service_flags: dashcore::network::constants::ServiceFlags,
     ) -> bool {
         true // Mock always has service
-    }
-
-    async fn get_peers_with_service(
-        &self,
-        _service_flags: dashcore::network::constants::ServiceFlags,
-    ) -> Vec<dash_spv::types::PeerInfo> {
-        self.peer_info() // Return same peer info
-    }
-
-    fn handle_pong(&mut self, _nonce: u64) -> dash_spv::error::NetworkResult<()> {
-        Ok(()) // No-op for mock
     }
 
     async fn update_peer_dsq_preference(

--- a/dash-spv/tests/edge_case_filter_sync_test.rs
+++ b/dash-spv/tests/edge_case_filter_sync_test.rs
@@ -93,29 +93,6 @@ impl NetworkManager for MockNetworkManager {
         Vec::new()
     }
 
-    async fn send_ping(&mut self) -> NetworkResult<u64> {
-        Ok(0)
-    }
-
-    async fn handle_ping(&mut self, _nonce: u64) -> NetworkResult<()> {
-        Ok(())
-    }
-
-    fn handle_pong(&mut self, _nonce: u64) -> NetworkResult<()> {
-        Ok(())
-    }
-
-    fn should_ping(&self) -> bool {
-        false
-    }
-
-    fn cleanup_old_pings(&mut self) {}
-
-    fn get_message_sender(&self) -> tokio::sync::mpsc::Sender<NetworkMessage> {
-        let (tx, _rx) = tokio::sync::mpsc::channel(1);
-        tx
-    }
-
     async fn get_peer_best_height(&self) -> dash_spv::error::NetworkResult<Option<u32>> {
         Ok(Some(100))
     }
@@ -125,13 +102,6 @@ impl NetworkManager for MockNetworkManager {
         _service_flags: dashcore::network::constants::ServiceFlags,
     ) -> bool {
         true
-    }
-
-    async fn get_peers_with_service(
-        &self,
-        _service_flags: dashcore::network::constants::ServiceFlags,
-    ) -> Vec<dash_spv::types::PeerInfo> {
-        vec![]
     }
 
     async fn get_last_message_peer_id(&self) -> dash_spv::types::PeerId {

--- a/dash-spv/tests/error_handling_test.rs
+++ b/dash-spv/tests/error_handling_test.rs
@@ -25,14 +25,14 @@ use dashcore::{
     BlockHash, Network, OutPoint, Txid,
 };
 use dashcore_hashes::Hash;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::RwLock;
 
 use dash_spv::error::*;
 use dash_spv::network::{NetworkManager, Peer};
 use dash_spv::storage::{DiskStorageManager, StorageManager};
 use dash_spv::sync::sequential::phases::SyncPhase;
 use dash_spv::sync::sequential::recovery::{RecoveryManager, RecoveryStrategy};
-use dash_spv::types::{ChainState, MempoolState, PeerInfo, UnconfirmedTransaction};
+use dash_spv::types::{ChainState, MempoolState, UnconfirmedTransaction};
 
 /// Mock network manager for testing error scenarios
 struct MockNetworkManager {
@@ -135,32 +135,6 @@ impl dash_spv::network::NetworkManager for MockNetworkManager {
         vec![]
     }
 
-    async fn send_ping(&mut self) -> NetworkResult<u64> {
-        let nonce = 1234u64;
-        self.send_message(dashcore::network::message::NetworkMessage::Ping(nonce)).await?;
-        Ok(nonce)
-    }
-
-    async fn handle_ping(&mut self, _nonce: u64) -> NetworkResult<()> {
-        Ok(())
-    }
-
-    fn handle_pong(&mut self, _nonce: u64) -> NetworkResult<()> {
-        Ok(())
-    }
-
-    fn should_ping(&self) -> bool {
-        false
-    }
-
-    fn cleanup_old_pings(&mut self) {}
-
-    fn get_message_sender(&self) -> mpsc::Sender<dashcore::network::message::NetworkMessage> {
-        // Create a dummy channel for testing
-        let (_tx, _rx) = mpsc::channel(1);
-        _tx
-    }
-
     async fn get_peer_best_height(&self) -> NetworkResult<Option<u32>> {
         Ok(Some(1000000))
     }
@@ -170,13 +144,6 @@ impl dash_spv::network::NetworkManager for MockNetworkManager {
         _service_flags: dashcore::network::constants::ServiceFlags,
     ) -> bool {
         true
-    }
-
-    async fn get_peers_with_service(
-        &self,
-        _service_flags: dashcore::network::constants::ServiceFlags,
-    ) -> Vec<PeerInfo> {
-        vec![]
     }
 
     async fn update_peer_dsq_preference(&mut self, _wants_dsq: bool) -> NetworkResult<()> {

--- a/dash-spv/tests/error_recovery_integration_test.rs
+++ b/dash-spv/tests/error_recovery_integration_test.rs
@@ -478,31 +478,6 @@ impl dash_spv::network::NetworkManager for MockNetworkManager {
         vec![]
     }
 
-    async fn send_ping(&mut self) -> dash_spv::error::NetworkResult<u64> {
-        Ok(1234)
-    }
-
-    async fn handle_ping(&mut self, _nonce: u64) -> dash_spv::error::NetworkResult<()> {
-        Ok(())
-    }
-
-    fn handle_pong(&mut self, _nonce: u64) -> dash_spv::error::NetworkResult<()> {
-        Ok(())
-    }
-
-    fn should_ping(&self) -> bool {
-        false
-    }
-
-    fn cleanup_old_pings(&mut self) {}
-
-    fn get_message_sender(
-        &self,
-    ) -> tokio::sync::mpsc::Sender<dashcore::network::message::NetworkMessage> {
-        let (_tx, _rx) = tokio::sync::mpsc::channel(1);
-        _tx
-    }
-
     async fn get_peer_best_height(&self) -> dash_spv::error::NetworkResult<Option<u32>> {
         Ok(Some(1000000))
     }
@@ -512,13 +487,6 @@ impl dash_spv::network::NetworkManager for MockNetworkManager {
         _service_flags: dashcore::network::constants::ServiceFlags,
     ) -> bool {
         true
-    }
-
-    async fn get_peers_with_service(
-        &self,
-        _service_flags: dashcore::network::constants::ServiceFlags,
-    ) -> Vec<dash_spv::types::PeerInfo> {
-        vec![]
     }
 
     async fn update_peer_dsq_preference(

--- a/dash-spv/tests/filter_header_verification_test.rs
+++ b/dash-spv/tests/filter_header_verification_test.rs
@@ -85,29 +85,6 @@ impl NetworkManager for MockNetworkManager {
         vec![]
     }
 
-    fn should_ping(&self) -> bool {
-        false
-    }
-
-    async fn send_ping(&mut self) -> Result<u64, NetworkError> {
-        Ok(0)
-    }
-
-    fn cleanup_old_pings(&mut self) {}
-
-    async fn handle_ping(&mut self, _nonce: u64) -> Result<(), NetworkError> {
-        Ok(())
-    }
-
-    fn handle_pong(&mut self, _nonce: u64) -> Result<(), NetworkError> {
-        Ok(())
-    }
-
-    fn get_message_sender(&self) -> tokio::sync::mpsc::Sender<NetworkMessage> {
-        let (tx, _rx) = tokio::sync::mpsc::channel(1);
-        tx
-    }
-
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -121,13 +98,6 @@ impl NetworkManager for MockNetworkManager {
         _service_flags: dashcore::network::constants::ServiceFlags,
     ) -> bool {
         true
-    }
-
-    async fn get_peers_with_service(
-        &self,
-        _service_flags: dashcore::network::constants::ServiceFlags,
-    ) -> Vec<dash_spv::types::PeerInfo> {
-        vec![]
     }
 
     async fn get_last_message_peer_id(&self) -> dash_spv::types::PeerId {


### PR DESCRIPTION
Just dropping some unused code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed automatic network keep-alive (ping/pong) handling and nonce validation; ping responses and validations are now logged only.
  * Simplified the network manager surface by removing several peer-query and message-routing helpers.
  * Streamlined monitor logic to stop periodic pinging and related cleanup/error paths.

* **Tests**
  * Updated or removed tests that depended on the removed ping/keep-alive and message-sender behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->