### PR TITLE
fix(spv): filter headers not starting from checkpoint on reconnect

### DIFF
--- a/dash-spv/src/storage/disk/filters.rs
+++ b/dash-spv/src/storage/disk/filters.rs
@@ -20,8 +20,6 @@ impl DiskStorageManager {
             let current_tip = self.cached_filter_tip_height.read().await;
             match *current_tip {
                 Some(tip) => {
-                    // If we're syncing from a checkpoint and the current tip is below it,
-                    // start from the checkpoint instead of continuing from the old tip
                     if sync_base_height > 0 && tip < sync_base_height {
                         sync_base_height
                     } else {

--- a/dash-spv/src/storage/disk/filters.rs
+++ b/dash-spv/src/storage/disk/filters.rs
@@ -19,7 +19,15 @@ impl DiskStorageManager {
         let mut next_blockchain_height = {
             let current_tip = self.cached_filter_tip_height.read().await;
             match *current_tip {
-                Some(tip) => tip + 1,
+                Some(tip) => {
+                    // If we're syncing from a checkpoint and the current tip is below it,
+                    // start from the checkpoint instead of continuing from the old tip
+                    if sync_base_height > 0 && tip < sync_base_height {
+                        sync_base_height
+                    } else {
+                        tip + 1
+                    }
+                }
                 None => {
                     // If we have a checkpoint, start from there, otherwise from 0
                     if sync_base_height > 0 {


### PR DESCRIPTION
If you sync from checkpoint, disconnect, and reconnect, filter headers were being loaded from storage at 0 instead of checkpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blockchain sync height calculation during checkpoint-based synchronization so the next sync height never regresses when the node's tip is behind the configured sync base, improving synchronization correctness and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->