### PR TITLE
chore: Drop `ChainHash` and related tests from `dash`

### DIFF
--- a/dash/src/network/constants.rs
+++ b/dash/src/network/constants.rs
@@ -37,14 +37,11 @@
 //! ```
 
 use core::convert::From;
-use core::fmt::Display;
 use core::{fmt, ops};
 
 use hashes::Hash;
 
 use crate::consensus::encode::{self, Decodable, Encodable};
-use crate::constants::ChainHash;
-use crate::error::impl_std_error;
 use crate::{BlockHash, io};
 use dash_network::Network;
 
@@ -100,33 +97,6 @@ impl NetworkExt for Network {
                 Some(BlockHash::from_byte_array(block_hash.try_into().expect("expected 32 bytes")))
             }
             _ => None,
-        }
-    }
-}
-
-/// Error in parsing network from chain hash.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UnknownChainHash(ChainHash);
-
-impl Display for UnknownChainHash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "unknown chain hash: {}", self.0)
-    }
-}
-
-impl_std_error!(UnknownChainHash);
-
-impl TryFrom<ChainHash> for Network {
-    type Error = UnknownChainHash;
-
-    fn try_from(chain_hash: ChainHash) -> Result<Self, Self::Error> {
-        match chain_hash {
-            // Note: any new network entries must be matched against here.
-            ChainHash::DASH => Ok(Network::Dash),
-            ChainHash::TESTNET => Ok(Network::Testnet),
-            ChainHash::DEVNET => Ok(Network::Devnet),
-            ChainHash::REGTEST => Ok(Network::Regtest),
-            _ => Err(UnknownChainHash(chain_hash)),
         }
     }
 }


### PR DESCRIPTION
This is basically only used as regression test for the genesis block hashes. Which we already also test in separate tests `<network>_genesis_full_block` (except for regtest which gets added here in this PR) anyway so its redundant.

Im trying to fixup the retest/devnet parameters in #227 but since devnet/regtest genesis are the same the use of `pub struct ChainHash([u8; 32]);` doest work anymore with:

```rust
impl TryFrom<ChainHash> for Network {
    type Error = UnknownChainHash;

    fn try_from(chain_hash: ChainHash) -> Result<Self, Self::Error> {
        match chain_hash {
            // Note: any new network entries must be matched against here.
            ChainHash::DASH => Ok(Network::Dash),
            ChainHash::TESTNET => Ok(Network::Testnet),
            ChainHash::DEVNET => Ok(Network::Devnet),
            ChainHash::REGTEST => Ok(Network::Regtest),
            _ => Err(UnknownChainHash(chain_hash)),
        }
    }
}
```

because we can't capture the same value twice in there. So its either refactoring it or dropping it. I thought dropping makes more sense. 

Note: The regtest test I added in here tests for invalid values but this will be fixed in #227.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated ChainHash type and its associated network constants and utilities.
  * Removed UnknownChainHash error type from network conversion handling.

* **Tests**
  * Updated genesis block validation test suite for improved Regtest network coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->