### PR TITLE
fix: SPV Regtest/Devnet support

### DIFF
--- a/dash/src/blockdata/constants.rs
+++ b/dash/src/blockdata/constants.rs
@@ -156,9 +156,9 @@ pub fn genesis_block(network: Network) -> Block {
                     version: block::Version::ONE,
                     prev_blockhash: Hash::all_zeros(),
                     merkle_root,
-                    time: 1598918400,
-                    bits: CompactTarget::from_consensus(0x1e0377ae),
-                    nonce: 52613770,
+                    time: 1417713337,
+                    bits: CompactTarget::from_consensus(0x207fffff),
+                    nonce: 1096447,
                 },
                 txdata,
             }
@@ -268,12 +268,12 @@ mod test {
             genesis_block.header.merkle_root.to_string(),
             "e0028eb9648db56b1ac77cf090b99048a8007e2bb64b68f092c03c7f56a662c7"
         );
-        assert_eq!(genesis_block.header.time, 1598918400);
-        assert_eq!(genesis_block.header.bits, CompactTarget::from_consensus(0x1e0377ae));
-        assert_eq!(genesis_block.header.nonce, 52613770);
+        assert_eq!(genesis_block.header.time, 1417713337);
+        assert_eq!(genesis_block.header.bits, CompactTarget::from_consensus(0x207fffff));
+        assert_eq!(genesis_block.header.nonce, 1096447);
         assert_eq!(
             genesis_block.header.block_hash().to_string(),
-            "4e5f930c5d73a8792fa681ba8c5eaf74aa63974a5b1f598dd508029aee70167b"
+            "000008ca1832a4baf228eb1553c03d3a2c8e02399550dd6ea8d65cec3ef23d2e"
         );
     }
 

--- a/dash/src/blockdata/constants.rs
+++ b/dash/src/blockdata/constants.rs
@@ -81,8 +81,9 @@ fn dash_genesis_tx() -> Transaction {
 
     // Inputs
     // Using raw script bytes to avoid push_slice issues
+    // Message: "Wired 09/Jan/2014 The Grand Experiment Goes Live: Overstock.com Is Now Accepting Bitcoins"
     let in_script = script::ScriptBuf::from(hex!(
-        "04ffff001d01044c5957697265642030392f4a616e2f32303134205468652047726e64204578706572696d656e7420476f6573204c6976653a204f76657273746f636b2e636f6d204973204e6f7720416363657074696e6720426974636f696e73"
+        "04ffff001d01044c5957697265642030392f4a616e2f3230313420546865204772616e64204578706572696d656e7420476f6573204c6976653a204f76657273746f636b2e636f6d204973204e6f7720416363657074696e6720426974636f696e73"
     ).to_vec());
     ret.input.push(TxIn {
         previous_output: OutPoint::null(),
@@ -170,9 +171,9 @@ pub fn genesis_block(network: Network) -> Block {
                     version: block::Version::ONE,
                     prev_blockhash: Hash::all_zeros(),
                     merkle_root,
-                    time: 1296688602,
+                    time: 1417713337,
                     bits: CompactTarget::from_consensus(0x207fffff),
-                    nonce: 2,
+                    nonce: 1096447,
                 },
                 txdata,
             }
@@ -199,7 +200,7 @@ mod test {
         assert_eq!(
             genesis_tx.input[0].script_sig.as_bytes(),
             &hex!(
-                "04ffff001d01044c5957697265642030392f4a616e2f32303134205468652047726e64204578706572696d656e7420476f6573204c6976653a204f76657273746f636b2e636f6d204973204e6f7720416363657074696e6720426974636f696e73"
+                "04ffff001d01044c5957697265642030392f4a616e2f3230313420546865204772616e64204578706572696d656e7420476f6573204c6976653a204f76657273746f636b2e636f6d204973204e6f7720416363657074696e6720426974636f696e73"
             )
         );
 
@@ -283,14 +284,14 @@ mod test {
         assert_eq!(genesis_block.header.prev_blockhash, Hash::all_zeros());
         assert_eq!(
             genesis_block.header.merkle_root.to_string(),
-            "babeaa0bf3af03c0f12d94da95c7f28168be22087a16fb207e7abda4ae654ee3"
+            "e0028eb9648db56b1ac77cf090b99048a8007e2bb64b68f092c03c7f56a662c7"
         );
-        assert_eq!(genesis_block.header.time, 1296688602);
+        assert_eq!(genesis_block.header.time, 1417713337);
         assert_eq!(genesis_block.header.bits, CompactTarget::from_consensus(0x207fffff));
-        assert_eq!(genesis_block.header.nonce, 2);
+        assert_eq!(genesis_block.header.nonce, 1096447);
         assert_eq!(
             genesis_block.header.block_hash().to_string(),
-            "53b3ed3030781ac19e4852d9c58f2804574f9866f3f7f69131eeb13f449f8007"
+            "000008ca1832a4baf228eb1553c03d3a2c8e02399550dd6ea8d65cec3ef23d2e"
         );
     }
 }

--- a/key-wallet/src/account/account_type.rs
+++ b/key-wallet/src/account/account_type.rs
@@ -260,7 +260,7 @@ impl AccountType {
                     Network::Dash => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_REGISTRATION_PATH_MAINNET))
                     }
-                    Network::Testnet | Network::Regtest => {
+                    Network::Testnet | Network::Devnet | Network::Regtest => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_REGISTRATION_PATH_TESTNET))
                     }
                     _ => Err(crate::error::Error::InvalidNetwork),
@@ -272,7 +272,9 @@ impl AccountType {
                 // Base path with registration index - actual key index added when deriving
                 let base_path = match network {
                     Network::Dash => crate::dip9::IDENTITY_TOPUP_PATH_MAINNET,
-                    Network::Testnet | Network::Regtest => crate::dip9::IDENTITY_TOPUP_PATH_TESTNET,
+                    Network::Testnet | Network::Devnet | Network::Regtest => {
+                        crate::dip9::IDENTITY_TOPUP_PATH_TESTNET
+                    }
                     _ => return Err(crate::error::Error::InvalidNetwork),
                 };
                 let mut path = DerivationPath::from(base_path);
@@ -288,7 +290,7 @@ impl AccountType {
                     Network::Dash => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_TOPUP_PATH_MAINNET))
                     }
-                    Network::Testnet | Network::Regtest => {
+                    Network::Testnet | Network::Devnet | Network::Regtest => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_TOPUP_PATH_TESTNET))
                     }
                     _ => Err(crate::error::Error::InvalidNetwork),
@@ -300,7 +302,7 @@ impl AccountType {
                     Network::Dash => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_INVITATION_PATH_MAINNET))
                     }
-                    Network::Testnet | Network::Regtest => {
+                    Network::Testnet | Network::Devnet | Network::Regtest => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_INVITATION_PATH_TESTNET))
                     }
                     _ => Err(crate::error::Error::InvalidNetwork),
@@ -354,7 +356,7 @@ impl AccountType {
                 // Base DashPay root + account 0' + user_id/friend_id (non-hardened per DIP-14/DIP-15)
                 let mut path = match network {
                     Network::Dash => DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_MAINNET),
-                    Network::Testnet | Network::Regtest => {
+                    Network::Testnet | Network::Devnet | Network::Regtest => {
                         DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_TESTNET)
                     }
                     _ => return Err(crate::error::Error::InvalidNetwork),
@@ -376,7 +378,7 @@ impl AccountType {
                 // Base DashPay root + account 0' + friend_id/user_id (non-hardened per DIP-14/DIP-15)
                 let mut path = match network {
                     Network::Dash => DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_MAINNET),
-                    Network::Testnet | Network::Regtest => {
+                    Network::Testnet | Network::Devnet | Network::Regtest => {
                         DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_TESTNET)
                     }
                     _ => return Err(crate::error::Error::InvalidNetwork),

--- a/key-wallet/src/account/account_type.rs
+++ b/key-wallet/src/account/account_type.rs
@@ -260,7 +260,7 @@ impl AccountType {
                     Network::Dash => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_REGISTRATION_PATH_MAINNET))
                     }
-                    Network::Testnet => {
+                    Network::Testnet | Network::Regtest => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_REGISTRATION_PATH_TESTNET))
                     }
                     _ => Err(crate::error::Error::InvalidNetwork),
@@ -272,7 +272,7 @@ impl AccountType {
                 // Base path with registration index - actual key index added when deriving
                 let base_path = match network {
                     Network::Dash => crate::dip9::IDENTITY_TOPUP_PATH_MAINNET,
-                    Network::Testnet => crate::dip9::IDENTITY_TOPUP_PATH_TESTNET,
+                    Network::Testnet | Network::Regtest => crate::dip9::IDENTITY_TOPUP_PATH_TESTNET,
                     _ => return Err(crate::error::Error::InvalidNetwork),
                 };
                 let mut path = DerivationPath::from(base_path);
@@ -288,7 +288,7 @@ impl AccountType {
                     Network::Dash => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_TOPUP_PATH_MAINNET))
                     }
-                    Network::Testnet => {
+                    Network::Testnet | Network::Regtest => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_TOPUP_PATH_TESTNET))
                     }
                     _ => Err(crate::error::Error::InvalidNetwork),
@@ -300,7 +300,7 @@ impl AccountType {
                     Network::Dash => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_INVITATION_PATH_MAINNET))
                     }
-                    Network::Testnet => {
+                    Network::Testnet | Network::Regtest => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_INVITATION_PATH_TESTNET))
                     }
                     _ => Err(crate::error::Error::InvalidNetwork),
@@ -354,7 +354,7 @@ impl AccountType {
                 // Base DashPay root + account 0' + user_id/friend_id (non-hardened per DIP-14/DIP-15)
                 let mut path = match network {
                     Network::Dash => DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_MAINNET),
-                    Network::Testnet => {
+                    Network::Testnet | Network::Regtest => {
                         DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_TESTNET)
                     }
                     _ => return Err(crate::error::Error::InvalidNetwork),
@@ -376,7 +376,7 @@ impl AccountType {
                 // Base DashPay root + account 0' + friend_id/user_id (non-hardened per DIP-14/DIP-15)
                 let mut path = match network {
                     Network::Dash => DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_MAINNET),
-                    Network::Testnet => {
+                    Network::Testnet | Network::Regtest => {
                         DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_TESTNET)
                     }
                     _ => return Err(crate::error::Error::InvalidNetwork),

--- a/key-wallet/src/derivation.rs
+++ b/key-wallet/src/derivation.rs
@@ -99,7 +99,9 @@ impl HDWallet {
     pub fn bip44_account(&self, account: u32) -> Result<ExtendedPrivKey> {
         let path = match self.master_key.network {
             crate::Network::Dash => crate::dip9::DASH_BIP44_PATH_MAINNET,
-            crate::Network::Testnet => crate::dip9::DASH_BIP44_PATH_TESTNET,
+            crate::Network::Testnet | crate::Network::Regtest => {
+                crate::dip9::DASH_BIP44_PATH_TESTNET
+            }
             _ => return Err(Error::InvalidNetwork),
         };
 
@@ -116,7 +118,7 @@ impl HDWallet {
     pub fn coinjoin_account(&self, account: u32) -> Result<ExtendedPrivKey> {
         let path = match self.master_key.network {
             crate::Network::Dash => crate::dip9::COINJOIN_PATH_MAINNET,
-            crate::Network::Testnet => crate::dip9::COINJOIN_PATH_TESTNET,
+            crate::Network::Testnet | crate::Network::Regtest => crate::dip9::COINJOIN_PATH_TESTNET,
             _ => return Err(Error::InvalidNetwork),
         };
 
@@ -137,7 +139,9 @@ impl HDWallet {
     ) -> Result<ExtendedPrivKey> {
         let path = match self.master_key.network {
             crate::Network::Dash => crate::dip9::IDENTITY_AUTHENTICATION_PATH_MAINNET,
-            crate::Network::Testnet => crate::dip9::IDENTITY_AUTHENTICATION_PATH_TESTNET,
+            crate::Network::Testnet | crate::Network::Regtest => {
+                crate::dip9::IDENTITY_AUTHENTICATION_PATH_TESTNET
+            }
             _ => return Err(Error::InvalidNetwork),
         };
 

--- a/key-wallet/src/derivation.rs
+++ b/key-wallet/src/derivation.rs
@@ -99,7 +99,7 @@ impl HDWallet {
     pub fn bip44_account(&self, account: u32) -> Result<ExtendedPrivKey> {
         let path = match self.master_key.network {
             crate::Network::Dash => crate::dip9::DASH_BIP44_PATH_MAINNET,
-            crate::Network::Testnet | crate::Network::Regtest => {
+            Network::Testnet | Network::Devnet | Network::Regtest => {
                 crate::dip9::DASH_BIP44_PATH_TESTNET
             }
             _ => return Err(Error::InvalidNetwork),
@@ -118,7 +118,9 @@ impl HDWallet {
     pub fn coinjoin_account(&self, account: u32) -> Result<ExtendedPrivKey> {
         let path = match self.master_key.network {
             crate::Network::Dash => crate::dip9::COINJOIN_PATH_MAINNET,
-            crate::Network::Testnet | crate::Network::Regtest => crate::dip9::COINJOIN_PATH_TESTNET,
+            Network::Testnet | Network::Devnet | Network::Regtest => {
+                crate::dip9::COINJOIN_PATH_TESTNET
+            }
             _ => return Err(Error::InvalidNetwork),
         };
 
@@ -139,7 +141,7 @@ impl HDWallet {
     ) -> Result<ExtendedPrivKey> {
         let path = match self.master_key.network {
             crate::Network::Dash => crate::dip9::IDENTITY_AUTHENTICATION_PATH_MAINNET,
-            crate::Network::Testnet | crate::Network::Regtest => {
+            Network::Testnet | Network::Devnet | Network::Regtest => {
                 crate::dip9::IDENTITY_AUTHENTICATION_PATH_TESTNET
             }
             _ => return Err(Error::InvalidNetwork),


### PR DESCRIPTION
Preparation to get integration tests in place with `DashSpvClient` <-> `dashd` sync. 

- Fix wallet accounts to consider regtest and devote
- Fix invalid genesis data for regtest/devnet to match https://github.com/dashpay/dash/blob/b51524e27047d68f56ab94b06a49b02648847dfa/src/chainparams.cpp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected genesis data and input script encoding; updated genesis header fields (time, bits, nonce), merkle roots and expected genesis block hashes so devnet/regtest chains and tests align with corrected encoding.
* **Behavior Changes**
  * Wallet derivation for identity and DashPay flows now treats Devnet and Regtest like Testnet, unifying derivation paths for non‑mainnet networks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->