### PR TITLE
fix: Properly handle immature transactions

### DIFF
--- a/dash-spv/src/client/block_processor.rs
+++ b/dash-spv/src/client/block_processor.rs
@@ -227,6 +227,10 @@ impl<W: WalletInterface + Send + Sync + 'static, S: StorageManager + Send + Sync
         // Process block with wallet
         let mut wallet = self.wallet.write().await;
         let txids = wallet.process_block(&block, height, self.network).await;
+
+        // Update chain height to process any matured coinbase transactions
+        wallet.update_chain_height(self.network, height).await;
+
         if !txids.is_empty() {
             tracing::info!(
                 "🎯 Wallet found {} relevant transactions in block {} at height {}",

--- a/dash-spv/src/client/block_processor_test.rs
+++ b/dash-spv/src/client/block_processor_test.rs
@@ -85,6 +85,8 @@ mod tests {
             let map = self.effects.lock().await;
             map.get(&tx.txid()).cloned()
         }
+
+        async fn update_chain_height(&mut self, _network: Network, _height: u32) {}
     }
 
     fn create_test_block(network: Network) -> Block {
@@ -299,6 +301,8 @@ mod tests {
             async fn describe(&self, _network: Network) -> String {
                 "NonMatchingWallet (test implementation)".to_string()
             }
+
+            async fn update_chain_height(&mut self, _network: Network, _height: u32) {}
         }
 
         let (task_tx, task_rx) = mpsc::unbounded_channel();

--- a/dash-spv/src/sync/sequential/message_handlers.rs
+++ b/dash-spv/src/sync/sequential/message_handlers.rs
@@ -764,6 +764,9 @@ impl<
 
         let relevant_txids = wallet.process_block(&block, block_height, self.config.network).await;
 
+        // Update chain height to process any matured coinbase transactions
+        wallet.update_chain_height(self.config.network, block_height).await;
+
         drop(wallet);
 
         if !relevant_txids.is_empty() {

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -69,4 +69,10 @@ pub trait WalletInterface: Send + Sync {
     async fn describe(&self, _network: Network) -> String {
         "Wallet interface description unavailable".to_string()
     }
+
+    /// Notify the wallet that the chain has advanced to a new height.
+    ///
+    /// This processes any coinbase transactions that have matured (reached 100 confirmations)
+    /// and adds their UTXOs to the spendable balance.
+    async fn update_chain_height(&mut self, network: Network, height: CoreBlockHeight);
 }

--- a/key-wallet-manager/src/wallet_manager/process_block.rs
+++ b/key-wallet-manager/src/wallet_manager/process_block.rs
@@ -213,4 +213,10 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
         format!("WalletManager: {} wallet(s) on {}\n{}", wallet_count, network, details.join("\n"))
     }
+
+    async fn update_chain_height(&mut self, network: Network, height: CoreBlockHeight) {
+        for info in self.wallet_infos.values_mut() {
+            info.update_chain_height(network, height);
+        }
+    }
 }

--- a/key-wallet/src/managed_account/managed_account_trait.rs
+++ b/key-wallet/src/managed_account/managed_account_trait.rs
@@ -10,7 +10,7 @@ use crate::wallet::balance::WalletBalance;
 use crate::Network;
 use alloc::collections::BTreeMap;
 use dashcore::blockdata::transaction::OutPoint;
-use dashcore::Txid;
+use dashcore::{Address, Txid};
 
 /// Common trait for all managed account types
 pub trait ManagedAccountTrait {
@@ -43,6 +43,19 @@ pub trait ManagedAccountTrait {
 
     /// Get mutable transactions
     fn transactions_mut(&mut self) -> &mut BTreeMap<Txid, TransactionRecord>;
+
+    /// Extract UTXOs from a transaction and add them to this account.
+    ///
+    /// Scans the transaction outputs for addresses belonging to `involved_addresses`
+    /// and creates UTXOs for any matches.
+    fn add_utxos_from_transaction(
+        &mut self,
+        tx: &dashcore::Transaction,
+        involved_addresses: &alloc::collections::BTreeSet<Address>,
+        network: Network,
+        height: u32,
+        is_confirmed: bool,
+    );
 
     /// Get UTXOs
     fn utxos(&self) -> &BTreeMap<OutPoint, Utxo>;

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -14,6 +14,8 @@ use crate::wallet::managed_wallet_info::TransactionRecord;
 use crate::wallet::ManagedWalletInfo;
 use crate::{Network, Utxo, Wallet, WalletBalance};
 use dashcore::{Address as DashAddress, Address, Transaction};
+
+use crate::account::ManagedAccountTrait;
 use std::collections::BTreeSet;
 
 /// Trait that wallet info types must implement to work with WalletManager
@@ -272,6 +274,17 @@ impl WalletInfoInterface for ManagedWalletInfo {
                                 false, // Not ours (we received)
                             );
                             account.transactions.insert(tx.txid, tx_record);
+
+                            // Add UTXOs for outputs that belong to this account
+                            let account_addresses: BTreeSet<Address> =
+                                account.all_addresses().into_iter().collect();
+                            account.add_utxos_from_transaction(
+                                &tx.transaction,
+                                &account_addresses,
+                                network,
+                                tx.height,
+                                true,
+                            );
                         }
                     }
 
@@ -289,6 +302,17 @@ impl WalletInfoInterface for ManagedWalletInfo {
                                 false,
                             );
                             account.transactions.insert(tx.txid, tx_record);
+
+                            // Add UTXOs for outputs that belong to this account
+                            let account_addresses: BTreeSet<Address> =
+                                account.all_addresses().into_iter().collect();
+                            account.add_utxos_from_transaction(
+                                &tx.transaction,
+                                &account_addresses,
+                                network,
+                                tx.height,
+                                true,
+                            );
                         }
                     }
 
@@ -305,6 +329,17 @@ impl WalletInfoInterface for ManagedWalletInfo {
                                 false,
                             );
                             account.transactions.insert(tx.txid, tx_record);
+
+                            // Add UTXOs for outputs that belong to this account
+                            let account_addresses: BTreeSet<Address> =
+                                account.all_addresses().into_iter().collect();
+                            account.add_utxos_from_transaction(
+                                &tx.transaction,
+                                &account_addresses,
+                                network,
+                                tx.height,
+                                true,
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
Check the individual commits, basically:

1. The first commit just moves the utxo adding code into a helper. 
2. The second commit makes sure `update_chain_height` gets called for the wallet for each block. This is to trigger the immature transaction re-processing which currently isnt triggered.
3. The last commit fixes UTXOs not being added when the matured transactions getting processed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of matured coinbase transactions to ensure their UTXOs are properly added to spendable balance after reaching confirmation requirements
  * Enhanced chain height synchronization during block processing for accurate transaction maturation tracking

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->