### PR TITLE
refactor: Less cloning in SPV message handling

### DIFF
--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -633,7 +633,7 @@ impl<
             );
 
             // Delegate message handling to the MessageHandler
-            handler.handle_network_message(message.clone()).await
+            handler.handle_network_message(&message).await
         };
 
         // Handle result and process special messages after releasing storage lock

--- a/dash-spv/src/sync/filters/download.rs
+++ b/dash-spv/src/sync/filters/download.rs
@@ -246,7 +246,7 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
 
     pub async fn store_filter_headers(
         &mut self,
-        cfheaders: dashcore::network::message_filter::CFHeaders,
+        cfheaders: &dashcore::network::message_filter::CFHeaders,
         storage: &mut S,
     ) -> SyncResult<()> {
         if cfheaders.filter_hashes.is_empty() {
@@ -256,7 +256,7 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
 
         // Get the height range for this batch
         let (start_height, stop_height, _header_tip_height) =
-            self.get_batch_height_range(&cfheaders, storage).await?;
+            self.get_batch_height_range(cfheaders, storage).await?;
 
         tracing::info!(
             "Received {} filter headers from height {} to {}",
@@ -308,7 +308,7 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
             // Use the handle_overlapping_headers method which properly handles the chain continuity
             let expected_start = current_filter_tip + 1;
 
-            match self.handle_overlapping_headers(&cfheaders, expected_start, storage).await {
+            match self.handle_overlapping_headers(cfheaders, expected_start, storage).await {
                 Ok((stored_count, _)) => {
                     if stored_count > 0 {
                         tracing::info!("✅ Successfully handled overlapping filter headers");
@@ -328,7 +328,7 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
             }
         } else {
             // Process the filter headers to convert them to the proper format
-            match self.process_filter_headers(&cfheaders, start_height, storage).await {
+            match self.process_filter_headers(cfheaders, start_height, storage).await {
                 Ok(new_filter_headers) => {
                     if !new_filter_headers.is_empty() {
                         // If this is the first batch (starting at height 1), store the genesis filter header first

--- a/dash-spv/src/sync/filters/headers.rs
+++ b/dash-spv/src/sync/filters/headers.rs
@@ -671,7 +671,7 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
                 );
 
                 // Store the verified filter headers
-                self.store_filter_headers(cf_headers.clone(), storage).await?;
+                self.store_filter_headers(&cf_headers, storage).await?;
 
                 // Update next expected height
                 self.next_cfheader_height_to_process = stop_height + 1;

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -443,11 +443,11 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
     /// Handle incoming MnListDiff message
     pub async fn handle_mnlistdiff_message(
         &mut self,
-        diff: MnListDiff,
+        diff: &MnListDiff,
         storage: &mut S,
         _network: &mut dyn NetworkManager,
     ) -> SyncResult<bool> {
-        self.insert_mn_list_diff(&diff, storage).await;
+        self.insert_mn_list_diff(diff, storage).await;
 
         // Decrement pending request counter if we were expecting this response
         if self.pending_mnlistdiff_requests > 0 {

--- a/dash-spv/src/sync/message_handlers.rs
+++ b/dash-spv/src/sync/message_handlers.rs
@@ -25,7 +25,7 @@ impl<
     /// Handle incoming network messages with phase filtering
     pub async fn handle_message(
         &mut self,
-        message: NetworkMessage,
+        message: &NetworkMessage,
         network: &mut N,
         storage: &mut S,
     ) -> SyncResult<()> {
@@ -55,10 +55,10 @@ impl<
         }
 
         // Check if this message is expected in the current phase
-        if !self.is_message_expected_in_phase(&message) {
+        if !self.is_message_expected_in_phase(message) {
             tracing::debug!(
                 "Ignoring unexpected {:?} message in phase {}",
-                std::mem::discriminant(&message),
+                std::mem::discriminant(message),
                 self.current_phase.name()
             );
             return Ok(());
@@ -286,7 +286,7 @@ impl<
 
     pub(super) async fn handle_headers2_message(
         &mut self,
-        headers2: dashcore::network::message_headers2::Headers2Message,
+        headers2: &dashcore::network::message_headers2::Headers2Message,
         peer_id: PeerId,
         network: &mut N,
         storage: &mut S,
@@ -345,12 +345,12 @@ impl<
 
     pub(super) async fn handle_headers_message(
         &mut self,
-        headers: Vec<dashcore::block::Header>,
+        headers: &[dashcore::block::Header],
         network: &mut N,
         storage: &mut S,
     ) -> SyncResult<()> {
         let continue_sync =
-            self.header_sync.handle_headers_message(headers.clone(), storage, network).await?;
+            self.header_sync.handle_headers_message(headers, storage, network).await?;
 
         // Calculate blockchain height before borrowing self.current_phase
         let blockchain_height = self.get_blockchain_height_from_storage(storage).await.unwrap_or(0);
@@ -400,7 +400,7 @@ impl<
 
     pub(super) async fn handle_mnlistdiff_message(
         &mut self,
-        diff: dashcore::network::message_sml::MnListDiff,
+        diff: &dashcore::network::message_sml::MnListDiff,
         network: &mut N,
         storage: &mut S,
     ) -> SyncResult<()> {
@@ -451,7 +451,7 @@ impl<
 
     pub(super) async fn handle_qrinfo_message(
         &mut self,
-        qr_info: dashcore::network::message_qrinfo::QRInfo,
+        qr_info: &dashcore::network::message_qrinfo::QRInfo,
         network: &mut N,
         storage: &mut S,
     ) -> SyncResult<()> {
@@ -509,7 +509,7 @@ impl<
 
     pub(super) async fn handle_cfheaders_message(
         &mut self,
-        cfheaders: dashcore::network::message_filter::CFHeaders,
+        cfheaders: &dashcore::network::message_filter::CFHeaders,
         network: &mut N,
         storage: &mut S,
     ) -> SyncResult<()> {
@@ -563,7 +563,7 @@ impl<
 
     pub(super) async fn handle_cfilter_message(
         &mut self,
-        cfilter: dashcore::network::message_filter::CFilter,
+        cfilter: &dashcore::network::message_filter::CFilter,
         network: &mut N,
         storage: &mut S,
     ) -> SyncResult<()> {
@@ -746,7 +746,7 @@ impl<
 
     pub(super) async fn handle_block_message(
         &mut self,
-        block: Block,
+        block: &Block,
         network: &mut N,
         storage: &mut S,
     ) -> SyncResult<()> {
@@ -762,7 +762,7 @@ impl<
             .map_err(|e| SyncError::Storage(format!("Failed to get block height: {}", e)))?
             .unwrap_or(0);
 
-        let relevant_txids = wallet.process_block(&block, block_height, self.config.network).await;
+        let relevant_txids = wallet.process_block(block, block_height, self.config.network).await;
 
         drop(wallet);
 

--- a/dash-spv/src/sync/post_sync.rs
+++ b/dash-spv/src/sync/post_sync.rs
@@ -119,7 +119,7 @@ impl<
     /// Handle new headers that arrive after initial sync (from inventory)
     pub async fn handle_new_headers(
         &mut self,
-        headers: Vec<BlockHeader>,
+        headers: &[BlockHeader],
         network: &mut N,
         storage: &mut S,
     ) -> SyncResult<()> {
@@ -148,7 +148,7 @@ impl<
 
         // Store the new headers
         storage
-            .store_headers(&headers)
+            .store_headers(headers)
             .await
             .map_err(|e| SyncError::Storage(format!("Failed to store headers: {}", e)))?;
 
@@ -235,7 +235,7 @@ impl<
             }
         }
 
-        for header in &headers {
+        for header in headers {
             let height = storage
                 .get_header_height_by_hash(&header.block_hash())
                 .await
@@ -387,7 +387,7 @@ impl<
     /// Handle filter headers that arrive after initial sync
     pub(super) async fn handle_post_sync_cfheaders(
         &mut self,
-        cfheaders: dashcore::network::message_filter::CFHeaders,
+        cfheaders: &dashcore::network::message_filter::CFHeaders,
         network: &mut N,
         storage: &mut S,
     ) -> SyncResult<()> {
@@ -423,7 +423,7 @@ impl<
     /// Handle filters that arrive after initial sync
     pub(super) async fn handle_post_sync_cfilter(
         &mut self,
-        cfilter: dashcore::network::message_filter::CFilter,
+        cfilter: &dashcore::network::message_filter::CFilter,
         _network: &mut N,
         storage: &mut S,
     ) -> SyncResult<()> {
@@ -466,7 +466,7 @@ impl<
     /// Handle masternode list diffs that arrive after initial sync (for ChainLock validation)
     pub(super) async fn handle_post_sync_mnlistdiff(
         &mut self,
-        diff: dashcore::network::message_sml::MnListDiff,
+        diff: &dashcore::network::message_sml::MnListDiff,
         network: &mut N,
         storage: &mut S,
     ) -> SyncResult<()> {


### PR DESCRIPTION
We currently clone all network messages in `DashSpvClient::handle_network_message` when passed to `MessageHandler::handle_network_message`. Then also some get cloned again further down the track. This PR changes it to pass references where possible and only clone whats needed .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal message passing and synchronization mechanisms to improve memory efficiency and reduce allocations during block processing, header management, and peer coordination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->