### PR TITLE
feat: Validate headers during sync

### DIFF
--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -18,7 +18,7 @@ use crate::network::constants::MESSAGE_RECEIVE_TIMEOUT;
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use crate::sync::headers::validate_headers;
-use crate::types::{DetailedSyncProgress, SyncProgress};
+use crate::types::{CachedHeader, DetailedSyncProgress, SyncProgress};
 use crate::ValidationMode;
 use key_wallet_manager::wallet_interface::WalletInterface;
 use std::time::{Duration, Instant, SystemTime};
@@ -950,7 +950,9 @@ impl<
                 // Validate the batch of headers
                 // Use basic validation only, the headers anyway are already validated since they
                 // come from storage.
-                if let Err(e) = validate_headers(&headers, ValidationMode::Basic) {
+                let cached_headers =
+                    headers.iter().map(|h| CachedHeader::new(*h)).collect::<Vec<CachedHeader>>();
+                if let Err(e) = validate_headers(&cached_headers, ValidationMode::Basic) {
                     tracing::error!(
                         "Header validation failed for range {}..{}: {:?}",
                         current_height,

--- a/dash-spv/src/sync/headers/manager.rs
+++ b/dash-spv/src/sync/headers/manager.rs
@@ -12,6 +12,7 @@ use crate::client::ClientConfig;
 use crate::error::{SyncError, SyncResult};
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
+use crate::sync::headers::validate_headers;
 use crate::sync::headers2::Headers2StateManager;
 use crate::types::{CachedHeader, ChainState};
 use std::sync::Arc;
@@ -249,7 +250,7 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
         let cached_headers: Vec<CachedHeader> =
             headers.iter().map(|h| CachedHeader::new(*h)).collect();
 
-        // Step 2: Validate Batch Connection Point
+        // Step 2: Validate Batch
         let first_cached = &cached_headers[0];
         let first_header = first_cached.header();
         let tip =
@@ -291,6 +292,12 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
                 )));
             }
         }
+
+        validate_headers(&cached_headers, self.config.validation_mode).map_err(|e| {
+            let error = format!("Header validation failed: {}", e);
+            tracing::error!(error);
+            SyncError::Validation(error)
+        })?;
 
         self.last_sync_progress = std::time::Instant::now();
 


### PR DESCRIPTION
We currently don't validate headers at all during sync. This PR fixes it.

### Timing on a Macbook with M2 Pro

#### Basic
```
Header chain validation passed for 2000 headers in mode: Basic, duration: 84.291834ms
Header chain validation passed for 2000 headers in mode: Basic, duration: 73.196375ms
Header chain validation passed for 2000 headers in mode: Basic, duration: 89.125333ms
Header chain validation passed for 2000 headers in mode: Basic, duration: 84.616459ms
```
#### Full
```
Header chain validation passed for 2000 headers in mode: Full, duration: 147.289208ms
Header chain validation passed for 2000 headers in mode: Full, duration: 161.37225ms
Header chain validation passed for 2000 headers in mode: Full, duration: 164.333167ms
Header chain validation passed for 2000 headers in mode: Full, duration: 147.604709ms
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened header validation during synchronization to detect and reject invalid headers immediately, preventing corrupted batches from being processed and halting sync on validation failure.
* **Tests**
  * Validation logic and edge cases expanded to ensure robustness across header handling scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->