### PR TITLE
chore: Pin rust version in `rust-toolchain.toml`

### DIFF
--- a/dash-spv/tests/handshake_test.rs
+++ b/dash-spv/tests/handshake_test.rs
@@ -92,23 +92,25 @@ async fn test_multiple_connect_disconnect_cycles() {
     for i in 1..=3 {
         println!("Attempt {} to connect to {}", i, peer_addr);
 
-        let connect_result = connection.connect_instance().await;
-        if connect_result.is_ok() {
-            assert!(connection.is_connected(), "Should be connected after successful connect");
+        match connection.connect_instance().await {
+            Ok(_) => {
+                assert!(connection.is_connected(), "Should be connected after successful connect");
 
-            // Brief delay
-            tokio::time::sleep(Duration::from_millis(100)).await;
+                // Brief delay
+                tokio::time::sleep(Duration::from_millis(100)).await;
 
-            // Disconnect
-            let disconnect_result = connection.disconnect().await;
-            assert!(disconnect_result.is_ok(), "Disconnect should succeed");
-            assert!(!connection.is_connected(), "Should be disconnected after disconnect");
+                // Disconnect
+                let disconnect_result = connection.disconnect().await;
+                assert!(disconnect_result.is_ok(), "Disconnect should succeed");
+                assert!(!connection.is_connected(), "Should be disconnected after disconnect");
 
-            // Brief delay before next attempt
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        } else {
-            println!("Connection attempt {} failed: {}", i, connect_result.unwrap_err());
-            break;
+                // Brief delay before next attempt
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            Err(e) => {
+                println!("Connection attempt {} failed: {}", i, e);
+                break;
+            }
         }
     }
 }

--- a/dash/src/signer.rs
+++ b/dash/src/signer.rs
@@ -141,8 +141,8 @@ pub fn ripemd160_sha256(data: &[u8]) -> Vec<u8> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::PublicKey;
     use crate::internal_macros::hex;
-    use crate::{PublicKey, assert_error_contains};
 
     struct Keys {
         private_key: Vec<u8>,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.92.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Rust `1.92.0` was released yesterday which caused new issues on CI which weren't caught locally. This PR introduces `rust-toolchain.toml` to pin the rust version to the new release which enforces CI and local development to always run the same version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored error handling in a handshake test for clearer failure reporting while preserving existing test behavior.
  * Adjusted test imports to simplify test code organization.

* **Chores**
  * Added Rust toolchain configuration (1.92.0) with rustfmt and clippy enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->