### PR TITLE
refactor: Make `synced_from_checkpoint` based on `sync_base_height`

### DIFF
--- a/dash-spv-ffi/tests/unit/test_type_conversions.rs
+++ b/dash-spv-ffi/tests/unit/test_type_conversions.rs
@@ -171,7 +171,6 @@ mod tests {
             masternode_engine: None,
             last_masternode_diff_height: None,
             sync_base_height: 0,
-            synced_from_checkpoint: false,
         };
 
         let ffi_state = FFIChainState::from(state);

--- a/dash-spv/src/chain/fork_detector.rs
+++ b/dash-spv/src/chain/fork_detector.rs
@@ -108,10 +108,7 @@ impl ForkDetector {
         // Check if this connects to the main chain (creates new fork)
         if let Ok(Some(height)) = storage.get_header_height(&prev_hash) {
             // Check if this would create a fork from before our checkpoint
-            if chain_state.synced_from_checkpoint
-                && chain_state.sync_base_height > 0
-                && height < chain_state.sync_base_height
-            {
+            if chain_state.synced_from_checkpoint() && height < chain_state.sync_base_height {
                 tracing::warn!(
                         "Rejecting header that would create fork from height {} (before checkpoint base {}). \
                         This likely indicates headers from genesis were received during checkpoint sync.",
@@ -140,11 +137,7 @@ impl ForkDetector {
         for (height, state_header) in chain_state.headers.iter().enumerate() {
             if prev_hash == state_header.block_hash() {
                 // Calculate the actual blockchain height for this index
-                let actual_height = if chain_state.synced_from_checkpoint {
-                    chain_state.sync_base_height + (height as u32)
-                } else {
-                    height as u32
-                };
+                let actual_height = chain_state.sync_base_height + (height as u32);
 
                 // This connects to a header in chain state but not in storage
                 // Treat it as extending main chain if it's the tip

--- a/dash-spv/src/chain/fork_detector_test.rs
+++ b/dash-spv/src/chain/fork_detector_test.rs
@@ -32,7 +32,6 @@ mod tests {
         let mut chain_state = ChainState::new();
 
         // Simulate checkpoint sync from height 1000
-        chain_state.synced_from_checkpoint = true;
         chain_state.sync_base_height = 1000;
 
         // Add a checkpoint header at height 1000

--- a/dash-spv/src/chain/reorg.rs
+++ b/dash-spv/src/chain/reorg.rs
@@ -103,7 +103,7 @@ impl ReorgManager {
 
         // Check reorg depth - account for checkpoint sync
         let reorg_depth = if let Some(state) = chain_state {
-            if state.synced_from_checkpoint && state.sync_base_height > 0 {
+            if state.synced_from_checkpoint() {
                 // During checkpoint sync, both current_tip.height and fork.fork_height
                 // should be interpreted relative to sync_base_height
 

--- a/dash-spv/src/chain/reorg_test.rs
+++ b/dash-spv/src/chain/reorg_test.rs
@@ -99,7 +99,6 @@ mod tests {
         let storage = MemoryStorage::new();
 
         // Simulate checkpoint sync from height 50000
-        chain_state.synced_from_checkpoint = true;
         chain_state.sync_base_height = 50000;
 
         // Current tip at height 50100

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -215,7 +215,7 @@ impl<
                     tracing::error!("Failed to load headers into sync manager: {}", e);
                     // For checkpoint sync, this is critical
                     let state = self.state.read().await;
-                    if state.synced_from_checkpoint {
+                    if state.synced_from_checkpoint() {
                         return Err(SpvError::Sync(e));
                     }
                     // For normal sync, we can continue as headers will be re-synced
@@ -403,11 +403,7 @@ impl<
                         );
 
                         // Update the sync manager's cached flags from the checkpoint-initialized state
-                        self.sync_manager.update_chain_state_cache(
-                            true,
-                            checkpoint.height,
-                            headers_len,
-                        );
+                        self.sync_manager.update_chain_state_cache(checkpoint.height, headers_len);
                         tracing::info!(
                             "Updated sync manager with checkpoint-initialized chain state"
                         );

--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -915,12 +915,7 @@ impl<
         let target_height = saved_state.chain_tip.height;
 
         // Determine first height to load. Skip genesis (already present) unless we started from a checkpoint base.
-        let mut current_height =
-            if saved_state.synced_from_checkpoint && saved_state.sync_base_height > 0 {
-                saved_state.sync_base_height
-            } else {
-                1u32
-            };
+        let mut current_height = saved_state.sync_base_height.max(1);
 
         while current_height <= target_height {
             let end_height = (current_height + BATCH_SIZE - 1).min(target_height);

--- a/dash-spv/src/storage/sync_state.rs
+++ b/dash-spv/src/storage/sync_state.rs
@@ -42,9 +42,6 @@ pub struct PersistentSyncState {
 
     /// Base height when syncing from a checkpoint (0 if syncing from genesis).
     pub sync_base_height: u32,
-
-    /// Whether the chain was synced from a checkpoint rather than genesis.
-    pub synced_from_checkpoint: bool,
 }
 
 /// Chain tip information.
@@ -195,7 +192,6 @@ impl PersistentSyncState {
                 .map(|work| format!("{:?}", work))
                 .unwrap_or_else(|| String::from("0")),
             sync_base_height: chain_state.sync_base_height,
-            synced_from_checkpoint: chain_state.synced_from_checkpoint,
         })
     }
 
@@ -324,6 +320,10 @@ impl PersistentSyncState {
         }
     }
 
+    pub fn synced_from_checkpoint(&self) -> bool {
+        self.sync_base_height > 0
+    }
+
     /// Get the best checkpoint to use for recovery.
     pub fn get_best_checkpoint(&self) -> Option<&SyncCheckpoint> {
         self.checkpoints.iter().rev().find(|cp| cp.validated)
@@ -378,7 +378,6 @@ mod tests {
             saved_at: SystemTime::now(),
             chain_work: String::new(),
             sync_base_height: 0,
-            synced_from_checkpoint: false,
         };
 
         // Valid state

--- a/dash-spv/src/sync/manager.rs
+++ b/dash-spv/src/sync/manager.rs
@@ -378,17 +378,8 @@ impl<
     }
 
     /// Update the chain state (used for checkpoint sync initialization)
-    pub fn update_chain_state_cache(
-        &mut self,
-        synced_from_checkpoint: bool,
-        sync_base_height: u32,
-        headers_len: u32,
-    ) {
-        self.header_sync.update_cached_from_state_snapshot(
-            synced_from_checkpoint,
-            sync_base_height,
-            headers_len,
-        );
+    pub fn update_chain_state_cache(&mut self, sync_base_height: u32, headers_len: u32) {
+        self.header_sync.update_cached_from_state_snapshot(sync_base_height, headers_len);
     }
 
     /// Get reference to the masternode engine if available.
@@ -420,9 +411,7 @@ impl<
             .unwrap_or(0);
 
         // Check if we're syncing from a checkpoint
-        if self.header_sync.is_synced_from_checkpoint()
-            && self.header_sync.get_sync_base_height() > 0
-        {
+        if self.header_sync.is_synced_from_checkpoint() {
             // For checkpoint sync, blockchain height = sync_base_height + storage_height
             Ok(self.header_sync.get_sync_base_height() + storage_height)
         } else {

--- a/dash-spv/src/types.rs
+++ b/dash-spv/src/types.rs
@@ -277,9 +277,6 @@ pub struct ChainState {
 
     /// Base height when syncing from a checkpoint (0 if syncing from genesis).
     pub sync_base_height: u32,
-
-    /// Whether the chain was synced from a checkpoint rather than genesis.
-    pub synced_from_checkpoint: bool,
 }
 
 impl ChainState {
@@ -323,9 +320,13 @@ impl ChainState {
 
         // Initialize checkpoint fields
         state.sync_base_height = 0;
-        state.synced_from_checkpoint = false;
 
         state
+    }
+
+    /// Whether the chain was synced from a checkpoint rather than genesis.
+    pub fn synced_from_checkpoint(&self) -> bool {
+        self.sync_base_height > 0
     }
 
     /// Get the current tip height.
@@ -461,7 +462,6 @@ impl ChainState {
 
         // Set sync base height to checkpoint
         self.sync_base_height = checkpoint_height;
-        self.synced_from_checkpoint = true;
 
         // Add the checkpoint header as our first header
         self.headers.push(checkpoint_header);
@@ -504,7 +504,6 @@ impl std::fmt::Debug for ChainState {
             .field("current_filter_tip", &self.current_filter_tip)
             .field("last_masternode_diff_height", &self.last_masternode_diff_height)
             .field("sync_base_height", &self.sync_base_height)
-            .field("synced_from_checkpoint", &self.synced_from_checkpoint)
             .finish()
     }
 }


### PR DESCRIPTION
This PR:

- Drops the `synced_from_checkpoint` variable in few structs and just makes the decision based on the `sync_base_height > 0` in a helper. 
- Drops a bunch of redundant `sync_base_height > 0` checks in statements like `synced_from_checkpoint && sync_base_height > 0` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized checkpoint synchronization state management by deriving sync status from existing height data, eliminating redundant flag storage and simplifying internal logic.
  * Streamlined header synchronization method signatures to reduce unnecessary parameters and improve code maintainability.
  * Enhanced state restoration efficiency through simplified checkpoint-based header loading workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->