### PR TITLE
feat: Implement segmented filter storage

### DIFF
--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -12,6 +12,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
+use crate::storage::disk::io::atomic_write;
+
 /// Maximum misbehavior score before a peer is banned
 const MAX_MISBEHAVIOR_SCORE: i32 = 100;
 
@@ -424,7 +426,7 @@ impl PeerReputationManager {
             .collect();
 
         let json = serde_json::to_string_pretty(&data)?;
-        tokio::fs::write(path, json).await
+        atomic_write(path, json.as_bytes()).await.map_err(std::io::Error::other)
     }
 
     /// Load reputation data from persistent storage

--- a/dash-spv/src/storage/disk/filters.rs
+++ b/dash-spv/src/storage/disk/filters.rs
@@ -7,6 +7,7 @@ use dashcore_hashes::Hash;
 
 use crate::error::StorageResult;
 
+use super::io::atomic_write;
 use super::manager::DiskStorageManager;
 use super::segments::SegmentState;
 
@@ -185,8 +186,7 @@ impl DiskStorageManager {
     /// Store a compact filter.
     pub async fn store_filter(&mut self, height: u32, filter: &[u8]) -> StorageResult<()> {
         let path = self.base_path.join(format!("filters/{}.dat", height));
-        tokio::fs::write(path, filter).await?;
-        Ok(())
+        atomic_write(&path, filter).await
     }
 
     /// Load a compact filter.

--- a/dash-spv/src/storage/disk/filters.rs
+++ b/dash-spv/src/storage/disk/filters.rs
@@ -6,10 +6,9 @@ use dashcore::hash_types::FilterHeader;
 use dashcore_hashes::Hash;
 
 use crate::error::StorageResult;
-
-use super::io::atomic_write;
+use crate::storage::disk::FILTERS_PER_SEGMENT;
 use super::manager::DiskStorageManager;
-use super::segments::SegmentState;
+use super::segments::{FilterDataIndexEntry, SegmentState};
 
 impl DiskStorageManager {
     /// Store filter headers.
@@ -185,19 +184,122 @@ impl DiskStorageManager {
 
     /// Store a compact filter.
     pub async fn store_filter(&mut self, height: u32, filter: &[u8]) -> StorageResult<()> {
-        let path = self.base_path.join(format!("filters/{}.dat", height));
-        atomic_write(&path, filter).await
+        let sync_base_height = *self.sync_base_height.read().await;
+
+        // Convert blockchain height to storage index
+        let storage_index = if sync_base_height > 0 && height >= sync_base_height {
+            height - sync_base_height
+        } else {
+            height
+        };
+
+        let segment_id = Self::get_filter_segment_id(storage_index);
+        let offset = Self::get_filter_segment_offset(storage_index);
+
+        // Ensure segment is loaded
+        super::segments::ensure_filter_data_segment_loaded(self, segment_id).await?;
+
+        // Update segment
+        {
+            let mut segments = self.active_filter_data_segments.write().await;
+            if let Some(segment) = segments.get_mut(&segment_id) {
+                // Ensure index has space
+                while segment.index.len() <= offset {
+                    segment.index.push(FilterDataIndexEntry::default());
+                }
+
+                // Calculate offset for this filter's data
+                let data_offset = segment.current_data_size;
+
+                // Update index entry
+                segment.index[offset] = FilterDataIndexEntry {
+                    offset: data_offset,
+                    length: filter.len() as u32,
+                };
+
+                // Store filter in cache
+                segment.filters.insert(offset, filter.to_vec());
+                segment.current_data_size += filter.len() as u64;
+                segment.filter_count = segment.index.iter().filter(|e| e.length > 0).count();
+
+                segment.state = SegmentState::Dirty;
+                segment.last_accessed = std::time::Instant::now();
+            }
+        }
+
+        // Save dirty segments periodically
+        if height.is_multiple_of(FILTERS_PER_SEGMENT / 4) {
+            super::segments::save_dirty_segments(self).await?;
+        }
+
+        Ok(())
     }
 
     /// Load a compact filter.
     pub async fn load_filter(&self, height: u32) -> StorageResult<Option<Vec<u8>>> {
-        let path = self.base_path.join(format!("filters/{}.dat", height));
-        if !path.exists() {
-            return Ok(None);
+        let sync_base_height = *self.sync_base_height.read().await;
+
+        // Convert blockchain height to storage index
+        let storage_index = if sync_base_height > 0 && height >= sync_base_height {
+            height - sync_base_height
+        } else {
+            height
+        };
+
+        let segment_id = Self::get_filter_segment_id(storage_index);
+        let offset = Self::get_filter_segment_offset(storage_index);
+
+        // First check in-memory cache (segment may not be saved to disk yet)
+        {
+            let segments = self.active_filter_data_segments.read().await;
+            if let Some(segment) = segments.get(&segment_id) {
+                // Check if filter exists in index
+                if offset < segment.index.len() && segment.index[offset].length > 0 {
+                    // Check if filter is cached in memory
+                    if let Some(filter) = segment.filters.get(&offset) {
+                        return Ok(Some(filter.clone()));
+                    }
+
+                    // Filter is in index but not cached - load from combined segment file
+                    let entry = &segment.index[offset];
+                    let file_data_offset = segment.file_data_offset;
+                    let segment_path = self
+                        .base_path
+                        .join(format!("filters/filter_data_segment_{:04}.dat", segment_id));
+                    if segment_path.exists() {
+                        let filter = super::io::load_filter_data_at_offset(
+                            &segment_path,
+                            entry.offset,
+                            file_data_offset,
+                            entry.length,
+                        )
+                        .await?;
+                        return Ok(Some(filter));
+                    }
+                }
+            }
         }
 
-        let data = tokio::fs::read(path).await?;
-        Ok(Some(data))
+        // Try loading from disk if segment not in memory
+        let segment_path =
+            self.base_path.join(format!("filters/filter_data_segment_{:04}.dat", segment_id));
+
+        if segment_path.exists() {
+            let (index, data_offset) = super::io::load_filter_data_index(&segment_path).await?;
+            if offset < index.len() && index[offset].length > 0 {
+                let entry = &index[offset];
+                let filter = super::io::load_filter_data_at_offset(
+                    &segment_path,
+                    entry.offset,
+                    data_offset,
+                    entry.length,
+                )
+                .await?;
+                return Ok(Some(filter));
+            }
+        }
+
+        Ok(None)
     }
 
     /// Clear all filter data.
@@ -207,6 +309,7 @@ impl DiskStorageManager {
 
         // Clear in-memory filter state
         self.active_filter_segments.write().await.clear();
+        self.active_filter_data_segments.write().await.clear();
         *self.cached_filter_tip_height.write().await = None;
 
         // Remove filter headers and compact filter files

--- a/dash-spv/src/storage/disk/io.rs
+++ b/dash-spv/src/storage/disk/io.rs
@@ -5,6 +5,13 @@ use std::fs::{self, File};
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
+use crate::error::{StorageError, StorageResult};
+
+use crate::storage::disk::segments::FilterDataIndexEntry;
+use crate::storage::disk::{
+    FILTER_DATA_HEADER_SIZE, FILTER_DATA_INDEX_ENTRY_SIZE, FILTER_DATA_SEGMENT_MAGIC,
+    FILTER_DATA_SEGMENT_VERSION,
+};
 use dashcore::{
     block::Header as BlockHeader,
     consensus::{encode, Decodable, Encodable},
@@ -12,8 +19,6 @@ use dashcore::{
     BlockHash,
 };
 use dashcore_hashes::Hash;
-
-use crate::error::{StorageError, StorageResult};
 
 /// Get the temporary file path for atomic writes.
 /// Uses process ID and a counter to ensure uniqueness even with concurrent writes.
@@ -198,6 +203,145 @@ pub(super) async fn save_index_to_disk(
         .map_err(|e| StorageError::WriteFailed(format!("Failed to serialize index: {}", e)))?;
 
     atomic_write(path, &data).await
+}
+
+/// Load filter data segment from the combined segment file.
+/// - Header (12 bytes): magic (4) + version (2) + count (2) + data_offset (4)
+/// - Index entries (12 bytes each): offset (8) + length (4)
+/// - Data section: raw filter bytes
+///
+/// Returns (index_entries, data_offset) where:
+/// - index_entries have RELATIVE offsets (relative to data section start)
+/// - data_offset is where the data section starts in the file
+pub(super) async fn load_filter_data_index(
+    path: &Path,
+) -> StorageResult<(Vec<FilterDataIndexEntry>, u64)> {
+    use tokio::io::AsyncReadExt;
+
+    let mut file =
+        tokio::fs::File::open(path).await.map_err(|e| StorageError::ReadFailed(e.to_string()))?;
+
+    // Read and validate magic bytes
+    let mut magic = [0u8; 4];
+    file.read_exact(&mut magic).await.map_err(|e| StorageError::ReadFailed(e.to_string()))?;
+
+    if magic != FILTER_DATA_SEGMENT_MAGIC {
+        return Err(StorageError::ReadFailed(
+            "Invalid filter data segment magic bytes".to_string(),
+        ));
+    }
+
+    let mut version_bytes = [0u8; 2];
+    file.read_exact(&mut version_bytes)
+        .await
+        .map_err(|e| StorageError::ReadFailed(e.to_string()))?;
+    let version = u16::from_le_bytes(version_bytes);
+    if version != FILTER_DATA_SEGMENT_VERSION {
+        return Err(StorageError::ReadFailed(format!(
+            "Unsupported filter data segment version: {}",
+            version
+        )));
+    }
+
+    let mut count_bytes = [0u8; 2];
+    file.read_exact(&mut count_bytes).await.map_err(|e| StorageError::ReadFailed(e.to_string()))?;
+    let count = u16::from_le_bytes(count_bytes) as usize;
+
+    // Read data offset (where data section starts)
+    let mut data_offset_bytes = [0u8; 4];
+    file.read_exact(&mut data_offset_bytes)
+        .await
+        .map_err(|e| StorageError::ReadFailed(e.to_string()))?;
+    let data_offset = u32::from_le_bytes(data_offset_bytes) as u64;
+
+    // Read entries and convert to relative offsets
+    let mut entries = Vec::with_capacity(count);
+    for _ in 0..count {
+        let mut offset_bytes = [0u8; 8];
+        let mut length_bytes = [0u8; 4];
+        file.read_exact(&mut offset_bytes)
+            .await
+            .map_err(|e| StorageError::ReadFailed(e.to_string()))?;
+        file.read_exact(&mut length_bytes)
+            .await
+            .map_err(|e| StorageError::ReadFailed(e.to_string()))?;
+
+        let absolute_offset = u64::from_le_bytes(offset_bytes);
+        // Convert to relative offset (relative to data section)
+        let relative_offset = absolute_offset.saturating_sub(data_offset);
+
+        entries.push(FilterDataIndexEntry {
+            offset: relative_offset,
+            length: u32::from_le_bytes(length_bytes),
+        });
+    }
+
+    Ok((entries, data_offset))
+}
+
+/// Load a single filter from the combined segment file.
+/// - relative_offset: offset relative to data section start
+/// - data_offset: where data section starts in the file
+/// - length: number of bytes to read
+///
+/// The actual seek position is relative_offset + data_offset.
+pub(super) async fn load_filter_data_at_offset(
+    path: &Path,
+    relative_offset: u64,
+    data_offset: u64,
+    length: u32,
+) -> StorageResult<Vec<u8>> {
+    use std::io::SeekFrom;
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+    let mut file =
+        tokio::fs::File::open(path).await.map_err(|e| StorageError::ReadFailed(e.to_string()))?;
+
+    let absolute_offset = relative_offset + data_offset;
+    file.seek(SeekFrom::Start(absolute_offset))
+        .await
+        .map_err(|e| StorageError::ReadFailed(e.to_string()))?;
+
+    let mut data = vec![0u8; length as usize];
+    file.read_exact(&mut data).await.map_err(|e| StorageError::ReadFailed(e.to_string()))?;
+
+    Ok(data)
+}
+
+/// Save filter data segment as a single combined file.
+/// Combined format ensures index and data are always consistent.
+/// Format:
+/// - Header (12 bytes): magic (4) + version (2) + count (2) + data_offset (4)
+/// - Index entries (12 bytes each): offset (8) + length (4)
+/// - Data section: raw filter bytes
+pub(super) async fn save_filter_data_segment(
+    segment_path: &Path,
+    index: &[FilterDataIndexEntry],
+    data: &[u8],
+) -> StorageResult<()> {
+    let index_size = (index.len() as u32) * FILTER_DATA_INDEX_ENTRY_SIZE;
+    let data_offset = FILTER_DATA_HEADER_SIZE + index_size;
+
+    // Build buffer
+    let mut buffer = Vec::with_capacity(data_offset as usize + data.len());
+
+    // Write header
+    buffer.extend_from_slice(&FILTER_DATA_SEGMENT_MAGIC);
+    buffer.extend_from_slice(&FILTER_DATA_SEGMENT_VERSION.to_le_bytes());
+    buffer.extend_from_slice(&(index.len() as u16).to_le_bytes());
+    buffer.extend_from_slice(&data_offset.to_le_bytes());
+
+    // Write index entries with absolute offsets
+    for entry in index {
+        let absolute_offset = entry.offset + data_offset as u64;
+        buffer.extend_from_slice(&absolute_offset.to_le_bytes());
+        buffer.extend_from_slice(&entry.length.to_le_bytes());
+    }
+
+    // Write data section
+    buffer.extend_from_slice(data);
+
+    atomic_write(segment_path, &buffer).await
 }
 
 #[cfg(test)]

--- a/dash-spv/src/storage/disk/io.rs
+++ b/dash-spv/src/storage/disk/io.rs
@@ -1,9 +1,9 @@
 //! Low-level I/O utilities for reading and writing segment files.
 
 use std::collections::HashMap;
-use std::fs::{self, File, OpenOptions};
-use std::io::{BufReader, BufWriter, Write};
-use std::path::Path;
+use std::fs::{self, File};
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
 
 use dashcore::{
     block::Header as BlockHeader,
@@ -14,6 +14,59 @@ use dashcore::{
 use dashcore_hashes::Hash;
 
 use crate::error::{StorageError, StorageResult};
+
+/// Get the temporary file path for atomic writes.
+/// Uses process ID and a counter to ensure uniqueness even with concurrent writes.
+fn get_temp_path(path: &Path) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    let mut temp_path = path.to_path_buf();
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("temp");
+    let unique_id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    temp_path.set_file_name(format!(".{}.{}.{}.tmp", file_name, pid, unique_id));
+    temp_path
+}
+
+/// Atomically write data to a file.
+/// Uses temporary file + sync + rename pattern for crash resilience.
+pub(crate) async fn atomic_write(path: &Path, data: &[u8]) -> StorageResult<()> {
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| StorageError::WriteFailed(format!("Failed to create directory: {}", e)))?;
+    }
+
+    let temp_path = get_temp_path(path);
+
+    // Write to temporary file
+    let write_result = async {
+        tokio::fs::write(&temp_path, data).await?;
+
+        // Sync to disk - open the file and call sync_all
+        let file = tokio::fs::File::open(&temp_path).await?;
+        file.sync_all().await?;
+
+        Ok::<(), std::io::Error>(())
+    }
+    .await;
+
+    // Clean up temp file on error
+    if let Err(e) = write_result {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        return Err(StorageError::WriteFailed(format!("Failed to write temp file: {}", e)));
+    }
+
+    // Atomic rename
+    if let Err(e) = tokio::fs::rename(&temp_path, path).await {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        return Err(StorageError::WriteFailed(format!("Failed to rename temp file: {}", e)));
+    }
+
+    Ok(())
+}
 
 /// Load headers from file.
 pub(super) async fn load_headers_from_file(path: &Path) -> StorageResult<Vec<BlockHeader>> {
@@ -101,34 +154,23 @@ pub(super) async fn save_segment_to_disk(
     path: &Path,
     headers: &[BlockHeader],
 ) -> StorageResult<()> {
-    tokio::task::spawn_blocking({
-        let path = path.to_path_buf();
-        let headers = headers.to_vec();
-        move || {
-            let file = OpenOptions::new().create(true).write(true).truncate(true).open(&path)?;
-            let mut writer = BufWriter::new(file);
-
-            // Only save actual headers, not sentinel headers
-            for header in headers {
-                // Skip sentinel headers (used for padding)
-                if header.version.to_consensus() == i32::MAX
-                    && header.time == u32::MAX
-                    && header.nonce == u32::MAX
-                    && header.prev_blockhash == BlockHash::from_byte_array([0xFF; 32])
-                {
-                    continue;
-                }
-                header.consensus_encode(&mut writer).map_err(|e| {
-                    StorageError::WriteFailed(format!("Failed to encode header: {}", e))
-                })?;
-            }
-
-            writer.flush()?;
-            Ok(())
+    // Build buffer with encoded headers
+    let mut buffer = Vec::new();
+    for header in headers {
+        // Skip sentinel headers (used for padding)
+        if header.version.to_consensus() == i32::MAX
+            && header.time == u32::MAX
+            && header.nonce == u32::MAX
+            && header.prev_blockhash == BlockHash::from_byte_array([0xFF; 32])
+        {
+            continue;
         }
-    })
-    .await
-    .map_err(|e| StorageError::WriteFailed(format!("Task join error: {}", e)))?
+        header
+            .consensus_encode(&mut buffer)
+            .map_err(|e| StorageError::WriteFailed(format!("Failed to encode header: {}", e)))?;
+    }
+
+    atomic_write(path, &buffer).await
 }
 
 /// Save a segment of filter headers to disk.
@@ -136,25 +178,15 @@ pub(super) async fn save_filter_segment_to_disk(
     path: &Path,
     filter_headers: &[FilterHeader],
 ) -> StorageResult<()> {
-    tokio::task::spawn_blocking({
-        let path = path.to_path_buf();
-        let filter_headers = filter_headers.to_vec();
-        move || {
-            let file = OpenOptions::new().create(true).write(true).truncate(true).open(&path)?;
-            let mut writer = BufWriter::new(file);
+    // Build buffer with encoded filter headers
+    let mut buffer = Vec::new();
+    for header in filter_headers {
+        header.consensus_encode(&mut buffer).map_err(|e| {
+            StorageError::WriteFailed(format!("Failed to encode filter header: {}", e))
+        })?;
+    }
 
-            for header in filter_headers {
-                header.consensus_encode(&mut writer).map_err(|e| {
-                    StorageError::WriteFailed(format!("Failed to encode filter header: {}", e))
-                })?;
-            }
-
-            writer.flush()?;
-            Ok(())
-        }
-    })
-    .await
-    .map_err(|e| StorageError::WriteFailed(format!("Task join error: {}", e)))?
+    atomic_write(path, &buffer).await
 }
 
 /// Save index to disk.
@@ -162,17 +194,195 @@ pub(super) async fn save_index_to_disk(
     path: &Path,
     index: &HashMap<BlockHash, u32>,
 ) -> StorageResult<()> {
-    tokio::task::spawn_blocking({
-        let path = path.to_path_buf();
-        let index = index.clone();
-        move || {
-            let data = bincode::serialize(&index).map_err(|e| {
-                StorageError::WriteFailed(format!("Failed to serialize index: {}", e))
-            })?;
-            fs::write(&path, data)?;
-            Ok(())
+    let data = bincode::serialize(index)
+        .map_err(|e| StorageError::WriteFailed(format!("Failed to serialize index: {}", e)))?;
+
+    atomic_write(path, &data).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_get_temp_path_uniqueness() {
+        let path = Path::new("some").join("path").join("file.dat");
+
+        let temp1 = get_temp_path(&path);
+        let temp2 = get_temp_path(&path);
+
+        assert_ne!(temp1, temp2, "Each call should produce a unique temp path");
+
+        // Check temp file is in same directory as original
+        assert_eq!(temp1.parent(), path.parent());
+
+        // Check temp file name starts with dot and ends with .tmp
+        let file_name = temp1.file_name().unwrap().to_string_lossy();
+        assert!(file_name.starts_with(".file.dat."));
+        assert!(file_name.ends_with(".tmp"));
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_creates_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test.dat");
+
+        let content = b"hello world";
+        atomic_write(&path, content).await.unwrap();
+
+        assert!(path.exists());
+        let read_content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_content, content);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_creates_parent_directories() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("nested").join("dirs").join("test.dat");
+
+        let content = b"nested content";
+        atomic_write(&path, content).await.unwrap();
+
+        assert!(path.exists());
+        let read_content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_content, content);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_overwrites_existing() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test.dat");
+
+        // Write initial content
+        tokio::fs::write(&path, b"initial").await.unwrap();
+
+        // Overwrite with atomic write
+        let new_content = b"new content";
+        atomic_write(&path, new_content).await.unwrap();
+
+        let read_content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_content, new_content);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_no_temp_file_on_success() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test.dat");
+
+        atomic_write(&path, b"data").await.unwrap();
+
+        // Check no .tmp files remain
+        let mut entries = tokio::fs::read_dir(temp_dir.path()).await.unwrap();
+        let mut tmp_files = Vec::new();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            if entry.file_name().to_string_lossy().ends_with(".tmp") {
+                tmp_files.push(entry.file_name());
+            }
         }
-    })
-    .await
-    .map_err(|e| StorageError::WriteFailed(format!("Task join error: {}", e)))?
+
+        assert!(tmp_files.is_empty(), "No temp files should remain after successful write");
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_preserves_original_on_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test.dat");
+
+        // Write initial content
+        let original = b"original content";
+        tokio::fs::write(&path, original).await.unwrap();
+
+        // Try to write to an invalid path (directory instead of file)
+        let invalid_path = temp_dir.path().join("test.dat").join("invalid");
+
+        let result = atomic_write(&invalid_path, b"new content").await;
+        assert!(result.is_err());
+
+        // Original file should still have original content
+        let read_content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_content, original);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_cleans_up_temp_on_error() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create a file that will block directory creation
+        let blocker_path = temp_dir.path().join("blocker");
+        tokio::fs::write(&blocker_path, b"I am a file").await.unwrap();
+
+        // Try to write to a path where parent "directory" is actually a file
+        let invalid_path = blocker_path.join("subdir").join("file.dat");
+
+        let result = atomic_write(&invalid_path, b"data").await;
+        assert!(result.is_err());
+
+        // No temp files should remain in the base temp dir
+        let entries: Vec<_> = fs::read_dir(temp_dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+
+        assert!(entries.is_empty(), "No temp files should remain after failed write");
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_binary_data() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("binary.dat");
+
+        // Write binary data with null bytes and various byte values
+        let binary_data: Vec<u8> = (0u8..=255).collect();
+        atomic_write(&path, &binary_data).await.unwrap();
+
+        let read_content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_content, binary_data);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_large_data() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("large.dat");
+
+        // Write 1MB of data
+        let large_data: Vec<u8> = (0..1_000_000).map(|i| (i % 256) as u8).collect();
+        atomic_write(&path, &large_data).await.unwrap();
+
+        let read_content = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_content.len(), large_data.len());
+        assert_eq!(read_content, large_data);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_write_cleans_up_temp_on_rename_failure() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("target.dat");
+
+        // Create a directory at the target path - rename will fail because
+        // you cannot rename a file over an existing directory
+        tokio::fs::create_dir(&path).await.unwrap();
+
+        let result = atomic_write(&path, b"data").await;
+        assert!(result.is_err());
+
+        // The target directory should still exist
+        assert!(path.exists());
+        assert!(path.is_dir());
+
+        // No temp files should remain
+        let entries: Vec<_> = fs::read_dir(temp_dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+
+        assert!(
+            entries.is_empty(),
+            "No temp files should remain after rename failure, found: {:?}",
+            entries.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+        );
+    }
 }

--- a/dash-spv/src/storage/disk/mod.rs
+++ b/dash-spv/src/storage/disk/mod.rs
@@ -33,3 +33,18 @@ pub(super) const HEADERS_PER_SEGMENT: u32 = 50_000;
 
 /// Maximum number of segments to keep in memory
 pub(super) const MAX_ACTIVE_SEGMENTS: usize = 10;
+
+// Filter data constants
+
+/// Filter data segment magic bytes: "FDSF" (Filter Data Segment Format)
+const FILTER_DATA_SEGMENT_MAGIC: [u8; 4] = [0x46, 0x44, 0x53, 0x46];
+/// Filter data segment format version
+const FILTER_DATA_SEGMENT_VERSION: u16 = 1;
+/// Filter data segment header size: magic (4) + version (2) + count (2) + data_offset (4)
+const FILTER_DATA_HEADER_SIZE: u32 = 12;
+/// Filter data index entry size: offset (8) + length (4)
+const FILTER_DATA_INDEX_ENTRY_SIZE: u32 = 12;
+/// Number of filters per segment file
+pub const FILTERS_PER_SEGMENT: u32 = 50_000;
+/// Maximum number of filter data segments to keep in memory
+const MAX_ACTIVE_FILTER_DATA_SEGMENTS: usize = 5;

--- a/dash-spv/src/storage/disk/mod.rs
+++ b/dash-spv/src/storage/disk/mod.rs
@@ -21,7 +21,7 @@
 
 mod filters;
 mod headers;
-mod io;
+pub(crate) mod io;
 mod manager;
 mod segments;
 mod state;

--- a/dash-spv/src/storage/disk/segments.rs
+++ b/dash-spv/src/storage/disk/segments.rs
@@ -14,7 +14,7 @@ use dashcore_hashes::Hash;
 use crate::error::StorageResult;
 
 use super::manager::DiskStorageManager;
-use super::{HEADERS_PER_SEGMENT, MAX_ACTIVE_SEGMENTS};
+use super::{HEADERS_PER_SEGMENT, MAX_ACTIVE_FILTER_DATA_SEGMENTS, MAX_ACTIVE_SEGMENTS};
 
 /// State of a segment in memory
 #[derive(Debug, Clone, PartialEq)]
@@ -42,6 +42,44 @@ pub(super) struct FilterSegmentCache {
     pub(super) filter_headers: Vec<FilterHeader>,
     pub(super) state: SegmentState,
     pub(super) last_saved: Instant,
+    pub(super) last_accessed: Instant,
+}
+
+/// Index entry for a single compact block filter in a data segment.
+/// Stores the byte offset and length needed to read the filter from the data file.
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct FilterDataIndexEntry {
+    /// Byte offset in the data file where this filter starts
+    pub(super) offset: u64,
+    /// Length of the filter data in bytes (0 means no filter stored)
+    pub(super) length: u32,
+}
+
+/// In-memory cache for a segment of compact block filters.
+/// Compact filters have variable length (typically 100 bytes to ~5KB).
+/// We store an index of offsets and cache individual filters on demand.
+#[derive(Clone)]
+pub(super) struct FilterDataSegmentCache {
+    pub(super) segment_id: u32,
+    /// Index entries for each filter position in the segment.
+    /// Position corresponds to (height % FILTERS_PER_SEGMENT).
+    /// Length of 0 indicates no filter stored at that position.
+    /// Offsets are RELATIVE to the data section (not file start).
+    pub(super) index: Vec<FilterDataIndexEntry>,
+    /// Cached filter data, keyed by segment offset.
+    /// Not all filters are cached - loaded on demand.
+    pub(super) filters: HashMap<usize, Vec<u8>>,
+    /// Number of filters stored in this segment
+    pub(super) filter_count: usize,
+    /// Current total size of data written (for calculating next offset)
+    pub(super) current_data_size: u64,
+    /// Byte offset where data section starts in the combined file (for loading filters)
+    pub(super) file_data_offset: u64,
+    /// Segment state
+    pub(super) state: SegmentState,
+    /// Last saved time
+    pub(super) last_saved: Instant,
+    /// Last access time
     pub(super) last_accessed: Instant,
 }
 
@@ -224,6 +262,122 @@ pub(super) async fn evict_oldest_filter_segment(
     Ok(())
 }
 
+/// Ensure a filter data segment is loaded in memory.
+pub(super) async fn ensure_filter_data_segment_loaded(
+    manager: &DiskStorageManager,
+    segment_id: u32,
+) -> StorageResult<()> {
+    manager.process_worker_notifications().await;
+
+    let mut segments = manager.active_filter_data_segments.write().await;
+
+    if segments.contains_key(&segment_id) {
+        if let Some(segment) = segments.get_mut(&segment_id) {
+            segment.last_accessed = Instant::now();
+        }
+        return Ok(());
+    }
+
+    // Load segment from disk
+    let segment_path =
+        manager.base_path.join(format!("filters/filter_data_segment_{:04}.dat", segment_id));
+
+    let (index, current_data_size, file_data_offset) = if segment_path.exists() {
+        let (loaded_index, data_offset) = super::io::load_filter_data_index(&segment_path).await?;
+        // Calculate data size from index entries
+        let data_size = loaded_index
+            .iter()
+            .filter(|e| e.length > 0)
+            .map(|e| e.offset + e.length as u64)
+            .max()
+            .unwrap_or(0);
+        (loaded_index, data_size, data_offset)
+    } else {
+        (Vec::new(), 0, 0)
+    };
+
+    let filter_count = index.iter().filter(|e| e.length > 0).count();
+
+    // Evict old segments if needed
+    if segments.len() >= MAX_ACTIVE_FILTER_DATA_SEGMENTS {
+        evict_oldest_filter_data_segment(manager, &mut segments).await?;
+    }
+
+    segments.insert(
+        segment_id,
+        FilterDataSegmentCache {
+            segment_id,
+            index,
+            filters: HashMap::new(),
+            filter_count,
+            current_data_size,
+            file_data_offset,
+            state: SegmentState::Clean,
+            last_saved: Instant::now(),
+            last_accessed: Instant::now(),
+        },
+    );
+
+    Ok(())
+}
+
+/// Evict the oldest (least recently accessed) filter data segment.
+pub(super) async fn evict_oldest_filter_data_segment(
+    manager: &DiskStorageManager,
+    segments: &mut HashMap<u32, FilterDataSegmentCache>,
+) -> StorageResult<()> {
+    if let Some((oldest_id, oldest_segment)) =
+        segments.iter().min_by_key(|(_, s)| s.last_accessed).map(|(id, s)| (*id, s.clone()))
+    {
+        if oldest_segment.state != SegmentState::Clean {
+            tracing::trace!(
+                "Synchronously saving filter data segment {} before eviction (state: {:?})",
+                oldest_segment.segment_id,
+                oldest_segment.state
+            );
+
+            // Reconstruct data from cached filters
+            let data = reconstruct_filter_data(&oldest_segment);
+
+            let segment_path = manager
+                .base_path
+                .join(format!("filters/filter_data_segment_{:04}.dat", oldest_segment.segment_id));
+
+            super::io::save_filter_data_segment(&segment_path, &oldest_segment.index, &data)
+                .await?;
+
+            tracing::debug!(
+                "Successfully saved filter data segment {} to disk",
+                oldest_segment.segment_id
+            );
+        }
+
+        segments.remove(&oldest_id);
+    }
+
+    Ok(())
+}
+
+/// Reconstruct filter data bytes from a segment cache for saving.
+fn reconstruct_filter_data(segment: &FilterDataSegmentCache) -> Vec<u8> {
+    let mut data = vec![0u8; segment.current_data_size as usize];
+
+    for (offset, filter) in &segment.filters {
+        if *offset < segment.index.len() {
+            let entry = &segment.index[*offset];
+            if entry.length > 0 {
+                let start = entry.offset as usize;
+                let end = start + entry.length as usize;
+                if end <= data.len() {
+                    data[start..end].copy_from_slice(filter);
+                }
+            }
+        }
+    }
+
+    data
+}
+
 /// Save all dirty segments to disk via background worker.
 pub(super) async fn save_dirty_segments(manager: &DiskStorageManager) -> StorageResult<()> {
     use super::manager::WorkerCommand;
@@ -288,6 +442,43 @@ pub(super) async fn save_dirty_segments(manager: &DiskStorageManager) -> Storage
         {
             let mut segments = manager.active_filter_segments.write().await;
             for segment_id in &filter_segment_ids_to_mark {
+                if let Some(segment) = segments.get_mut(segment_id) {
+                    segment.state = SegmentState::Saving;
+                    segment.last_saved = Instant::now();
+                }
+            }
+        }
+
+        // Collect filter data segments to save (only dirty ones)
+        let (filter_data_segments_to_save, filter_data_segment_ids_to_mark) = {
+            let segments = manager.active_filter_data_segments.read().await;
+            let to_save: Vec<_> = segments
+                .values()
+                .filter(|s| s.state == SegmentState::Dirty)
+                .map(|s| {
+                    let data = reconstruct_filter_data(s);
+                    (s.segment_id, s.index.clone(), data)
+                })
+                .collect();
+            let ids_to_mark: Vec<_> = to_save.iter().map(|(id, _, _)| *id).collect();
+            (to_save, ids_to_mark)
+        };
+
+        // Send filter data segments to worker
+        for (segment_id, index, data) in filter_data_segments_to_save {
+            let _ = tx
+                .send(WorkerCommand::SaveFilterDataSegment {
+                    segment_id,
+                    index,
+                    data,
+                })
+                .await;
+        }
+
+        // Mark ONLY the filter data segments we're actually saving as Saving
+        {
+            let mut segments = manager.active_filter_data_segments.write().await;
+            for segment_id in &filter_data_segment_ids_to_mark {
                 if let Some(segment) = segments.get_mut(segment_id) {
                     segment.state = SegmentState::Saving;
                     segment.last_saved = Instant::now();

--- a/dash-spv/src/storage/disk/state.rs
+++ b/dash-spv/src/storage/disk/state.rs
@@ -11,6 +11,7 @@ use crate::error::StorageResult;
 use crate::storage::{MasternodeState, StorageManager, StorageStats};
 use crate::types::{ChainState, MempoolState, UnconfirmedTransaction};
 
+use super::io::atomic_write;
 use super::manager::DiskStorageManager;
 
 impl DiskStorageManager {
@@ -42,7 +43,8 @@ impl DiskStorageManager {
         });
 
         let path = self.base_path.join("state/chain.json");
-        tokio::fs::write(path, state_data.to_string()).await?;
+        let json = state_data.to_string();
+        atomic_write(&path, json.as_bytes()).await?;
 
         Ok(())
     }
@@ -104,7 +106,7 @@ impl DiskStorageManager {
             ))
         })?;
 
-        tokio::fs::write(path, json).await?;
+        atomic_write(&path, json.as_bytes()).await?;
         Ok(())
     }
 
@@ -141,12 +143,7 @@ impl DiskStorageManager {
             ))
         })?;
 
-        // Write to a temporary file first for atomicity
-        let temp_path = path.with_extension("tmp");
-        tokio::fs::write(&temp_path, json.as_bytes()).await?;
-
-        // Atomically rename to final path
-        tokio::fs::rename(&temp_path, &path).await?;
+        atomic_write(&path, json.as_bytes()).await?;
 
         tracing::debug!("Saved sync state at height {}", state.chain_tip.height);
         Ok(())
@@ -192,10 +189,8 @@ impl DiskStorageManager {
         height: u32,
         checkpoint: &crate::storage::sync_state::SyncCheckpoint,
     ) -> StorageResult<()> {
-        let checkpoints_dir = self.base_path.join("checkpoints");
-        tokio::fs::create_dir_all(&checkpoints_dir).await?;
-
-        let path = checkpoints_dir.join(format!("checkpoint_{:08}.json", height));
+        let path =
+            self.base_path.join("checkpoints").join(format!("checkpoint_{:08}.json", height));
         let json = serde_json::to_string(checkpoint).map_err(|e| {
             crate::error::StorageError::WriteFailed(format!(
                 "Failed to serialize checkpoint: {}",
@@ -203,7 +198,7 @@ impl DiskStorageManager {
             ))
         })?;
 
-        tokio::fs::write(&path, json.as_bytes()).await?;
+        atomic_write(&path, json.as_bytes()).await?;
         tracing::debug!("Stored checkpoint at height {}", height);
         Ok(())
     }
@@ -257,10 +252,7 @@ impl DiskStorageManager {
         height: u32,
         chain_lock: &dashcore::ChainLock,
     ) -> StorageResult<()> {
-        let chainlocks_dir = self.base_path.join("chainlocks");
-        tokio::fs::create_dir_all(&chainlocks_dir).await?;
-
-        let path = chainlocks_dir.join(format!("chainlock_{:08}.bin", height));
+        let path = self.base_path.join("chainlocks").join(format!("chainlock_{:08}.bin", height));
         let data = bincode::serialize(chain_lock).map_err(|e| {
             crate::error::StorageError::WriteFailed(format!(
                 "Failed to serialize chain lock: {}",
@@ -268,7 +260,7 @@ impl DiskStorageManager {
             ))
         })?;
 
-        tokio::fs::write(&path, &data).await?;
+        atomic_write(&path, &data).await?;
         tracing::debug!("Stored chain lock at height {}", height);
         Ok(())
     }
@@ -335,7 +327,7 @@ impl DiskStorageManager {
     /// Store metadata.
     pub async fn store_metadata(&mut self, key: &str, value: &[u8]) -> StorageResult<()> {
         let path = self.base_path.join(format!("state/{}.dat", key));
-        tokio::fs::write(path, value).await?;
+        atomic_write(&path, value).await?;
         Ok(())
     }
 

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -16,7 +16,7 @@ use dashcore::{block::Header as BlockHeader, hash_types::FilterHeader, Txid};
 use crate::error::StorageResult;
 use crate::types::{ChainState, MempoolState, UnconfirmedTransaction};
 
-pub use disk::DiskStorageManager;
+pub use disk::{DiskStorageManager, FILTERS_PER_SEGMENT};
 pub use memory::MemoryStorageManager;
 pub use sync_state::{PersistentSyncState, RecoverySuggestion, SyncStateValidation};
 pub use sync_storage::MemoryStorage;

--- a/dash-spv/src/sync/message_handlers.rs
+++ b/dash-spv/src/sync/message_handlers.rs
@@ -611,6 +611,12 @@ impl<
             return Ok(());
         }
 
+        // Store the verified filter to disk
+        storage
+            .store_filter(height, &cfilter.filter)
+            .await
+            .map_err(|e| SyncError::Storage(format!("Failed to store filter: {}", e)))?;
+
         let matches = self
             .filter_sync
             .check_filter_for_matches(

--- a/dash-spv/tests/filter_data_segment_test.rs
+++ b/dash-spv/tests/filter_data_segment_test.rs
@@ -1,0 +1,1260 @@
+//! Tests for segmented compact block filter storage.
+//!
+//! These tests verify the segmented storage implementation for BIP-158 compact block filters.
+//! Filters are variable-length (100 bytes to ~5KB typical) and stored using index+data files.
+
+use dash_spv::storage::{DiskStorageManager, FILTERS_PER_SEGMENT};
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+/// Create test filter data for a given height.
+/// Uses height to create unique, recognizable filter data.
+fn create_test_filter(height: u32) -> Vec<u8> {
+    // Create variable-length filter data based on height
+    // Simulates real BIP-158 filters which vary in size
+    let length = 100 + (height % 500) as usize; // 100-599 bytes
+    let mut data = Vec::with_capacity(length);
+
+    // Store height in first 4 bytes for verification
+    data.extend_from_slice(&height.to_le_bytes());
+
+    // Fill rest with predictable pattern
+    for i in 4..length {
+        data.push(((height + i as u32) % 256) as u8);
+    }
+    data
+}
+
+#[tokio::test]
+async fn test_store_single_filter() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    let filter = create_test_filter(42);
+    storage.store_filter(42, &filter).await.unwrap();
+
+    let loaded = storage.load_filter(42).await.unwrap();
+    assert_eq!(loaded, Some(filter));
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_store_multiple_filters_same_segment() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // Store 10 filters in the same segment (segment 0: heights 0-49999)
+    let heights = [0, 10, 100, 1000, 5000, 10000, 25000, 40000, 49000, 49999];
+
+    for &height in &heights {
+        let filter = create_test_filter(height);
+        storage.store_filter(height, &filter).await.unwrap();
+    }
+
+    // Verify all filters
+    for &height in &heights {
+        let expected = create_test_filter(height);
+        let loaded = storage.load_filter(height).await.unwrap();
+        assert_eq!(loaded, Some(expected), "Filter at height {} mismatch", height);
+    }
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_store_filters_across_segments() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // Store filters across segment boundary (50000 filters per segment)
+    let heights = [49998, 49999, 50000, 50001, 100000, 100001];
+
+    for &height in &heights {
+        let filter = create_test_filter(height);
+        storage.store_filter(height, &filter).await.unwrap();
+    }
+
+    // Verify all filters
+    for &height in &heights {
+        let expected = create_test_filter(height);
+        let loaded = storage.load_filter(height).await.unwrap();
+        assert_eq!(loaded, Some(expected), "Filter at height {} mismatch", height);
+    }
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_load_nonexistent_filter() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // Load filter that was never stored
+    let loaded = storage.load_filter(12345).await.unwrap();
+    assert_eq!(loaded, None);
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_filter_segment_persistence() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    let heights = [100, 1000, 50000, 50001];
+
+    // Store filters
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        for &height in &heights {
+            let filter = create_test_filter(height);
+            storage.store_filter(height, &filter).await.unwrap();
+        }
+
+        // Wait for background save
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Load in new instance
+    {
+        let storage = DiskStorageManager::new(path).await.unwrap();
+
+        for &height in &heights {
+            let expected = create_test_filter(height);
+            let loaded = storage.load_filter(height).await.unwrap();
+            assert_eq!(loaded, Some(expected), "Filter at height {} not persisted", height);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_filter_with_varying_sizes() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // Test filters of different sizes (simulating real BIP-158 filter variance)
+    let test_cases = [
+        (0, vec![0u8; 50]),   // Very small filter
+        (1, vec![1u8; 200]),  // Typical small filter
+        (2, vec![2u8; 500]),  // Medium filter
+        (3, vec![3u8; 2000]), // Large filter
+        (4, vec![4u8; 5000]), // Very large filter
+    ];
+
+    for (height, filter) in &test_cases {
+        storage.store_filter(*height, filter).await.unwrap();
+    }
+
+    for (height, expected) in &test_cases {
+        let loaded = storage.load_filter(*height).await.unwrap();
+        assert_eq!(loaded.as_ref(), Some(expected), "Filter at height {} size mismatch", height);
+    }
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_clear_filters_clears_data() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // Store some filters
+    for height in [100, 1000, 50000] {
+        let filter = create_test_filter(height);
+        storage.store_filter(height, &filter).await.unwrap();
+    }
+
+    // Verify they exist
+    assert!(storage.load_filter(100).await.unwrap().is_some());
+
+    // Clear filters
+    storage.clear_filters().await.unwrap();
+
+    // Verify they're gone
+    assert_eq!(storage.load_filter(100).await.unwrap(), None);
+    assert_eq!(storage.load_filter(1000).await.unwrap(), None);
+    assert_eq!(storage.load_filter(50000).await.unwrap(), None);
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_store_filter_at_height_zero() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    let filter = vec![0xDE, 0xAD, 0xBE, 0xEF];
+    storage.store_filter(0, &filter).await.unwrap();
+
+    let loaded = storage.load_filter(0).await.unwrap();
+    assert_eq!(loaded, Some(filter));
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_overwrite_existing_filter() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    let filter_v1 = vec![1, 2, 3, 4];
+    let filter_v2 = vec![5, 6, 7, 8, 9, 10];
+
+    storage.store_filter(100, &filter_v1).await.unwrap();
+    assert_eq!(storage.load_filter(100).await.unwrap(), Some(filter_v1));
+
+    storage.store_filter(100, &filter_v2).await.unwrap();
+    assert_eq!(storage.load_filter(100).await.unwrap(), Some(filter_v2));
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_empty_filter() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    let empty_filter: Vec<u8> = vec![];
+    storage.store_filter(42, &empty_filter).await.unwrap();
+
+    // Empty filter stored with length 0 should return None (not found)
+    // because the index entry has length=0 which is treated as "no filter"
+    let loaded = storage.load_filter(42).await.unwrap();
+    assert_eq!(loaded, None);
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_sequential_filters() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // Store 100 sequential filters (common real-world pattern)
+    for height in 0..100 {
+        let filter = create_test_filter(height);
+        storage.store_filter(height, &filter).await.unwrap();
+    }
+
+    // Verify all
+    for height in 0..100 {
+        let expected = create_test_filter(height);
+        let loaded = storage.load_filter(height).await.unwrap();
+        assert_eq!(loaded, Some(expected), "Filter at height {} mismatch", height);
+    }
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_segment_eviction() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // Store filters across many segments to trigger eviction
+    // MAX_ACTIVE_FILTER_DATA_SEGMENTS is 5, so storing in 7 segments should trigger eviction
+    let heights = [0, 50000, 100000, 150000, 200000, 250000, 300000];
+
+    for &height in &heights {
+        let filter = create_test_filter(height);
+        storage.store_filter(height, &filter).await.unwrap();
+    }
+
+    // Wait for background save
+    sleep(Duration::from_millis(500)).await;
+
+    // All filters should still be loadable (from disk if evicted)
+    for &height in &heights {
+        let expected = create_test_filter(height);
+        let loaded = storage.load_filter(height).await.unwrap();
+        assert_eq!(loaded, Some(expected), "Filter at height {} not found after eviction", height);
+    }
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_load_from_disk_after_restart() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    // Store and persist filters
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        for height in [0, 1000, 2000] {
+            let filter = create_test_filter(height);
+            storage.store_filter(height, &filter).await.unwrap();
+        }
+
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Fresh storage instance - segments not in memory
+    {
+        let storage = DiskStorageManager::new(path).await.unwrap();
+
+        // These should load from disk (.idx + .dat files)
+        for height in [0, 1000, 2000] {
+            let expected = create_test_filter(height);
+            let loaded = storage.load_filter(height).await.unwrap();
+            assert_eq!(loaded, Some(expected), "Filter at height {} not loaded from disk", height);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_segment_file_format_on_disk() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        storage.store_filter(0, &[1, 2, 3]).await.unwrap();
+        storage.store_filter(1, &[4, 5, 6, 7, 8]).await.unwrap();
+
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Verify combined segment file exists and has correct magic bytes
+    let segment_path = path.join("filters/filter_data_segment_0000.dat");
+    assert!(segment_path.exists(), "Segment file should exist");
+
+    let segment_data = std::fs::read(&segment_path).unwrap();
+    assert!(segment_data.len() >= 12, "Segment file too small");
+
+    // Check magic bytes: "FDSF" (Filter Data Segment Format)
+    assert_eq!(&segment_data[0..4], b"FDSF", "Invalid magic bytes");
+
+    // Check version
+    let version = u16::from_le_bytes([segment_data[4], segment_data[5]]);
+    assert_eq!(version, 1, "Invalid version");
+
+    // Check entry count
+    let count = u16::from_le_bytes([segment_data[6], segment_data[7]]);
+    assert!(count >= 2, "Should have at least 2 entries");
+
+    // Check data offset
+    let data_offset =
+        u32::from_le_bytes([segment_data[8], segment_data[9], segment_data[10], segment_data[11]]);
+    assert!(data_offset > 12, "Data offset should be after header");
+}
+
+#[tokio::test]
+async fn test_load_from_reloaded_segment_after_eviction() {
+    // This tests the "filter in index but not in memory cache" code path.
+    // Scenario:
+    // 1. Store filter in segment 0
+    // 2. Evict segment 0 by filling other segments
+    // 3. Store NEW filter in segment 0 (reloads segment from disk, index loaded but filters empty)
+    // 4. Load ORIGINAL filter (should load from disk via index)
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // Store original filter at height 1000 (segment 0)
+    let original_filter = vec![0xAA; 100];
+    storage.store_filter(1000, &original_filter).await.unwrap();
+
+    // Force save so data is on disk
+    sleep(Duration::from_millis(500)).await;
+
+    // Fill segments 1-5 to evict segment 0 (MAX_ACTIVE_FILTER_DATA_SEGMENTS is 5)
+    for seg in 1..=5 {
+        let height = seg * 50000;
+        storage.store_filter(height, &create_test_filter(height)).await.unwrap();
+    }
+
+    // Store NEW filter in segment 0 - this reloads segment from disk
+    let new_filter = vec![0xBB; 50];
+    storage.store_filter(2000, &new_filter).await.unwrap();
+
+    // Load original filter - segment is in memory but original filter not in cache
+    let loaded = storage.load_filter(1000).await.unwrap();
+    assert_eq!(loaded, Some(original_filter), "Original filter should load from disk via index");
+
+    // Also verify new filter works
+    let loaded_new = storage.load_filter(2000).await.unwrap();
+    assert_eq!(loaded_new, Some(new_filter));
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_load_nonexistent_filter_from_loaded_segment() {
+    // Tests loading a filter that doesn't exist from a segment that IS loaded
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // Store filter at height 100 to load segment 0
+    storage.store_filter(100, &[1, 2, 3]).await.unwrap();
+
+    // Try to load filter at height 200 (same segment, never stored)
+    let loaded = storage.load_filter(200).await.unwrap();
+    assert_eq!(loaded, None);
+
+    // Try to load filter at height 50000 (different segment, never loaded)
+    let loaded2 = storage.load_filter(50000).await.unwrap();
+    assert_eq!(loaded2, None);
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_startup_loads_filter_data_tip() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    // Store filters and verify tip is tracked
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        // Store filters at various heights
+        storage.store_filter(0, &[1, 2, 3]).await.unwrap();
+        storage.store_filter(100, &[4, 5, 6]).await.unwrap();
+        storage.store_filter(500, &[7, 8, 9]).await.unwrap();
+
+        // Verify tip is tracked during storage
+        let tip = storage.get_filter_data_tip_height().await.unwrap();
+        assert_eq!(tip, Some(500), "Tip should be 500 after storing");
+
+        // Wait for background save and shutdown
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Restart and verify tip is restored from disk
+    {
+        let storage = DiskStorageManager::new(path).await.unwrap();
+
+        let tip = storage.get_filter_data_tip_height().await.unwrap();
+        assert_eq!(tip, Some(500), "Tip should be restored to 500 after restart");
+    }
+}
+
+#[tokio::test]
+async fn test_sparse_index_persistence() {
+    // Tests that sparse index (gaps in heights) persists correctly
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    let heights = [10, 100, 500, 1000, 5000];
+
+    // Store sparse filters
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        for &height in &heights {
+            let filter = create_test_filter(height);
+            storage.store_filter(height, &filter).await.unwrap();
+        }
+
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Verify all sparse entries are loadable after restart
+    {
+        let storage = DiskStorageManager::new(path).await.unwrap();
+
+        for &height in &heights {
+            let expected = create_test_filter(height);
+            let loaded = storage.load_filter(height).await.unwrap();
+            assert_eq!(loaded, Some(expected), "Sparse filter at {} should load", height);
+        }
+
+        // Verify gaps return None
+        assert_eq!(storage.load_filter(50).await.unwrap(), None);
+        assert_eq!(storage.load_filter(200).await.unwrap(), None);
+    }
+}
+
+#[tokio::test]
+async fn test_reconstruct_filter_data_on_eviction() {
+    // This test verifies reconstruct_filter_data works by forcing eviction
+    // of a dirty segment and then loading the data back
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // Store filters with specific patterns to verify reconstruction
+    let test_data: Vec<(u32, Vec<u8>)> =
+        vec![(0, vec![0xAA; 100]), (1, vec![0xBB; 200]), (2, vec![0xCC; 150])];
+
+    for (height, filter) in &test_data {
+        storage.store_filter(*height, filter).await.unwrap();
+    }
+
+    // Force eviction by filling other segments (MAX_ACTIVE_FILTER_DATA_SEGMENTS is 5)
+    for seg in 1..=5 {
+        let height = seg * 50000;
+        storage.store_filter(height, &[seg as u8; 50]).await.unwrap();
+    }
+
+    // Wait for any background saves
+    sleep(Duration::from_millis(500)).await;
+
+    // Now access segment 0 again - it was evicted, so data must be reconstructed/loaded from disk
+    // First store a new filter to trigger segment reload
+    storage.store_filter(3, &[0xDD; 75]).await.unwrap();
+
+    // Verify original filters are still accessible (loaded from disk via reconstructed data)
+    for (height, expected) in &test_data {
+        let loaded = storage.load_filter(*height).await.unwrap();
+        assert_eq!(loaded.as_ref(), Some(expected), "Filter at {} after eviction", height);
+    }
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_multi_segment_with_multiple_filters_per_segment() {
+    // Tests storing multiple filters in multiple segments and loading them back
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    // Define filters across 3 segments (0, 1, 2) with multiple filters each
+    // Segment 0: heights 0-49999, Segment 1: 50000-99999, Segment 2: 100000-149999
+    let test_filters: Vec<(u32, Vec<u8>)> = vec![
+        // Segment 0
+        (0, vec![0x00; 100]),
+        (100, vec![0x01; 150]),
+        (1000, vec![0x02; 200]),
+        (49999, vec![0x03; 250]),
+        // Segment 1
+        (50000, vec![0x10; 120]),
+        (50500, vec![0x11; 180]),
+        (75000, vec![0x12; 220]),
+        (99999, vec![0x13; 280]),
+        // Segment 2
+        (100000, vec![0x20; 130]),
+        (125000, vec![0x21; 190]),
+        (149999, vec![0x22; 240]),
+    ];
+
+    // Store all filters
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        for (height, filter) in &test_filters {
+            storage.store_filter(*height, filter).await.unwrap();
+        }
+
+        // Verify all are immediately accessible
+        for (height, expected) in &test_filters {
+            let loaded = storage.load_filter(*height).await.unwrap();
+            assert_eq!(loaded.as_ref(), Some(expected), "Filter {} not found before save", height);
+        }
+
+        // Wait for background save
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Verify all combined segment files exist
+    for seg in 0..3 {
+        let seg_path = path.join(format!("filters/filter_data_segment_{:04}.dat", seg));
+        assert!(seg_path.exists(), "Segment {} file missing", seg);
+    }
+
+    // Load from fresh instance and verify all filters
+    {
+        let storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        // Verify tip height is the max height stored
+        let tip = storage.get_filter_data_tip_height().await.unwrap();
+        assert_eq!(tip, Some(149999), "Tip should be highest stored height");
+
+        // Verify all filters load correctly from disk
+        for (height, expected) in &test_filters {
+            let loaded = storage.load_filter(*height).await.unwrap();
+            assert_eq!(
+                loaded.as_ref(),
+                Some(expected),
+                "Filter {} not found after restart",
+                height
+            );
+        }
+
+        // Verify gaps return None
+        assert_eq!(storage.load_filter(500).await.unwrap(), None);
+        assert_eq!(storage.load_filter(60000).await.unwrap(), None);
+        assert_eq!(storage.load_filter(110000).await.unwrap(), None);
+    }
+}
+
+#[tokio::test]
+async fn test_multi_segment_sequential_then_random_access() {
+    // Tests sequential storage followed by random access pattern across segments
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // Store sequential filters across segment boundary
+    let heights: Vec<u32> = (49990..50010).collect(); // 20 filters spanning segments 0 and 1
+
+    for height in &heights {
+        let filter = create_test_filter(*height);
+        storage.store_filter(*height, &filter).await.unwrap();
+    }
+
+    // Random access pattern - jump between segments
+    let access_order = [50005, 49995, 50000, 49999, 50009, 49990];
+    for &height in &access_order {
+        let expected = create_test_filter(height);
+        let loaded = storage.load_filter(height).await.unwrap();
+        assert_eq!(loaded, Some(expected), "Random access to {} failed", height);
+    }
+
+    storage.shutdown().await.unwrap();
+}
+
+// =============================================================================
+// Crash Resilience Tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_no_temp_files_after_save() {
+    // Verifies atomic writes don't leave temp files behind
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        // Store several filters to trigger saves
+        for height in [0, 100, 1000, 5000] {
+            let filter = create_test_filter(height);
+            storage.store_filter(height, &filter).await.unwrap();
+        }
+
+        // Wait for background save
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Check no .tmp files exist in filters directory
+    let filters_dir = path.join("filters");
+    if filters_dir.exists() {
+        for entry in std::fs::read_dir(&filters_dir).unwrap() {
+            let entry = entry.unwrap();
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            assert!(
+                !name_str.ends_with(".tmp"),
+                "Temp file {} should not exist after shutdown",
+                name_str
+            );
+            assert!(
+                !name_str.starts_with("."),
+                "Hidden temp file {} should not exist after shutdown",
+                name_str
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_atomic_write_data_integrity() {
+    // Verifies data written with atomic writes is readable and correct
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    let test_filters: Vec<(u32, Vec<u8>)> = vec![
+        (0, vec![0xDE, 0xAD, 0xBE, 0xEF]),
+        (1, (0..255).collect()),
+        (2, vec![0xFF; 1000]),
+        (3, vec![0x00; 500]),
+    ];
+
+    // Store and shutdown
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        for (height, filter) in &test_filters {
+            storage.store_filter(*height, filter).await.unwrap();
+        }
+
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Reload and verify byte-by-byte
+    {
+        let storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        for (height, expected) in &test_filters {
+            let loaded = storage.load_filter(*height).await.unwrap();
+            assert!(loaded.is_some(), "Filter {} should exist", height);
+            let loaded = loaded.unwrap();
+            assert_eq!(loaded.len(), expected.len(), "Filter {} length mismatch", height);
+            assert_eq!(&loaded, expected, "Filter {} data mismatch", height);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_file_not_corrupted_after_multiple_overwrites() {
+    // Verifies that multiple overwrites using atomic writes don't corrupt data
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        // Overwrite the same filter multiple times
+        for i in 0..10 {
+            let filter = vec![i as u8; 100 + i * 10];
+            storage.store_filter(0, &filter).await.unwrap();
+            sleep(Duration::from_millis(100)).await;
+        }
+
+        // Final value should be the last one
+        let final_filter = vec![9u8; 190];
+        let loaded = storage.load_filter(0).await.unwrap();
+        assert_eq!(loaded, Some(final_filter.clone()));
+
+        storage.shutdown().await.unwrap();
+    }
+
+    // Verify after restart
+    {
+        let storage = DiskStorageManager::new(path).await.unwrap();
+
+        let final_filter = vec![9u8; 190];
+        let loaded = storage.load_filter(0).await.unwrap();
+        assert_eq!(loaded, Some(final_filter));
+    }
+}
+
+#[tokio::test]
+async fn test_concurrent_segment_saves() {
+    // Verifies that concurrent saves to different segments work correctly
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        // Rapidly store filters across multiple segments
+        let heights = [
+            0, 50000, 100000, 150000, 200000, // Different segments
+            1, 50001, 100001, 150001, 200001, // Same segments, different offsets
+        ];
+
+        for &height in &heights {
+            let filter = create_test_filter(height);
+            storage.store_filter(height, &filter).await.unwrap();
+        }
+
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Verify all filters
+    {
+        let storage = DiskStorageManager::new(path).await.unwrap();
+
+        let heights = [0, 50000, 100000, 150000, 200000, 1, 50001, 100001, 150001, 200001];
+
+        for &height in &heights {
+            let expected = create_test_filter(height);
+            let loaded = storage.load_filter(height).await.unwrap();
+            assert_eq!(
+                loaded,
+                Some(expected),
+                "Filter {} corrupted after concurrent saves",
+                height
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_full_segment_with_sparse_filters() {
+    // Tests storing filters across the full range of a segment (0 to FILTERS_PER_SEGMENT-1)
+    // Uses sparse storage to avoid excessive test time while still testing segment boundaries
+
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    let test_heights: Vec<u32> = vec![
+        0,                         // Start of segment
+        1,                         // Second position
+        100,                       // Early in segment
+        1000,                      // Mid-early
+        FILTERS_PER_SEGMENT / 2,   // Middle
+        FILTERS_PER_SEGMENT - 100, // Near end
+        FILTERS_PER_SEGMENT - 2,   // Second to last
+        FILTERS_PER_SEGMENT - 1,   // Last position in segment
+    ];
+
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        // Store filters at sparse positions across the segment
+        for &height in &test_heights {
+            let filter = create_test_filter(height);
+            storage.store_filter(height, &filter).await.unwrap();
+        }
+
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Verify all stored filters persist correctly
+    {
+        let storage = DiskStorageManager::new(path).await.unwrap();
+
+        for &height in &test_heights {
+            let expected = create_test_filter(height);
+            let loaded = storage.load_filter(height).await.unwrap();
+            assert_eq!(
+                loaded,
+                Some(expected),
+                "Filter at height {} not found or incorrect after restart",
+                height
+            );
+        }
+
+        // Verify non-stored positions return None
+        let non_stored = storage.load_filter(500).await.unwrap();
+        assert_eq!(non_stored, None, "Non-stored filter should return None");
+    }
+}
+
+#[tokio::test]
+async fn test_multiple_full_segments() {
+    // Tests multiple segments, each with filters at boundary positions
+
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    // Heights that span 3 full segments
+    let test_heights: Vec<u32> = vec![
+        // Segment 0
+        0,
+        FILTERS_PER_SEGMENT - 1,
+        // Segment 1
+        FILTERS_PER_SEGMENT,
+        FILTERS_PER_SEGMENT + FILTERS_PER_SEGMENT / 2,
+        2 * FILTERS_PER_SEGMENT - 1,
+        // Segment 2
+        2 * FILTERS_PER_SEGMENT,
+        2 * FILTERS_PER_SEGMENT + 100,
+        3 * FILTERS_PER_SEGMENT - 1,
+    ];
+
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        for &height in &test_heights {
+            let filter = create_test_filter(height);
+            storage.store_filter(height, &filter).await.unwrap();
+        }
+
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Verify after restart
+    {
+        let storage = DiskStorageManager::new(path).await.unwrap();
+
+        for &height in &test_heights {
+            let expected = create_test_filter(height);
+            let loaded = storage.load_filter(height).await.unwrap();
+            assert_eq!(
+                loaded,
+                Some(expected),
+                "Filter at height {} in multi-segment test not found",
+                height
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_file_format_detailed_validation() {
+    // Validates every field of the file format in detail
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    // Store filters with known sizes for precise validation
+    let filter1 = vec![0xAA; 150]; // 150 bytes at height 0
+    let filter2 = vec![0xBB; 200]; // 200 bytes at height 5
+    let filter3 = vec![0xCC; 100]; // 100 bytes at height 10
+
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        storage.store_filter(0, &filter1).await.unwrap();
+        storage.store_filter(5, &filter2).await.unwrap();
+        storage.store_filter(10, &filter3).await.unwrap();
+
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Read and validate raw file structure
+    let segment_path = path.join("filters/filter_data_segment_0000.dat");
+    let segment_data = std::fs::read(&segment_path).unwrap();
+
+    // Header validation (12 bytes)
+    // Magic: "FDSF" (0x46, 0x44, 0x53, 0x46)
+    assert_eq!(segment_data[0], 0x46, "Magic byte 0 should be 'F'");
+    assert_eq!(segment_data[1], 0x44, "Magic byte 1 should be 'D'");
+    assert_eq!(segment_data[2], 0x53, "Magic byte 2 should be 'S'");
+    assert_eq!(segment_data[3], 0x46, "Magic byte 3 should be 'F'");
+
+    // Version: 1 (little-endian u16)
+    let version = u16::from_le_bytes([segment_data[4], segment_data[5]]);
+    assert_eq!(version, 1, "Version should be 1");
+
+    // Count: should be 11 (indices 0-10 inclusive, even if some are empty)
+    let count = u16::from_le_bytes([segment_data[6], segment_data[7]]);
+    assert_eq!(count, 11, "Count should be 11 (highest index + 1)");
+
+    // Data offset: header (12) + index entries (11 * 12 = 132) = 144
+    let data_offset =
+        u32::from_le_bytes([segment_data[8], segment_data[9], segment_data[10], segment_data[11]]);
+    assert_eq!(data_offset, 144, "Data offset should be 144 bytes");
+
+    // Validate index entries (12 bytes each: offset u64 + length u32)
+    let index_start = 12;
+
+    // Entry 0: filter1 at offset 0, length 150
+    let entry0_offset = u64::from_le_bytes([
+        segment_data[index_start],
+        segment_data[index_start + 1],
+        segment_data[index_start + 2],
+        segment_data[index_start + 3],
+        segment_data[index_start + 4],
+        segment_data[index_start + 5],
+        segment_data[index_start + 6],
+        segment_data[index_start + 7],
+    ]);
+    let entry0_length = u32::from_le_bytes([
+        segment_data[index_start + 8],
+        segment_data[index_start + 9],
+        segment_data[index_start + 10],
+        segment_data[index_start + 11],
+    ]);
+    // Offsets in file are ABSOLUTE (relative to file start, not data section)
+    // data_offset = 144, so first filter is at absolute offset 144
+    assert_eq!(entry0_offset, 144, "Entry 0 absolute offset should be 144 (data_offset + 0)");
+    assert_eq!(entry0_length, 150, "Entry 0 length should be 150");
+
+    // Entry 5: filter2 at absolute offset 294 (144 + 150), length 200
+    let entry5_start = index_start + 5 * 12;
+    let entry5_offset = u64::from_le_bytes([
+        segment_data[entry5_start],
+        segment_data[entry5_start + 1],
+        segment_data[entry5_start + 2],
+        segment_data[entry5_start + 3],
+        segment_data[entry5_start + 4],
+        segment_data[entry5_start + 5],
+        segment_data[entry5_start + 6],
+        segment_data[entry5_start + 7],
+    ]);
+    let entry5_length = u32::from_le_bytes([
+        segment_data[entry5_start + 8],
+        segment_data[entry5_start + 9],
+        segment_data[entry5_start + 10],
+        segment_data[entry5_start + 11],
+    ]);
+    assert_eq!(entry5_offset, 294, "Entry 5 absolute offset should be 294 (144 + 150)");
+    assert_eq!(entry5_length, 200, "Entry 5 length should be 200");
+
+    // Entry 10: filter3 at absolute offset 494 (144 + 150 + 200), length 100
+    let entry10_start = index_start + 10 * 12;
+    let entry10_offset = u64::from_le_bytes([
+        segment_data[entry10_start],
+        segment_data[entry10_start + 1],
+        segment_data[entry10_start + 2],
+        segment_data[entry10_start + 3],
+        segment_data[entry10_start + 4],
+        segment_data[entry10_start + 5],
+        segment_data[entry10_start + 6],
+        segment_data[entry10_start + 7],
+    ]);
+    let entry10_length = u32::from_le_bytes([
+        segment_data[entry10_start + 8],
+        segment_data[entry10_start + 9],
+        segment_data[entry10_start + 10],
+        segment_data[entry10_start + 11],
+    ]);
+    assert_eq!(entry10_offset, 494, "Entry 10 absolute offset should be 494 (144 + 350)");
+    assert_eq!(entry10_length, 100, "Entry 10 length should be 100");
+
+    // Verify empty entries have length 0
+    for empty_idx in [1, 2, 3, 4, 6, 7, 8, 9] {
+        let empty_start = index_start + empty_idx * 12;
+        let empty_length = u32::from_le_bytes([
+            segment_data[empty_start + 8],
+            segment_data[empty_start + 9],
+            segment_data[empty_start + 10],
+            segment_data[empty_start + 11],
+        ]);
+        assert_eq!(empty_length, 0, "Empty entry {} should have length 0", empty_idx);
+    }
+
+    // Validate data section content
+    let data_start = data_offset as usize;
+
+    // Filter 1 data at offset 0
+    assert_eq!(&segment_data[data_start..data_start + 150], &filter1[..], "Filter 1 data mismatch");
+
+    // Filter 2 data at offset 150
+    assert_eq!(
+        &segment_data[data_start + 150..data_start + 350],
+        &filter2[..],
+        "Filter 2 data mismatch"
+    );
+
+    // Filter 3 data at offset 350
+    assert_eq!(
+        &segment_data[data_start + 350..data_start + 450],
+        &filter3[..],
+        "Filter 3 data mismatch"
+    );
+
+    // Verify total file size
+    let expected_size = 12 + (11 * 12) + 150 + 200 + 100; // header + index + data
+    assert_eq!(segment_data.len(), expected_size, "Total file size mismatch");
+}
+
+#[tokio::test]
+async fn test_large_filter_storage() {
+    // Test storing and loading large filters (1MB+)
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // Create 1MB filter
+    let large_filter: Vec<u8> = (0..1_000_000u32).map(|i| (i % 256) as u8).collect();
+
+    storage.store_filter(0, &large_filter).await.unwrap();
+
+    // Verify it can be loaded correctly
+    let loaded = storage.load_filter(0).await.unwrap();
+    assert_eq!(loaded.as_ref().map(|v| v.len()), Some(1_000_000), "Large filter size mismatch");
+    assert_eq!(loaded, Some(large_filter), "Large filter content mismatch");
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_filter_data_integrity_after_many_writes() {
+    // Test that repeated writes to same positions maintain data integrity
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    let heights = [0, 100, 500, 1000];
+    let mut final_filters: std::collections::HashMap<u32, Vec<u8>> =
+        std::collections::HashMap::new();
+
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        // Write multiple times to same heights
+        for round in 0..5usize {
+            for &height in &heights {
+                let filter = vec![(round * 10 + height as usize % 10) as u8; 100 + round * 50];
+                storage.store_filter(height, &filter).await.unwrap();
+                final_filters.insert(height, filter);
+            }
+        }
+
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Verify only final values are present
+    {
+        let storage = DiskStorageManager::new(path).await.unwrap();
+
+        for (&height, expected) in &final_filters {
+            let loaded = storage.load_filter(height).await.unwrap();
+            assert_eq!(
+                loaded.as_ref(),
+                Some(expected),
+                "Filter at height {} should contain final write value",
+                height
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_index_gaps_handling() {
+    // Test that gaps in filter heights are handled correctly
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    // Store filters with large gaps
+    let heights_with_filters = [0, 1000, 5000, 10000, 49999];
+    let mut filters: std::collections::HashMap<u32, Vec<u8>> = std::collections::HashMap::new();
+
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        for &height in &heights_with_filters {
+            let filter = create_test_filter(height);
+            filters.insert(height, filter.clone());
+            storage.store_filter(height, &filter).await.unwrap();
+        }
+
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Verify segment file structure
+    let segment_path = path.join("filters/filter_data_segment_0000.dat");
+    let segment_data = std::fs::read(&segment_path).unwrap();
+
+    // Count should be 50000 (highest index + 1)
+    let count = u16::from_le_bytes([segment_data[6], segment_data[7]]);
+    assert_eq!(count, 50000, "Count should cover highest index");
+
+    // Verify reload works correctly
+    {
+        let storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        // Stored filters should load correctly
+        for (&height, expected) in &filters {
+            let loaded = storage.load_filter(height).await.unwrap();
+            assert_eq!(loaded, Some(expected.clone()), "Stored filter at {} missing", height);
+        }
+
+        // Non-stored heights should return None
+        for gap_height in [1, 500, 999, 2000, 7500, 20000] {
+            let loaded = storage.load_filter(gap_height).await.unwrap();
+            assert_eq!(loaded, None, "Gap at height {} should return None", gap_height);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_filter_boundary_values() {
+    // Test filters with boundary/edge values
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = DiskStorageManager::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    // All zeros filter
+    let zeros = vec![0u8; 100];
+    storage.store_filter(0, &zeros).await.unwrap();
+
+    // All ones filter
+    let ones = vec![0xFF; 100];
+    storage.store_filter(1, &ones).await.unwrap();
+
+    // Alternating pattern
+    let alternating: Vec<u8> = (0..100)
+        .map(|i| {
+            if i % 2 == 0 {
+                0x55
+            } else {
+                0xAA
+            }
+        })
+        .collect();
+    storage.store_filter(2, &alternating).await.unwrap();
+
+    // Single byte
+    let single = vec![0x42];
+    storage.store_filter(3, &single).await.unwrap();
+
+    // Verify all load correctly
+    assert_eq!(storage.load_filter(0).await.unwrap(), Some(zeros));
+    assert_eq!(storage.load_filter(1).await.unwrap(), Some(ones));
+    assert_eq!(storage.load_filter(2).await.unwrap(), Some(alternating));
+    assert_eq!(storage.load_filter(3).await.unwrap(), Some(single));
+
+    storage.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_segment_tip_height_tracking() {
+    // Test that filter data tip height is tracked correctly
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+
+        // Initial tip should be None
+        let tip = storage.get_filter_data_tip_height().await.unwrap();
+        assert_eq!(tip, None, "Initial tip should be None");
+
+        // Store at height 100
+        storage.store_filter(100, &[1, 2, 3]).await.unwrap();
+        let tip = storage.get_filter_data_tip_height().await.unwrap();
+        assert_eq!(tip, Some(100), "Tip should be 100 after first store");
+
+        // Store at lower height - tip should NOT change
+        storage.store_filter(50, &[4, 5, 6]).await.unwrap();
+        let tip = storage.get_filter_data_tip_height().await.unwrap();
+        assert_eq!(tip, Some(100), "Tip should remain 100 after storing at lower height");
+
+        // Store at higher height - tip should update
+        storage.store_filter(200, &[7, 8, 9]).await.unwrap();
+        let tip = storage.get_filter_data_tip_height().await.unwrap();
+        assert_eq!(tip, Some(200), "Tip should be 200 after storing higher");
+
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Verify tip persists after restart
+    {
+        let storage = DiskStorageManager::new(path).await.unwrap();
+        let tip = storage.get_filter_data_tip_height().await.unwrap();
+        assert_eq!(tip, Some(200), "Tip should persist as 200 after restart");
+    }
+}
+
+#[tokio::test]
+async fn test_concurrent_reads_single_segment() {
+    // Test concurrent read access to same segment
+    use std::sync::Arc;
+
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().to_path_buf();
+
+    // Pre-populate segment
+    let filters: Vec<(u32, Vec<u8>)> = (0..100).map(|h| (h, create_test_filter(h))).collect();
+
+    {
+        let mut storage = DiskStorageManager::new(path.clone()).await.unwrap();
+        for (height, filter) in &filters {
+            storage.store_filter(*height, filter).await.unwrap();
+        }
+        sleep(Duration::from_millis(500)).await;
+        storage.shutdown().await.unwrap();
+    }
+
+    // Concurrent reads
+    let storage = Arc::new(DiskStorageManager::new(path).await.unwrap());
+
+    let mut handles = vec![];
+    for _ in 0..10 {
+        let storage_clone = Arc::clone(&storage);
+        let filters_clone = filters.clone();
+        let handle = tokio::spawn(async move {
+            for (height, expected) in filters_clone {
+                let loaded = storage_clone.load_filter(height).await.unwrap();
+                assert_eq!(loaded, Some(expected), "Concurrent read failed at height {}", height);
+            }
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+}


### PR DESCRIPTION
We currently save filters 1 per file which is quite excessive so this PR implements a segmented storage for the filters similar to what we have for headers and filter headers already.

Based on:
- #245 