### PR TITLE
avoid re-downloading filters during SyncPhase::DownloadingFilters

### DIFF
--- a/dash-spv/src/storage/disk/state.rs
+++ b/dash-spv/src/storage/disk/state.rs
@@ -553,6 +553,10 @@ impl StorageManager for DiskStorageManager {
         Self::get_filter_tip_height(self).await
     }
 
+    async fn get_stored_filter_height(&self) -> StorageResult<Option<u32>> {
+        Self::get_stored_filter_height(self).await
+    }
+
     async fn store_masternode_state(&mut self, state: &MasternodeState) -> StorageResult<()> {
         Self::store_masternode_state(self, state).await
     }

--- a/dash-spv/src/storage/memory.rs
+++ b/dash-spv/src/storage/memory.rs
@@ -258,6 +258,15 @@ impl StorageManager for MemoryStorageManager {
         }
     }
 
+    async fn get_stored_filter_height(&self) -> StorageResult<Option<u32>> {
+        // For memory storage, find the highest filter in the HashMap
+        if self.filters.is_empty() {
+            Ok(None)
+        } else {
+            Ok(self.filters.keys().max().copied())
+        }
+    }
+
     async fn store_masternode_state(&mut self, state: &MasternodeState) -> StorageResult<()> {
         self.masternode_state = Some(state.clone());
         Ok(())

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -127,6 +127,10 @@ pub trait StorageManager: Send + Sync {
     /// Get the current filter tip blockchain height.
     async fn get_filter_tip_height(&self) -> StorageResult<Option<u32>>;
 
+    /// Get the highest stored compact filter height by checking which filters are persisted.
+    /// This is distinct from filter header tip - it shows which filters are actually downloaded.
+    async fn get_stored_filter_height(&self) -> StorageResult<Option<u32>>;
+
     /// Store masternode state.
     async fn store_masternode_state(&mut self, state: &MasternodeState) -> StorageResult<()>;
 


### PR DESCRIPTION
Fix extracted from https://github.com/dashpay/rust-dashcore/pull/189.

This fix aims to avoid re-downloading filters by starting from the last stored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter downloads now resume from the last stored filter height, reducing rework after interrupted syncs.

* **Bug Fixes**
  * Graceful handling when no filter headers are available.
  * Improved sync phase transitions and logic to avoid invalid or redundant filter downloads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->