### PR TITLE
refactor: Cleanup `HeaderValidator` and `ValidationManager`

### DIFF
--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -62,7 +62,7 @@ impl<
         .map_err(SpvError::Sync)?;
 
         // Create validation manager
-        let validation = ValidationManager::new(config.validation_mode);
+        let validation = ValidationManager::new(config.validation_mode, config.network);
 
         // Create ChainLock manager
         let chainlock_manager = Arc::new(ChainLockManager::new(true));

--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -931,7 +931,7 @@ impl<
             // Validate headers before adding to chain state
             {
                 // Validate the batch of headers
-                if let Err(e) = self.validation.validate_header_chain(&headers, false) {
+                if let Err(e) = self.validation.validate_headers(&headers) {
                     tracing::error!(
                         "Header validation failed for range {}..{}: {:?}",
                         current_height,

--- a/dash-spv/src/validation/mod.rs
+++ b/dash-spv/src/validation/mod.rs
@@ -4,7 +4,7 @@ pub mod headers;
 pub mod instantlock;
 pub mod quorum;
 
-use dashcore::{block::Header as BlockHeader, InstantLock};
+use dashcore::{block::Header as BlockHeader, InstantLock, Network};
 
 use crate::error::ValidationResult;
 use crate::types::ValidationMode;
@@ -22,10 +22,10 @@ pub struct ValidationManager {
 
 impl ValidationManager {
     /// Create a new validation manager.
-    pub fn new(mode: ValidationMode) -> Self {
+    pub fn new(mode: ValidationMode, network: Network) -> Self {
         Self {
             mode,
-            header_validator: HeaderValidator::new(mode),
+            header_validator: HeaderValidator::new(mode, network),
             instantlock_validator: InstantLockValidator::new(),
         }
     }
@@ -36,27 +36,12 @@ impl ValidationManager {
         header: &BlockHeader,
         prev_header: Option<&BlockHeader>,
     ) -> ValidationResult<()> {
-        match self.mode {
-            ValidationMode::None => Ok(()),
-            ValidationMode::Basic | ValidationMode::Full => {
-                self.header_validator.validate(header, prev_header)
-            }
-        }
+        self.header_validator.validate(header, prev_header)
     }
 
     /// Validate a chain of headers.
-    pub fn validate_header_chain(
-        &self,
-        headers: &[BlockHeader],
-        validate_pow: bool,
-    ) -> ValidationResult<()> {
-        match self.mode {
-            ValidationMode::None => Ok(()),
-            ValidationMode::Basic => self.header_validator.validate_chain_basic(headers),
-            ValidationMode::Full => {
-                self.header_validator.validate_chain_full(headers, validate_pow)
-            }
-        }
+    pub fn validate_headers(&self, headers: &[BlockHeader]) -> ValidationResult<()> {
+        self.header_validator.validate_headers(headers)
     }
 
     /// Validate an InstantLock (structural validation only).


### PR DESCRIPTION
The header validation is currently not active at all, this PR cleans it up and there will be a follow up to enable the validation during sync.

- Some simplifications and name changes
- Some unused code
- Dropping the network change parts since the rest of the codebase doesnt support it anyway
- Making the `ValidationMode::Full` mode checking PoW by default, not based on yet another parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated header validation into a single, unified validation API.
  * Validators and manager now require explicit network selection at construction rather than being set later.
  * Simplified validation flow and logging for clearer, mode-aware behavior.

* **Tests**
  * Updated and expanded tests to use the unified validation API and explicit network initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->