### PR TITLE
feat: Add `atomic_write` for atomic file writing

### DIFF
--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -12,6 +12,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
+use crate::storage::disk::io::atomic_write;
+
 /// Maximum misbehavior score before a peer is banned
 const MAX_MISBEHAVIOR_SCORE: i32 = 100;
 
@@ -424,7 +426,7 @@ impl PeerReputationManager {
             .collect();
 
         let json = serde_json::to_string_pretty(&data)?;
-        tokio::fs::write(path, json).await
+        atomic_write(path, json.as_bytes()).await.map_err(std::io::Error::other)
     }
 
     /// Load reputation data from persistent storage

--- a/dash-spv/src/storage/disk/filters.rs
+++ b/dash-spv/src/storage/disk/filters.rs
@@ -7,6 +7,7 @@ use dashcore_hashes::Hash;
 
 use crate::error::StorageResult;
 
+use super::io::atomic_write;
 use super::manager::DiskStorageManager;
 use super::segments::SegmentState;
 
@@ -185,8 +186,7 @@ impl DiskStorageManager {
     /// Store a compact filter.
     pub async fn store_filter(&mut self, height: u32, filter: &[u8]) -> StorageResult<()> {
         let path = self.base_path.join(format!("filters/{}.dat", height));
-        tokio::fs::write(path, filter).await?;
-        Ok(())
+        atomic_write(&path, filter).await
     }
 
     /// Load a compact filter.

--- a/dash-spv/src/storage/disk/io.rs
+++ b/dash-spv/src/storage/disk/io.rs
@@ -1,9 +1,9 @@
 //! Low-level I/O utilities for reading and writing segment files.
 
 use std::collections::HashMap;
-use std::fs::{self, File, OpenOptions};
-use std::io::{BufReader, BufWriter, Write};
-use std::path::Path;
+use std::fs::{self, File};
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
 
 use dashcore::{
     block::Header as BlockHeader,
@@ -14,6 +14,59 @@ use dashcore::{
 use dashcore_hashes::Hash;
 
 use crate::error::{StorageError, StorageResult};
+
+/// Get the temporary file path for atomic writes.
+/// Uses process ID and a counter to ensure uniqueness even with concurrent writes.
+fn get_temp_path(path: &Path) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    let mut temp_path = path.to_path_buf();
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("temp");
+    let unique_id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    temp_path.set_file_name(format!(".{}.{}.{}.tmp", file_name, pid, unique_id));
+    temp_path
+}
+
+/// Atomically write data to a file.
+/// Uses temporary file + sync + rename pattern for crash resilience.
+pub(crate) async fn atomic_write(path: &Path, data: &[u8]) -> StorageResult<()> {
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| StorageError::WriteFailed(format!("Failed to create directory: {}", e)))?;
+    }
+
+    let temp_path = get_temp_path(path);
+
+    // Write to temporary file
+    let write_result = async {
+        tokio::fs::write(&temp_path, data).await?;
+
+        // Sync to disk - open the file and call sync_all
+        let file = tokio::fs::File::open(&temp_path).await?;
+        file.sync_all().await?;
+
+        Ok::<(), std::io::Error>(())
+    }
+    .await;
+
+    // Clean up temp file on error
+    if let Err(e) = write_result {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        return Err(StorageError::WriteFailed(format!("Failed to write temp file: {}", e)));
+    }
+
+    // Atomic rename
+    if let Err(e) = tokio::fs::rename(&temp_path, path).await {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        return Err(StorageError::WriteFailed(format!("Failed to rename temp file: {}", e)));
+    }
+
+    Ok(())
+}
 
 /// Load headers from file.
 pub(super) async fn load_headers_from_file(path: &Path) -> StorageResult<Vec<BlockHeader>> {
@@ -101,34 +154,23 @@ pub(super) async fn save_segment_to_disk(
     path: &Path,
     headers: &[BlockHeader],
 ) -> StorageResult<()> {
-    tokio::task::spawn_blocking({
-        let path = path.to_path_buf();
-        let headers = headers.to_vec();
-        move || {
-            let file = OpenOptions::new().create(true).write(true).truncate(true).open(&path)?;
-            let mut writer = BufWriter::new(file);
-
-            // Only save actual headers, not sentinel headers
-            for header in headers {
-                // Skip sentinel headers (used for padding)
-                if header.version.to_consensus() == i32::MAX
-                    && header.time == u32::MAX
-                    && header.nonce == u32::MAX
-                    && header.prev_blockhash == BlockHash::from_byte_array([0xFF; 32])
-                {
-                    continue;
-                }
-                header.consensus_encode(&mut writer).map_err(|e| {
-                    StorageError::WriteFailed(format!("Failed to encode header: {}", e))
-                })?;
-            }
-
-            writer.flush()?;
-            Ok(())
+    // Build buffer with encoded headers
+    let mut buffer = Vec::new();
+    for header in headers {
+        // Skip sentinel headers (used for padding)
+        if header.version.to_consensus() == i32::MAX
+            && header.time == u32::MAX
+            && header.nonce == u32::MAX
+            && header.prev_blockhash == BlockHash::from_byte_array([0xFF; 32])
+        {
+            continue;
         }
-    })
-    .await
-    .map_err(|e| StorageError::WriteFailed(format!("Task join error: {}", e)))?
+        header
+            .consensus_encode(&mut buffer)
+            .map_err(|e| StorageError::WriteFailed(format!("Failed to encode header: {}", e)))?;
+    }
+
+    atomic_write(path, &buffer).await
 }
 
 /// Save a segment of filter headers to disk.
@@ -136,25 +178,15 @@ pub(super) async fn save_filter_segment_to_disk(
     path: &Path,
     filter_headers: &[FilterHeader],
 ) -> StorageResult<()> {
-    tokio::task::spawn_blocking({
-        let path = path.to_path_buf();
-        let filter_headers = filter_headers.to_vec();
-        move || {
-            let file = OpenOptions::new().create(true).write(true).truncate(true).open(&path)?;
-            let mut writer = BufWriter::new(file);
+    // Build buffer with encoded filter headers
+    let mut buffer = Vec::new();
+    for header in filter_headers {
+        header.consensus_encode(&mut buffer).map_err(|e| {
+            StorageError::WriteFailed(format!("Failed to encode filter header: {}", e))
+        })?;
+    }
 
-            for header in filter_headers {
-                header.consensus_encode(&mut writer).map_err(|e| {
-                    StorageError::WriteFailed(format!("Failed to encode filter header: {}", e))
-                })?;
-            }
-
-            writer.flush()?;
-            Ok(())
-        }
-    })
-    .await
-    .map_err(|e| StorageError::WriteFailed(format!("Task join error: {}", e)))?
+    atomic_write(path, &buffer).await
 }
 
 /// Save index to disk.
@@ -162,17 +194,195 @@ pub(super) async fn save_index_to_disk(
     path: &Path,
     index: &HashMap<BlockHash, u32>,
 ) -> StorageResult<()> {
-    tokio::task::spawn_blocking({
-        let path = path.to_path_buf();
-        let index = index.clone();
-        move || {
-            let data = bincode::serialize(&index).map_err(|e| {
-                StorageError::WriteFailed(format!("Failed to serialize index: {}", e))
-            })?;
-            fs::write(&path, data)?;
-            Ok(())
+    let data = bincode::serialize(index)
+        .map_err(|e| StorageError::WriteFailed(format!("Failed to serialize index: {}", e)))?;
+
+    atomic_write(path, &data).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_get_temp_path_uniqueness() {
+        let path = Path::new("some").join("path").join("file.dat");
+
+        let temp1 = get_temp_path(&path);
+        let temp2 = get_temp_path(&path);
+
+        assert_ne!(temp1, temp2, "Each call should produce a unique temp path");
+
+        // Check temp file is in same directory as original
+        assert_eq!(temp1.parent(), path.parent());
+
+        // Check temp file name starts with dot and ends with .tmp
+        let file_name = temp1.file_name().unwrap().to_string_lossy();
+        assert!(file_name.starts_with(".file.dat."));
+        assert!(file_name.ends_with(".tmp"));
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_creates_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test.dat");
+
+        let content = b"hello world";
+        atomic_write(&path, content).await.unwrap();
+
+        assert!(path.exists());
+        let read_content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_content, content);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_creates_parent_directories() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("nested").join("dirs").join("test.dat");
+
+        let content = b"nested content";
+        atomic_write(&path, content).await.unwrap();
+
+        assert!(path.exists());
+        let read_content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_content, content);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_overwrites_existing() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test.dat");
+
+        // Write initial content
+        tokio::fs::write(&path, b"initial").await.unwrap();
+
+        // Overwrite with atomic write
+        let new_content = b"new content";
+        atomic_write(&path, new_content).await.unwrap();
+
+        let read_content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_content, new_content);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_no_temp_file_on_success() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test.dat");
+
+        atomic_write(&path, b"data").await.unwrap();
+
+        // Check no .tmp files remain
+        let mut entries = tokio::fs::read_dir(temp_dir.path()).await.unwrap();
+        let mut tmp_files = Vec::new();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            if entry.file_name().to_string_lossy().ends_with(".tmp") {
+                tmp_files.push(entry.file_name());
+            }
         }
-    })
-    .await
-    .map_err(|e| StorageError::WriteFailed(format!("Task join error: {}", e)))?
+
+        assert!(tmp_files.is_empty(), "No temp files should remain after successful write");
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_preserves_original_on_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test.dat");
+
+        // Write initial content
+        let original = b"original content";
+        tokio::fs::write(&path, original).await.unwrap();
+
+        // Try to write to an invalid path (directory instead of file)
+        let invalid_path = temp_dir.path().join("test.dat").join("invalid");
+
+        let result = atomic_write(&invalid_path, b"new content").await;
+        assert!(result.is_err());
+
+        // Original file should still have original content
+        let read_content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_content, original);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_cleans_up_temp_on_error() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create a file that will block directory creation
+        let blocker_path = temp_dir.path().join("blocker");
+        tokio::fs::write(&blocker_path, b"I am a file").await.unwrap();
+
+        // Try to write to a path where parent "directory" is actually a file
+        let invalid_path = blocker_path.join("subdir").join("file.dat");
+
+        let result = atomic_write(&invalid_path, b"data").await;
+        assert!(result.is_err());
+
+        // No temp files should remain in the base temp dir
+        let entries: Vec<_> = fs::read_dir(temp_dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+
+        assert!(entries.is_empty(), "No temp files should remain after failed write");
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_binary_data() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("binary.dat");
+
+        // Write binary data with null bytes and various byte values
+        let binary_data: Vec<u8> = (0u8..=255).collect();
+        atomic_write(&path, &binary_data).await.unwrap();
+
+        let read_content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_content, binary_data);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_large_data() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("large.dat");
+
+        // Write 1MB of data
+        let large_data: Vec<u8> = (0..1_000_000).map(|i| (i % 256) as u8).collect();
+        atomic_write(&path, &large_data).await.unwrap();
+
+        let read_content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_content.len(), large_data.len());
+        assert_eq!(read_content, large_data);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_cleans_up_temp_on_rename_failure() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("target.dat");
+
+        // Create a directory at the target path - rename will fail because
+        // you cannot rename a file over an existing directory
+        tokio::fs::create_dir(&path).await.unwrap();
+
+        let result = atomic_write(&path, b"data").await;
+        assert!(result.is_err());
+
+        // The target directory should still exist
+        assert!(path.exists());
+        assert!(path.is_dir());
+
+        // No temp files should remain
+        let entries: Vec<_> = fs::read_dir(temp_dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+
+        assert!(
+            entries.is_empty(),
+            "No temp files should remain after rename failure, found: {:?}",
+            entries.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+        );
+    }
 }

--- a/dash-spv/src/storage/disk/mod.rs
+++ b/dash-spv/src/storage/disk/mod.rs
@@ -21,7 +21,7 @@
 
 mod filters;
 mod headers;
-mod io;
+pub(crate) mod io;
 mod manager;
 mod segments;
 mod state;

--- a/dash-spv/src/storage/disk/state.rs
+++ b/dash-spv/src/storage/disk/state.rs
@@ -11,6 +11,7 @@ use crate::error::StorageResult;
 use crate::storage::{MasternodeState, StorageManager, StorageStats};
 use crate::types::{ChainState, MempoolState, UnconfirmedTransaction};
 
+use super::io::atomic_write;
 use super::manager::DiskStorageManager;
 
 impl DiskStorageManager {
@@ -42,7 +43,8 @@ impl DiskStorageManager {
         });
 
         let path = self.base_path.join("state/chain.json");
-        tokio::fs::write(path, state_data.to_string()).await?;
+        let json = state_data.to_string();
+        atomic_write(&path, json.as_bytes()).await?;
 
         Ok(())
     }
@@ -104,7 +106,7 @@ impl DiskStorageManager {
             ))
         })?;
 
-        tokio::fs::write(path, json).await?;
+        atomic_write(&path, json.as_bytes()).await?;
         Ok(())
     }
 
@@ -141,12 +143,7 @@ impl DiskStorageManager {
             ))
         })?;
 
-        // Write to a temporary file first for atomicity
-        let temp_path = path.with_extension("tmp");
-        tokio::fs::write(&temp_path, json.as_bytes()).await?;
-
-        // Atomically rename to final path
-        tokio::fs::rename(&temp_path, &path).await?;
+        atomic_write(&path, json.as_bytes()).await?;
 
         tracing::debug!("Saved sync state at height {}", state.chain_tip.height);
         Ok(())
@@ -192,10 +189,8 @@ impl DiskStorageManager {
         height: u32,
         checkpoint: &crate::storage::sync_state::SyncCheckpoint,
     ) -> StorageResult<()> {
-        let checkpoints_dir = self.base_path.join("checkpoints");
-        tokio::fs::create_dir_all(&checkpoints_dir).await?;
-
-        let path = checkpoints_dir.join(format!("checkpoint_{:08}.json", height));
+        let path =
+            self.base_path.join("checkpoints").join(format!("checkpoint_{:08}.json", height));
         let json = serde_json::to_string(checkpoint).map_err(|e| {
             crate::error::StorageError::WriteFailed(format!(
                 "Failed to serialize checkpoint: {}",
@@ -203,7 +198,7 @@ impl DiskStorageManager {
             ))
         })?;
 
-        tokio::fs::write(&path, json.as_bytes()).await?;
+        atomic_write(&path, json.as_bytes()).await?;
         tracing::debug!("Stored checkpoint at height {}", height);
         Ok(())
     }
@@ -257,10 +252,7 @@ impl DiskStorageManager {
         height: u32,
         chain_lock: &dashcore::ChainLock,
     ) -> StorageResult<()> {
-        let chainlocks_dir = self.base_path.join("chainlocks");
-        tokio::fs::create_dir_all(&chainlocks_dir).await?;
-
-        let path = chainlocks_dir.join(format!("chainlock_{:08}.bin", height));
+        let path = self.base_path.join("chainlocks").join(format!("chainlock_{:08}.bin", height));
         let data = bincode::serialize(chain_lock).map_err(|e| {
             crate::error::StorageError::WriteFailed(format!(
                 "Failed to serialize chain lock: {}",
@@ -268,7 +260,7 @@ impl DiskStorageManager {
             ))
         })?;
 
-        tokio::fs::write(&path, &data).await?;
+        atomic_write(&path, &data).await?;
         tracing::debug!("Stored chain lock at height {}", height);
         Ok(())
     }
@@ -335,7 +327,7 @@ impl DiskStorageManager {
     /// Store metadata.
     pub async fn store_metadata(&mut self, key: &str, value: &[u8]) -> StorageResult<()> {
         let path = self.base_path.join(format!("state/{}.dat", key));
-        tokio::fs::write(path, value).await?;
+        atomic_write(&path, value).await?;
         Ok(())
     }
 


### PR DESCRIPTION
Introduces atomic file writes for all SPV storage operations with a tempfile + rename pattern to ensure files dont get corrupted if a crash happens during write.

  - Adds `atomic_write` function
  - Updates all file writes: headers, filter headers, index, chain state, sync state, checkpoints, chainlocks, metadata, peers, peer-reputation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Storage operations (state, filters, checkpoints, network/reputation data) now use crash‑resilient atomic file writes, reducing risk of corruption and improving stability.

* **New Features**
  * Added robust on‑disk handling for filter headers to improve load reliability.

* **Tests**
  * Added comprehensive tests covering atomic write behavior, overwrite semantics, and large/binary data handling.

* **Chores**
  * Adjusted internal module visibility for safer integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->