### PR TITLE
refactor: Rename `SequentialSyncManager` to `SyncManager`

### DIFF
--- a/dash-spv/ARCHITECTURE.md
+++ b/dash-spv/ARCHITECTURE.md
@@ -92,7 +92,7 @@
            │
            ▼
     ┌─────────────────────────────────────────┐
-    │     SequentialSyncManager               │
+    │     SyncManager               │
     │  - HeadersSync                          │
     │  - MasternodeSync                       │
     │  - FilterSync (4,027 lines - TOO BIG)   │
@@ -108,7 +108,7 @@
 ### Data Flow
 
 ```
-Network Messages → MessageHandler → SequentialSyncManager
+Network Messages → MessageHandler → SyncManager
                                           │
                                           ▼
                               ┌─────────────────────┐
@@ -1011,7 +1011,7 @@ The sync module coordinates all blockchain synchronization. This is the most com
 ```
 sync/sequential/ (4,785 lines total across 11 modules)
 ├── mod.rs (52 lines) - Module coordinator and re-exports
-├── manager.rs (234 lines) - Core SequentialSyncManager struct and accessors
+├── manager.rs (234 lines) - Core SyncManager struct and accessors
 ├── lifecycle.rs (225 lines) - Initialization, startup, and shutdown
 ├── phase_execution.rs (519 lines) - Phase execution, transitions, timeout handling
 ├── message_handlers.rs (808 lines) - Handlers for sync phase messages

--- a/dash-spv/CLAUDE.md
+++ b/dash-spv/CLAUDE.md
@@ -24,7 +24,7 @@ The project follows a layered, trait-based architecture with clear separation of
 ### Key Design Patterns
 - **Trait-based abstractions**: `NetworkManager`, `StorageManager` for swappable implementations
 - **Async/await throughout**: Built on tokio runtime
-- **Sequential sync**: Uses `SequentialSyncManager` for organized phase-based synchronization
+- **Sequential sync**: Uses `SyncManager` for organized phase-based synchronization
 - **State management**: Each sync phase tracked independently with clear state transitions
 - **Modular validation**: Configurable validation modes (None/Basic/Full)
 
@@ -97,7 +97,7 @@ cargo check --all-features
 ## Key Concepts
 
 ### Sync Coordination
-The `SequentialSyncManager` coordinates all synchronization through a phase-based approach:
+The `SyncManager` coordinates all synchronization through a phase-based approach:
 - **Phase 1: Headers** - Synchronize blockchain headers
 - **Phase 2: Masternode List** - Download masternode state
 - **Phase 3: Filter Headers** - Synchronize compact filter headers
@@ -157,7 +157,7 @@ Basic wallet functionality for address monitoring:
 The sync system uses a sequential phase-based pattern:
 1. Create `DashSpvClient` with desired configuration
 2. Call `start()` to begin synchronization
-3. The client internally uses `SequentialSyncManager` to progress through sync phases
+3. The client internally uses `SyncManager` to progress through sync phases
 4. Monitor progress via `get_sync_progress()` or progress receiver
 5. Each phase completes before the next begins
 

--- a/dash-spv/src/client/core.rs
+++ b/dash-spv/src/client/core.rs
@@ -20,7 +20,7 @@ use crate::mempool_filter::MempoolFilter;
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use crate::sync::filters::FilterNotificationSender;
-use crate::sync::sequential::SequentialSyncManager;
+use crate::sync::sequential::SyncManager;
 use crate::types::{ChainState, DetailedSyncProgress, MempoolState, SpvEvent, SpvStats};
 use crate::validation::ValidationManager;
 use key_wallet_manager::wallet_interface::WalletInterface;
@@ -127,12 +127,12 @@ pub struct DashSpvClient<W: WalletInterface, N: NetworkManager, S: StorageManage
     ///
     /// If concurrent access becomes necessary (e.g., for monitoring sync progress from
     /// multiple threads), consider:
-    /// - Using interior mutability patterns (Arc<Mutex<SequentialSyncManager>>)
+    /// - Using interior mutability patterns (Arc<Mutex<SyncManager>>)
     /// - Extracting read-only state into a separate shared structure
     /// - Implementing a message-passing architecture for sync commands
     ///
     /// The current design prioritizes simplicity and correctness over concurrent access.
-    pub(super) sync_manager: SequentialSyncManager<S, N, W>,
+    pub(super) sync_manager: SyncManager<S, N, W>,
     pub(super) validation: ValidationManager,
     pub(super) chainlock_manager: Arc<ChainLockManager>,
     pub(super) running: Arc<RwLock<bool>>,
@@ -179,7 +179,7 @@ impl<
 
     /// Get mutable reference to sync manager (for testing).
     #[cfg(test)]
-    pub fn sync_manager_mut(&mut self) -> &mut SequentialSyncManager<S, N, W> {
+    pub fn sync_manager_mut(&mut self) -> &mut SyncManager<S, N, W> {
         &mut self.sync_manager
     }
 

--- a/dash-spv/src/client/filter_sync.rs
+++ b/dash-spv/src/client/filter_sync.rs
@@ -3,7 +3,7 @@
 use crate::error::{Result, SpvError};
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
-use crate::sync::sequential::SequentialSyncManager;
+use crate::sync::sequential::SyncManager;
 use crate::types::FilterMatch;
 use crate::types::SpvStats;
 use key_wallet_manager::wallet_interface::WalletInterface;
@@ -12,7 +12,7 @@ use tokio::sync::RwLock;
 
 /// Filter synchronization manager for coordinating filter downloads and checking.
 pub struct FilterSyncCoordinator<'a, S: StorageManager, N: NetworkManager, W: WalletInterface> {
-    sync_manager: &'a mut SequentialSyncManager<S, N, W>,
+    sync_manager: &'a mut SyncManager<S, N, W>,
     storage: &'a mut S,
     network: &'a mut N,
     stats: &'a Arc<RwLock<SpvStats>>,
@@ -28,7 +28,7 @@ impl<
 {
     /// Create a new filter sync coordinator.
     pub fn new(
-        sync_manager: &'a mut SequentialSyncManager<S, N, W>,
+        sync_manager: &'a mut SyncManager<S, N, W>,
         storage: &'a mut S,
         network: &'a mut N,
         stats: &'a Arc<RwLock<SpvStats>>,

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -17,7 +17,7 @@ use crate::error::{Result, SpvError};
 use crate::mempool_filter::MempoolFilter;
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
-use crate::sync::sequential::SequentialSyncManager;
+use crate::sync::sequential::SyncManager;
 use crate::types::{ChainState, MempoolState, SpvStats};
 use crate::validation::ValidationManager;
 use dashcore::network::constants::NetworkExt;
@@ -52,7 +52,7 @@ impl<
         // Create sync manager
         let received_filter_heights = stats.read().await.received_filter_heights.clone();
         tracing::info!("Creating sequential sync manager");
-        let sync_manager = SequentialSyncManager::new(
+        let sync_manager = SyncManager::new(
             &config,
             received_filter_heights,
             wallet.clone(),

--- a/dash-spv/src/client/message_handler.rs
+++ b/dash-spv/src/client/message_handler.rs
@@ -5,7 +5,7 @@ use crate::error::{Result, SpvError};
 use crate::mempool_filter::MempoolFilter;
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
-use crate::sync::sequential::SequentialSyncManager;
+use crate::sync::sequential::SyncManager;
 use crate::types::{MempoolState, SpvEvent, SpvStats};
 // Removed local ad-hoc compact filter construction in favor of always processing full blocks
 use key_wallet_manager::wallet_interface::WalletInterface;
@@ -14,7 +14,7 @@ use tokio::sync::RwLock;
 
 /// Network message handler for processing incoming Dash protocol messages.
 pub struct MessageHandler<'a, S: StorageManager, N: NetworkManager, W: WalletInterface> {
-    sync_manager: &'a mut SequentialSyncManager<S, N, W>,
+    sync_manager: &'a mut SyncManager<S, N, W>,
     storage: &'a mut S,
     network: &'a mut N,
     config: &'a ClientConfig,
@@ -35,7 +35,7 @@ impl<
     /// Create a new message handler.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        sync_manager: &'a mut SequentialSyncManager<S, N, W>,
+        sync_manager: &'a mut SyncManager<S, N, W>,
         storage: &'a mut S,
         network: &'a mut N,
         config: &'a ClientConfig,

--- a/dash-spv/src/client/message_handler_test.rs
+++ b/dash-spv/src/client/message_handler_test.rs
@@ -12,7 +12,7 @@ mod tests {
     use crate::storage::memory::MemoryStorageManager;
     use crate::storage::StorageManager;
     use crate::sync::filters::FilterNotificationSender;
-    use crate::sync::sequential::SequentialSyncManager;
+    use crate::sync::sequential::SyncManager;
     use crate::types::{ChainState, MempoolState, SpvEvent, SpvStats};
     use crate::validation::ValidationManager;
     use crate::wallet::Wallet;
@@ -29,7 +29,7 @@ mod tests {
     async fn setup_test_components() -> (
         Box<dyn NetworkManager>,
         Box<dyn StorageManager>,
-        SequentialSyncManager,
+        SyncManager,
         ClientConfig,
         Arc<RwLock<SpvStats>>,
         Option<FilterNotificationSender>,
@@ -52,7 +52,7 @@ mod tests {
 
         // Create sync manager
         let received_filter_heights = Arc::new(Mutex::new(HashSet::new()));
-        let sync_manager = SequentialSyncManager::new(&config, received_filter_heights).unwrap();
+        let sync_manager = SyncManager::new(&config, received_filter_heights).unwrap();
 
         (
             network,

--- a/dash-spv/src/sync/sequential/lifecycle.rs
+++ b/dash-spv/src/sync/sequential/lifecycle.rs
@@ -1,4 +1,4 @@
-//! Lifecycle management for SequentialSyncManager (initialization, startup, shutdown).
+//! Lifecycle management for SyncManager (initialization, startup, shutdown).
 
 use std::time::{Duration, Instant};
 
@@ -14,7 +14,7 @@ use key_wallet_manager::{wallet_interface::WalletInterface, Network as WalletNet
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use super::manager::SequentialSyncManager;
+use super::manager::SyncManager;
 use super::phases::SyncPhase;
 use super::transitions::TransitionManager;
 
@@ -22,7 +22,7 @@ impl<
         S: StorageManager + Send + Sync + 'static,
         N: NetworkManager + Send + Sync + 'static,
         W: WalletInterface,
-    > SequentialSyncManager<S, N, W>
+    > SyncManager<S, N, W>
 {
     /// Create a new sequential sync manager
     pub fn new(

--- a/dash-spv/src/sync/sequential/manager.rs
+++ b/dash-spv/src/sync/sequential/manager.rs
@@ -1,4 +1,4 @@
-//! Core SequentialSyncManager struct and simple accessor methods.
+//! Core SyncManager struct and simple accessor methods.
 
 use std::time::{Duration, Instant};
 
@@ -58,7 +58,7 @@ pub(super) const CHAINLOCK_VALIDATION_MASTERNODE_OFFSET: u32 = 8;
 /// The generic design enables comprehensive testing while maintaining zero-cost abstraction.
 ///
 /// [`DashSpvClient`]: crate::client::DashSpvClient
-pub struct SequentialSyncManager<S: StorageManager, N: NetworkManager, W: WalletInterface> {
+pub struct SyncManager<S: StorageManager, N: NetworkManager, W: WalletInterface> {
     pub(super) _phantom_s: std::marker::PhantomData<S>,
     pub(super) _phantom_n: std::marker::PhantomData<N>,
     /// Current synchronization phase
@@ -101,7 +101,7 @@ impl<
         S: StorageManager + Send + Sync + 'static,
         N: NetworkManager + Send + Sync + 'static,
         W: WalletInterface,
-    > SequentialSyncManager<S, N, W>
+    > SyncManager<S, N, W>
 {
     /// Get the current chain height from the header sync manager
     pub fn get_chain_height(&self) -> u32 {

--- a/dash-spv/src/sync/sequential/message_handlers.rs
+++ b/dash-spv/src/sync/sequential/message_handlers.rs
@@ -13,14 +13,14 @@ use crate::storage::StorageManager;
 use crate::types::PeerId;
 use key_wallet_manager::wallet_interface::WalletInterface;
 
-use super::manager::SequentialSyncManager;
+use super::manager::SyncManager;
 use super::phases::SyncPhase;
 
 impl<
         S: StorageManager + Send + Sync + 'static,
         N: NetworkManager + Send + Sync + 'static,
         W: WalletInterface,
-    > SequentialSyncManager<S, N, W>
+    > SyncManager<S, N, W>
 {
     /// Handle incoming network messages with phase filtering
     pub async fn handle_message(

--- a/dash-spv/src/sync/sequential/mod.rs
+++ b/dash-spv/src/sync/sequential/mod.rs
@@ -42,6 +42,6 @@ pub mod phases;
 pub mod transitions;
 
 // Re-exports
-pub use manager::SequentialSyncManager;
+pub use manager::SyncManager;
 pub use phases::{PhaseTransition, SyncPhase};
 pub use transitions::TransitionManager;

--- a/dash-spv/src/sync/sequential/phase_execution.rs
+++ b/dash-spv/src/sync/sequential/phase_execution.rs
@@ -7,14 +7,14 @@ use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use key_wallet_manager::wallet_interface::WalletInterface;
 
-use super::manager::SequentialSyncManager;
+use super::manager::SyncManager;
 use super::phases::SyncPhase;
 
 impl<
         S: StorageManager + Send + Sync + 'static,
         N: NetworkManager + Send + Sync + 'static,
         W: WalletInterface,
-    > SequentialSyncManager<S, N, W>
+    > SyncManager<S, N, W>
 {
     /// Execute the current sync phase
     pub(super) async fn execute_current_phase(

--- a/dash-spv/src/sync/sequential/post_sync.rs
+++ b/dash-spv/src/sync/sequential/post_sync.rs
@@ -10,14 +10,14 @@ use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use key_wallet_manager::wallet_interface::WalletInterface;
 
-use super::manager::{SequentialSyncManager, CHAINLOCK_VALIDATION_MASTERNODE_OFFSET};
+use super::manager::{SyncManager, CHAINLOCK_VALIDATION_MASTERNODE_OFFSET};
 use super::phases::SyncPhase;
 
 impl<
         S: StorageManager + Send + Sync + 'static,
         N: NetworkManager + Send + Sync + 'static,
         W: WalletInterface,
-    > SequentialSyncManager<S, N, W>
+    > SyncManager<S, N, W>
 {
     /// Handle inventory messages for sequential sync
     pub async fn handle_inventory(


### PR DESCRIPTION
Just since that is the only sync manager we have and should focus on for time being i think.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal component naming and organization for better code clarity.
  * Updated architecture documentation to reflect structural changes.

* **Documentation**
  * Enhanced synchronization phase documentation with additional phase details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->