### PR TITLE
fix: Drop duplicated received filter update

### DIFF
--- a/dash-spv/src/sync/message_handlers.rs
+++ b/dash-spv/src/sync/message_handlers.rs
@@ -629,20 +629,6 @@ impl<
             stats_lock.last_filter_received_time = Some(std::time::Instant::now());
         }
 
-        // Get the shared filter heights arc from stats
-        let stats_lock = self.stats.read().await;
-        let received_filter_heights = stats_lock.received_filter_heights.clone();
-        drop(stats_lock); // Release the stats lock before acquiring the mutex
-
-        // Now lock the heights and insert
-        let mut heights = received_filter_heights.lock().await;
-        heights.insert(height);
-        tracing::trace!(
-            "📊 Recorded filter received at height {} for block {}",
-            height,
-            cfilter.block_hash
-        );
-
         if matches {
             // Update filter match statistics
             {


### PR DESCRIPTION
This fixes an issue introduced in #211 where the `receiver_filter_heights` lock isn't released after inserting the received height, and then the same task tries to acquire the lock again just a bit below in `mark_filter_received` -> deadlock.

So, #211 should have not introduced the filter height updates here since they already exist in `mark_filter_received`. Yet the stats updates introduced in the same place are legit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified filter synchronization by removing redundant per-height received-filter tracking and related logging, preventing unnecessary contention.

* **Refactor**
  * Streamlined internal filter state updates to reduce locking and improve performance while preserving reported filter counts and timestamps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->