### PR TITLE
refactor: Make filter loading range based

### DIFF
--- a/dash-spv/src/storage/disk/state.rs
+++ b/dash-spv/src/storage/disk/state.rs
@@ -600,13 +600,8 @@ impl StorageManager for DiskStorageManager {
         self.filters.write().await.store_items_at_height(&[filter.to_vec()], height, self).await
     }
 
-    async fn load_filter(&self, height: u32) -> StorageResult<Option<Vec<u8>>> {
-        self.filters
-            .write()
-            .await
-            .get_items(height..height + 1)
-            .await
-            .map(|items| items.first().cloned())
+    async fn load_filters(&self, range: std::ops::Range<u32>) -> StorageResult<Vec<Vec<u8>>> {
+        self.filters.write().await.get_items(range).await
     }
 
     async fn store_metadata(&mut self, key: &str, value: &[u8]) -> StorageResult<()> {

--- a/dash-spv/src/storage/memory.rs
+++ b/dash-spv/src/storage/memory.rs
@@ -201,8 +201,14 @@ impl StorageManager for MemoryStorageManager {
         Ok(())
     }
 
-    async fn load_filter(&self, height: u32) -> StorageResult<Option<Vec<u8>>> {
-        Ok(self.filters.get(&height).cloned())
+    async fn load_filters(&self, range: Range<u32>) -> StorageResult<Vec<Vec<u8>>> {
+        let mut result = Vec::new();
+        for height in range {
+            if let Some(filter) = self.filters.get(&height) {
+                result.push(filter.clone());
+            }
+        }
+        Ok(result)
     }
 
     async fn store_metadata(&mut self, key: &str, value: &[u8]) -> StorageResult<()> {

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -142,8 +142,8 @@ pub trait StorageManager: Send + Sync {
     /// Store a compact filter at a blockchain height.
     async fn store_filter(&mut self, height: u32, filter: &[u8]) -> StorageResult<()>;
 
-    /// Load a compact filter by blockchain height.
-    async fn load_filter(&self, height: u32) -> StorageResult<Option<Vec<u8>>>;
+    /// Load compact filters in the given blockchain height range.
+    async fn load_filters(&self, range: Range<u32>) -> StorageResult<Vec<Vec<u8>>>;
 
     /// Store metadata.
     async fn store_metadata(&mut self, key: &str, value: &[u8]) -> StorageResult<()>;

--- a/dash-spv/tests/segmented_storage_test.rs
+++ b/dash-spv/tests/segmented_storage_test.rs
@@ -314,11 +314,13 @@ async fn test_mixed_operations() {
     assert_eq!(storage.get_tip_height().await.unwrap(), Some(74_999));
     assert_eq!(storage.get_filter_tip_height().await.unwrap(), Some(74_999));
 
-    assert_eq!(storage.load_filter(1000).await.unwrap().unwrap(), vec![(1000 % 256) as u8; 100]);
-    assert_eq!(
-        storage.load_filter(50_000).await.unwrap().unwrap(),
-        vec![(50_000 % 256) as u8; 100]
-    );
+    let filters = storage.load_filters(1000..1001).await.unwrap();
+    assert_eq!(filters.len(), 1);
+    assert_eq!(filters[0], vec![(1000 % 256) as u8; 100]);
+
+    let filters = storage.load_filters(50_000..50_001).await.unwrap();
+    assert_eq!(filters.len(), 1);
+    assert_eq!(filters[0], vec![(50_000 % 256) as u8; 100]);
 
     assert_eq!(storage.load_metadata("test_key").await.unwrap().unwrap(), b"test_value");
 


### PR DESCRIPTION
Enable batch loading of filters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Storage filter retrieval system refactored to support batch loading across height ranges. Filters are now retrieved in bulk for specified ranges rather than individually, enabling multiple filters to be fetched in a single operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->