### PR TITLE
ci: Add workflow to label PRs with merge conflicts

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -1,0 +1,22 @@
+name: Merge Conflict Check
+
+on:
+  push:
+    branches:
+      - master
+      - 'v*-dev'
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  conflict-check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check for merge conflicts and label
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "merge-conflict"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This PR has merge conflicts with the base branch. Please rebase or merge the base branch into your branch to resolve them."


### PR DESCRIPTION
Just adds a workflow to label conflicting PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated merge conflict detection for pull requests. Conflicted PRs are now automatically labeled and notified, encouraging contributors to rebase or merge changes before integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->