### PR TITLE
feat: Parallelize header validation with `rayon`

### DIFF
--- a/dash-spv/Cargo.toml
+++ b/dash-spv/Cargo.toml
@@ -46,6 +46,9 @@ rand = "0.8"
 hex = "0.4"
 indexmap = "2.0"
 
+# Parallelization
+rayon = "1.11"
+
 # Terminal UI (optional)
 crossterm = { version = "0.27", optional = true }
 

--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -19,7 +19,6 @@ use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use crate::sync::headers::validate_headers;
 use crate::types::{CachedHeader, DetailedSyncProgress, SyncProgress};
-use crate::ValidationMode;
 use key_wallet_manager::wallet_interface::WalletInterface;
 use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -947,7 +946,7 @@ impl<
                 // come from storage.
                 let cached_headers =
                     headers.iter().map(|h| CachedHeader::new(*h)).collect::<Vec<CachedHeader>>();
-                if let Err(e) = validate_headers(&cached_headers, ValidationMode::Basic) {
+                if let Err(e) = validate_headers(&cached_headers) {
                     tracing::error!(
                         "Header validation failed for range {}..{}: {:?}",
                         current_height,

--- a/dash-spv/src/sync/headers/manager.rs
+++ b/dash-spv/src/sync/headers/manager.rs
@@ -15,6 +15,7 @@ use crate::storage::StorageManager;
 use crate::sync::headers::validate_headers;
 use crate::sync::headers2::Headers2StateManager;
 use crate::types::{CachedHeader, ChainState};
+use crate::ValidationMode;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -282,11 +283,13 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
             }
         }
 
-        validate_headers(&cached_headers, self.config.validation_mode).map_err(|e| {
-            let error = format!("Header validation failed: {}", e);
-            tracing::error!(error);
-            SyncError::Validation(error)
-        })?;
+        if self.config.validation_mode != ValidationMode::None {
+            validate_headers(&cached_headers).map_err(|e| {
+                let error = format!("Header validation failed: {}", e);
+                tracing::error!(error);
+                SyncError::Validation(error)
+            })?;
+        }
 
         self.last_sync_progress = std::time::Instant::now();
 

--- a/dash-spv/src/sync/headers/validation.rs
+++ b/dash-spv/src/sync/headers/validation.rs
@@ -1,62 +1,38 @@
 //! Header validation functionality.
 
-use dashcore::error::Error as DashError;
+use rayon::prelude::*;
 use std::time::Instant;
 
 use crate::error::{ValidationError, ValidationResult};
-use crate::types::{CachedHeader, ValidationMode};
+use crate::types::CachedHeader;
 
-/// Validate a chain of headers considering the validation mode.
-pub fn validate_headers(headers: &[CachedHeader], mode: ValidationMode) -> ValidationResult<()> {
-    if mode == ValidationMode::None {
-        tracing::debug!("Skipping header validation: disabled");
-        return Ok(());
-    }
-
-    if headers.is_empty() {
-        tracing::debug!("Skipping header validation: empty headers");
-        return Ok(());
-    }
-
+/// Validate a chain of headers.
+pub fn validate_headers(headers: &[CachedHeader]) -> ValidationResult<()> {
     let start = Instant::now();
 
-    let mut prev_header_hash = None;
-    for header in headers {
-        // Check chain continuity if we have previous header
-        if let Some(prev) = prev_header_hash {
-            if header.prev_blockhash != prev {
-                return Err(ValidationError::InvalidHeaderChain(
-                    "Header does not connect to previous header".to_string(),
-                ));
-            }
+    // Check PoW of i and continuity of i-1 to i in parallel
+    headers.par_iter().enumerate().try_for_each(|(i, header)| {
+        // For the first header, skip chain continuity check since we don't have i-1 here
+        if i > 0 && header.prev_blockhash != headers[i - 1].block_hash() {
+            return Err(ValidationError::InvalidHeaderChain(format!(
+                "Header {:?} does not connect to {:?}",
+                headers[i - 1],
+                header
+            )));
         }
-
-        if mode == ValidationMode::Full {
-            // Validate proof of work with X11 hashing
-            let target = header.target();
-            if let Err(e) = header.validate_pow(target) {
-                return match e {
-                    DashError::BlockBadProofOfWork => Err(ValidationError::InvalidProofOfWork),
-                    DashError::BlockBadTarget => {
-                        Err(ValidationError::InvalidHeaderChain("Invalid target".to_string()))
-                    }
-                    _ => Err(ValidationError::InvalidHeaderChain(format!(
-                        "PoW validation error: {:?}",
-                        e
-                    ))),
-                };
-            }
+        // Check if PoW target is met
+        if !header.target().is_met_by(header.block_hash()) {
+            return Err(ValidationError::InvalidProofOfWork);
         }
+        Ok(())
+    })?;
 
-        prev_header_hash = Some(header.block_hash());
-    }
-
-    tracing::debug!(
-        "Header chain validation passed for {} headers in mode: {:?}, duration: {:?}",
+    tracing::trace!(
+        "Header chain validation passed for {} headers, duration: {:?}",
         headers.len(),
-        mode,
         start.elapsed(),
     );
+
     Ok(())
 }
 
@@ -64,7 +40,7 @@ pub fn validate_headers(headers: &[CachedHeader], mode: ValidationMode) -> Valid
 mod tests {
     use super::validate_headers;
     use crate::error::ValidationError;
-    use crate::types::{CachedHeader, ValidationMode};
+    use crate::types::CachedHeader;
     use dashcore::{
         block::{Header as BlockHeader, Version},
         blockdata::constants::genesis_block,
@@ -72,499 +48,101 @@ mod tests {
     };
     use dashcore_hashes::Hash;
 
-    /// Create a test header with given parameters
-    fn create_test_header(
-        prev_hash: dashcore::BlockHash,
-        nonce: u32,
-        bits: u32,
-        time: u32,
-    ) -> CachedHeader {
+    // Very easy target to pass PoW checks for continuity tests
+    const MAX_TARGET: u32 = 0x2100ffff;
+
+    fn create_test_header(prev_hash: dashcore::BlockHash, nonce: u32) -> CachedHeader {
         CachedHeader::new(BlockHeader {
-            version: Version::from_consensus(0x20000000),
+            version: Version::from_consensus(1),
             prev_blockhash: prev_hash,
-            merkle_root: dashcore::TxMerkleNode::from_byte_array([0; 32]),
-            time,
-            bits: dashcore::CompactTarget::from_consensus(bits),
+            merkle_root: dashcore::TxMerkleNode::all_zeros(),
+            time: 0,
+            bits: CompactTarget::from_consensus(MAX_TARGET),
             nonce,
         })
     }
 
-    /// Create a test header with specific parameters
-    fn create_test_header_with_params(
-        version: u32,
-        prev_hash: dashcore::BlockHash,
-        merkle_root: [u8; 32],
-        time: u32,
-        bits: u32,
-        nonce: u32,
-    ) -> CachedHeader {
-        CachedHeader::new(BlockHeader {
-            version: Version::from_consensus(version as i32),
-            prev_blockhash: prev_hash,
-            merkle_root: dashcore::TxMerkleNode::from_byte_array(merkle_root),
-            time,
-            bits: CompactTarget::from_consensus(bits),
-            nonce,
-        })
-    }
-
-    // ==================== Basic Tests ====================
-
     #[test]
-    fn test_validation_mode_none_always_passes() {
-        let header = create_test_header(
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            0,
-            0x1e0fffff,
-            1234567890,
-        );
-
-        // Should pass with no previous header
-        assert!(validate_headers(std::slice::from_ref(&header), ValidationMode::None).is_ok());
-
-        // Should pass even with invalid chain continuity
-        let prev_header = create_test_header(
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [1; 32],
-            )),
-            1,
-            0x1e0fffff,
-            1234567890,
-        );
-        assert!(validate_headers(&[prev_header, header], ValidationMode::None).is_ok());
+    fn test_empty_headers() {
+        assert!(validate_headers(&[]).is_ok());
     }
 
     #[test]
-    fn test_basic_validation_chain_continuity() {
-        // Create two headers that connect properly
-        let header1 = create_test_header(
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            1,
-            0x1e0fffff,
-            1234567890,
-        );
-        let header2 = create_test_header(header1.block_hash(), 2, 0x1e0fffff, 1234567900);
-
-        // Should pass when headers connect
-        assert!(validate_headers(&[header1.clone(), header2], ValidationMode::Basic).is_ok());
-
-        // Should fail when headers don't connect
-        let disconnected_header = create_test_header(
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [99; 32],
-            )),
-            3,
-            0x1e0fffff,
-            1234567910,
-        );
-        let result = validate_headers(&[header1, disconnected_header], ValidationMode::Basic);
-        assert!(matches!(result, Err(ValidationError::InvalidHeaderChain(_))));
+    fn test_single_header() {
+        let header = create_test_header(dashcore::BlockHash::all_zeros(), 0);
+        assert!(validate_headers(&[header]).is_ok());
     }
 
     #[test]
-    fn test_basic_validation_no_pow_check() {
-        // Create header with invalid PoW (would fail full validation)
-        let header = create_test_header(
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            0, // Invalid nonce that won't produce valid PoW
-            0x1e0fffff,
-            1234567890,
-        );
-
-        // Should pass basic validation (no PoW check)
-        assert!(validate_headers(&[header], ValidationMode::Basic).is_ok());
-    }
-
-    #[test]
-    fn test_full_validation_includes_pow() {
-        // Create header with invalid PoW
-        let header = create_test_header(
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            0,          // Invalid nonce
-            0x1d00ffff, // Difficulty that requires real PoW
-            1234567890,
-        );
-
-        // Should fail full validation due to invalid PoW
-        let result = validate_headers(&[header], ValidationMode::Full);
-        assert!(matches!(result, Err(ValidationError::InvalidProofOfWork)));
-    }
-
-    #[test]
-    fn test_validate_headers_empty() {
-        for mode in [ValidationMode::None, ValidationMode::Basic, ValidationMode::Full] {
-            let headers: Vec<CachedHeader> = vec![];
-            // Empty chain should pass
-            assert!(validate_headers(&headers, mode).is_ok());
-        }
-    }
-
-    #[test]
-    fn test_validate_headers_basic_single_header() {
-        let header = create_test_header(
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            1,
-            0x1e0fffff,
-            1234567890,
-        );
-
-        // Single header should pass (no chain validation needed)
-        assert!(validate_headers(&[header], ValidationMode::Basic).is_ok());
-    }
-
-    #[test]
-    fn test_validate_headers_basic_valid_chain() {
-        // Create a valid chain of headers
+    fn test_valid_chain() {
         let mut headers = vec![];
-        let mut prev_hash = dashcore::BlockHash::from_raw_hash(
-            dashcore_hashes::hash_x11::Hash::from_byte_array([0; 32]),
-        );
+        let mut prev_hash = dashcore::BlockHash::all_zeros();
 
-        for i in 0..5 {
-            let header = create_test_header(prev_hash, i, 0x1e0fffff, 1234567890 + i * 600);
+        for i in 0..10 {
+            let header = create_test_header(prev_hash, i);
             prev_hash = header.block_hash();
             headers.push(header);
         }
 
-        // Valid chain should pass
-        assert!(validate_headers(&headers, ValidationMode::Basic).is_ok());
+        assert!(validate_headers(&headers).is_ok());
     }
 
     #[test]
-    fn test_validate_headers_basic_broken_chain() {
-        // Create a chain with a break in the middle
-        let header1 = create_test_header(
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            1,
-            0x1e0fffff,
-            1234567890,
-        );
-        let header2 = create_test_header(header1.block_hash(), 2, 0x1e0fffff, 1234567900);
-        let header3 = create_test_header(
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [99; 32],
-            )), // Broken link
-            3,
-            0x1e0fffff,
-            1234567910,
-        );
+    fn test_broken_chain() {
+        let header1 = create_test_header(dashcore::BlockHash::all_zeros(), 0);
+        let header2 = create_test_header(header1.block_hash(), 1);
+        // header3 doesn't connect to header2
+        let header3 = create_test_header(dashcore::BlockHash::all_zeros(), 2);
 
-        let headers = vec![header1, header2, header3];
-
-        // Should fail due to broken chain
-        let result = validate_headers(&headers, ValidationMode::Basic);
+        let result = validate_headers(&[header1, header2, header3]);
         assert!(matches!(result, Err(ValidationError::InvalidHeaderChain(_))));
     }
 
     #[test]
-    fn test_validate_headers_full_with_pow() {
-        // Create headers with invalid PoW
-        let header1 = create_test_header(
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            0,          // Invalid nonce
-            0x1d00ffff, // Difficulty that requires real PoW
-            1234567890,
-        );
+    fn test_invalid_pow() {
+        let header = CachedHeader::new(BlockHeader {
+            version: Version::from_consensus(1),
+            prev_blockhash: dashcore::BlockHash::all_zeros(),
+            merkle_root: dashcore::TxMerkleNode::all_zeros(),
+            time: 0,
+            bits: CompactTarget::from_consensus(0x1d00ffff), // Hard target
+            nonce: 0,
+        });
 
-        // Should fail when PoW validation is enabled
-        let result = validate_headers(std::slice::from_ref(&header1), ValidationMode::Full);
+        let result = validate_headers(&[header]);
         assert!(matches!(result, Err(ValidationError::InvalidProofOfWork)));
     }
 
-    // ==================== Edge Case Tests ====================
-
     #[test]
-    fn test_genesis_block_validation() {
+    fn test_genesis_blocks() {
         for network in [Network::Dash, Network::Testnet, Network::Regtest] {
             let genesis = CachedHeader::new(genesis_block(network).header);
-
-            // Genesis block should validate with no previous header
-            assert!(validate_headers(std::slice::from_ref(&genesis), ValidationMode::Full).is_ok());
-
-            // Genesis block with itself as previous should fail
-            let result = validate_headers(&[genesis.clone(), genesis], ValidationMode::Full);
-            assert!(matches!(result, Err(ValidationError::InvalidHeaderChain(_))));
+            assert!(
+                validate_headers(&[genesis]).is_ok(),
+                "Genesis block for {:?} should validate",
+                network
+            );
         }
     }
 
     #[test]
-    fn test_maximum_target_validation() {
-        // Create header with maximum allowed target (easiest difficulty)
-        let max_target_bits = 0x1e0fffff; // Maximum target for testing
-        let header = create_test_header_with_params(
-            0x20000000,
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            [0; 32],
-            1234567890,
-            max_target_bits,
-            1, // May need adjustment for valid PoW
-        );
+    fn test_invalid_pow_mid_chain() {
+        let header1 = create_test_header(dashcore::BlockHash::all_zeros(), 0);
+        let header2 = create_test_header(header1.block_hash(), 1);
 
-        // Should validate (though PoW might fail - that's expected)
-        let _ = validate_headers(&[header], ValidationMode::Full);
-    }
+        // Header 3 has valid continuity but impossible PoW target
+        let header3 = CachedHeader::new(BlockHeader {
+            version: Version::from_consensus(1),
+            prev_blockhash: header2.block_hash(),
+            merkle_root: dashcore::TxMerkleNode::all_zeros(),
+            time: 0,
+            bits: CompactTarget::from_consensus(0x1d00ffff), // Hard target
+            nonce: 0,
+        });
 
-    #[test]
-    fn test_minimum_target_validation() {
-        // Create header with very low target (hardest difficulty)
-        let min_target_bits = 0x17000000; // Very difficult target
-        let header = create_test_header_with_params(
-            0x20000000,
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            [0; 32],
-            1234567890,
-            min_target_bits,
-            0, // Will definitely fail PoW
-        );
+        let header4 = create_test_header(header3.block_hash(), 3);
 
-        // Should fail PoW validation
-        let result = validate_headers(&[header], ValidationMode::Full);
+        let result = validate_headers(&[header1, header2, header3, header4]);
         assert!(matches!(result, Err(ValidationError::InvalidProofOfWork)));
-    }
-
-    #[test]
-    fn test_zero_prev_blockhash() {
-        // First header with zero prev_blockhash (like genesis)
-        let header1 = create_test_header_with_params(
-            0x20000000,
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            [1; 32],
-            1234567890,
-            0x1e0fffff,
-            1,
-        );
-
-        // Second header pointing to first
-        let header2 = create_test_header_with_params(
-            0x20000000,
-            header1.block_hash(),
-            [2; 32],
-            1234567900,
-            0x1e0fffff,
-            2,
-        );
-
-        // Should validate single header
-        assert!(validate_headers(std::slice::from_ref(&header1), ValidationMode::Basic).is_ok());
-
-        // Should validate chain continuity
-        assert!(validate_headers(&[header1, header2], ValidationMode::Basic).is_ok());
-    }
-
-    #[test]
-    fn test_all_ff_prev_blockhash() {
-        // Header with all 0xFF prev_blockhash
-        let header = create_test_header_with_params(
-            0x20000000,
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0xFF; 32],
-            )),
-            [1; 32],
-            1234567890,
-            0x1e0fffff,
-            1,
-        );
-
-        // Should validate when single header
-        assert!(validate_headers(std::slice::from_ref(&header), ValidationMode::Basic).is_ok());
-
-        // Create a previous header that would NOT match
-        let prev_header = create_test_header_with_params(
-            0x20000000,
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            [0; 32],
-            1234567880,
-            0x1e0fffff,
-            0,
-        );
-
-        // Should fail chain continuity
-        let result = validate_headers(&[prev_header, header], ValidationMode::Basic);
-        assert!(matches!(result, Err(ValidationError::InvalidHeaderChain(_))));
-    }
-
-    #[test]
-    fn test_timestamp_boundaries() {
-        // Test with minimum timestamp (0)
-        let header_min_time = create_test_header_with_params(
-            0x20000000,
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            [1; 32],
-            0, // Minimum timestamp
-            0x1e0fffff,
-            1,
-        );
-        assert!(validate_headers(&[header_min_time], ValidationMode::Basic).is_ok());
-
-        // Test with maximum timestamp (u32::MAX)
-        let header_max_time = create_test_header_with_params(
-            0x20000000,
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            [2; 32],
-            u32::MAX, // Maximum timestamp
-            0x1e0fffff,
-            2,
-        );
-        assert!(validate_headers(&[header_max_time], ValidationMode::Basic).is_ok());
-    }
-
-    #[test]
-    fn test_version_edge_cases() {
-        // Test various version values
-        let versions = [0, 1, 0x20000000, 0x20000001, u32::MAX];
-
-        for (i, &version) in versions.iter().enumerate() {
-            let header = create_test_header_with_params(
-                version,
-                dashcore::BlockHash::from_raw_hash(
-                    dashcore_hashes::hash_x11::Hash::from_byte_array([0; 32]),
-                ),
-                [i as u8; 32],
-                1234567890 + i as u32,
-                0x1e0fffff,
-                i as u32,
-            );
-
-            // All versions should pass basic validation
-            assert!(validate_headers(&[header], ValidationMode::Basic).is_ok());
-        }
-    }
-
-    #[test]
-    fn test_large_chain_validation() {
-        // Create a large chain
-        let chain_size = 1000;
-        let mut headers = Vec::with_capacity(chain_size);
-        let mut prev_hash = dashcore::BlockHash::from_raw_hash(
-            dashcore_hashes::hash_x11::Hash::from_byte_array([0; 32]),
-        );
-
-        for i in 0..chain_size {
-            let header = create_test_header_with_params(
-                0x20000000,
-                prev_hash,
-                [(i % 256) as u8; 32],
-                1234567890 + i as u32 * 600,
-                0x1e0fffff,
-                i as u32,
-            );
-            prev_hash = header.block_hash();
-            headers.push(header);
-        }
-
-        // Should validate entire chain
-        assert!(validate_headers(&headers, ValidationMode::Basic).is_ok());
-
-        // Break the chain in the middle
-        let broken_index = chain_size / 2;
-        headers[broken_index] = create_test_header_with_params(
-            0x20000000,
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [99; 32],
-            )),
-            [99; 32],
-            1234567890,
-            0x1e0fffff,
-            999999,
-        );
-
-        // Should fail validation
-        let result = validate_headers(&headers, ValidationMode::Basic);
-        assert!(matches!(result, Err(ValidationError::InvalidHeaderChain(_))));
-    }
-
-    #[test]
-    fn test_single_header_chain_validation() {
-        let header = create_test_header_with_params(
-            0x20000000,
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            [1; 32],
-            1234567890,
-            0x1e0fffff,
-            1,
-        );
-
-        // Single header chain should validate
-        assert!(validate_headers(&[header], ValidationMode::Basic).is_ok());
-    }
-
-    #[test]
-    fn test_duplicate_headers_in_chain() {
-        let header = create_test_header_with_params(
-            0x20000000,
-            dashcore::BlockHash::from_raw_hash(dashcore_hashes::hash_x11::Hash::from_byte_array(
-                [0; 32],
-            )),
-            [1; 32],
-            1234567890,
-            0x1e0fffff,
-            1,
-        );
-
-        // Chain with duplicate headers (same header repeated)
-        let headers = vec![header.clone(), header];
-
-        // Should fail because second header's prev_blockhash won't match first header's hash
-        let result = validate_headers(&headers, ValidationMode::Basic);
-        assert!(matches!(result, Err(ValidationError::InvalidHeaderChain(_))));
-    }
-
-    #[test]
-    fn test_merkle_root_variations() {
-        // Test various merkle root patterns
-        let merkle_patterns = [
-            [0u8; 32],  // All zeros
-            [0xFF; 32], // All ones
-            [0xAA; 32], // Alternating bits
-            [0x55; 32], // Alternating bits (inverse)
-        ];
-
-        let mut prev_hash = dashcore::BlockHash::from_raw_hash(
-            dashcore_hashes::hash_x11::Hash::from_byte_array([0; 32]),
-        );
-
-        for (i, &merkle_root) in merkle_patterns.iter().enumerate() {
-            let header = create_test_header_with_params(
-                0x20000000,
-                prev_hash,
-                merkle_root,
-                1234567890 + i as u32 * 600,
-                0x1e0fffff,
-                i as u32,
-            );
-
-            // All merkle roots should be valid for basic validation
-            assert!(validate_headers(std::slice::from_ref(&header), ValidationMode::Basic).is_ok());
-
-            prev_hash = header.block_hash();
-        }
     }
 }


### PR DESCRIPTION
This PR improves header validation timings and refactors the validation mode out of `validate_headers` since there is no difference in validation mode timings anymore. It also overhauls the header validation tests to remove all the clutter and have few focused tests.

Improvements are archived by:
 
 - Check PoW of i and continuity of i-1 to i in parallel by leveraging a `rayon` parallel iterator.
 - Using `CachedHeader` to avoid multiple `block_hash` calculations of the same header
 - Calling `Target::is_met_by` directly which drops another `block_hash` call inside `validate_pow`.

  | Validation Mode | Before       | After       |
  |-----------------|--------------|-------------|
  | Basic           | ~80 ms     | ~12 ms    |
  | Full            | ~150 ms    | ~12 ms    |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added parallelization dependency to improve performance.

* **Refactor**
  * Simplified header validation logic with updated validation checks for chain continuity and proof of work verification.
  * Validation now executes conditionally based on configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->