### PR TITLE
feat: Add logging module with file rotation support

### DIFF
--- a/dash-spv-ffi/FFI_API.md
+++ b/dash-spv-ffi/FFI_API.md
@@ -1176,14 +1176,14 @@ dash_spv_ffi_enable_test_mode() -> ()
 #### `dash_spv_ffi_init_logging`
 
 ```c
-dash_spv_ffi_init_logging(level: *const c_char) -> i32
+dash_spv_ffi_init_logging(level: *const c_char, enable_console: bool, log_dir: *const c_char, max_files: usize,) -> i32
 ```
 
 **Description:**
-Initialize logging for the SPV library.  # Safety - `level` may be null or point to a valid, NUL-terminated C string. - If non-null, the pointer must remain valid for the duration of this call.
+Initialize logging for the SPV library.  # Arguments - `level`: Log level string (null uses RUST_LOG env var or defaults to INFO). Valid values: "error", "warn", "info", "debug", "trace" - `enable_console`: Whether to output logs to console (stderr) - `log_dir`: Directory for log files (null to disable file logging) - `max_files`: Maximum archived log files to retain (ignored if log_dir is null)  # Safety - `level` and `log_dir` may be null or point to valid, NUL-terminated C strings.
 
 **Safety:**
-- `level` may be null or point to a valid, NUL-terminated C string. - If non-null, the pointer must remain valid for the duration of this call.
+- `level` and `log_dir` may be null or point to valid, NUL-terminated C strings.
 
 **Module:** `utils`
 

--- a/dash-spv-ffi/README.md
+++ b/dash-spv-ffi/README.md
@@ -47,7 +47,7 @@ See `examples/basic_usage.c` for a simple example of using the FFI bindings.
 #include "dash_spv_ffi.h"
 
 // Initialize logging
-dash_spv_ffi_init_logging("info");
+dash_spv_ffi_init_logging("info", true, NULL, 0);
 
 // Create configuration
 FFIClientConfig* config = dash_spv_ffi_config_testnet();

--- a/dash-spv-ffi/examples/basic_usage.c
+++ b/dash-spv-ffi/examples/basic_usage.c
@@ -4,7 +4,7 @@
 
 int main() {
     // Initialize logging
-    if (dash_spv_ffi_init_logging("info") != 0) {
+    if (dash_spv_ffi_init_logging("info", true, NULL, 0) != 0) {
         fprintf(stderr, "Failed to initialize logging\n");
         return 1;
     }

--- a/dash-spv-ffi/include/dash_spv_ffi.h
+++ b/dash-spv-ffi/include/dash_spv_ffi.h
@@ -979,11 +979,22 @@ void dash_spv_ffi_unconfirmed_transaction_destroy_addresses(struct FFIString *ad
 /**
  * Initialize logging for the SPV library.
  *
+ * # Arguments
+ * - `level`: Log level string (null uses RUST_LOG env var or defaults to INFO).
+ *   Valid values: "error", "warn", "info", "debug", "trace"
+ * - `enable_console`: Whether to output logs to console (stderr)
+ * - `log_dir`: Directory for log files (null to disable file logging)
+ * - `max_files`: Maximum archived log files to retain (ignored if log_dir is null)
+ *
  * # Safety
- * - `level` may be null or point to a valid, NUL-terminated C string.
- * - If non-null, the pointer must remain valid for the duration of this call.
+ * - `level` and `log_dir` may be null or point to valid, NUL-terminated C strings.
  */
- int32_t dash_spv_ffi_init_logging(const char *level) ;
+
+int32_t dash_spv_ffi_init_logging(const char *level,
+                                  bool enable_console,
+                                  const char *log_dir,
+                                  uintptr_t max_files)
+;
 
  const char *dash_spv_ffi_version(void) ;
 

--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -121,7 +121,7 @@ fn main() {
         // Initialize tracing/logging via FFI so `tracing::info!` emits output
         let level = matches.get_one::<String>("log-level").map(String::as_str).unwrap_or("info");
         let level_c = CString::new(level).unwrap();
-        let _ = dash_spv_ffi_init_logging(level_c.as_ptr());
+        let _ = dash_spv_ffi_init_logging(level_c.as_ptr(), true, std::ptr::null(), 0);
 
         // Build config
         let cfg = dash_spv_ffi_config_new(network);

--- a/dash-spv-ffi/src/error.rs
+++ b/dash-spv-ffi/src/error.rs
@@ -60,6 +60,7 @@ impl From<SpvError> for FFIErrorCode {
             SpvError::Io(_) => FFIErrorCode::RuntimeError,
             SpvError::Config(_) => FFIErrorCode::ConfigError,
             SpvError::Parse(_) => FFIErrorCode::ValidationError,
+            SpvError::Logging(_) => FFIErrorCode::RuntimeError,
             SpvError::Wallet(_) => FFIErrorCode::WalletError,
             SpvError::QuorumLookupError(_) => FFIErrorCode::ValidationError,
             SpvError::General(_) => FFIErrorCode::Unknown,

--- a/dash-spv-ffi/src/utils.rs
+++ b/dash-spv-ffi/src/utils.rs
@@ -1,19 +1,47 @@
-use crate::{set_last_error, FFIErrorCode};
 use std::ffi::CStr;
 use std::os::raw::c_char;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use crate::{set_last_error, FFIErrorCode};
+use dash_spv::{LogFileConfig, LoggingConfig};
+
+/// Static storage for the logging guard to keep it alive for the FFI lifetime.
+/// The guard must remain alive for log flushing to work correctly.
+static LOGGING_GUARD: OnceLock<dash_spv::LoggingGuard> = OnceLock::new();
 
 /// Initialize logging for the SPV library.
 ///
+/// # Arguments
+/// - `level`: Log level string (null uses RUST_LOG env var or defaults to INFO).
+///   Valid values: "error", "warn", "info", "debug", "trace"
+/// - `enable_console`: Whether to output logs to console (stderr)
+/// - `log_dir`: Directory for log files (null to disable file logging)
+/// - `max_files`: Maximum archived log files to retain (ignored if log_dir is null)
+///
 /// # Safety
-/// - `level` may be null or point to a valid, NUL-terminated C string.
-/// - If non-null, the pointer must remain valid for the duration of this call.
+/// - `level` and `log_dir` may be null or point to valid, NUL-terminated C strings.
 #[no_mangle]
-pub unsafe extern "C" fn dash_spv_ffi_init_logging(level: *const c_char) -> i32 {
-    let level_str = if level.is_null() {
-        "info"
+pub unsafe extern "C" fn dash_spv_ffi_init_logging(
+    level: *const c_char,
+    enable_console: bool,
+    log_dir: *const c_char,
+    max_files: usize,
+) -> i32 {
+    let level_filter = if level.is_null() {
+        None
     } else {
         match CStr::from_ptr(level).to_str() {
-            Ok(s) => s,
+            Ok(s) => match s.parse() {
+                Ok(lf) => Some(lf),
+                Err(_) => {
+                    set_last_error(&format!(
+                        "Invalid log level '{}'. Valid: error, warn, info, debug, trace",
+                        s
+                    ));
+                    return FFIErrorCode::InvalidArgument as i32;
+                }
+            },
             Err(e) => {
                 set_last_error(&format!("Invalid UTF-8 in log level: {}", e));
                 return FFIErrorCode::InvalidArgument as i32;
@@ -21,8 +49,36 @@ pub unsafe extern "C" fn dash_spv_ffi_init_logging(level: *const c_char) -> i32 
         }
     };
 
-    match dash_spv::init_logging(level_str) {
-        Ok(()) => FFIErrorCode::Success as i32,
+    let file_config = if log_dir.is_null() {
+        None
+    } else {
+        match CStr::from_ptr(log_dir).to_str() {
+            Ok(s) => Some(LogFileConfig {
+                log_dir: PathBuf::from(s),
+                max_files,
+            }),
+            Err(e) => {
+                set_last_error(&format!("Invalid UTF-8 in log directory: {}", e));
+                return FFIErrorCode::InvalidArgument as i32;
+            }
+        }
+    };
+
+    let config = LoggingConfig {
+        level: level_filter,
+        console: enable_console,
+        file: file_config,
+    };
+
+    match dash_spv::init_logging(config) {
+        Ok(guard) => {
+            // Store guard in static to keep it alive for log flushing.
+            // OnceLock::set returns Err if already set (first init wins).
+            if LOGGING_GUARD.set(guard).is_err() {
+                tracing::warn!("Logging already initialized, ignoring subsequent init");
+            }
+            FFIErrorCode::Success as i32
+        }
         Err(e) => {
             set_last_error(&format!("Failed to initialize logging: {}", e));
             FFIErrorCode::RuntimeError as i32

--- a/dash-spv-ffi/tests/test_event_callbacks.rs
+++ b/dash-spv-ffi/tests/test_event_callbacks.rs
@@ -138,7 +138,7 @@ extern "C" fn test_balance_callback(confirmed: u64, unconfirmed: u64, user_data:
 fn test_event_callbacks_setup() {
     // Initialize logging
     unsafe {
-        dash_spv_ffi_init_logging(c"debug".as_ptr());
+        dash_spv_ffi_init_logging(c"debug".as_ptr(), true, std::ptr::null(), 0);
     }
 
     // Create test data
@@ -238,7 +238,7 @@ fn test_event_callbacks_setup() {
 #[serial]
 fn test_enhanced_event_callbacks() {
     unsafe {
-        dash_spv_ffi_init_logging(c"info".as_ptr());
+        dash_spv_ffi_init_logging(c"info".as_ptr(), true, std::ptr::null(), 0);
 
         // Create test data
         let event_data = TestEventData::new();

--- a/dash-spv-ffi/tests/test_utils.rs
+++ b/dash-spv-ffi/tests/test_utils.rs
@@ -11,15 +11,15 @@ mod tests {
     fn test_init_logging() {
         unsafe {
             let level = CString::new("debug").unwrap();
-            let result = dash_spv_ffi_init_logging(level.as_ptr());
+            let result = dash_spv_ffi_init_logging(level.as_ptr(), true, std::ptr::null(), 0);
             // May fail if already initialized, but should handle gracefully
             assert!(
                 result == FFIErrorCode::Success as i32
                     || result == FFIErrorCode::RuntimeError as i32
             );
 
-            // Test with null pointer (should use default)
-            let result = dash_spv_ffi_init_logging(std::ptr::null());
+            // Test with null level pointer (should use RUST_LOG or default to INFO)
+            let result = dash_spv_ffi_init_logging(std::ptr::null(), true, std::ptr::null(), 0);
             assert!(
                 result == FFIErrorCode::Success as i32
                     || result == FFIErrorCode::RuntimeError as i32

--- a/dash-spv/Cargo.toml
+++ b/dash-spv/Cargo.toml
@@ -19,7 +19,7 @@ key-wallet-manager = { path = "../key-wallet-manager" }
 blsful = { git = "https://github.com/dashpay/agora-blsful", rev = "0c34a7a488a0bd1c9a9a2196e793b303ad35c900" }
 
 # CLI
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 
 # Async runtime
 tokio = { version = "1.0", features = ["full"] }
@@ -37,7 +37,9 @@ bincode = "1.3"
 
 # Logging
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+tracing-appender = "0.2"
+chrono = "0.4.20"
 
 # Utilities
 rand = "0.8"

--- a/dash-spv/examples/filter_sync.rs
+++ b/dash-spv/examples/filter_sync.rs
@@ -2,7 +2,7 @@
 
 use dash_spv::network::PeerNetworkManager;
 use dash_spv::storage::MemoryStorageManager;
-use dash_spv::{init_logging, ClientConfig, DashSpvClient};
+use dash_spv::{init_console_logging, ClientConfig, DashSpvClient, LevelFilter};
 use dashcore::Address;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet_manager::wallet_manager::WalletManager;
@@ -14,7 +14,7 @@ use tokio_util::sync::CancellationToken;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logging
-    init_logging("info")?;
+    let _logging_guard = init_console_logging(LevelFilter::INFO)?;
 
     // Parse a Dash address to watch
     let watch_address = Address::<dashcore::address::NetworkUnchecked>::from_str(

--- a/dash-spv/examples/simple_sync.rs
+++ b/dash-spv/examples/simple_sync.rs
@@ -2,7 +2,7 @@
 
 use dash_spv::network::PeerNetworkManager;
 use dash_spv::storage::MemoryStorageManager;
-use dash_spv::{init_logging, ClientConfig, DashSpvClient};
+use dash_spv::{init_console_logging, ClientConfig, DashSpvClient, LevelFilter};
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 
 use key_wallet_manager::wallet_manager::WalletManager;
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logging
-    init_logging("info")?;
+    let _logging_guard = init_console_logging(LevelFilter::INFO)?;
 
     // Create a simple configuration
     let config = ClientConfig::mainnet()

--- a/dash-spv/examples/spv_with_wallet.rs
+++ b/dash-spv/examples/spv_with_wallet.rs
@@ -4,7 +4,7 @@
 
 use dash_spv::network::PeerNetworkManager;
 use dash_spv::storage::DiskStorageManager;
-use dash_spv::{ClientConfig, DashSpvClient};
+use dash_spv::{ClientConfig, DashSpvClient, LevelFilter};
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet_manager::wallet_manager::WalletManager;
 use std::sync::Arc;
@@ -14,7 +14,7 @@ use tokio_util::sync::CancellationToken;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logging
-    dash_spv::init_logging("info")?;
+    let _logging_guard = dash_spv::init_console_logging(LevelFilter::INFO)?;
 
     // Create SPV client configuration
     let mut config = ClientConfig::testnet();

--- a/dash-spv/src/error.rs
+++ b/dash-spv/src/error.rs
@@ -33,6 +33,9 @@ pub enum SpvError {
     #[error("Parse error: {0}")]
     Parse(#[from] ParseError),
 
+    #[error("Logging error: {0}")]
+    Logging(#[from] LoggingError),
+
     #[error("Wallet error: {0}")]
     Wallet(#[from] WalletError),
 
@@ -54,6 +57,19 @@ pub enum ParseError {
 
     #[error("Invalid argument value for {0}: {1}")]
     InvalidArgument(String, String),
+}
+
+/// Logging-related errors.
+#[derive(Debug, Error)]
+pub enum LoggingError {
+    #[error("Failed to create log directory: {0}")]
+    DirectoryCreation(#[from] std::io::Error),
+
+    #[error("Subscriber initialization failed: {0}")]
+    SubscriberInit(String),
+
+    #[error("Log rotation failed: {0}")]
+    RotationFailed(String),
 }
 
 /// Network-related errors.
@@ -240,6 +256,9 @@ pub type ValidationResult<T> = std::result::Result<T, ValidationError>;
 
 /// Type alias for sync operation results.
 pub type SyncResult<T> = std::result::Result<T, SyncError>;
+
+/// Type alias for logging operation results.
+pub type LoggingResult<T> = std::result::Result<T, LoggingError>;
 
 /// Wallet-related errors.
 #[derive(Debug, Error)]

--- a/dash-spv/src/lib.rs
+++ b/dash-spv/src/lib.rs
@@ -62,6 +62,7 @@ pub mod bloom;
 pub mod chain;
 pub mod client;
 pub mod error;
+pub mod logging;
 pub mod mempool_filter;
 pub mod network;
 pub mod storage;
@@ -73,7 +74,11 @@ pub mod validation;
 
 // Re-export main types for convenience
 pub use client::{ClientConfig, DashSpvClient};
-pub use error::{NetworkError, SpvError, StorageError, SyncError, ValidationError};
+pub use error::{
+    LoggingError, LoggingResult, NetworkError, SpvError, StorageError, SyncError, ValidationError,
+};
+pub use logging::{init_console_logging, init_logging, LogFileConfig, LoggingConfig, LoggingGuard};
+pub use tracing::level_filters::LevelFilter;
 pub use types::{ChainState, FilterMatch, PeerInfo, SpvStats, SyncProgress, ValidationMode};
 
 // Re-export commonly used dashcore types
@@ -93,27 +98,3 @@ pub use dashcore::sml::llmq_type::LLMQType;
 
 /// Current version of the dash-spv library.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Initialize logging with the given level.
-///
-/// This is a convenience function that sets up tracing-subscriber
-/// with a simple format suitable for most applications.
-pub fn init_logging(level: &str) -> Result<(), Box<dyn std::error::Error>> {
-    use tracing_subscriber::fmt;
-
-    let level = match level {
-        "error" => tracing::Level::ERROR,
-        "warn" => tracing::Level::WARN,
-        "info" => tracing::Level::INFO,
-        "debug" => tracing::Level::DEBUG,
-        "trace" => tracing::Level::TRACE,
-        _ => tracing::Level::INFO,
-    };
-
-    fmt()
-        .with_target(false)
-        .with_thread_ids(false)
-        .with_max_level(level)
-        .try_init()
-        .map_err(|e| format!("Failed to initialize logging: {}", e).into())
-}

--- a/dash-spv/src/logging.rs
+++ b/dash-spv/src/logging.rs
@@ -1,0 +1,629 @@
+//! Logging configuration and file rotation for the Dash SPV client.
+//!
+//! This module provides configurable logging with optional file output and automatic rotation.
+
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Local};
+use tracing::level_filters::LevelFilter;
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+use crate::error::{LoggingError, LoggingResult};
+
+/// Prefix for archived log files.
+const LOG_FILE_PREFIX: &str = "dash-spv.";
+/// Name of the active log file.
+const ACTIVE_LOG_NAME: &str = "run.log";
+
+/// Guard that must be kept alive to ensure log flushing on shutdown.
+/// When this guard is dropped, all buffered log entries will be flushed.
+#[derive(Debug)]
+pub struct LoggingGuard {
+    _worker_guard: Option<WorkerGuard>,
+}
+
+/// Configuration for logging output.
+#[derive(Debug, Clone)]
+pub struct LoggingConfig {
+    /// Log level filter. If None, falls back to INFO.
+    pub level: Option<LevelFilter>,
+    /// Whether to output logs to console (stderr).
+    pub console: bool,
+    /// Optional file logging configuration.
+    pub file: Option<LogFileConfig>,
+}
+
+/// Configuration for log file output.
+#[derive(Debug, Clone)]
+pub struct LogFileConfig {
+    /// Directory where log files will be stored.
+    pub log_dir: PathBuf,
+    /// Maximum number of archived log files to keep.
+    pub max_files: usize,
+}
+
+/// Initialize console-only logging with the given level.
+///
+/// This is a convenience function for simple use cases.
+/// For file logging, use [`init_logging`] with a [`LoggingConfig`].
+pub fn init_console_logging(level: LevelFilter) -> LoggingResult<LoggingGuard> {
+    init_logging(LoggingConfig {
+        level: Some(level),
+        console: true,
+        file: None,
+    })
+}
+
+/// Initialize logging with the given configuration.
+///
+/// Returns a `LoggingGuard` that must be kept alive for the duration of the application.
+/// When the guard is dropped, all buffered log entries will be flushed to disk.
+///
+/// # Arguments
+///
+/// * `config` - Logging configuration specifying level, console, and file output options.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The log directory cannot be created
+/// - The tracing subscriber cannot be initialized
+///
+/// Note: If neither console nor file output is enabled, logging is disabled
+/// (tracing macros become no-ops) and Ok is returned.
+///
+/// # Example
+///
+/// ```no_run
+/// use dash_spv::logging::{init_logging, LoggingConfig, LogFileConfig};
+/// use dash_spv::LevelFilter;
+/// use std::path::PathBuf;
+///
+/// // Console-only logging
+/// let _guard = init_logging(LoggingConfig {
+///     level: Some(LevelFilter::INFO),
+///     console: true,
+///     file: None,
+/// }).unwrap();
+///
+/// // File logging only (CLI default)
+/// let _guard = init_logging(LoggingConfig {
+///     level: Some(LevelFilter::INFO),
+///     console: false,
+///     file: Some(LogFileConfig {
+///         log_dir: PathBuf::from("/path/to/data/logs"),
+///         max_files: 20,
+///     }),
+/// }).unwrap();
+/// ```
+pub fn init_logging(config: LoggingConfig) -> LoggingResult<LoggingGuard> {
+    // No output configured - tracing macros become no-ops
+    if !config.console && config.file.is_none() {
+        return Ok(LoggingGuard {
+            _worker_guard: None,
+        });
+    }
+
+    // Build env filter from explicit level or RUST_LOG
+    let env_filter = match config.level {
+        Some(level) => EnvFilter::new(level.to_string()),
+        None => EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new(LevelFilter::INFO.to_string())),
+    };
+
+    // Set up file layer if requested
+    let (file_layer, guard) = if let Some(ref file_config) = config.file {
+        let (non_blocking, guard) = setup_file_logging(file_config)?;
+        let layer = fmt::layer()
+            .with_target(true)
+            .with_thread_ids(false)
+            .with_ansi(false)
+            .with_writer(non_blocking);
+        (Some(layer), Some(guard))
+    } else {
+        (None, None)
+    };
+
+    // Set up console layer if requested
+    let console_layer =
+        config.console.then(|| fmt::layer().with_target(false).with_thread_ids(false));
+
+    // Combine layers and initialize
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(file_layer)
+        .with(console_layer)
+        .try_init()
+        .map_err(|e| LoggingError::SubscriberInit(e.to_string()))?;
+
+    Ok(LoggingGuard {
+        _worker_guard: guard,
+    })
+}
+
+/// Set up file logging: create directory, rotate old log, cleanup, and create writer.
+fn setup_file_logging(config: &LogFileConfig) -> LoggingResult<(NonBlocking, WorkerGuard)> {
+    // Create logs directory if needed
+    fs::create_dir_all(&config.log_dir)?;
+
+    // Rotate previous run.log to archived name
+    rotate_previous_log(&config.log_dir)?;
+
+    // Clean up old archived log files
+    cleanup_old_logs(&config.log_dir, config.max_files)?;
+
+    // Create file appender for run.log
+    let log_path = config.log_dir.join(ACTIVE_LOG_NAME);
+    let file = File::create(&log_path)?;
+
+    // Wrap in non-blocking writer
+    Ok(tracing_appender::non_blocking(file))
+}
+
+/// Rotate the previous run.log to an archived name.
+///
+/// If run.log exists, renames it to `dash-spv.YYYY-MM-DD.HHMMSS.log` based on
+/// the file modification time.
+fn rotate_previous_log(log_dir: &Path) -> LoggingResult<()> {
+    let run_log_path = log_dir.join(ACTIVE_LOG_NAME);
+
+    if !run_log_path.exists() {
+        return Ok(());
+    }
+
+    // Get timestamp from file modification time
+    let timestamp = get_file_modification_time(&run_log_path).unwrap_or_else(Local::now);
+
+    // Format: dash-spv.2025-01-15.143025.log
+    let archive_name = format!("{}{}.log", LOG_FILE_PREFIX, timestamp.format("%Y-%m-%d.%H%M%S"));
+    let archive_path = log_dir.join(&archive_name);
+
+    // Handle collision: if archive already exists, add a suffix
+    let final_path = if archive_path.exists() {
+        (1..=999)
+            .map(|i| {
+                log_dir.join(format!(
+                    "{}{}-{}.log",
+                    LOG_FILE_PREFIX,
+                    timestamp.format("%Y-%m-%d.%H%M%S"),
+                    i
+                ))
+            })
+            .find(|p| !p.exists())
+            .ok_or_else(|| {
+                LoggingError::RotationFailed("too many log files with same timestamp".to_string())
+            })?
+    } else {
+        archive_path
+    };
+
+    fs::rename(&run_log_path, &final_path).map_err(|e| LoggingError::RotationFailed(e.to_string()))
+}
+
+/// Get file modification time as DateTime.
+fn get_file_modification_time(path: &Path) -> Option<DateTime<Local>> {
+    let metadata = fs::metadata(path).ok()?;
+    let modified = metadata.modified().ok()?;
+    Some(DateTime::from(modified))
+}
+
+/// Delete oldest archived log files if count exceeds max_files.
+///
+/// Only deletes files matching the pattern `dash-spv.*.log`. The active `run.log`
+/// is never deleted.
+fn cleanup_old_logs(log_dir: &Path, max_files: usize) -> LoggingResult<()> {
+    let mut archived_logs: Vec<_> = fs::read_dir(log_dir)
+        .map_err(|e| LoggingError::RotationFailed(format!("failed to read log dir: {}", e)))?
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .map(|name| name.starts_with(LOG_FILE_PREFIX) && name.ends_with(".log"))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    if archived_logs.len() <= max_files {
+        return Ok(());
+    }
+
+    // Sort by modification time (oldest first)
+    archived_logs.sort_by(|a, b| {
+        let a_time = a.metadata().and_then(|m| m.modified()).ok();
+        let b_time = b.metadata().and_then(|m| m.modified()).ok();
+        a_time.cmp(&b_time)
+    });
+
+    // Remove oldest files to get down to max_files
+    let to_remove = archived_logs.len() - max_files;
+    for entry in archived_logs.into_iter().take(to_remove) {
+        if let Err(e) = fs::remove_file(entry.path()) {
+            tracing::warn!("Failed to remove old log file {:?}: {}", entry.path(), e);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_rotate_previous_log_no_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Should succeed when no run.log exists
+        rotate_previous_log(log_dir).unwrap();
+
+        // Verify no files were created
+        let files: Vec<_> = fs::read_dir(log_dir).unwrap().collect();
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_rotate_previous_log_renames_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Create a run.log with some content
+        let run_log = log_dir.join(ACTIVE_LOG_NAME);
+        let mut file = File::create(&run_log).unwrap();
+        writeln!(file, "INFO test message").unwrap();
+        drop(file);
+
+        // Rotate
+        rotate_previous_log(log_dir).unwrap();
+
+        // Verify run.log is gone
+        assert!(!run_log.exists());
+
+        // Verify archived file exists with correct name pattern
+        let files: Vec<_> = fs::read_dir(log_dir).unwrap().filter_map(|e| e.ok()).collect();
+        assert_eq!(files.len(), 1);
+
+        let archived_name = files[0].file_name().to_string_lossy().to_string();
+        assert!(archived_name.starts_with("dash-spv."));
+        assert!(archived_name.ends_with(".log"));
+    }
+
+    #[test]
+    fn test_cleanup_old_logs_under_limit() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Create 3 archived log files
+        for i in 1..=3 {
+            let name = format!("dash-spv.2025-01-{:02}.120000.log", i);
+            File::create(log_dir.join(&name)).unwrap();
+        }
+
+        // Cleanup with limit of 7
+        cleanup_old_logs(log_dir, 7).unwrap();
+
+        // All 3 files should remain
+        let files: Vec<_> = fs::read_dir(log_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(LOG_FILE_PREFIX))
+            .collect();
+        assert_eq!(files.len(), 3);
+    }
+
+    #[test]
+    fn test_cleanup_old_logs_over_limit() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Create 10 archived log files with different mtimes
+        for i in 1..=10 {
+            let name = format!("dash-spv.2025-01-{:02}.120000.log", i);
+            let path = log_dir.join(&name);
+            let mut file = File::create(&path).unwrap();
+            writeln!(file, "log {}", i).unwrap();
+            drop(file);
+            // Add small delay to ensure different mtimes
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        // Cleanup with limit of 3
+        cleanup_old_logs(log_dir, 3).unwrap();
+
+        // Only 3 files should remain
+        let files: Vec<_> = fs::read_dir(log_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(LOG_FILE_PREFIX))
+            .collect();
+        assert_eq!(files.len(), 3);
+    }
+
+    #[test]
+    fn test_cleanup_old_logs_ignores_run_log() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Create run.log (should not be deleted)
+        File::create(log_dir.join(ACTIVE_LOG_NAME)).unwrap();
+
+        // Create 5 archived log files
+        for i in 1..=5 {
+            let name = format!("dash-spv.2025-01-{:02}.120000.log", i);
+            File::create(log_dir.join(&name)).unwrap();
+        }
+
+        // Cleanup with limit of 2
+        cleanup_old_logs(log_dir, 2).unwrap();
+
+        // run.log should still exist
+        assert!(log_dir.join(ACTIVE_LOG_NAME).exists());
+
+        // Only 2 archived files should remain
+        let archived: Vec<_> = fs::read_dir(log_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(LOG_FILE_PREFIX))
+            .collect();
+        assert_eq!(archived.len(), 2);
+    }
+
+    #[test]
+    fn test_cleanup_old_logs_boundary_conditions() {
+        // Test max_files = 0 removes all archived logs
+        {
+            let temp_dir = TempDir::new().unwrap();
+            let log_dir = temp_dir.path();
+
+            for i in 1..=3 {
+                let name = format!("dash-spv.2025-01-{:02}.120000.log", i);
+                let path = log_dir.join(&name);
+                let mut file = File::create(&path).unwrap();
+                writeln!(file, "log {}", i).unwrap();
+                drop(file);
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+
+            cleanup_old_logs(log_dir, 0).unwrap();
+
+            let archived: Vec<_> = fs::read_dir(log_dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_string_lossy().starts_with(LOG_FILE_PREFIX))
+                .collect();
+            assert_eq!(archived.len(), 0);
+        }
+
+        // Test max_files = 1 keeps only newest
+        {
+            let temp_dir = TempDir::new().unwrap();
+            let log_dir = temp_dir.path();
+
+            for i in 1..=5 {
+                let name = format!("dash-spv.2025-01-{:02}.120000.log", i);
+                let path = log_dir.join(&name);
+                let mut file = File::create(&path).unwrap();
+                writeln!(file, "log {}", i).unwrap();
+                drop(file);
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+
+            cleanup_old_logs(log_dir, 1).unwrap();
+
+            let archived: Vec<_> = fs::read_dir(log_dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_string_lossy().starts_with(LOG_FILE_PREFIX))
+                .collect();
+            assert_eq!(archived.len(), 1);
+        }
+    }
+
+    #[test]
+    fn test_consecutive_rotations() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Simulate 3 consecutive startups
+        for _ in 1..=3 {
+            let run_log = log_dir.join(ACTIVE_LOG_NAME);
+            let mut file = File::create(&run_log).unwrap();
+            writeln!(file, "INFO startup").unwrap();
+            drop(file);
+
+            // Small delay to ensure different mtime (and thus different archive names)
+            std::thread::sleep(std::time::Duration::from_millis(1100));
+
+            rotate_previous_log(log_dir).unwrap();
+        }
+
+        // Should have 3 archived logs, no run.log
+        assert!(!log_dir.join(ACTIVE_LOG_NAME).exists());
+
+        let archived: Vec<_> = fs::read_dir(log_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(LOG_FILE_PREFIX))
+            .collect();
+        assert_eq!(archived.len(), 3);
+    }
+
+    #[test]
+    fn test_cleanup_ignores_non_log_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Create some archived log files with staggered mtimes
+        for i in 1..=5 {
+            let name = format!("dash-spv.2025-01-{:02}.120000.log", i);
+            let path = log_dir.join(&name);
+            let mut file = File::create(&path).unwrap();
+            writeln!(file, "log {}", i).unwrap();
+            drop(file);
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        // Create some non-log files that should not be touched
+        File::create(log_dir.join("other.txt")).unwrap();
+        File::create(log_dir.join("dash-spv.backup")).unwrap();
+        File::create(log_dir.join("something.log")).unwrap();
+
+        // Cleanup with limit of 2
+        cleanup_old_logs(log_dir, 2).unwrap();
+
+        // Non-log files should still exist
+        assert!(log_dir.join("other.txt").exists());
+        assert!(log_dir.join("dash-spv.backup").exists());
+        assert!(log_dir.join("something.log").exists());
+
+        // Only 2 archived logs should remain (matching dash-spv.*.log pattern)
+        let archived: Vec<_> = fs::read_dir(log_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let name = e.file_name().to_string_lossy().to_string();
+                name.starts_with(LOG_FILE_PREFIX) && name.ends_with(".log")
+            })
+            .collect();
+        assert_eq!(archived.len(), 2);
+    }
+
+    #[test]
+    fn test_get_file_modification_time() {
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("test.txt");
+
+        File::create(&test_file).unwrap();
+
+        let mtime = get_file_modification_time(&test_file);
+        assert!(mtime.is_some());
+
+        // Should be recent (within last minute)
+        let now = Local::now();
+        let dt = mtime.unwrap();
+        let diff = now.signed_duration_since(dt);
+        assert!(diff.num_seconds() < 60);
+    }
+
+    #[test]
+    fn test_get_file_modification_time_nonexistent() {
+        let temp_dir = TempDir::new().unwrap();
+        let nonexistent = temp_dir.path().join("does_not_exist.txt");
+
+        let mtime = get_file_modification_time(&nonexistent);
+        assert!(mtime.is_none());
+    }
+
+    #[test]
+    fn test_rotate_preserves_content() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Create run.log with specific content
+        let run_log = log_dir.join(ACTIVE_LOG_NAME);
+        let mut file = File::create(&run_log).unwrap();
+        writeln!(file, "2025-01-15T14:30:25.123456 INFO first message").unwrap();
+        writeln!(file, "2025-01-15T14:30:26.123456 INFO second message").unwrap();
+        writeln!(file, "2025-01-15T14:30:27.123456 INFO third message").unwrap();
+        drop(file);
+
+        // Rotate
+        rotate_previous_log(log_dir).unwrap();
+
+        // Find the archived file
+        let archived: Vec<_> = fs::read_dir(log_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(LOG_FILE_PREFIX))
+            .collect();
+        assert_eq!(archived.len(), 1);
+
+        // Read the archived content
+        let content = fs::read_to_string(archived[0].path()).unwrap();
+        assert!(content.contains("first message"));
+        assert!(content.contains("second message"));
+        assert!(content.contains("third message"));
+    }
+
+    #[test]
+    fn test_init_logging_no_output_succeeds() {
+        // Neither console nor file is valid - tracing macros become no-ops
+        let result = init_logging(LoggingConfig {
+            level: Some(LevelFilter::INFO),
+            console: false,
+            file: None,
+        });
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_setup_file_logging_creates_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path().join("nested").join("logs");
+
+        // Directory doesn't exist yet
+        assert!(!log_dir.exists());
+
+        let config = LogFileConfig {
+            log_dir: log_dir.clone(),
+            max_files: 7,
+        };
+
+        let result = setup_file_logging(&config);
+        assert!(result.is_ok());
+
+        // Directory should now exist
+        assert!(log_dir.exists());
+
+        // run.log should exist
+        assert!(log_dir.join(ACTIVE_LOG_NAME).exists());
+    }
+
+    #[test]
+    fn test_setup_file_logging_rotates_and_cleans() {
+        let temp_dir = TempDir::new().unwrap();
+        let log_dir = temp_dir.path();
+
+        // Create an existing run.log
+        let run_log = log_dir.join(ACTIVE_LOG_NAME);
+        let mut file = File::create(&run_log).unwrap();
+        writeln!(file, "2025-01-15T10:00:00.000000 INFO old session").unwrap();
+        drop(file);
+
+        // Create 5 archived logs
+        for i in 1..=5 {
+            let name = format!("dash-spv.2025-01-{:02}.120000.log", i);
+            let path = log_dir.join(&name);
+            let mut f = File::create(&path).unwrap();
+            writeln!(f, "log {}", i).unwrap();
+            drop(f);
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        let config = LogFileConfig {
+            log_dir: log_dir.to_path_buf(),
+            max_files: 3,
+        };
+
+        let result = setup_file_logging(&config);
+        assert!(result.is_ok());
+
+        // Old run.log should be archived (now we have 6 archives total, but limit is 3)
+        // After cleanup, should have 3 archived + 1 new run.log
+        let archived: Vec<_> = fs::read_dir(log_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(LOG_FILE_PREFIX))
+            .collect();
+        assert_eq!(archived.len(), 3);
+
+        // New run.log should exist (and be empty or have just been created)
+        assert!(log_dir.join(ACTIVE_LOG_NAME).exists());
+    }
+}


### PR DESCRIPTION
  Introduces a new logging module for the SPV client with:
  - Configurable log file rotation
  - Active log file: `run.log` and rotated files: `dash-spv.YYYYMMDD_HHMMSS.log`
  - Separate console and file output options
  - CLI flags: `--log-level`, `--no-log-file`, `--print-to-console`, `--max-log-files`, `--log-url`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable logging API: console/file output, log directory, max archived files, rotation, archival naming, cleanup, and a LoggingGuard to keep logging active.

* **CLI**
  * New flags and RUST_LOG support to control logging behavior and early logging initialization.

* **Errors**
  * Added LoggingError/LoggingResult and mapping of logging failures into existing error flow.

* **Refactor**
  * Logging moved into a dedicated module and initialization surface updated.

* **Tests**
  * Tests for rotation, cleanup, and initialization added.

* **Documentation**
  * README and examples updated to use the new logging calls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->