### PR TITLE
refactor: Rename `HeaderSyncManagerWithReorg` -> `HeaderSyncManager`

### DIFF
--- a/dash-spv/src/sync/headers.rs
+++ b/dash-spv/src/sync/headers.rs
@@ -1,6 +1,4 @@
-//! Header synchronization with reorganization support
-//!
-//! This module extends the basic header sync with fork detection and reorg handling.
+//! Header synchronization with fork detection and reorganization handling.
 
 use dashcore::{
     block::{Header as BlockHeader, Version},
@@ -45,8 +43,8 @@ impl Default for ReorgConfig {
     }
 }
 
-/// Manages header synchronization with reorg support
-pub struct HeaderSyncManagerWithReorg<S: StorageManager, N: NetworkManager> {
+/// Manages header synchronization with fork detection and reorganization support
+pub struct HeaderSyncManager<S: StorageManager, N: NetworkManager> {
     _phantom_s: std::marker::PhantomData<S>,
     _phantom_n: std::marker::PhantomData<N>,
     config: ClientConfig,
@@ -67,9 +65,9 @@ pub struct HeaderSyncManagerWithReorg<S: StorageManager, N: NetworkManager> {
 }
 
 impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync + 'static>
-    HeaderSyncManagerWithReorg<S, N>
+    HeaderSyncManager<S, N>
 {
-    /// Create a new header sync manager with reorg support
+    /// Create a new header sync manager
     pub fn new(
         config: &ClientConfig,
         reorg_config: ReorgConfig,
@@ -229,14 +227,14 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
         Ok(loaded_count)
     }
 
-    /// Handle a Headers message with fork detection and reorg support
+    /// Handle a Headers message
     pub async fn handle_headers_message(
         &mut self,
         headers: Vec<BlockHeader>,
         storage: &mut S,
         network: &mut N,
     ) -> SyncResult<bool> {
-        tracing::info!("🔍 Handle headers message with {} headers (reorg-aware)", headers.len());
+        tracing::info!("🔍 Handle headers message with {} headers", headers.len());
 
         // Step 1: Handle Empty Batch
         if headers.is_empty() {
@@ -656,7 +654,7 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
             return Err(SyncError::SyncInProgress);
         }
 
-        tracing::info!("Preparing header synchronization with reorg support");
+        tracing::info!("Preparing header synchronization");
         tracing::info!(
             "Chain state before prepare_sync: sync_base_height={}, synced_from_checkpoint={}, headers_count={}",
             self.get_sync_base_height(),
@@ -804,7 +802,7 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
         self.syncing_headers = true;
         self.last_sync_progress = std::time::Instant::now();
         tracing::info!(
-            "✅ Prepared header sync state with reorg support, ready to request headers from {:?}",
+            "✅ Prepared header sync state, ready to request headers from {:?}",
             base_hash
         );
 
@@ -813,7 +811,7 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
 
     /// Start synchronizing headers (initialize the sync state).
     pub async fn start_sync(&mut self, network: &mut N, storage: &mut S) -> SyncResult<bool> {
-        tracing::info!("Starting header synchronization with reorg support");
+        tracing::info!("Starting header synchronization");
 
         // Prepare sync state (this will check if sync is already in progress)
         let base_hash = self.prepare_sync(storage).await?;

--- a/dash-spv/src/sync/mod.rs
+++ b/dash-spv/src/sync/mod.rs
@@ -5,10 +5,10 @@
 
 pub mod embedded_data;
 pub mod filters;
+pub mod headers;
 pub mod headers2_state;
-pub mod headers_with_reorg;
 pub mod masternodes;
 pub mod sequential;
 pub use filters::FilterSyncManager;
-pub use headers_with_reorg::{HeaderSyncManagerWithReorg, ReorgConfig};
+pub use headers::{HeaderSyncManager, ReorgConfig};
 pub use masternodes::MasternodeSyncManager;

--- a/dash-spv/src/sync/sequential/lifecycle.rs
+++ b/dash-spv/src/sync/sequential/lifecycle.rs
@@ -8,9 +8,7 @@ use crate::client::ClientConfig;
 use crate::error::{SyncError, SyncResult};
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
-use crate::sync::{
-    FilterSyncManager, HeaderSyncManagerWithReorg, MasternodeSyncManager, ReorgConfig,
-};
+use crate::sync::{FilterSyncManager, HeaderSyncManager, MasternodeSyncManager, ReorgConfig};
 use crate::types::{SharedFilterHeights, SpvStats};
 use key_wallet_manager::{wallet_interface::WalletInterface, Network as WalletNetwork};
 use std::sync::Arc;
@@ -40,10 +38,9 @@ impl<
         Ok(Self {
             current_phase: SyncPhase::Idle,
             transition_manager: TransitionManager::new(config),
-            header_sync: HeaderSyncManagerWithReorg::new(config, reorg_config, chain_state)
-                .map_err(|e| {
-                    SyncError::InvalidState(format!("Failed to create header sync manager: {}", e))
-                })?,
+            header_sync: HeaderSyncManager::new(config, reorg_config, chain_state).map_err(
+                |e| SyncError::InvalidState(format!("Failed to create header sync manager: {}", e)),
+            )?,
             filter_sync: FilterSyncManager::new(config, received_filter_heights),
             masternode_sync: MasternodeSyncManager::new(config),
             config: config.clone(),

--- a/dash-spv/src/sync/sequential/manager.rs
+++ b/dash-spv/src/sync/sequential/manager.rs
@@ -6,7 +6,7 @@ use crate::client::ClientConfig;
 use crate::error::SyncResult;
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
-use crate::sync::{FilterSyncManager, HeaderSyncManagerWithReorg, MasternodeSyncManager};
+use crate::sync::{FilterSyncManager, HeaderSyncManager, MasternodeSyncManager};
 use crate::types::SyncProgress;
 use key_wallet_manager::wallet_interface::WalletInterface;
 
@@ -47,7 +47,7 @@ pub(super) const CHAINLOCK_VALIDATION_MASTERNODE_OFFSET: u32 = 8;
 /// - Optimize across trait boundaries
 ///
 /// ### 3. **Delegation Pattern** 🔗
-/// The sync manager delegates to specialized sub-managers (`HeaderSyncManagerWithReorg`,
+/// The sync manager delegates to specialized sub-managers (`HeaderSyncManager`,
 /// `FilterSyncManager`, `MasternodeSyncManager`), each also generic over `S` and `N`.
 /// This maintains type consistency throughout the sync pipeline.
 ///
@@ -68,7 +68,7 @@ pub struct SequentialSyncManager<S: StorageManager, N: NetworkManager, W: Wallet
     pub(super) transition_manager: TransitionManager,
 
     /// Existing sync managers (wrapped and controlled)
-    pub(super) header_sync: HeaderSyncManagerWithReorg<S, N>,
+    pub(super) header_sync: HeaderSyncManager<S, N>,
     pub(super) filter_sync: FilterSyncManager<S, N>,
     pub(super) masternode_sync: MasternodeSyncManager<S, N>,
 


### PR DESCRIPTION
Just renaming the "with reorg" away in all places after dropping the old implementation of `HeaderSyncManager` in #208.

Based on:
- #208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the header synchronization API by consolidating module structure and updating public type naming for improved consistency and clarity.
  * Updated documentation to reflect streamlined header synchronization functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->