### PR TITLE
fix: Let the examples start the network monitoring

### DIFF
--- a/dash-spv/examples/filter_sync.rs
+++ b/dash-spv/examples/filter_sync.rs
@@ -8,6 +8,7 @@ use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet_manager::wallet_manager::WalletManager;
 use std::str::FromStr;
 use std::sync::Arc;
+use tokio::signal;
 use tokio::sync::RwLock;
 
 #[tokio::main]
@@ -44,7 +45,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Full sync including filters
     let progress = client.sync_to_tip().await?;
 
-    println!("Synchronization completed!");
+    tokio::select! {
+        result = client.monitor_network() => {
+            println!("monitor_network result {:?}", result);
+        },
+        _ = signal::ctrl_c() => {
+            println!("monitor_network canceled");
+        }
+    }
+
     println!("Headers synced: {}", progress.header_height);
     println!("Filter headers synced: {}", progress.filter_header_height);
 

--- a/dash-spv/examples/simple_sync.rs
+++ b/dash-spv/examples/simple_sync.rs
@@ -7,6 +7,7 @@ use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 
 use key_wallet_manager::wallet_manager::WalletManager;
 use std::sync::Arc;
+use tokio::signal;
 use tokio::sync::RwLock;
 
 #[tokio::main]
@@ -46,6 +47,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stats = client.stats().await?;
     println!("Headers downloaded: {}", stats.headers_downloaded);
     println!("Bytes received: {}", stats.bytes_received);
+
+    tokio::select! {
+        result = client.monitor_network() => {
+            println!("monitor_network result {:?}", result);
+        },
+        _ = signal::ctrl_c() => {
+            println!("monitor_network canceled");
+        }
+    }
 
     // Stop the client
     client.stop().await?;

--- a/dash-spv/examples/spv_with_wallet.rs
+++ b/dash-spv/examples/spv_with_wallet.rs
@@ -8,6 +8,7 @@ use dash_spv::{ClientConfig, DashSpvClient};
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet_manager::wallet_manager::WalletManager;
 use std::sync::Arc;
+use tokio::signal;
 use tokio::sync::RwLock;
 
 #[tokio::main]
@@ -47,6 +48,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // - Mempool transactions via process_mempool_transaction()
     // - Reorgs via handle_reorg()
     // - Compact filter checks via check_compact_filter()
+    tokio::select! {
+        result = client.monitor_network() => {
+            println!("monitor_network result {:?}", result);
+        },
+        _ = signal::ctrl_c() => {
+            println!("monitor_network canceled");
+        }
+    }
 
     // Stop the client
     println!("Stopping SPV client...");


### PR DESCRIPTION
The examples currently don't start `PeerNetworkManager::monitor_network` so there is no communication happening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced example applications with graceful shutdown support. Users can now cleanly interrupt and terminate running processes by pressing Ctrl+C instead of forced termination, enabling proper cleanup and preventing potential data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->