### PR TITLE
feat: Less validation before the last checkpoint

### DIFF
--- a/dash-spv/src/chain/checkpoints.rs
+++ b/dash-spv/src/chain/checkpoints.rs
@@ -119,6 +119,11 @@ impl CheckpointManager {
         &self.sorted_heights
     }
 
+    /// Check if we're past the last checkpoint
+    pub fn is_past_checkpoints(&self, height: u32) -> bool {
+        self.sorted_heights.last().is_none_or(|&last| height > last)
+    }
+
     /// Get the last checkpoint before a given timestamp
     pub fn last_checkpoint_before_timestamp(&self, timestamp: u32) -> Option<&Checkpoint> {
         let mut best_checkpoint = None;

--- a/dash-spv/src/client/config.rs
+++ b/dash-spv/src/client/config.rs
@@ -146,6 +146,9 @@ pub struct ClientConfig {
     /// Used to determine appropriate checkpoint for sync.
     pub wallet_creation_time: Option<u32>,
 
+    /// Force basic validation only (skip PoW) before the last checkpoint to speed up sync. (default: true)
+    pub trust_checkpoints: bool,
+
     // QRInfo configuration (simplified per plan)
     /// Request extra share data in QRInfo (default: false per DMLviewer.patch).
     pub qr_info_extra_share: bool,
@@ -194,6 +197,7 @@ impl Default for ClientConfig {
             blocks_request_rate_limit: None,
             start_from_height: None,
             wallet_creation_time: None,
+            trust_checkpoints: true,
             // CFHeaders flow control defaults
             max_concurrent_cfheaders_requests_parallel: 50,
             cfheaders_request_timeout_secs: 30,
@@ -327,6 +331,12 @@ impl ClientConfig {
     /// Set the starting height for synchronization.
     pub fn with_start_height(mut self, height: u32) -> Self {
         self.start_from_height = Some(height);
+        self
+    }
+
+    /// Set whether to trust checkpoints during sync.
+    pub fn with_trust_checkpoints(mut self, trust: bool) -> Self {
+        self.trust_checkpoints = trust;
         self
     }
 

--- a/dash-spv/src/main.rs
+++ b/dash-spv/src/main.rs
@@ -125,6 +125,12 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 .help("Start syncing from a specific block height using the nearest checkpoint. Use 'now' for the latest checkpoint")
                 .value_name("HEIGHT"),
         )
+        .arg(
+            Arg::new("no-trust-checkpoints")
+                .long("no-trust-checkpoints")
+                .help("Disable checkpoint trust to use the configured validation mode for all headers")
+                .action(clap::ArgAction::SetTrue),
+        )
         .get_matches();
 
     // Get log level (will be used after we know if terminal UI is enabled)
@@ -190,6 +196,9 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
     if matches.get_flag("no-mempool") {
         config.enable_mempool_tracking = false;
+    }
+    if matches.get_flag("no-trust-checkpoints") {
+        config = config.with_trust_checkpoints(false);
     }
 
     // Set start height if specified

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -51,6 +51,7 @@ mod peer_network_manager_tests {
             blocks_request_rate_limit: None,
             start_from_height: None,
             wallet_creation_time: None,
+            trust_checkpoints: true,
             // QRInfo fields
             qr_info_extra_share: true,
             qr_info_timeout: Duration::from_secs(30),


### PR DESCRIPTION
Add `trust-checkpoints` config parameter to either trust checkpoints `trust-checkpoint=true` which means the client uses basic validation only below the last checkpoint height or with `trust-checkpoints=false` it uses the configured validation mode configuration `validation-mode`. Defaults to `trust-checkpoints=true`.