### PR TITLE
feat: Introduce `DashSpvClientInterface`

### DIFF
--- a/dash-spv-ffi/src/error.rs
+++ b/dash-spv-ffi/src/error.rs
@@ -52,6 +52,7 @@ pub extern "C" fn dash_spv_ffi_clear_error() {
 impl From<SpvError> for FFIErrorCode {
     fn from(err: SpvError) -> Self {
         match err {
+            SpvError::ChannelFailure(_, _) => FFIErrorCode::RuntimeError,
             SpvError::Network(_) => FFIErrorCode::NetworkError,
             SpvError::Storage(_) => FFIErrorCode::StorageError,
             SpvError::Validation(_) => FFIErrorCode::ValidationError,
@@ -60,6 +61,7 @@ impl From<SpvError> for FFIErrorCode {
             SpvError::Config(_) => FFIErrorCode::ConfigError,
             SpvError::Parse(_) => FFIErrorCode::ValidationError,
             SpvError::Wallet(_) => FFIErrorCode::WalletError,
+            SpvError::QuorumLookupError(_) => FFIErrorCode::ValidationError,
             SpvError::General(_) => FFIErrorCode::Unknown,
         }
     }

--- a/dash-spv/examples/simple_sync.rs
+++ b/dash-spv/examples/simple_sync.rs
@@ -7,8 +7,8 @@ use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 
 use key_wallet_manager::wallet_manager::WalletManager;
 use std::sync::Arc;
-use tokio::signal;
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -48,17 +48,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Headers downloaded: {}", stats.headers_downloaded);
     println!("Bytes received: {}", stats.bytes_received);
 
-    tokio::select! {
-        result = client.monitor_network() => {
-            println!("monitor_network result {:?}", result);
-        },
-        _ = signal::ctrl_c() => {
-            println!("monitor_network canceled");
-        }
-    }
+    let (_command_sender, command_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let shutdown_token = CancellationToken::new();
 
-    // Stop the client
-    client.stop().await?;
+    client.run(command_receiver, shutdown_token).await?;
 
     println!("Done!");
     Ok(())

--- a/dash-spv/examples/spv_with_wallet.rs
+++ b/dash-spv/examples/spv_with_wallet.rs
@@ -8,8 +8,8 @@ use dash_spv::{ClientConfig, DashSpvClient};
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet_manager::wallet_manager::WalletManager;
 use std::sync::Arc;
-use tokio::signal;
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -48,18 +48,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // - Mempool transactions via process_mempool_transaction()
     // - Reorgs via handle_reorg()
     // - Compact filter checks via check_compact_filter()
-    tokio::select! {
-        result = client.monitor_network() => {
-            println!("monitor_network result {:?}", result);
-        },
-        _ = signal::ctrl_c() => {
-            println!("monitor_network canceled");
-        }
-    }
 
-    // Stop the client
-    println!("Stopping SPV client...");
-    client.stop().await?;
+    let (_command_sender, command_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let shutdown_token = CancellationToken::new();
+
+    client.run(command_receiver, shutdown_token).await?;
 
     println!("Done!");
     Ok(())

--- a/dash-spv/src/client/interface.rs
+++ b/dash-spv/src/client/interface.rs
@@ -1,0 +1,79 @@
+use crate::error::SpvError;
+use dashcore::sml::llmq_type::LLMQType;
+use dashcore::sml::quorum_entry::qualified_quorum_entry::QualifiedQuorumEntry;
+use dashcore::QuorumHash;
+use std::fmt::Display;
+use tokio::sync::{mpsc, oneshot};
+
+pub type Result<T> = std::result::Result<T, SpvError>;
+
+pub type GetQuorumByHeightResult = Result<QualifiedQuorumEntry>;
+
+async fn receive<Type>(context: String, receiver: oneshot::Receiver<Type>) -> Result<Type> {
+    receiver.await.map_err(|error| SpvError::ChannelFailure(context, error.to_string()))
+}
+
+pub enum DashSpvClientCommand {
+    GetQuorumByHeight {
+        height: u32,
+        quorum_type: LLMQType,
+        quorum_hash: QuorumHash,
+        sender: oneshot::Sender<GetQuorumByHeightResult>,
+    },
+}
+
+impl DashSpvClientCommand {
+    pub async fn send(
+        self,
+        context: String,
+        sender: mpsc::UnboundedSender<DashSpvClientCommand>,
+    ) -> Result<()> {
+        sender.send(self).map_err(|error| SpvError::ChannelFailure(context, error.to_string()))?;
+        Ok(())
+    }
+}
+
+impl Display for DashSpvClientCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            DashSpvClientCommand::GetQuorumByHeight {
+                height,
+                quorum_type,
+                quorum_hash,
+                sender: _,
+            } => format!("GetQuorumByHeight({height}, {quorum_type}, {quorum_hash})"),
+        };
+        write!(f, "{}", str)
+    }
+}
+
+#[derive(Clone)]
+pub struct DashSpvClientInterface {
+    pub command_sender: mpsc::UnboundedSender<DashSpvClientCommand>,
+}
+
+impl DashSpvClientInterface {
+    pub fn new(command_sender: mpsc::UnboundedSender<DashSpvClientCommand>) -> Self {
+        Self {
+            command_sender,
+        }
+    }
+
+    pub async fn get_quorum_by_height(
+        &self,
+        height: u32,
+        quorum_type: LLMQType,
+        quorum_hash: QuorumHash,
+    ) -> GetQuorumByHeightResult {
+        let (sender, receiver) = oneshot::channel();
+        let command = DashSpvClientCommand::GetQuorumByHeight {
+            height,
+            quorum_type,
+            quorum_hash,
+            sender,
+        };
+        let context = command.to_string();
+        command.send(context.clone(), self.command_sender.clone()).await?;
+        receive(context, receiver).await?
+    }
+}

--- a/dash-spv/src/client/mod.rs
+++ b/dash-spv/src/client/mod.rs
@@ -37,6 +37,7 @@
 pub mod block_processor;
 pub mod config;
 pub mod filter_sync;
+pub mod interface;
 pub mod message_handler;
 pub mod status_display;
 

--- a/dash-spv/src/client/queries.rs
+++ b/dash-spv/src/client/queries.rs
@@ -10,9 +10,11 @@ use crate::error::{Result, SpvError};
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use crate::types::AddressBalance;
+use dashcore::sml::llmq_type::LLMQType;
 use dashcore::sml::masternode_list::MasternodeList;
 use dashcore::sml::masternode_list_engine::MasternodeListEngine;
 use dashcore::sml::quorum_entry::qualified_quorum_entry::QualifiedQuorumEntry;
+use dashcore::QuorumHash;
 use key_wallet_manager::wallet_interface::WalletInterface;
 
 use super::DashSpvClient;
@@ -73,27 +75,15 @@ impl<
     pub fn get_quorum_at_height(
         &self,
         height: u32,
-        quorum_type: u8,
-        quorum_hash: &[u8; 32],
-    ) -> Option<&QualifiedQuorumEntry> {
-        use dashcore::sml::llmq_type::LLMQType;
-        use dashcore::QuorumHash;
-        use dashcore_hashes::Hash;
-
-        let llmq_type: LLMQType = LLMQType::from(quorum_type);
-        if llmq_type == LLMQType::LlmqtypeUnknown {
-            tracing::warn!("Invalid quorum type {} requested at height {}", quorum_type, height);
-            return None;
-        };
-
-        let qhash = QuorumHash::from_byte_array(*quorum_hash);
-
+        quorum_type: LLMQType,
+        quorum_hash: QuorumHash,
+    ) -> Result<QualifiedQuorumEntry> {
         // First check if we have the masternode list at this height
         match self.get_masternode_list_at_height(height) {
             Some(ml) => {
                 // We have the masternode list, now look for the quorum
-                match ml.quorums.get(&llmq_type) {
-                    Some(quorums) => match quorums.get(&qhash) {
+                match ml.quorums.get(&quorum_type) {
+                    Some(quorums) => match quorums.get(&quorum_hash) {
                         Some(quorum) => {
                             tracing::debug!(
                                 "Found quorum type {} at height {} with hash {}",
@@ -101,17 +91,16 @@ impl<
                                 height,
                                 hex::encode(quorum_hash)
                             );
-                            Some(quorum)
+                            Ok(quorum.clone())
                         }
                         None => {
-                            tracing::warn!(
-                                "Quorum not found: type {} at height {} with hash {} (masternode list exists with {} quorums of this type)",
-                                quorum_type,
-                                height,
-                                hex::encode(quorum_hash),
-                                quorums.len()
-                            );
-                            None
+                            let message = format!("Quorum not found: type {} at height {} with hash {} (masternode list exists with {} quorums of this type)",
+                                                quorum_type,
+                                                height,
+                                                hex::encode(quorum_hash),
+                                                quorums.len());
+                            tracing::warn!(message);
+                            Err(SpvError::QuorumLookupError(message))
                         }
                     },
                     None => {
@@ -120,7 +109,10 @@ impl<
                             quorum_type,
                             height
                         );
-                        None
+                        Err(SpvError::QuorumLookupError(format!(
+                            "No quorums of type {} found at height {}",
+                            quorum_type, height
+                        )))
                     }
                 }
             }
@@ -129,7 +121,10 @@ impl<
                     "No masternode list found at height {} - cannot retrieve quorum",
                     height
                 );
-                None
+                Err(SpvError::QuorumLookupError(format!(
+                    "No masternode list found at height {}",
+                    height
+                )))
             }
         }
     }

--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -11,15 +11,17 @@
 //! This is the largest module as it handles all coordination between network,
 //! storage, and the sync manager.
 
-use std::time::{Duration, Instant, SystemTime};
-
 use super::{BlockProcessingTask, DashSpvClient, MessageHandler};
+use crate::client::interface::DashSpvClientCommand;
 use crate::error::{Result, SpvError};
 use crate::network::constants::MESSAGE_RECEIVE_TIMEOUT;
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use crate::types::{DetailedSyncProgress, SyncProgress};
 use key_wallet_manager::wallet_interface::WalletInterface;
+use std::time::{Duration, Instant, SystemTime};
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio_util::sync::CancellationToken;
 
 impl<
         W: WalletInterface + Send + Sync + 'static,
@@ -66,7 +68,11 @@ impl<
     ///
     /// This is the sole network message receiver to prevent race conditions.
     /// All sync operations coordinate through this monitoring loop.
-    pub async fn monitor_network(&mut self) -> Result<()> {
+    pub async fn monitor_network(
+        &mut self,
+        mut command_receiver: UnboundedReceiver<DashSpvClientCommand>,
+        token: CancellationToken,
+    ) -> Result<()> {
         let running = self.running.read().await;
         if !*running {
             return Err(SpvError::Config("Client not running".to_string()));
@@ -475,86 +481,142 @@ impl<
                 last_chainlock_validation_check = Instant::now();
             }
 
-            // Handle network messages with timeout for responsiveness
-            match tokio::time::timeout(MESSAGE_RECEIVE_TIMEOUT, self.network.receive_message())
-                .await
-            {
-                Ok(msg_result) => match msg_result {
-                    Ok(Some(message)) => {
-                        // Wrap message handling in comprehensive error handling
-                        match self.handle_network_message(message).await {
-                            Ok(_) => {
-                                // Message handled successfully
-                            }
-                            Err(e) => {
-                                tracing::error!("Error handling network message: {}", e);
-
-                                // Categorize error severity
-                                match &e {
-                                    SpvError::Network(_) => {
-                                        tracing::warn!("Network error during message handling - may recover automatically");
-                                    }
-                                    SpvError::Storage(_) => {
-                                        tracing::error!("Storage error during message handling - this may affect data consistency");
-                                    }
-                                    SpvError::Validation(_) => {
-                                        tracing::warn!("Validation error during message handling - message rejected");
-                                    }
-                                    _ => {
-                                        tracing::error!("Unexpected error during message handling");
-                                    }
-                                }
-
-                                // Continue monitoring despite errors
-                                tracing::debug!(
-                                    "Continuing network monitoring despite message handling error"
-                                );
-                            }
+            tokio::select! {
+                received = command_receiver.recv() => {
+                    match received {
+                    None => {tracing::warn!("DashSpvClientCommand channel closed.");},
+                    Some(command) => {
+                            self.handle_command(command).await.unwrap_or_else(|e| tracing::error!("Failed to handle command: {}", e));
                         }
                     }
-                    Ok(None) => {
-                        // No message available, brief pause before continuing
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                    }
-                    Err(e) => {
-                        // Handle specific network error types
-                        if let crate::error::NetworkError::ConnectionFailed(msg) = &e {
-                            if msg.contains("No connected peers") || self.network.peer_count() == 0
-                            {
-                                tracing::warn!("All peers disconnected during monitoring, checking connection health");
-
-                                // Wait for potential reconnection
-                                let mut wait_count = 0;
-                                while wait_count < 10 && self.network.peer_count() == 0 {
-                                    tokio::time::sleep(Duration::from_millis(500)).await;
-                                    wait_count += 1;
+                }
+                received = self.network.receive_message() => {
+                    match received {
+                        Ok(None) => {
+                            continue;
+                        }
+                        Ok(Some(message)) => {
+                            // Wrap message handling in comprehensive error handling
+                            match self.handle_network_message(message).await {
+                                Ok(_) => {
+                                    // Message handled successfully
                                 }
+                                Err(e) => {
+                                    tracing::error!("Error handling network message: {}", e);
 
-                                if self.network.peer_count() > 0 {
-                                    tracing::info!(
-                                        "✅ Reconnected to {} peer(s), resuming monitoring",
-                                        self.network.peer_count()
-                                    );
-                                    continue;
-                                } else {
-                                    tracing::warn!(
-                                        "No peers available after waiting, will retry monitoring"
+                                    // Categorize error severity
+                                    match &e {
+                                        SpvError::Network(_) => {
+                                            tracing::warn!("Network error during message handling - may recover automatically");
+                                        }
+                                        SpvError::Storage(_) => {
+                                            tracing::error!("Storage error during message handling - this may affect data consistency");
+                                        }
+                                        SpvError::Validation(_) => {
+                                            tracing::warn!("Validation error during message handling - message rejected");
+                                        }
+                                        _ => {
+                                            tracing::error!("Unexpected error during message handling");
+                                        }
+                                    }
+
+                                    // Continue monitoring despite errors
+                                    tracing::debug!(
+                                        "Continuing network monitoring despite message handling error"
                                     );
                                 }
                             }
-                        }
+                        },
+                        Err(err) => {
+                            // Handle specific network error types
+                            if let crate::error::NetworkError::ConnectionFailed(msg) = &err {
+                                if msg.contains("No connected peers") || self.network.peer_count() == 0 {
+                                    tracing::warn!("All peers disconnected during monitoring, checking connection health");
 
-                        tracing::error!("Network error during monitoring: {}", e);
-                        tokio::time::sleep(Duration::from_secs(5)).await;
+                                    // Wait for potential reconnection
+                                    let mut wait_count = 0;
+                                    while wait_count < 10 && self.network.peer_count() == 0 {
+                                        tokio::time::sleep(Duration::from_millis(500)).await;
+                                        wait_count += 1;
+                                    }
+
+                                    if self.network.peer_count() > 0 {
+                                        tracing::info!(
+                                            "✅ Reconnected to {} peer(s), resuming monitoring",
+                                            self.network.peer_count()
+                                        );
+                                        continue
+                                    } else {
+                                        tracing::warn!(
+                                            "No peers available after waiting, will retry monitoring"
+                                        );
+                                    }
+                                }
+                            }
+
+                            tracing::error!("Network error during monitoring: {}", err);
+                            tokio::time::sleep(Duration::from_secs(5)).await;
+                        }
                     }
-                },
-                Err(_) => {
-                    // Timeout occurred - this is expected and allows checking running state
-                    // Continue the loop to check if we should stop
+                }
+                _ = tokio::time::sleep(MESSAGE_RECEIVE_TIMEOUT) => {}
+                _ = token.cancelled() => {
+                    log::debug!("DashSpvClient run loop cancelled");
+                    break
                 }
             }
         }
 
+        Ok(())
+    }
+
+    pub async fn run(
+        mut self,
+        command_receiver: UnboundedReceiver<DashSpvClientCommand>,
+        shutdown_token: CancellationToken,
+    ) -> Result<()> {
+        let client_token = shutdown_token.clone();
+
+        let client_task = tokio::spawn(async move {
+            let result = self.monitor_network(command_receiver, client_token).await;
+            if let Err(e) = &result {
+                tracing::error!("Error running client: {}", e);
+            }
+            if let Err(e) = self.stop().await {
+                tracing::error!("Error stopping client: {}", e);
+            }
+            result
+        });
+
+        let shutdown_task = tokio::spawn(async move {
+            if let Err(e) = tokio::signal::ctrl_c().await {
+                tracing::error!("Error waiting for ctrl_c: {}", e);
+            }
+            tracing::debug!("Shutdown signal received");
+            shutdown_token.cancel();
+        });
+
+        let (client_result, _) = tokio::join!(client_task, shutdown_task);
+        client_result.map_err(|e| SpvError::General(format!("client_task panicked: {e}")))?
+    }
+
+    async fn handle_command(&mut self, command: DashSpvClientCommand) -> Result<()> {
+        match command {
+            DashSpvClientCommand::GetQuorumByHeight {
+                height,
+                quorum_type,
+                quorum_hash,
+                sender,
+            } => {
+                let result = self.get_quorum_at_height(height, quorum_type, quorum_hash);
+                if sender.send(result).is_err() {
+                    return Err(SpvError::ChannelFailure(
+                        format!("GetQuorumByHeight({height}, {quorum_type}, {quorum_hash})"),
+                        "Failed to send quorum result".to_string(),
+                    ));
+                }
+            }
+        }
         Ok(())
     }
 

--- a/dash-spv/src/error.rs
+++ b/dash-spv/src/error.rs
@@ -6,6 +6,9 @@ use thiserror::Error;
 /// Main error type for the Dash SPV client.
 #[derive(Debug, Error)]
 pub enum SpvError {
+    #[error("Channel failure for: {0} - Failure: {1}")]
+    ChannelFailure(String, String),
+
     #[error("Network error: {0}")]
     Network(#[from] NetworkError),
 
@@ -32,6 +35,9 @@ pub enum SpvError {
 
     #[error("Wallet error: {0}")]
     Wallet(#[from] WalletError),
+
+    #[error("Quorum lookup error: {0}")]
+    QuorumLookupError(String),
 }
 
 /// Parse-related errors.


### PR DESCRIPTION
This introduces a new interface for command based access to `DashSpvClient` data from within different threads without the need of any arcs/locks but instead via async channels.

 This was implemented as a more general alternative for #200 so for now it only contains `DashSpvClientInterface:: get_quorum_by_height`.

### Example:

```rust
let (command_sender, command_receiver) = tokio::sync::mpsc::unbounded_channel();
let shutdown_token = CancellationToken::new();

let client_task = tokio::spawn(async move {
    tracing::info!("Run SPV client...");
    client.run(command_receiver, shutdown_token)
});

let client_interface = DashSpvClientInterface::new(command_sender);
let quorum_hash = QuorumHash::from_str("4acfa5c6d92071d206da5b767039d42f24e7ab1a694a5b8014cddc088311e448").unwrap();
let result = client_interface.get_quorum_by_height(0, LLMQType::Llmqtype25_67, quorum_hash).await;
println!("get_quorum_by_height result: {:?}", result);

tokio::join!(client_task);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-driven interface for asynchronous SPV client operations.
  * Introduced async quorum lookup capability with improved error reporting.
  * Implemented cancellation token–based shutdown mechanism for better lifecycle management.

* **Bug Fixes**
  * Enhanced error handling for channel and quorum lookup failures with explicit error codes.

* **API Changes**
  * Updated client lifecycle methods to support command-driven workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->