### PR TITLE
fix: More follow-up to #190

### DIFF
--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -13,13 +13,13 @@
 
 use std::time::{Duration, Instant, SystemTime};
 
+use super::{BlockProcessingTask, DashSpvClient, MessageHandler};
 use crate::error::{Result, SpvError};
+use crate::network::constants::MESSAGE_RECEIVE_TIMEOUT;
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use crate::types::{DetailedSyncProgress, SyncProgress};
 use key_wallet_manager::wallet_interface::WalletInterface;
-
-use super::{BlockProcessingTask, DashSpvClient, MessageHandler};
 
 impl<
         W: WalletInterface + Send + Sync + 'static,
@@ -491,7 +491,7 @@ impl<
             }
 
             // Handle network messages with timeout for responsiveness
-            match tokio::time::timeout(Duration::from_millis(1000), self.network.receive_message())
+            match tokio::time::timeout(MESSAGE_RECEIVE_TIMEOUT, self.network.receive_message())
                 .await
             {
                 Ok(msg_result) => match msg_result {

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -331,8 +331,8 @@ impl PeerNetworkManager {
                         message = peer_guard.receive_message() => {
                             message
                         },
-                        _ = tokio::time::sleep(MESSAGE_RECEIVE_TIMEOUT) => {
-                            Err(NetworkError::Timeout)
+                        _ = tokio::time::sleep(MESSAGE_POLL_INTERVAL) => {
+                            Ok(None)
                         },
                         _ = shutdown_token.cancelled() => {
                             log::info!("Breaking peer reader loop for {} - shutdown signal received while reading (iteration {})", addr, loop_iteration);


### PR DESCRIPTION
The sleep timeout branch introduced in #188 returns an `Err(NetworkError::Timeout)` which leads to a misbehavior update below in the `msg_result` match and eventually in a peer ban. This shouldn't happen because the `sleep` timing out only means that there is no data available right now. Instead, it now returns `Ok(None)` which will just keep things going.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network timeout handling to treat idle polling periods as normal operations rather than error conditions, enhancing stability during message reception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->