### PR TITLE
refactor: Single network `Wallet` and `ManagedWalletInfo`

### DIFF
--- a/dash-spv-ffi/tests/test_wallet_manager.rs
+++ b/dash-spv-ffi/tests/test_wallet_manager.rs
@@ -63,7 +63,7 @@ mod tests {
                 .create_wallet_from_mnemonic_return_serialized_bytes(
                     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
                     "",
-                    &[Network::Dash],
+                    Network::Dash,
                     None,
                     WalletAccountCreationOptions::Default,
                     false,

--- a/dash-spv/src/main.rs
+++ b/dash-spv/src/main.rs
@@ -292,7 +292,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let wallet_id = wallet_manager.create_wallet_from_mnemonic(
         "enemy check owner stumble unaware debris suffer peanut good fabric bleak outside",
         "",
-        &[network],
+        network,
         None,
         key_wallet::wallet::initialization::WalletAccountCreationOptions::default(),
     )?;
@@ -495,7 +495,7 @@ async fn run_client<S: dash_spv::storage::StorageManager + Send + Sync + 'static
 
                                 // Derive a conservative incoming total by summing tx outputs to our addresses.
                                 let incoming_sum = if let Some(ns) = mgr.get_network_state(network_for_logger) {
-                                    let addrs = mgr.monitored_addresses(network_for_logger);
+                                    let addrs = mgr.monitored_addresses();
                                     let addr_set: std::collections::HashSet<_> = addrs.into_iter().collect();
                                     let mut sum_incoming: u64 = 0;
                                     for rec in ns.transactions.values() {
@@ -615,7 +615,7 @@ async fn run_client<S: dash_spv::storage::StorageManager + Send + Sync + 'static
     // Display current wallet addresses
     {
         let wallet_lock = wallet.read().await;
-        let monitored = wallet_lock.monitored_addresses(config.network);
+        let monitored = wallet_lock.monitored_addresses();
         if !monitored.is_empty() {
             tracing::info!("Wallet monitoring {} addresses:", monitored.len());
             for (i, addr) in monitored.iter().take(10).enumerate() {
@@ -657,7 +657,7 @@ async fn run_client<S: dash_spv::storage::StorageManager + Send + Sync + 'static
     // Check filters for matches if wallet has addresses before starting monitoring
     let should_check_filters = {
         let wallet_lock = wallet.read().await;
-        let monitored = wallet_lock.monitored_addresses(config.network);
+        let monitored = wallet_lock.monitored_addresses();
         !monitored.is_empty() && !matches.get_flag("no-filters")
     };
 

--- a/key-wallet-ffi/FFI_API.md
+++ b/key-wallet-ffi/FFI_API.md
@@ -819,7 +819,7 @@ Get the parent wallet ID of a managed account  Note: ManagedAccount doesn't stor
 #### `managed_wallet_check_transaction`
 
 ```c
-managed_wallet_check_transaction(managed_wallet: *mut FFIManagedWalletInfo, wallet: *mut FFIWallet, network: FFINetwork, tx_bytes: *const u8, tx_len: usize, context_type: FFITransactionContext, block_height: c_uint, block_hash: *const u8, // 32 bytes if not null timestamp: u64, update_state: bool, result_out: *mut FFITransactionCheckResult, error: *mut FFIError,) -> bool
+managed_wallet_check_transaction(managed_wallet: *mut FFIManagedWalletInfo, wallet: *mut FFIWallet, tx_bytes: *const u8, tx_len: usize, context_type: FFITransactionContext, block_height: c_uint, block_hash: *const u8, // 32 bytes if not null timestamp: u64, update_state: bool, result_out: *mut FFITransactionCheckResult, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -851,7 +851,7 @@ Free managed wallet info  # Safety  - `managed_wallet` must be a valid pointer t
 #### `managed_wallet_generate_addresses_to_index`
 
 ```c
-managed_wallet_generate_addresses_to_index(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, network: FFINetwork, account_type: FFIAccountType, account_index: c_uint, pool_type: FFIAddressPoolType, target_index: c_uint, error: *mut FFIError,) -> bool
+managed_wallet_generate_addresses_to_index(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, account_type: FFIAccountType, account_index: c_uint, pool_type: FFIAddressPoolType, target_index: c_uint, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -867,14 +867,14 @@ Generate addresses up to a specific index in a pool  This ensures that addresses
 #### `managed_wallet_get_account`
 
 ```c
-managed_wallet_get_account(manager: *const FFIWalletManager, wallet_id: *const u8, network: FFINetwork, account_index: c_uint, account_type: FFIAccountType,) -> FFIManagedAccountResult
+managed_wallet_get_account(manager: *const FFIWalletManager, wallet_id: *const u8, account_index: c_uint, account_type: FFIAccountType,) -> FFIManagedAccountResult
 ```
 
 **Description:**
-Get a managed account from a managed wallet  This function gets a ManagedAccount from the wallet manager's managed wallet info, returning a managed account handle that wraps the ManagedAccount.  # Safety  - `manager` must be a valid pointer to an FFIWalletManager instance - `wallet_id` must be a valid pointer to a 32-byte wallet ID - `network` must specify exactly one network - The caller must ensure all pointers remain valid for the duration of this call - The returned account must be freed with `managed_account_free` when no longer needed
+Get a managed account from a managed wallet  This function gets a ManagedAccount from the wallet manager's managed wallet info, returning a managed account handle that wraps the ManagedAccount.  # Safety  - `manager` must be a valid pointer to an FFIWalletManager instance - `wallet_id` must be a valid pointer to a 32-byte wallet ID - The caller must ensure all pointers remain valid for the duration of this call - The returned account must be freed with `managed_account_free` when no longer needed
 
 **Safety:**
-- `manager` must be a valid pointer to an FFIWalletManager instance - `wallet_id` must be a valid pointer to a 32-byte wallet ID - `network` must specify exactly one network - The caller must ensure all pointers remain valid for the duration of this call - The returned account must be freed with `managed_account_free` when no longer needed
+- `manager` must be a valid pointer to an FFIWalletManager instance - `wallet_id` must be a valid pointer to a 32-byte wallet ID - The caller must ensure all pointers remain valid for the duration of this call - The returned account must be freed with `managed_account_free` when no longer needed
 
 **Module:** `managed_account`
 
@@ -883,7 +883,7 @@ Get a managed account from a managed wallet  This function gets a ManagedAccount
 #### `managed_wallet_get_account_collection`
 
 ```c
-managed_wallet_get_account_collection(manager: *const FFIWalletManager, wallet_id: *const u8, network: FFINetwork, error: *mut FFIError,) -> *mut FFIManagedAccountCollection
+managed_wallet_get_account_collection(manager: *const FFIWalletManager, wallet_id: *const u8, error: *mut FFIError,) -> *mut FFIManagedAccountCollection
 ```
 
 **Description:**
@@ -899,14 +899,14 @@ Get managed account collection for a specific network from wallet manager  # Saf
 #### `managed_wallet_get_account_count`
 
 ```c
-managed_wallet_get_account_count(manager: *const FFIWalletManager, wallet_id: *const u8, network: FFINetwork, error: *mut FFIError,) -> c_uint
+managed_wallet_get_account_count(manager: *const FFIWalletManager, wallet_id: *const u8, error: *mut FFIError,) -> c_uint
 ```
 
 **Description:**
-Get number of accounts in a managed wallet  # Safety  - `manager` must be a valid pointer to an FFIWalletManager instance - `wallet_id` must be a valid pointer to a 32-byte wallet ID - `network` must specify exactly one network - `error` must be a valid pointer to an FFIError structure or null - The caller must ensure all pointers remain valid for the duration of this call
+Get number of accounts in a managed wallet  # Safety  - `manager` must be a valid pointer to an FFIWalletManager instance - `wallet_id` must be a valid pointer to a 32-byte wallet ID - `error` must be a valid pointer to an FFIError structure or null - The caller must ensure all pointers remain valid for the duration of this call
 
 **Safety:**
-- `manager` must be a valid pointer to an FFIWalletManager instance - `wallet_id` must be a valid pointer to a 32-byte wallet ID - `network` must specify exactly one network - `error` must be a valid pointer to an FFIError structure or null - The caller must ensure all pointers remain valid for the duration of this call
+- `manager` must be a valid pointer to an FFIWalletManager instance - `wallet_id` must be a valid pointer to a 32-byte wallet ID - `error` must be a valid pointer to an FFIError structure or null - The caller must ensure all pointers remain valid for the duration of this call
 
 **Module:** `managed_account`
 
@@ -915,7 +915,7 @@ Get number of accounts in a managed wallet  # Safety  - `manager` must be a vali
 #### `managed_wallet_get_address_pool_info`
 
 ```c
-managed_wallet_get_address_pool_info(managed_wallet: *const FFIManagedWalletInfo, network: FFINetwork, account_type: FFIAccountType, account_index: c_uint, pool_type: FFIAddressPoolType, info_out: *mut FFIAddressPoolInfo, error: *mut FFIError,) -> bool
+managed_wallet_get_address_pool_info(managed_wallet: *const FFIManagedWalletInfo, account_type: FFIAccountType, account_index: c_uint, pool_type: FFIAddressPoolType, info_out: *mut FFIAddressPoolInfo, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -947,7 +947,7 @@ Get wallet balance from managed wallet info  Returns the balance breakdown inclu
 #### `managed_wallet_get_bip_44_external_address_range`
 
 ```c
-managed_wallet_get_bip_44_external_address_range(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, network: FFINetwork, account_index: std::os::raw::c_uint, start_index: std::os::raw::c_uint, end_index: std::os::raw::c_uint, addresses_out: *mut *mut *mut c_char, count_out: *mut usize, error: *mut FFIError,) -> bool
+managed_wallet_get_bip_44_external_address_range(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, account_index: std::os::raw::c_uint, start_index: std::os::raw::c_uint, end_index: std::os::raw::c_uint, addresses_out: *mut *mut *mut c_char, count_out: *mut usize, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -963,7 +963,7 @@ Get BIP44 external (receive) addresses in the specified range  Returns external 
 #### `managed_wallet_get_bip_44_internal_address_range`
 
 ```c
-managed_wallet_get_bip_44_internal_address_range(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, network: FFINetwork, account_index: std::os::raw::c_uint, start_index: std::os::raw::c_uint, end_index: std::os::raw::c_uint, addresses_out: *mut *mut *mut c_char, count_out: *mut usize, error: *mut FFIError,) -> bool
+managed_wallet_get_bip_44_internal_address_range(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, account_index: std::os::raw::c_uint, start_index: std::os::raw::c_uint, end_index: std::os::raw::c_uint, addresses_out: *mut *mut *mut c_char, count_out: *mut usize, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -979,7 +979,7 @@ Get BIP44 internal (change) addresses in the specified range  Returns internal a
 #### `managed_wallet_get_dashpay_external_account`
 
 ```c
-managed_wallet_get_dashpay_external_account(manager: *const FFIWalletManager, wallet_id: *const u8, network: FFINetwork, account_index: c_uint, user_identity_id: *const u8, friend_identity_id: *const u8,) -> FFIManagedAccountResult
+managed_wallet_get_dashpay_external_account(manager: *const FFIWalletManager, wallet_id: *const u8, account_index: c_uint, user_identity_id: *const u8, friend_identity_id: *const u8,) -> FFIManagedAccountResult
 ```
 
 **Description:**
@@ -995,7 +995,7 @@ Get a managed DashPay external account by composite key  # Safety - Pointers mus
 #### `managed_wallet_get_dashpay_receiving_account`
 
 ```c
-managed_wallet_get_dashpay_receiving_account(manager: *const FFIWalletManager, wallet_id: *const u8, network: FFINetwork, account_index: c_uint, user_identity_id: *const u8, friend_identity_id: *const u8,) -> FFIManagedAccountResult
+managed_wallet_get_dashpay_receiving_account(manager: *const FFIWalletManager, wallet_id: *const u8, account_index: c_uint, user_identity_id: *const u8, friend_identity_id: *const u8,) -> FFIManagedAccountResult
 ```
 
 **Description:**
@@ -1011,7 +1011,7 @@ Get a managed DashPay receiving funds account by composite key  # Safety - `mana
 #### `managed_wallet_get_next_bip44_change_address`
 
 ```c
-managed_wallet_get_next_bip44_change_address(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, network: FFINetwork, account_index: std::os::raw::c_uint, error: *mut FFIError,) -> *mut c_char
+managed_wallet_get_next_bip44_change_address(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, account_index: std::os::raw::c_uint, error: *mut FFIError,) -> *mut c_char
 ```
 
 **Description:**
@@ -1027,7 +1027,7 @@ Get the next unused change address  Generates the next unused change address for
 #### `managed_wallet_get_next_bip44_receive_address`
 
 ```c
-managed_wallet_get_next_bip44_receive_address(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, network: FFINetwork, account_index: std::os::raw::c_uint, error: *mut FFIError,) -> *mut c_char
+managed_wallet_get_next_bip44_receive_address(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, account_index: std::os::raw::c_uint, error: *mut FFIError,) -> *mut c_char
 ```
 
 **Description:**
@@ -1043,14 +1043,14 @@ Get the next unused receive address  Generates the next unused receive address f
 #### `managed_wallet_get_top_up_account_with_registration_index`
 
 ```c
-managed_wallet_get_top_up_account_with_registration_index(manager: *const FFIWalletManager, wallet_id: *const u8, network: FFINetwork, registration_index: c_uint,) -> FFIManagedAccountResult
+managed_wallet_get_top_up_account_with_registration_index(manager: *const FFIWalletManager, wallet_id: *const u8, registration_index: c_uint,) -> FFIManagedAccountResult
 ```
 
 **Description:**
-Get a managed IdentityTopUp account with a specific registration index  This is used for top-up accounts that are bound to a specific identity. Returns a managed account handle that wraps the ManagedAccount.  # Safety  - `manager` must be a valid pointer to an FFIWalletManager instance - `wallet_id` must be a valid pointer to a 32-byte wallet ID - `network` must specify exactly one network - The caller must ensure all pointers remain valid for the duration of this call - The returned account must be freed with `managed_account_free` when no longer needed
+Get a managed IdentityTopUp account with a specific registration index  This is used for top-up accounts that are bound to a specific identity. Returns a managed account handle that wraps the ManagedAccount.  # Safety  - `manager` must be a valid pointer to an FFIWalletManager instance - `wallet_id` must be a valid pointer to a 32-byte wallet ID - The caller must ensure all pointers remain valid for the duration of this call - The returned account must be freed with `managed_account_free` when no longer needed
 
 **Safety:**
-- `manager` must be a valid pointer to an FFIWalletManager instance - `wallet_id` must be a valid pointer to a 32-byte wallet ID - `network` must specify exactly one network - The caller must ensure all pointers remain valid for the duration of this call - The returned account must be freed with `managed_account_free` when no longer needed
+- `manager` must be a valid pointer to an FFIWalletManager instance - `wallet_id` must be a valid pointer to a 32-byte wallet ID - The caller must ensure all pointers remain valid for the duration of this call - The returned account must be freed with `managed_account_free` when no longer needed
 
 **Module:** `managed_account`
 
@@ -1059,7 +1059,7 @@ Get a managed IdentityTopUp account with a specific registration index  This is 
 #### `managed_wallet_get_utxos`
 
 ```c
-managed_wallet_get_utxos(managed_info: *const FFIManagedWalletInfo, network: FFINetwork, utxos_out: *mut *mut FFIUTXO, count_out: *mut usize, error: *mut FFIError,) -> bool
+managed_wallet_get_utxos(managed_info: *const FFIManagedWalletInfo, utxos_out: *mut *mut FFIUTXO, count_out: *mut usize, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -1091,7 +1091,7 @@ Free managed wallet info returned by wallet_manager_get_managed_wallet_info  # S
 #### `managed_wallet_mark_address_used`
 
 ```c
-managed_wallet_mark_address_used(managed_wallet: *mut FFIManagedWalletInfo, network: FFINetwork, address: *const c_char, error: *mut FFIError,) -> bool
+managed_wallet_mark_address_used(managed_wallet: *mut FFIManagedWalletInfo, address: *const c_char, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -1107,7 +1107,7 @@ Mark an address as used in the pool  This updates the pool's tracking of which a
 #### `managed_wallet_set_gap_limit`
 
 ```c
-managed_wallet_set_gap_limit(managed_wallet: *mut FFIManagedWalletInfo, network: FFINetwork, account_type: FFIAccountType, account_index: c_uint, pool_type: FFIAddressPoolType, gap_limit: c_uint, error: *mut FFIError,) -> bool
+managed_wallet_set_gap_limit(managed_wallet: *mut FFIManagedWalletInfo, account_type: FFIAccountType, account_index: c_uint, pool_type: FFIAddressPoolType, gap_limit: c_uint, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -1123,7 +1123,7 @@ Set the gap limit for an address pool  The gap limit determines how many unused 
 #### `wallet_add_account`
 
 ```c
-wallet_add_account(wallet: *mut FFIWallet, network: FFINetwork, account_type: crate::types::FFIAccountType, account_index: c_uint,) -> crate::types::FFIAccountResult
+wallet_add_account(wallet: *mut FFIWallet, account_type: crate::types::FFIAccountType, account_index: c_uint,) -> crate::types::FFIAccountResult
 ```
 
 **Description:**
@@ -1139,7 +1139,7 @@ This function dereferences a raw pointer to FFIWallet. The caller must ensure th
 #### `wallet_add_account_with_string_xpub`
 
 ```c
-wallet_add_account_with_string_xpub(wallet: *mut FFIWallet, network: FFINetwork, account_type: crate::types::FFIAccountType, account_index: c_uint, xpub_string: *const c_char,) -> crate::types::FFIAccountResult
+wallet_add_account_with_string_xpub(wallet: *mut FFIWallet, account_type: crate::types::FFIAccountType, account_index: c_uint, xpub_string: *const c_char,) -> crate::types::FFIAccountResult
 ```
 
 **Description:**
@@ -1155,7 +1155,7 @@ This function dereferences raw pointers. The caller must ensure that: - The wall
 #### `wallet_add_account_with_xpub_bytes`
 
 ```c
-wallet_add_account_with_xpub_bytes(wallet: *mut FFIWallet, network: FFINetwork, account_type: crate::types::FFIAccountType, account_index: c_uint, xpub_bytes: *const u8, xpub_len: usize,) -> crate::types::FFIAccountResult
+wallet_add_account_with_xpub_bytes(wallet: *mut FFIWallet, account_type: crate::types::FFIAccountType, account_index: c_uint, xpub_bytes: *const u8, xpub_len: usize,) -> crate::types::FFIAccountResult
 ```
 
 **Description:**
@@ -1171,7 +1171,7 @@ This function dereferences raw pointers. The caller must ensure that: - The wall
 #### `wallet_add_dashpay_external_account_with_xpub_bytes`
 
 ```c
-wallet_add_dashpay_external_account_with_xpub_bytes(wallet: *mut FFIWallet, network: FFINetwork, account_index: c_uint, user_identity_id: *const u8, friend_identity_id: *const u8, xpub_bytes: *const u8, xpub_len: usize,) -> FFIAccountResult
+wallet_add_dashpay_external_account_with_xpub_bytes(wallet: *mut FFIWallet, account_index: c_uint, user_identity_id: *const u8, friend_identity_id: *const u8, xpub_bytes: *const u8, xpub_len: usize,) -> FFIAccountResult
 ```
 
 **Description:**
@@ -1187,7 +1187,7 @@ Add a DashPay external (watch-only) account with xpub bytes  # Safety - `wallet`
 #### `wallet_add_dashpay_receiving_account`
 
 ```c
-wallet_add_dashpay_receiving_account(wallet: *mut FFIWallet, network: FFINetwork, account_index: c_uint, user_identity_id: *const u8, friend_identity_id: *const u8,) -> FFIAccountResult
+wallet_add_dashpay_receiving_account(wallet: *mut FFIWallet, account_index: c_uint, user_identity_id: *const u8, friend_identity_id: *const u8,) -> FFIAccountResult
 ```
 
 **Description:**
@@ -1203,14 +1203,14 @@ Add a DashPay receiving funds account  # Safety - `wallet` must be a valid point
 #### `wallet_build_and_sign_transaction`
 
 ```c
-wallet_build_and_sign_transaction(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, network: FFINetwork, account_index: c_uint, outputs: *const FFITxOutput, outputs_count: usize, fee_per_kb: u64, current_height: u32, tx_bytes_out: *mut *mut u8, tx_len_out: *mut usize, error: *mut FFIError,) -> bool
+wallet_build_and_sign_transaction(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, account_index: c_uint, outputs: *const FFITxOutput, outputs_count: usize, fee_per_kb: u64, current_height: u32, tx_bytes_out: *mut *mut u8, tx_len_out: *mut usize, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
-Build and sign a transaction using the wallet's managed info  This is the recommended way to build transactions. It handles: - UTXO selection using coin selection algorithms - Fee calculation - Change address generation - Transaction signing  # Safety  - `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo - `wallet` must be a valid pointer to an FFIWallet - `network` must be a valid FFINetwork - `outputs` must be a valid pointer to an array of FFITxOutput with at least `outputs_count` elements - `tx_bytes_out` must be a valid pointer to store the transaction bytes pointer - `tx_len_out` must be a valid pointer to store the transaction length - `error` must be a valid pointer to an FFIError - The returned transaction bytes must be freed with `transaction_bytes_free`
+Build and sign a transaction using the wallet's managed info  This is the recommended way to build transactions. It handles: - UTXO selection using coin selection algorithms - Fee calculation - Change address generation - Transaction signing  # Safety  - `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo - `wallet` must be a valid pointer to an FFIWallet - `outputs` must be a valid pointer to an array of FFITxOutput with at least `outputs_count` elements - `tx_bytes_out` must be a valid pointer to store the transaction bytes pointer - `tx_len_out` must be a valid pointer to store the transaction length - `error` must be a valid pointer to an FFIError - The returned transaction bytes must be freed with `transaction_bytes_free`
 
 **Safety:**
-- `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo - `wallet` must be a valid pointer to an FFIWallet - `network` must be a valid FFINetwork - `outputs` must be a valid pointer to an array of FFITxOutput with at least `outputs_count` elements - `tx_bytes_out` must be a valid pointer to store the transaction bytes pointer - `tx_len_out` must be a valid pointer to store the transaction length - `error` must be a valid pointer to an FFIError - The returned transaction bytes must be freed with `transaction_bytes_free`
+- `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo - `wallet` must be a valid pointer to an FFIWallet - `outputs` must be a valid pointer to an array of FFITxOutput with at least `outputs_count` elements - `tx_bytes_out` must be a valid pointer to store the transaction bytes pointer - `tx_len_out` must be a valid pointer to store the transaction length - `error` must be a valid pointer to an FFIError - The returned transaction bytes must be freed with `transaction_bytes_free`
 
 **Module:** `transaction`
 
@@ -1235,7 +1235,7 @@ Build a transaction (unsigned)  This creates an unsigned transaction. Use wallet
 #### `wallet_check_transaction`
 
 ```c
-wallet_check_transaction(wallet: *mut FFIWallet, network: FFINetwork, tx_bytes: *const u8, tx_len: usize, context_type: FFITransactionContext, block_height: u32, block_hash: *const u8, // 32 bytes if not null timestamp: u64, update_state: bool, result_out: *mut FFITransactionCheckResult, error: *mut FFIError,) -> bool
+wallet_check_transaction(wallet: *mut FFIWallet, tx_bytes: *const u8, tx_len: usize, context_type: FFITransactionContext, block_height: u32, block_hash: *const u8, // 32 bytes if not null timestamp: u64, update_state: bool, result_out: *mut FFITransactionCheckResult, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -1363,7 +1363,7 @@ Create a new random wallet with options  # Safety  - `account_options` must be a
 #### `wallet_derive_extended_private_key`
 
 ```c
-wallet_derive_extended_private_key(wallet: *const FFIWallet, network: FFINetwork, derivation_path: *const c_char, error: *mut FFIError,) -> *mut FFIExtendedPrivateKey
+wallet_derive_extended_private_key(wallet: *const FFIWallet, derivation_path: *const c_char, error: *mut FFIError,) -> *mut FFIExtendedPrivateKey
 ```
 
 **Description:**
@@ -1379,7 +1379,7 @@ Derive extended private key at a specific path Returns an opaque FFIExtendedPriv
 #### `wallet_derive_extended_public_key`
 
 ```c
-wallet_derive_extended_public_key(wallet: *const FFIWallet, network: FFINetwork, derivation_path: *const c_char, error: *mut FFIError,) -> *mut FFIExtendedPublicKey
+wallet_derive_extended_public_key(wallet: *const FFIWallet, derivation_path: *const c_char, error: *mut FFIError,) -> *mut FFIExtendedPublicKey
 ```
 
 **Description:**
@@ -1395,7 +1395,7 @@ Derive extended public key at a specific path Returns an opaque FFIExtendedPubli
 #### `wallet_derive_private_key`
 
 ```c
-wallet_derive_private_key(wallet: *const FFIWallet, network: FFINetwork, derivation_path: *const c_char, error: *mut FFIError,) -> *mut FFIPrivateKey
+wallet_derive_private_key(wallet: *const FFIWallet, derivation_path: *const c_char, error: *mut FFIError,) -> *mut FFIPrivateKey
 ```
 
 **Description:**
@@ -1411,7 +1411,7 @@ Derive private key at a specific path Returns an opaque FFIPrivateKey pointer th
 #### `wallet_derive_private_key_as_wif`
 
 ```c
-wallet_derive_private_key_as_wif(wallet: *const FFIWallet, network: FFINetwork, derivation_path: *const c_char, error: *mut FFIError,) -> *mut c_char
+wallet_derive_private_key_as_wif(wallet: *const FFIWallet, derivation_path: *const c_char, error: *mut FFIError,) -> *mut c_char
 ```
 
 **Description:**
@@ -1427,7 +1427,7 @@ Derive private key at a specific path and return as WIF string  # Safety  - `wal
 #### `wallet_derive_public_key`
 
 ```c
-wallet_derive_public_key(wallet: *const FFIWallet, network: FFINetwork, derivation_path: *const c_char, error: *mut FFIError,) -> *mut FFIPublicKey
+wallet_derive_public_key(wallet: *const FFIWallet, derivation_path: *const c_char, error: *mut FFIError,) -> *mut FFIPublicKey
 ```
 
 **Description:**
@@ -1443,7 +1443,7 @@ Derive public key at a specific path Returns an opaque FFIPublicKey pointer that
 #### `wallet_derive_public_key_as_hex`
 
 ```c
-wallet_derive_public_key_as_hex(wallet: *const FFIWallet, network: FFINetwork, derivation_path: *const c_char, error: *mut FFIError,) -> *mut c_char
+wallet_derive_public_key_as_hex(wallet: *const FFIWallet, derivation_path: *const c_char, error: *mut FFIError,) -> *mut c_char
 ```
 
 **Description:**
@@ -1491,7 +1491,7 @@ Free a const wallet handle  This is a const-safe wrapper for wallet_free() that 
 #### `wallet_get_account`
 
 ```c
-wallet_get_account(wallet: *const FFIWallet, network: FFINetwork, account_index: c_uint, account_type: FFIAccountType,) -> FFIAccountResult
+wallet_get_account(wallet: *const FFIWallet, account_index: c_uint, account_type: FFIAccountType,) -> FFIAccountResult
 ```
 
 **Description:**
@@ -1507,7 +1507,7 @@ Get an account handle for a specific account type Returns a result containing ei
 #### `wallet_get_account_collection`
 
 ```c
-wallet_get_account_collection(wallet: *const FFIWallet, network: FFINetwork, error: *mut FFIError,) -> *mut FFIAccountCollection
+wallet_get_account_collection(wallet: *const FFIWallet, error: *mut FFIError,) -> *mut FFIAccountCollection
 ```
 
 **Description:**
@@ -1523,7 +1523,7 @@ Get account collection for a specific network from wallet  # Safety  - `wallet` 
 #### `wallet_get_account_count`
 
 ```c
-wallet_get_account_count(wallet: *const FFIWallet, network: FFINetwork, error: *mut FFIError,) -> c_uint
+wallet_get_account_count(wallet: *const FFIWallet, error: *mut FFIError,) -> c_uint
 ```
 
 **Description:**
@@ -1539,7 +1539,7 @@ Get number of accounts  # Safety  - `wallet` must be a valid pointer to an FFIWa
 #### `wallet_get_account_xpriv`
 
 ```c
-wallet_get_account_xpriv(wallet: *const FFIWallet, network: FFINetwork, account_index: c_uint, error: *mut FFIError,) -> *mut c_char
+wallet_get_account_xpriv(wallet: *const FFIWallet, account_index: c_uint, error: *mut FFIError,) -> *mut c_char
 ```
 
 **Description:**
@@ -1555,7 +1555,7 @@ Get extended private key for account  # Safety  - `wallet` must be a valid point
 #### `wallet_get_account_xpub`
 
 ```c
-wallet_get_account_xpub(wallet: *const FFIWallet, network: FFINetwork, account_index: c_uint, error: *mut FFIError,) -> *mut c_char
+wallet_get_account_xpub(wallet: *const FFIWallet, account_index: c_uint, error: *mut FFIError,) -> *mut c_char
 ```
 
 **Description:**
@@ -1587,7 +1587,7 @@ Get wallet ID (32-byte hash)  # Safety  - `wallet` must be a valid pointer to an
 #### `wallet_get_top_up_account_with_registration_index`
 
 ```c
-wallet_get_top_up_account_with_registration_index(wallet: *const FFIWallet, network: FFINetwork, registration_index: c_uint,) -> FFIAccountResult
+wallet_get_top_up_account_with_registration_index(wallet: *const FFIWallet, registration_index: c_uint,) -> FFIAccountResult
 ```
 
 **Description:**
@@ -1619,7 +1619,7 @@ This function is deprecated and returns an empty list. Use `managed_wallet_get_u
 #### `wallet_get_xpub`
 
 ```c
-wallet_get_xpub(wallet: *const FFIWallet, network: FFINetwork, account_index: c_uint, error: *mut FFIError,) -> *mut c_char
+wallet_get_xpub(wallet: *const FFIWallet, account_index: c_uint, error: *mut FFIError,) -> *mut c_char
 ```
 
 **Description:**

--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -25,16 +25,6 @@
 #include <stdbool.h>
 
 /*
- FFI Network type (single network)
- */
-typedef enum {
-    DASH = 0,
-    TESTNET = 1,
-    REGTEST = 2,
-    DEVNET = 3,
-} FFINetwork;
-
-/*
  Account type enumeration matching all key_wallet AccountType variants
 
  This enum provides a complete FFI representation of all account types
@@ -128,6 +118,16 @@ typedef enum {
     INVALID_STATE = 11,
     INTERNAL_ERROR = 12,
 } FFIErrorCode;
+
+/*
+ FFI Network type (single network)
+ */
+typedef enum {
+    DASH = 0,
+    TESTNET = 1,
+    REGTEST = 2,
+    DEVNET = 3,
+} FFINetwork;
 
 /*
  Address pool type
@@ -816,7 +816,6 @@ extern "C" {
  */
 
 FFIAccountResult wallet_get_account(const FFIWallet *wallet,
-                                    FFINetwork network,
                                     unsigned int account_index,
                                     FFIAccountType account_type)
 ;
@@ -833,7 +832,6 @@ FFIAccountResult wallet_get_account(const FFIWallet *wallet,
  */
 
 FFIAccountResult wallet_get_top_up_account_with_registration_index(const FFIWallet *wallet,
-                                                                   FFINetwork network,
                                                                    unsigned int registration_index)
 ;
 
@@ -1059,11 +1057,7 @@ FFIAccountType eddsa_account_get_account_type(const FFIEdDSAAccount *account,
  - `error` must be a valid pointer to an FFIError structure or null
  - The caller must ensure both pointers remain valid for the duration of this call
  */
-
-unsigned int wallet_get_account_count(const FFIWallet *wallet,
-                                      FFINetwork network,
-                                      FFIError *error)
-;
+ unsigned int wallet_get_account_count(const FFIWallet *wallet, FFIError *error) ;
 
 /*
  Get account collection for a specific network from wallet
@@ -1074,11 +1068,7 @@ unsigned int wallet_get_account_count(const FFIWallet *wallet,
  - `error` must be a valid pointer to an FFIError structure or null
  - The returned pointer must be freed with `account_collection_free` when no longer needed
  */
-
-FFIAccountCollection *wallet_get_account_collection(const FFIWallet *wallet,
-                                                    FFINetwork network,
-                                                    FFIError *error)
-;
+ FFIAccountCollection *wallet_get_account_collection(const FFIWallet *wallet, FFIError *error) ;
 
 /*
  Free an account collection handle
@@ -1697,7 +1687,6 @@ FFIPrivateKey *account_derive_private_key_from_mnemonic(const FFIAccount *accoun
  */
 
 bool managed_wallet_get_address_pool_info(const FFIManagedWalletInfo *managed_wallet,
-                                          FFINetwork network,
                                           FFIAccountType account_type,
                                           unsigned int account_index,
                                           FFIAddressPoolType pool_type,
@@ -1718,7 +1707,6 @@ bool managed_wallet_get_address_pool_info(const FFIManagedWalletInfo *managed_wa
  */
 
 bool managed_wallet_set_gap_limit(FFIManagedWalletInfo *managed_wallet,
-                                  FFINetwork network,
                                   FFIAccountType account_type,
                                   unsigned int account_index,
                                   FFIAddressPoolType pool_type,
@@ -1742,7 +1730,6 @@ bool managed_wallet_set_gap_limit(FFIManagedWalletInfo *managed_wallet,
 
 bool managed_wallet_generate_addresses_to_index(FFIManagedWalletInfo *managed_wallet,
                                                 const FFIWallet *wallet,
-                                                FFINetwork network,
                                                 FFIAccountType account_type,
                                                 unsigned int account_index,
                                                 FFIAddressPoolType pool_type,
@@ -1764,7 +1751,6 @@ bool managed_wallet_generate_addresses_to_index(FFIManagedWalletInfo *managed_wa
  */
 
 bool managed_wallet_mark_address_used(FFIManagedWalletInfo *managed_wallet,
-                                      FFINetwork network,
                                       const char *address,
                                       FFIError *error)
 ;
@@ -2091,7 +2077,6 @@ int32_t key_wallet_derive_private_key_from_seed(const uint8_t *seed,
  */
 
 char *wallet_get_account_xpriv(const FFIWallet *wallet,
-                               FFINetwork network,
                                unsigned int account_index,
                                FFIError *error)
 ;
@@ -2107,7 +2092,6 @@ char *wallet_get_account_xpriv(const FFIWallet *wallet,
  */
 
 char *wallet_get_account_xpub(const FFIWallet *wallet,
-                              FFINetwork network,
                               unsigned int account_index,
                               FFIError *error)
 ;
@@ -2125,7 +2109,6 @@ char *wallet_get_account_xpub(const FFIWallet *wallet,
  */
 
 FFIPrivateKey *wallet_derive_private_key(const FFIWallet *wallet,
-                                         FFINetwork network,
                                          const char *derivation_path,
                                          FFIError *error)
 ;
@@ -2143,7 +2126,6 @@ FFIPrivateKey *wallet_derive_private_key(const FFIWallet *wallet,
  */
 
 FFIExtendedPrivateKey *wallet_derive_extended_private_key(const FFIWallet *wallet,
-                                                          FFINetwork network,
                                                           const char *derivation_path,
                                                           FFIError *error)
 ;
@@ -2160,7 +2142,6 @@ FFIExtendedPrivateKey *wallet_derive_extended_private_key(const FFIWallet *walle
  */
 
 char *wallet_derive_private_key_as_wif(const FFIWallet *wallet,
-                                       FFINetwork network,
                                        const char *derivation_path,
                                        FFIError *error)
 ;
@@ -2243,7 +2224,6 @@ FFIPrivateKey *extended_private_key_get_private_key(const FFIExtendedPrivateKey 
  */
 
 FFIPublicKey *wallet_derive_public_key(const FFIWallet *wallet,
-                                       FFINetwork network,
                                        const char *derivation_path,
                                        FFIError *error)
 ;
@@ -2261,7 +2241,6 @@ FFIPublicKey *wallet_derive_public_key(const FFIWallet *wallet,
  */
 
 FFIExtendedPublicKey *wallet_derive_extended_public_key(const FFIWallet *wallet,
-                                                        FFINetwork network,
                                                         const char *derivation_path,
                                                         FFIError *error)
 ;
@@ -2278,7 +2257,6 @@ FFIExtendedPublicKey *wallet_derive_extended_public_key(const FFIWallet *wallet,
  */
 
 char *wallet_derive_public_key_as_hex(const FFIWallet *wallet,
-                                      FFINetwork network,
                                       const char *derivation_path,
                                       FFIError *error)
 ;
@@ -2391,14 +2369,12 @@ bool derivation_path_parse(const char *path,
 
  - `manager` must be a valid pointer to an FFIWalletManager instance
  - `wallet_id` must be a valid pointer to a 32-byte wallet ID
- - `network` must specify exactly one network
  - The caller must ensure all pointers remain valid for the duration of this call
  - The returned account must be freed with `managed_account_free` when no longer needed
  */
 
 FFIManagedAccountResult managed_wallet_get_account(const FFIWalletManager *manager,
                                                    const uint8_t *wallet_id,
-                                                   FFINetwork network,
                                                    unsigned int account_index,
                                                    FFIAccountType account_type)
 ;
@@ -2413,14 +2389,12 @@ FFIManagedAccountResult managed_wallet_get_account(const FFIWalletManager *manag
 
  - `manager` must be a valid pointer to an FFIWalletManager instance
  - `wallet_id` must be a valid pointer to a 32-byte wallet ID
- - `network` must specify exactly one network
  - The caller must ensure all pointers remain valid for the duration of this call
  - The returned account must be freed with `managed_account_free` when no longer needed
  */
 
 FFIManagedAccountResult managed_wallet_get_top_up_account_with_registration_index(const FFIWalletManager *manager,
                                                                                   const uint8_t *wallet_id,
-                                                                                  FFINetwork network,
                                                                                   unsigned int registration_index)
 ;
 
@@ -2434,7 +2408,6 @@ FFIManagedAccountResult managed_wallet_get_top_up_account_with_registration_inde
 
 FFIManagedAccountResult managed_wallet_get_dashpay_receiving_account(const FFIWalletManager *manager,
                                                                      const uint8_t *wallet_id,
-                                                                     FFINetwork network,
                                                                      unsigned int account_index,
                                                                      const uint8_t *user_identity_id,
                                                                      const uint8_t *friend_identity_id)
@@ -2449,7 +2422,6 @@ FFIManagedAccountResult managed_wallet_get_dashpay_receiving_account(const FFIWa
 
 FFIManagedAccountResult managed_wallet_get_dashpay_external_account(const FFIWalletManager *manager,
                                                                     const uint8_t *wallet_id,
-                                                                    FFINetwork network,
                                                                     unsigned int account_index,
                                                                     const uint8_t *user_identity_id,
                                                                     const uint8_t *friend_identity_id)
@@ -2589,14 +2561,12 @@ bool managed_account_get_transactions(const FFIManagedAccount *account,
 
  - `manager` must be a valid pointer to an FFIWalletManager instance
  - `wallet_id` must be a valid pointer to a 32-byte wallet ID
- - `network` must specify exactly one network
  - `error` must be a valid pointer to an FFIError structure or null
  - The caller must ensure all pointers remain valid for the duration of this call
  */
 
 unsigned int managed_wallet_get_account_count(const FFIWalletManager *manager,
                                               const uint8_t *wallet_id,
-                                              FFINetwork network,
                                               FFIError *error)
 ;
 
@@ -2670,7 +2640,6 @@ FFIAddressPool *managed_account_get_address_pool(const FFIManagedAccount *accoun
 
 FFIManagedAccountCollection *managed_wallet_get_account_collection(const FFIWalletManager *manager,
                                                                    const uint8_t *wallet_id,
-                                                                   FFINetwork network,
                                                                    FFIError *error)
 ;
 
@@ -3032,7 +3001,6 @@ void managed_account_collection_summary_free(FFIManagedAccountCollectionSummary 
 
 char *managed_wallet_get_next_bip44_receive_address(FFIManagedWalletInfo *managed_wallet,
                                                     const FFIWallet *wallet,
-                                                    FFINetwork network,
                                                     unsigned int account_index,
                                                     FFIError *error)
 ;
@@ -3053,7 +3021,6 @@ char *managed_wallet_get_next_bip44_receive_address(FFIManagedWalletInfo *manage
 
 char *managed_wallet_get_next_bip44_change_address(FFIManagedWalletInfo *managed_wallet,
                                                    const FFIWallet *wallet,
-                                                   FFINetwork network,
                                                    unsigned int account_index,
                                                    FFIError *error)
 ;
@@ -3076,7 +3043,6 @@ char *managed_wallet_get_next_bip44_change_address(FFIManagedWalletInfo *managed
 
 bool managed_wallet_get_bip_44_external_address_range(FFIManagedWalletInfo *managed_wallet,
                                                       const FFIWallet *wallet,
-                                                      FFINetwork network,
                                                       unsigned int account_index,
                                                       unsigned int start_index,
                                                       unsigned int end_index,
@@ -3103,7 +3069,6 @@ bool managed_wallet_get_bip_44_external_address_range(FFIManagedWalletInfo *mana
 
 bool managed_wallet_get_bip_44_internal_address_range(FFIManagedWalletInfo *managed_wallet,
                                                       const FFIWallet *wallet,
-                                                      FFINetwork network,
                                                       unsigned int account_index,
                                                       unsigned int start_index,
                                                       unsigned int end_index,
@@ -3280,7 +3245,6 @@ bool wallet_sign_transaction(const FFIWallet *wallet,
 
  - `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo
  - `wallet` must be a valid pointer to an FFIWallet
- - `network` must be a valid FFINetwork
  - `outputs` must be a valid pointer to an array of FFITxOutput with at least `outputs_count` elements
  - `tx_bytes_out` must be a valid pointer to store the transaction bytes pointer
  - `tx_len_out` must be a valid pointer to store the transaction length
@@ -3290,7 +3254,6 @@ bool wallet_sign_transaction(const FFIWallet *wallet,
 
 bool wallet_build_and_sign_transaction(FFIManagedWalletInfo *managed_wallet,
                                        const FFIWallet *wallet,
-                                       FFINetwork network,
                                        unsigned int account_index,
                                        const FFITxOutput *outputs,
                                        size_t outputs_count,
@@ -3317,7 +3280,6 @@ bool wallet_build_and_sign_transaction(FFIManagedWalletInfo *managed_wallet,
  */
 
 bool wallet_check_transaction(FFIWallet *wallet,
-                              FFINetwork network,
                               const uint8_t *tx_bytes,
                               size_t tx_len,
                               FFITransactionContext context_type,
@@ -3541,7 +3503,6 @@ FFIManagedWalletInfo *wallet_create_managed_wallet(const FFIWallet *wallet,
 
 bool managed_wallet_check_transaction(FFIManagedWalletInfo *managed_wallet,
                                       FFIWallet *wallet,
-                                      FFINetwork network,
                                       const uint8_t *tx_bytes,
                                       size_t tx_len,
                                       FFITransactionContext context_type,
@@ -3613,7 +3574,6 @@ bool managed_wallet_check_transaction(FFIManagedWalletInfo *managed_wallet,
  */
 
 bool managed_wallet_get_utxos(const FFIManagedWalletInfo *managed_info,
-                              FFINetwork network,
                               FFIUTXO **utxos_out,
                               size_t *count_out,
                               FFIError *error)
@@ -3788,12 +3748,7 @@ FFIWallet *wallet_create_random_with_options(FFINetworks networks,
  - The caller must ensure all pointers remain valid for the duration of this call
  - The returned C string must be freed by the caller when no longer needed
  */
-
-char *wallet_get_xpub(const FFIWallet *wallet,
-                      FFINetwork network,
-                      unsigned int account_index,
-                      FFIError *error)
-;
+ char *wallet_get_xpub(const FFIWallet *wallet, unsigned int account_index, FFIError *error) ;
 
 /*
  Free a wallet
@@ -3834,7 +3789,6 @@ char *wallet_get_xpub(const FFIWallet *wallet,
  */
 
 FFIAccountResult wallet_add_account(FFIWallet *wallet,
-                                    FFINetwork network,
                                     FFIAccountType account_type,
                                     unsigned int account_index)
 ;
@@ -3848,7 +3802,6 @@ FFIAccountResult wallet_add_account(FFIWallet *wallet,
  */
 
 FFIAccountResult wallet_add_dashpay_receiving_account(FFIWallet *wallet,
-                                                      FFINetwork network,
                                                       unsigned int account_index,
                                                       const uint8_t *user_identity_id,
                                                       const uint8_t *friend_identity_id)
@@ -3863,7 +3816,6 @@ FFIAccountResult wallet_add_dashpay_receiving_account(FFIWallet *wallet,
  */
 
 FFIAccountResult wallet_add_dashpay_external_account_with_xpub_bytes(FFIWallet *wallet,
-                                                                     FFINetwork network,
                                                                      unsigned int account_index,
                                                                      const uint8_t *user_identity_id,
                                                                      const uint8_t *friend_identity_id,
@@ -3884,7 +3836,6 @@ FFIAccountResult wallet_add_dashpay_external_account_with_xpub_bytes(FFIWallet *
  */
 
 FFIAccountResult wallet_add_account_with_xpub_bytes(FFIWallet *wallet,
-                                                    FFINetwork network,
                                                     FFIAccountType account_type,
                                                     unsigned int account_index,
                                                     const uint8_t *xpub_bytes,
@@ -3904,7 +3855,6 @@ FFIAccountResult wallet_add_account_with_xpub_bytes(FFIWallet *wallet,
  */
 
 FFIAccountResult wallet_add_account_with_string_xpub(FFIWallet *wallet,
-                                                     FFINetwork network,
                                                      FFIAccountType account_type,
                                                      unsigned int account_index,
                                                      const char *xpub_string)

--- a/key-wallet-ffi/src/account.rs
+++ b/key-wallet-ffi/src/account.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_uint;
 use std::sync::Arc;
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFIAccountResult, FFIAccountType, FFINetwork, FFINetworks, FFIWallet};
+use crate::types::{FFIAccountResult, FFIAccountType, FFINetworks, FFIWallet};
 #[cfg(feature = "bls")]
 use key_wallet::account::BLSAccount;
 #[cfg(feature = "eddsa")]
@@ -81,7 +81,6 @@ impl FFIEdDSAAccount {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_account(
     wallet: *const FFIWallet,
-    network: FFINetwork,
     account_index: c_uint,
     account_type: FFIAccountType,
 ) -> FFIAccountResult {
@@ -90,15 +89,9 @@ pub unsafe extern "C" fn wallet_get_account(
     }
 
     let wallet = &*wallet;
-    let network_rust: key_wallet::Network = network.into();
-
     let account_type_rust = account_type.to_account_type(account_index);
 
-    match wallet
-        .inner()
-        .accounts_on_network(network_rust)
-        .and_then(|account_collection| account_collection.account_of_type(account_type_rust))
-    {
+    match wallet.inner().accounts.account_of_type(account_type_rust) {
         Some(account) => {
             let ffi_account = FFIAccount::new(account);
             FFIAccountResult::success(Box::into_raw(Box::new(ffi_account)))
@@ -118,7 +111,6 @@ pub unsafe extern "C" fn wallet_get_account(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_top_up_account_with_registration_index(
     wallet: *const FFIWallet,
-    network: FFINetwork,
     registration_index: c_uint,
 ) -> FFIAccountResult {
     if wallet.is_null() {
@@ -126,18 +118,13 @@ pub unsafe extern "C" fn wallet_get_top_up_account_with_registration_index(
     }
 
     let wallet = &*wallet;
-    let network_rust: key_wallet::Network = network.into();
 
     // This function is specifically for IdentityTopUp accounts
     let account_type = key_wallet::AccountType::IdentityTopUp {
         registration_index,
     };
 
-    match wallet
-        .inner()
-        .accounts_on_network(network_rust)
-        .and_then(|account_collection| account_collection.account_of_type(account_type))
-    {
+    match wallet.inner().accounts.account_of_type(account_type) {
         Some(account) => {
             let ffi_account = FFIAccount::new(account);
             FFIAccountResult::success(Box::into_raw(Box::new(ffi_account)))
@@ -565,7 +552,6 @@ pub unsafe extern "C" fn eddsa_account_get_is_watch_only(account: *const FFIEdDS
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_account_count(
     wallet: *const FFIWallet,
-    network: FFINetwork,
     error: *mut FFIError,
 ) -> c_uint {
     if wallet.is_null() {
@@ -574,23 +560,14 @@ pub unsafe extern "C" fn wallet_get_account_count(
     }
 
     let wallet = &*wallet;
-    let network: key_wallet::Network = network.into();
-
-    match wallet.inner().accounts.get(&network) {
-        Some(accounts) => {
-            FFIError::set_success(error);
-            let count = accounts.standard_bip44_accounts.len()
-                + accounts.standard_bip32_accounts.len()
-                + accounts.coinjoin_accounts.len()
-                + accounts.identity_registration.is_some() as usize
-                + accounts.identity_topup.len();
-            count as c_uint
-        }
-        None => {
-            FFIError::set_success(error);
-            0
-        }
-    }
+    let accounts = &wallet.inner().accounts;
+    FFIError::set_success(error);
+    let count = accounts.standard_bip44_accounts.len()
+        + accounts.standard_bip32_accounts.len()
+        + accounts.coinjoin_accounts.len()
+        + accounts.identity_registration.is_some() as usize
+        + accounts.identity_topup.len();
+    count as c_uint
 }
 
 #[cfg(test)]

--- a/key-wallet-ffi/src/account_collection.rs
+++ b/key-wallet-ffi/src/account_collection.rs
@@ -10,7 +10,6 @@ use std::ptr;
 use crate::account::FFIAccount;
 use crate::error::{FFIError, FFIErrorCode};
 use crate::types::FFIWallet;
-use crate::FFINetwork;
 
 /// Opaque handle to an account collection
 pub struct FFIAccountCollection {
@@ -84,7 +83,6 @@ pub struct FFIAccountCollectionSummary {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_account_collection(
     wallet: *const FFIWallet,
-    network: FFINetwork,
     error: *mut FFIError,
 ) -> *mut FFIAccountCollection {
     if wallet.is_null() {
@@ -93,26 +91,9 @@ pub unsafe extern "C" fn wallet_get_account_collection(
     }
 
     let wallet = &*wallet;
-    let network_rust: key_wallet::Network = network.into();
-
-    match wallet.inner().accounts_on_network(network_rust) {
-        Some(collection) => {
-            let ffi_collection = FFIAccountCollection::new(collection);
-            Box::into_raw(Box::new(ffi_collection))
-        }
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::NotFound,
-                format!(
-                    "No accounts found for network {:?}, wallet has networks {:?}",
-                    network_rust,
-                    wallet.inner().networks_supported()
-                ),
-            );
-            ptr::null_mut()
-        }
-    }
+    FFIError::set_success(error);
+    let ffi_collection = FFIAccountCollection::new(&wallet.inner().accounts);
+    Box::into_raw(Box::new(ffi_collection))
 }
 
 /// Free an account collection handle
@@ -1100,8 +1081,7 @@ mod tests {
             assert!(!wallet.is_null());
 
             // Get account collection
-            let collection =
-                wallet_get_account_collection(wallet, FFINetwork::Testnet, ptr::null_mut());
+            let collection = wallet_get_account_collection(wallet, ptr::null_mut());
             assert!(!collection.is_null());
 
             // Check that we have some accounts
@@ -1155,8 +1135,7 @@ mod tests {
             assert!(!wallet.is_null());
 
             // Get account collection
-            let collection =
-                wallet_get_account_collection(wallet, FFINetwork::Testnet, ptr::null_mut());
+            let collection = wallet_get_account_collection(wallet, ptr::null_mut());
             assert!(!collection.is_null());
 
             // Check for provider operator keys account (BLS)
@@ -1202,8 +1181,7 @@ mod tests {
             assert!(!wallet.is_null());
 
             // Get account collection
-            let collection =
-                wallet_get_account_collection(wallet, FFINetwork::Testnet, ptr::null_mut());
+            let collection = wallet_get_account_collection(wallet, ptr::null_mut());
             assert!(!collection.is_null());
 
             // Check for provider platform keys account (EdDSA)
@@ -1273,8 +1251,7 @@ mod tests {
             assert!(!wallet.is_null());
 
             // Get account collection
-            let collection =
-                wallet_get_account_collection(wallet, FFINetwork::Testnet, ptr::null_mut());
+            let collection = wallet_get_account_collection(wallet, ptr::null_mut());
             assert!(!collection.is_null());
 
             // Get the summary
@@ -1326,8 +1303,7 @@ mod tests {
             assert!(!wallet.is_null());
 
             // Get account collection
-            let collection =
-                wallet_get_account_collection(wallet, FFINetwork::Testnet, ptr::null_mut());
+            let collection = wallet_get_account_collection(wallet, ptr::null_mut());
 
             // With SpecificAccounts and empty lists, collection might be null or empty
             if collection.is_null() {
@@ -1411,8 +1387,7 @@ mod tests {
             assert!(!wallet.is_null());
 
             // Get account collection
-            let collection =
-                wallet_get_account_collection(wallet, FFINetwork::Testnet, ptr::null_mut());
+            let collection = wallet_get_account_collection(wallet, ptr::null_mut());
             assert!(!collection.is_null());
 
             // Get the summary data
@@ -1498,8 +1473,7 @@ mod tests {
             assert!(!wallet.is_null());
 
             // Get account collection
-            let collection =
-                wallet_get_account_collection(wallet, FFINetwork::Testnet, ptr::null_mut());
+            let collection = wallet_get_account_collection(wallet, ptr::null_mut());
 
             // With AllAccounts but empty lists, collection should still exist
             if collection.is_null() {
@@ -1569,8 +1543,7 @@ mod tests {
             assert!(!wallet.is_null());
 
             // Get account collection
-            let collection =
-                wallet_get_account_collection(wallet, FFINetwork::Testnet, ptr::null_mut());
+            let collection = wallet_get_account_collection(wallet, ptr::null_mut());
             assert!(!collection.is_null());
 
             // Get multiple summaries to test memory management

--- a/key-wallet-ffi/src/account_tests.rs
+++ b/key-wallet-ffi/src/account_tests.rs
@@ -10,9 +10,7 @@ mod tests {
 
     #[test]
     fn test_wallet_get_account_null_wallet() {
-        let result = unsafe {
-            wallet_get_account(ptr::null(), FFINetwork::Testnet, 0, FFIAccountType::StandardBIP44)
-        };
+        let result = unsafe { wallet_get_account(ptr::null(), 0, FFIAccountType::StandardBIP44) };
 
         assert!(result.account.is_null());
         assert_ne!(result.error_code, 0);
@@ -44,9 +42,7 @@ mod tests {
         };
 
         // Try to get the default account (should exist)
-        let result = unsafe {
-            wallet_get_account(wallet, FFINetwork::Testnet, 0, FFIAccountType::StandardBIP44)
-        };
+        let result = unsafe { wallet_get_account(wallet, 0, FFIAccountType::StandardBIP44) };
 
         // Note: Since the account may not exist yet (depends on wallet creation logic),
         // we just check that the call doesn't return an error for invalid parameters
@@ -76,8 +72,7 @@ mod tests {
     fn test_wallet_get_account_count_null_wallet() {
         let mut error = FFIError::success();
 
-        let count =
-            unsafe { wallet_get_account_count(ptr::null(), FFINetwork::Testnet, &mut error) };
+        let count = unsafe { wallet_get_account_count(ptr::null(), &mut error) };
 
         assert_eq!(count, 0);
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
@@ -100,46 +95,10 @@ mod tests {
             )
         };
 
-        let count = unsafe { wallet_get_account_count(wallet, FFINetwork::Testnet, &mut error) };
+        let count = unsafe { wallet_get_account_count(wallet, &mut error) };
 
         // Should have at least one default account
         assert!(count >= 1);
-        assert_eq!(error.code, FFIErrorCode::Success);
-
-        // Clean up
-        unsafe {
-            wallet::wallet_free(wallet);
-        }
-    }
-
-    #[test]
-    fn test_wallet_get_account_count_empty_network() {
-        let mut error = FFIError::success();
-
-        // Create a wallet
-        let mnemonic = CString::new("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about").unwrap();
-        let passphrase = CString::new("").unwrap();
-
-        let wallet = unsafe {
-            wallet::wallet_create_from_mnemonic(
-                mnemonic.as_ptr(),
-                passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
-                &mut error,
-            )
-        };
-
-        // Try to get account count for a different network (Mainnet)
-        let count = unsafe {
-            wallet_get_account_count(
-                wallet,
-                FFINetwork::Dash, // Different network
-                &mut error,
-            )
-        };
-
-        // Should return 0 for network with no accounts
-        assert_eq!(count, 0);
         assert_eq!(error.code, FFIErrorCode::Success);
 
         // Clean up
@@ -185,9 +144,7 @@ mod tests {
         assert_eq!(error.code, FFIErrorCode::Success);
 
         // Get an account
-        let result = unsafe {
-            wallet_get_account(wallet, FFINetwork::Testnet, 0, FFIAccountType::StandardBIP44)
-        };
+        let result = unsafe { wallet_get_account(wallet, 0, FFIAccountType::StandardBIP44) };
 
         if !result.account.is_null() {
             // Test all the getter functions

--- a/key-wallet-ffi/src/address_pool.rs
+++ b/key-wallet-ffi/src/address_pool.rs
@@ -10,7 +10,6 @@ use crate::error::{FFIError, FFIErrorCode};
 use crate::managed_wallet::FFIManagedWalletInfo;
 use crate::types::{FFIAccountType, FFIWallet};
 use crate::utils::rust_string_to_c;
-use crate::FFINetwork;
 use key_wallet::account::ManagedAccountCollection;
 use key_wallet::managed_account::address_pool::{
     AddressInfo, AddressPool, KeySource, PublicKeyType,
@@ -277,7 +276,6 @@ pub struct FFIAddressPoolInfo {
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_get_address_pool_info(
     managed_wallet: *const FFIManagedWalletInfo,
-    network: FFINetwork,
     account_type: FFIAccountType,
     account_index: c_uint,
     pool_type: FFIAddressPoolType,
@@ -291,31 +289,18 @@ pub unsafe extern "C" fn managed_wallet_get_address_pool_info(
 
     let wrapper = &*managed_wallet;
     let managed_wallet = wrapper.inner();
-    let network_rust: key_wallet::Network = network.into();
 
     let account_type_rust = account_type.to_account_type(account_index);
 
-    // Get the account collection
-    let collection = match managed_wallet.accounts.get(&network_rust) {
-        Some(collection) => collection,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::NotFound,
-                "No accounts for network".to_string(),
-            );
-            return false;
-        }
-    };
-
     // Get the specific managed account
-    let managed_account = match get_managed_account_by_type(collection, &account_type_rust) {
-        Some(account) => account,
-        None => {
-            FFIError::set_error(error, FFIErrorCode::NotFound, "Account not found".to_string());
-            return false;
-        }
-    };
+    let managed_account =
+        match get_managed_account_by_type(&managed_wallet.accounts, &account_type_rust) {
+            Some(account) => account,
+            None => {
+                FFIError::set_error(error, FFIErrorCode::NotFound, "Account not found".to_string());
+                return false;
+            }
+        };
 
     // Get the appropriate address pool
     let pool = match pool_type {
@@ -398,7 +383,6 @@ pub unsafe extern "C" fn managed_wallet_get_address_pool_info(
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_set_gap_limit(
     managed_wallet: *mut FFIManagedWalletInfo,
-    network: FFINetwork,
     account_type: FFIAccountType,
     account_index: c_uint,
     pool_type: FFIAddressPoolType,
@@ -411,31 +395,18 @@ pub unsafe extern "C" fn managed_wallet_set_gap_limit(
     }
 
     let managed_wallet = (&mut *managed_wallet).inner_mut();
-    let network_rust: key_wallet::Network = network.into();
 
     let account_type_rust = account_type.to_account_type(account_index);
 
-    // Get the account collection
-    let collection = match managed_wallet.accounts.get_mut(&network_rust) {
-        Some(collection) => collection,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::NotFound,
-                "No accounts for network".to_string(),
-            );
-            return false;
-        }
-    };
-
     // Get the specific managed account
-    let managed_account = match get_managed_account_by_type_mut(collection, &account_type_rust) {
-        Some(account) => account,
-        None => {
-            FFIError::set_error(error, FFIErrorCode::NotFound, "Account not found".to_string());
-            return false;
-        }
-    };
+    let managed_account =
+        match get_managed_account_by_type_mut(&mut managed_wallet.accounts, &account_type_rust) {
+            Some(account) => account,
+            None => {
+                FFIError::set_error(error, FFIErrorCode::NotFound, "Account not found".to_string());
+                return false;
+            }
+        };
 
     // Get the appropriate address pool
     let pool = match pool_type {
@@ -508,7 +479,6 @@ pub unsafe extern "C" fn managed_wallet_set_gap_limit(
 pub unsafe extern "C" fn managed_wallet_generate_addresses_to_index(
     managed_wallet: *mut FFIManagedWalletInfo,
     wallet: *const FFIWallet,
-    network: FFINetwork,
     account_type: FFIAccountType,
     account_index: c_uint,
     pool_type: FFIAddressPoolType,
@@ -522,17 +492,14 @@ pub unsafe extern "C" fn managed_wallet_generate_addresses_to_index(
 
     let managed_wallet = (&mut *managed_wallet).inner_mut();
     let wallet = &*wallet;
-    let network_rust: key_wallet::Network = network.into();
 
     let account_type_rust = account_type.to_account_type(account_index);
 
     let account_type_to_check = account_type_rust.into();
 
-    let xpub_opt = wallet.inner().extended_public_key_for_account_type(
-        &account_type_to_check,
-        Some(account_index),
-        network_rust,
-    );
+    let xpub_opt = wallet
+        .inner()
+        .extended_public_key_for_account_type(&account_type_to_check, Some(account_index));
 
     let xpub = match xpub_opt {
         Some(xpub) => xpub,
@@ -548,27 +515,15 @@ pub unsafe extern "C" fn managed_wallet_generate_addresses_to_index(
 
     let key_source = KeySource::Public(xpub);
 
-    // Get the account collection
-    let collection = match managed_wallet.accounts.get_mut(&network_rust) {
-        Some(collection) => collection,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::NotFound,
-                "No accounts for network".to_string(),
-            );
-            return false;
-        }
-    };
-
     // Get the specific managed account
-    let managed_account = match get_managed_account_by_type_mut(collection, &account_type_rust) {
-        Some(account) => account,
-        None => {
-            FFIError::set_error(error, FFIErrorCode::NotFound, "Account not found".to_string());
-            return false;
-        }
-    };
+    let managed_account =
+        match get_managed_account_by_type_mut(&mut managed_wallet.accounts, &account_type_rust) {
+            Some(account) => account,
+            None => {
+                FFIError::set_error(error, FFIErrorCode::NotFound, "Account not found".to_string());
+                return false;
+            }
+        };
 
     // Get the appropriate address pool and generate addresses
     let result = match pool_type {
@@ -673,7 +628,6 @@ pub unsafe extern "C" fn managed_wallet_generate_addresses_to_index(
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_mark_address_used(
     managed_wallet: *mut FFIManagedWalletInfo,
-    network: FFINetwork,
     address: *const c_char,
     error: *mut FFIError,
 ) -> bool {
@@ -683,7 +637,6 @@ pub unsafe extern "C" fn managed_wallet_mark_address_used(
     }
 
     let managed_wallet = (&mut *managed_wallet).inner_mut();
-    let network_rust: key_wallet::Network = network.into();
 
     // Parse the address string
     let address_str = match std::ffi::CStr::from_ptr(address).to_str() {
@@ -718,17 +671,7 @@ pub unsafe extern "C" fn managed_wallet_mark_address_used(
     let address = unchecked_addr.assume_checked();
 
     // Get the account collection
-    let collection = match managed_wallet.accounts.get_mut(&network_rust) {
-        Some(collection) => collection,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::NotFound,
-                "No accounts for network".to_string(),
-            );
-            return false;
-        }
-    };
+    let collection = &mut managed_wallet.accounts;
 
     // Try to mark the address as used in any account that contains it
     let marked = {
@@ -1021,7 +964,7 @@ pub unsafe extern "C" fn address_info_array_free(infos: *mut *mut FFIAddressInfo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{FFINetwork, FFINetworks};
+    use crate::FFINetworks;
 
     #[test]
     fn test_address_pool_type_values() {
@@ -1151,7 +1094,6 @@ mod tests {
             let result = crate::managed_account::managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
                 0,
                 FFIAccountType::StandardBIP44,
             );
@@ -1252,7 +1194,6 @@ mod tests {
             let result = crate::managed_account::managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
                 0,
                 FFIAccountType::StandardBIP44,
             );

--- a/key-wallet-ffi/src/keys.rs
+++ b/key-wallet-ffi/src/keys.rs
@@ -59,7 +59,6 @@ impl FFIPrivateKey {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_account_xpriv(
     wallet: *const FFIWallet,
-    network: FFINetwork,
     account_index: c_uint,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -69,9 +68,8 @@ pub unsafe extern "C" fn wallet_get_account_xpriv(
     }
 
     let wallet = unsafe { &*wallet };
-    let network_rust: key_wallet::Network = network.into();
 
-    match wallet.inner().get_bip44_account(network_rust, account_index) {
+    match wallet.inner().get_bip44_account(account_index) {
         Some(account) => {
             // Extended private key is not available on Account
             // Only the wallet has access to private keys
@@ -109,7 +107,6 @@ pub unsafe extern "C" fn wallet_get_account_xpriv(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_get_account_xpub(
     wallet: *const FFIWallet,
-    network: FFINetwork,
     account_index: c_uint,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -119,9 +116,8 @@ pub unsafe extern "C" fn wallet_get_account_xpub(
     }
 
     let wallet = unsafe { &*wallet };
-    let network_rust: key_wallet::Network = network.into();
 
-    match wallet.inner().get_bip44_account(network_rust, account_index) {
+    match wallet.inner().get_bip44_account(account_index) {
         Some(account) => {
             let xpub = account.extended_public_key();
             FFIError::set_success(error);
@@ -156,7 +152,6 @@ pub unsafe extern "C" fn wallet_get_account_xpub(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_derive_private_key(
     wallet: *const FFIWallet,
-    network: FFINetwork,
     derivation_path: *const c_char,
     error: *mut FFIError,
 ) -> *mut FFIPrivateKey {
@@ -193,10 +188,9 @@ pub unsafe extern "C" fn wallet_derive_private_key(
     };
 
     let wallet = unsafe { &*wallet };
-    let network_rust: key_wallet::Network = network.into();
 
     // Use the new wallet method to derive the private key
-    match wallet.inner().derive_private_key(network_rust, &path) {
+    match wallet.inner().derive_private_key(&path) {
         Ok(private_key) => {
             FFIError::set_success(error);
             Box::into_raw(Box::new(FFIPrivateKey {
@@ -226,7 +220,6 @@ pub unsafe extern "C" fn wallet_derive_private_key(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_derive_extended_private_key(
     wallet: *const FFIWallet,
-    network: FFINetwork,
     derivation_path: *const c_char,
     error: *mut FFIError,
 ) -> *mut FFIExtendedPrivateKey {
@@ -263,10 +256,9 @@ pub unsafe extern "C" fn wallet_derive_extended_private_key(
     };
 
     let wallet = unsafe { &*wallet };
-    let network_rust: key_wallet::Network = network.into();
 
     // Use the new wallet method to derive the extended private key
-    match wallet.inner().derive_extended_private_key(network_rust, &path) {
+    match wallet.inner().derive_extended_private_key(&path) {
         Ok(extended_private_key) => {
             FFIError::set_success(error);
             Box::into_raw(Box::new(FFIExtendedPrivateKey {
@@ -295,7 +287,6 @@ pub unsafe extern "C" fn wallet_derive_extended_private_key(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_derive_private_key_as_wif(
     wallet: *const FFIWallet,
-    network: FFINetwork,
     derivation_path: *const c_char,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -332,10 +323,9 @@ pub unsafe extern "C" fn wallet_derive_private_key_as_wif(
     };
 
     let wallet = unsafe { &*wallet };
-    let network_rust: key_wallet::Network = network.into();
 
     // Use the new wallet method to derive the private key as WIF
-    match wallet.inner().derive_private_key_as_wif(network_rust, &path) {
+    match wallet.inner().derive_private_key_as_wif(&path) {
         Ok(wif) => {
             FFIError::set_success(error);
             match CString::new(wif) {
@@ -522,7 +512,6 @@ pub unsafe extern "C" fn private_key_to_wif(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_derive_public_key(
     wallet: *const FFIWallet,
-    network: FFINetwork,
     derivation_path: *const c_char,
     error: *mut FFIError,
 ) -> *mut FFIPublicKey {
@@ -560,10 +549,9 @@ pub unsafe extern "C" fn wallet_derive_public_key(
 
     unsafe {
         let wallet = &*wallet;
-        let network_rust: key_wallet::Network = network.into();
 
         // Use the new wallet method to derive the public key
-        match wallet.inner().derive_public_key(network_rust, &path) {
+        match wallet.inner().derive_public_key(&path) {
             Ok(public_key) => {
                 FFIError::set_success(error);
                 Box::into_raw(Box::new(FFIPublicKey {
@@ -594,7 +582,6 @@ pub unsafe extern "C" fn wallet_derive_public_key(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_derive_extended_public_key(
     wallet: *const FFIWallet,
-    network: FFINetwork,
     derivation_path: *const c_char,
     error: *mut FFIError,
 ) -> *mut FFIExtendedPublicKey {
@@ -632,10 +619,9 @@ pub unsafe extern "C" fn wallet_derive_extended_public_key(
 
     unsafe {
         let wallet = &*wallet;
-        let network_rust: key_wallet::Network = network.into();
 
         // Use the new wallet method to derive the extended public key
-        match wallet.inner().derive_extended_public_key(network_rust, &path) {
+        match wallet.inner().derive_extended_public_key(&path) {
             Ok(extended_public_key) => {
                 FFIError::set_success(error);
                 Box::into_raw(Box::new(FFIExtendedPublicKey {
@@ -665,7 +651,6 @@ pub unsafe extern "C" fn wallet_derive_extended_public_key(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_derive_public_key_as_hex(
     wallet: *const FFIWallet,
-    network: FFINetwork,
     derivation_path: *const c_char,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -703,10 +688,9 @@ pub unsafe extern "C" fn wallet_derive_public_key_as_hex(
 
     unsafe {
         let wallet = &*wallet;
-        let network_rust: key_wallet::Network = network.into();
 
         // Use the new wallet method to derive the public key as hex
-        match wallet.inner().derive_public_key_as_hex(network_rust, &path) {
+        match wallet.inner().derive_public_key_as_hex(&path) {
             Ok(hex) => {
                 FFIError::set_success(error);
                 match CString::new(hex) {

--- a/key-wallet-ffi/src/keys_tests.rs
+++ b/key-wallet-ffi/src/keys_tests.rs
@@ -29,12 +29,7 @@ mod tests {
 
             // Derive an extended private key
             let path = CString::new("m/44'/1'/0'").unwrap();
-            let ext_priv = wallet_derive_extended_private_key(
-                wallet,
-                FFINetwork::Testnet,
-                path.as_ptr(),
-                &mut error,
-            );
+            let ext_priv = wallet_derive_extended_private_key(wallet, path.as_ptr(), &mut error);
             assert!(!ext_priv.is_null());
             assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -68,12 +63,7 @@ mod tests {
             extended_private_key_free(ext_priv);
 
             // Now test extended public key
-            let ext_pub = wallet_derive_extended_public_key(
-                wallet,
-                FFINetwork::Testnet,
-                path.as_ptr(),
-                &mut error,
-            );
+            let ext_pub = wallet_derive_extended_public_key(wallet, path.as_ptr(), &mut error);
             assert!(!ext_pub.is_null());
             assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -128,8 +118,7 @@ mod tests {
         assert!(!wallet.is_null());
 
         // Try to get account xpriv - should fail
-        let xpriv_str =
-            unsafe { wallet_get_account_xpriv(wallet, FFINetwork::Testnet, 0, &mut error) };
+        let xpriv_str = unsafe { wallet_get_account_xpriv(wallet, 0, &mut error) };
 
         // Should return null (not implemented for security)
         assert!(xpriv_str.is_null());
@@ -160,8 +149,7 @@ mod tests {
         assert!(!wallet.is_null());
 
         // Get account xpub
-        let xpub_str =
-            unsafe { wallet_get_account_xpub(wallet, FFINetwork::Testnet, 0, &mut error) };
+        let xpub_str = unsafe { wallet_get_account_xpub(wallet, 0, &mut error) };
 
         assert!(!xpub_str.is_null());
 
@@ -196,9 +184,7 @@ mod tests {
 
         // Try to derive private key - should now succeed (44'/1'/0'/0/0 for Dash)
         let path = CString::new("m/44'/1'/0'/0/0").unwrap();
-        let privkey_ptr = unsafe {
-            wallet_derive_private_key(wallet, FFINetwork::Testnet, path.as_ptr(), &mut error)
-        };
+        let privkey_ptr = unsafe { wallet_derive_private_key(wallet, path.as_ptr(), &mut error) };
 
         // Should succeed and return a valid pointer
         assert!(!privkey_ptr.is_null());
@@ -250,9 +236,7 @@ mod tests {
 
         // Derive public key using derivation path (44'/1'/0'/0/0 for Dash)
         let path = CString::new("m/44'/1'/0'/0/0").unwrap();
-        let pubkey_ptr = unsafe {
-            wallet_derive_public_key(wallet, FFINetwork::Testnet, path.as_ptr(), &mut error)
-        };
+        let pubkey_ptr = unsafe { wallet_derive_public_key(wallet, path.as_ptr(), &mut error) };
 
         if pubkey_ptr.is_null() {
             panic!("pubkey_ptr is null, error: {:?}", error);
@@ -303,12 +287,7 @@ mod tests {
 
             // Derive public key as hex directly
             let path = CString::new("m/44'/1'/0'/0/0").unwrap();
-            let hex_str = wallet_derive_public_key_as_hex(
-                wallet,
-                FFINetwork::Testnet,
-                path.as_ptr(),
-                &mut error,
-            );
+            let hex_str = wallet_derive_public_key_as_hex(wallet, path.as_ptr(), &mut error);
             assert!(!hex_str.is_null());
             assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -405,8 +384,7 @@ mod tests {
         let mut error = FFIError::success();
 
         // Test with null wallet
-        let xpriv =
-            unsafe { wallet_get_account_xpriv(ptr::null(), FFINetwork::Testnet, 0, &mut error) };
+        let xpriv = unsafe { wallet_get_account_xpriv(ptr::null(), 0, &mut error) };
         assert!(xpriv.is_null());
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
 
@@ -435,9 +413,8 @@ mod tests {
 
         // Test with null wallet (44'/1'/0'/0/0 for Dash)
         let path = CString::new("m/44'/1'/0'/0/0").unwrap();
-        let pubkey_ptr = unsafe {
-            wallet_derive_public_key(ptr::null(), FFINetwork::Testnet, path.as_ptr(), &mut error)
-        };
+        let pubkey_ptr =
+            unsafe { wallet_derive_public_key(ptr::null(), path.as_ptr(), &mut error) };
 
         assert!(pubkey_ptr.is_null());
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
@@ -456,9 +433,7 @@ mod tests {
         };
 
         // Test with null path
-        let pubkey_ptr = unsafe {
-            wallet_derive_public_key(wallet, FFINetwork::Testnet, ptr::null(), &mut error)
-        };
+        let pubkey_ptr = unsafe { wallet_derive_public_key(wallet, ptr::null(), &mut error) };
 
         assert!(pubkey_ptr.is_null());
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
@@ -594,9 +569,7 @@ mod tests {
 
         // Test different account indices
         for account_index in 0..3 {
-            let xpub_str = unsafe {
-                wallet_get_account_xpub(wallet, FFINetwork::Testnet, account_index, &mut error)
-            };
+            let xpub_str = unsafe { wallet_get_account_xpub(wallet, account_index, &mut error) };
 
             if !xpub_str.is_null() {
                 let xpub = unsafe { CStr::from_ptr(xpub_str).to_str().unwrap() };
@@ -610,8 +583,7 @@ mod tests {
         }
 
         // Test with null wallet
-        let xpub_str =
-            unsafe { wallet_get_account_xpub(ptr::null(), FFINetwork::Testnet, 0, &mut error) };
+        let xpub_str = unsafe { wallet_get_account_xpub(ptr::null(), 0, &mut error) };
 
         assert!(xpub_str.is_null());
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
@@ -650,9 +622,7 @@ mod tests {
         for path_str in test_paths.iter() {
             let path = CString::new(*path_str).unwrap();
 
-            let pubkey_ptr = unsafe {
-                wallet_derive_public_key(wallet, FFINetwork::Testnet, path.as_ptr(), &mut error)
-            };
+            let pubkey_ptr = unsafe { wallet_derive_public_key(wallet, path.as_ptr(), &mut error) };
 
             if !pubkey_ptr.is_null() {
                 // Get hex representation to verify

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -11,8 +11,9 @@ use dashcore::hashes::Hash;
 
 use crate::address_pool::{FFIAddressPool, FFIAddressPoolType};
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFIAccountType, FFINetwork};
+use crate::types::FFIAccountType;
 use crate::wallet_manager::FFIWalletManager;
+use crate::FFINetwork;
 use key_wallet::account::account_collection::DashpayAccountKey;
 use key_wallet::managed_account::address_pool::AddressPool;
 use key_wallet::managed_account::ManagedAccount;
@@ -82,14 +83,12 @@ impl FFIManagedAccountResult {
 ///
 /// - `manager` must be a valid pointer to an FFIWalletManager instance
 /// - `wallet_id` must be a valid pointer to a 32-byte wallet ID
-/// - `network` must specify exactly one network
 /// - The caller must ensure all pointers remain valid for the duration of this call
 /// - The returned account must be freed with `managed_account_free` when no longer needed
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_get_account(
     manager: *const FFIWalletManager,
     wallet_id: *const u8,
-    network: FFINetwork,
     account_index: c_uint,
     account_type: FFIAccountType,
 ) -> FFIManagedAccountResult {
@@ -106,12 +105,6 @@ pub unsafe extern "C" fn managed_wallet_get_account(
             "Wallet ID is null".to_string(),
         );
     }
-
-    // Convert wallet_id to array
-    let mut wallet_id_array = [0u8; 32];
-    std::ptr::copy_nonoverlapping(wallet_id, wallet_id_array.as_mut_ptr(), 32);
-
-    let network_rust: key_wallet::Network = network.into();
 
     // Get the managed wallet info from the manager
     let mut error = FFIError::success();
@@ -134,74 +127,58 @@ pub unsafe extern "C" fn managed_wallet_get_account(
     let managed_wallet = &*managed_wallet_ptr;
     let account_type_rust = account_type.to_account_type(account_index);
 
-    // Get the managed account from the managed wallet info
-    let result = match managed_wallet.inner().accounts.get(&network_rust) {
-        Some(managed_collection) => {
-            use key_wallet::account::StandardAccountType;
+    let result = {
+        use key_wallet::account::StandardAccountType;
 
-            let managed_account = match account_type_rust {
-                AccountType::Standard {
-                    index,
-                    standard_account_type,
-                } => match standard_account_type {
-                    StandardAccountType::BIP44Account => {
-                        managed_collection.standard_bip44_accounts.get(&index)
-                    }
-                    StandardAccountType::BIP32Account => {
-                        managed_collection.standard_bip32_accounts.get(&index)
-                    }
-                },
-                AccountType::CoinJoin {
-                    index,
-                } => managed_collection.coinjoin_accounts.get(&index),
-                AccountType::IdentityRegistration => {
-                    managed_collection.identity_registration.as_ref()
+        let managed_collection = &managed_wallet.inner().accounts;
+        let managed_account = match account_type_rust {
+            AccountType::Standard {
+                index,
+                standard_account_type,
+            } => match standard_account_type {
+                StandardAccountType::BIP44Account => {
+                    managed_collection.standard_bip44_accounts.get(&index)
                 }
-                AccountType::IdentityTopUp {
-                    registration_index,
-                } => managed_collection.identity_topup.get(&registration_index),
-                AccountType::IdentityTopUpNotBoundToIdentity => {
-                    managed_collection.identity_topup_not_bound.as_ref()
+                StandardAccountType::BIP32Account => {
+                    managed_collection.standard_bip32_accounts.get(&index)
                 }
-                AccountType::IdentityInvitation => managed_collection.identity_invitation.as_ref(),
-                AccountType::ProviderVotingKeys => managed_collection.provider_voting_keys.as_ref(),
-                AccountType::ProviderOwnerKeys => managed_collection.provider_owner_keys.as_ref(),
-                AccountType::ProviderOperatorKeys => {
-                    managed_collection.provider_operator_keys.as_ref()
-                }
-                AccountType::ProviderPlatformKeys => {
-                    managed_collection.provider_platform_keys.as_ref()
-                }
-                AccountType::DashpayReceivingFunds {
-                    ..
-                } => None,
-                AccountType::DashpayExternalAccount {
-                    ..
-                } => None,
-                AccountType::PlatformPayment {
-                    ..
-                } => None,
-            };
-
-            match managed_account {
-                Some(account) => {
-                    let ffi_account = FFIManagedAccount::new(account);
-                    FFIManagedAccountResult::success(Box::into_raw(Box::new(ffi_account)))
-                }
-                None => FFIManagedAccountResult::error(
-                    FFIErrorCode::NotFound,
-                    "Account not found".to_string(),
-                ),
+            },
+            AccountType::CoinJoin {
+                index,
+            } => managed_collection.coinjoin_accounts.get(&index),
+            AccountType::IdentityRegistration => managed_collection.identity_registration.as_ref(),
+            AccountType::IdentityTopUp {
+                registration_index,
+            } => managed_collection.identity_topup.get(&registration_index),
+            AccountType::IdentityTopUpNotBoundToIdentity => {
+                managed_collection.identity_topup_not_bound.as_ref()
             }
-        }
-        None => FFIManagedAccountResult::error(
-            FFIErrorCode::NotFound,
-            format!(
-                "No accounts found for network {:?}, wallet has networks {:?}",
-                network_rust,
-                managed_wallet.inner().networks_supported()
+            AccountType::IdentityInvitation => managed_collection.identity_invitation.as_ref(),
+            AccountType::ProviderVotingKeys => managed_collection.provider_voting_keys.as_ref(),
+            AccountType::ProviderOwnerKeys => managed_collection.provider_owner_keys.as_ref(),
+            AccountType::ProviderOperatorKeys => managed_collection.provider_operator_keys.as_ref(),
+            AccountType::ProviderPlatformKeys => managed_collection.provider_platform_keys.as_ref(),
+            AccountType::DashpayReceivingFunds {
+                ..
+            } => None,
+            AccountType::DashpayExternalAccount {
+                ..
+            } => None,
+            AccountType::PlatformPayment {
+                ..
+            } => None,
+        };
+
+        match managed_account {
+            Some(account) => {
+                let ffi_account = FFIManagedAccount::new(account);
+                FFIManagedAccountResult::success(Box::into_raw(Box::new(ffi_account)))
+            }
+            None => FFIManagedAccountResult::error(
+                FFIErrorCode::NotFound,
+                "Account not found".to_string(),
             ),
-        ),
+        }
     };
 
     // Clean up the managed wallet pointer
@@ -219,14 +196,12 @@ pub unsafe extern "C" fn managed_wallet_get_account(
 ///
 /// - `manager` must be a valid pointer to an FFIWalletManager instance
 /// - `wallet_id` must be a valid pointer to a 32-byte wallet ID
-/// - `network` must specify exactly one network
 /// - The caller must ensure all pointers remain valid for the duration of this call
 /// - The returned account must be freed with `managed_account_free` when no longer needed
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_get_top_up_account_with_registration_index(
     manager: *const FFIWalletManager,
     wallet_id: *const u8,
-    network: FFINetwork,
     registration_index: c_uint,
 ) -> FFIManagedAccountResult {
     if manager.is_null() {
@@ -242,12 +217,6 @@ pub unsafe extern "C" fn managed_wallet_get_top_up_account_with_registration_ind
             "Wallet ID is null".to_string(),
         );
     }
-
-    // Convert wallet_id to array
-    let mut wallet_id_array = [0u8; 32];
-    std::ptr::copy_nonoverlapping(wallet_id, wallet_id_array.as_mut_ptr(), 32);
-
-    let network_rust: key_wallet::Network = network.into();
 
     // Get the managed wallet info from the manager
     let mut error = FFIError::success();
@@ -269,29 +238,16 @@ pub unsafe extern "C" fn managed_wallet_get_top_up_account_with_registration_ind
 
     let managed_wallet = &*managed_wallet_ptr;
 
-    // Get the IdentityTopUp account from the managed collection
-    let result = match managed_wallet.inner().accounts.get(&network_rust) {
-        Some(managed_collection) => {
-            match managed_collection.identity_topup.get(&registration_index) {
-                Some(account) => {
-                    let ffi_account = FFIManagedAccount::new(account);
-                    FFIManagedAccountResult::success(Box::into_raw(Box::new(ffi_account)))
-                }
-                None => FFIManagedAccountResult::error(
-                    FFIErrorCode::NotFound,
-                    format!(
-                        "IdentityTopUp account for registration index {} not found",
-                        registration_index
-                    ),
-                ),
-            }
+    let result = match managed_wallet.inner().accounts.identity_topup.get(&registration_index) {
+        Some(account) => {
+            let ffi_account = FFIManagedAccount::new(account);
+            FFIManagedAccountResult::success(Box::into_raw(Box::new(ffi_account)))
         }
         None => FFIManagedAccountResult::error(
             FFIErrorCode::NotFound,
             format!(
-                "No accounts found for network {:?}, wallet has networks {:?}",
-                network_rust,
-                managed_wallet.inner().networks_supported()
+                "IdentityTopUp account for registration index {} not found",
+                registration_index
             ),
         ),
     };
@@ -311,7 +267,6 @@ pub unsafe extern "C" fn managed_wallet_get_top_up_account_with_registration_ind
 pub unsafe extern "C" fn managed_wallet_get_dashpay_receiving_account(
     manager: *const FFIWalletManager,
     wallet_id: *const u8,
-    network: FFINetwork,
     account_index: c_uint,
     user_identity_id: *const u8,
     friend_identity_id: *const u8,
@@ -350,22 +305,15 @@ pub unsafe extern "C" fn managed_wallet_get_dashpay_receiving_account(
             },
         );
     }
-    let network_rust: key_wallet::Network = network.into();
     let managed_wallet = &*managed_wallet_ptr;
-    let result = match managed_wallet.inner().accounts.get(&network_rust) {
-        Some(coll) => match coll.dashpay_receival_accounts.get(&key) {
-            Some(account) => FFIManagedAccountResult::success(Box::into_raw(Box::new(
-                FFIManagedAccount::new(account),
-            ))),
-            None => FFIManagedAccountResult::error(
-                FFIErrorCode::NotFound,
-                "Account not found".to_string(),
-            ),
-        },
-        None => FFIManagedAccountResult::error(
-            FFIErrorCode::NotFound,
-            "No accounts for network".to_string(),
-        ),
+
+    let result = match managed_wallet.inner().accounts.dashpay_receival_accounts.get(&key) {
+        Some(account) => FFIManagedAccountResult::success(Box::into_raw(Box::new(
+            FFIManagedAccount::new(account),
+        ))),
+        None => {
+            FFIManagedAccountResult::error(FFIErrorCode::NotFound, "Account not found".to_string())
+        }
     };
     crate::managed_wallet::managed_wallet_info_free(managed_wallet_ptr);
     result
@@ -379,7 +327,6 @@ pub unsafe extern "C" fn managed_wallet_get_dashpay_receiving_account(
 pub unsafe extern "C" fn managed_wallet_get_dashpay_external_account(
     manager: *const FFIWalletManager,
     wallet_id: *const u8,
-    network: FFINetwork,
     account_index: c_uint,
     user_identity_id: *const u8,
     friend_identity_id: *const u8,
@@ -418,22 +365,15 @@ pub unsafe extern "C" fn managed_wallet_get_dashpay_external_account(
             },
         );
     }
-    let network_rust: key_wallet::Network = network.into();
     let managed_wallet = &*managed_wallet_ptr;
-    let result = match managed_wallet.inner().accounts.get(&network_rust) {
-        Some(coll) => match coll.dashpay_external_accounts.get(&key) {
-            Some(account) => FFIManagedAccountResult::success(Box::into_raw(Box::new(
-                FFIManagedAccount::new(account),
-            ))),
-            None => FFIManagedAccountResult::error(
-                FFIErrorCode::NotFound,
-                "Account not found".to_string(),
-            ),
-        },
-        None => FFIManagedAccountResult::error(
-            FFIErrorCode::NotFound,
-            "No accounts for network".to_string(),
-        ),
+
+    let result = match managed_wallet.inner().accounts.dashpay_external_accounts.get(&key) {
+        Some(account) => FFIManagedAccountResult::success(Box::into_raw(Box::new(
+            FFIManagedAccount::new(account),
+        ))),
+        None => {
+            FFIManagedAccountResult::error(FFIErrorCode::NotFound, "Account not found".to_string())
+        }
     };
     crate::managed_wallet::managed_wallet_info_free(managed_wallet_ptr);
     result
@@ -770,22 +710,18 @@ pub unsafe extern "C" fn managed_account_result_free_error(result: *mut FFIManag
 ///
 /// - `manager` must be a valid pointer to an FFIWalletManager instance
 /// - `wallet_id` must be a valid pointer to a 32-byte wallet ID
-/// - `network` must specify exactly one network
 /// - `error` must be a valid pointer to an FFIError structure or null
 /// - The caller must ensure all pointers remain valid for the duration of this call
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_get_account_count(
     manager: *const FFIWalletManager,
     wallet_id: *const u8,
-    network: FFINetwork,
     error: *mut FFIError,
 ) -> c_uint {
     if manager.is_null() || wallet_id.is_null() {
         FFIError::set_error(error, FFIErrorCode::InvalidInput, "Null pointer provided".to_string());
         return 0;
     }
-
-    let network_rust: key_wallet::Network = network.into();
 
     // Get the wallet from the manager
     let wallet_ptr = crate::wallet_manager::wallet_manager_get_wallet(manager, wallet_id, error);
@@ -796,26 +732,19 @@ pub unsafe extern "C" fn managed_wallet_get_account_count(
     }
 
     let wallet = &*wallet_ptr;
-    let count = match wallet.inner().accounts.get(&network_rust) {
-        Some(accounts) => {
-            FFIError::set_success(error);
-            let count = accounts.standard_bip44_accounts.len()
-                + accounts.standard_bip32_accounts.len()
-                + accounts.coinjoin_accounts.len()
-                + accounts.identity_registration.is_some() as usize
-                + accounts.identity_topup.len();
-            count as c_uint
-        }
-        None => {
-            FFIError::set_success(error);
-            0
-        }
-    };
+
+    FFIError::set_success(error);
+    let accounts = &wallet.inner().accounts;
+    let count = accounts.standard_bip44_accounts.len()
+        + accounts.standard_bip32_accounts.len()
+        + accounts.coinjoin_accounts.len()
+        + accounts.identity_registration.is_some() as usize
+        + accounts.identity_topup.len();
 
     // Clean up the wallet pointer
     crate::wallet::wallet_free_const(wallet_ptr);
 
-    count
+    count as c_uint
 }
 
 // Note: BLS and EdDSA accounts are handled through regular FFIManagedAccount
@@ -1089,7 +1018,6 @@ mod tests {
             let result = managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
                 0,
                 FFIAccountType::StandardBIP44,
             );
@@ -1153,13 +1081,8 @@ mod tests {
             assert_eq!(count_out, 1);
 
             // Try to get a non-existent CoinJoin account
-            let mut result = managed_wallet_get_account(
-                manager,
-                wallet_ids_out,
-                FFINetwork::Testnet,
-                0,
-                FFIAccountType::CoinJoin,
-            );
+            let mut result =
+                managed_wallet_get_account(manager, wallet_ids_out, 0, FFIAccountType::CoinJoin);
 
             assert!(result.account.is_null());
             assert_ne!(result.error_code, 0);
@@ -1232,12 +1155,7 @@ mod tests {
             assert!(success);
 
             // Get account count
-            let count = managed_wallet_get_account_count(
-                manager,
-                wallet_ids_out,
-                FFINetwork::Testnet,
-                &mut error,
-            );
+            let count = managed_wallet_get_account_count(manager, wallet_ids_out, &mut error);
 
             // Should have at least the accounts we created
             assert!(count >= 5); // 3 BIP44 + 1 BIP32 + 1 CoinJoin
@@ -1292,7 +1210,6 @@ mod tests {
             let result = managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
                 0,
                 FFIAccountType::StandardBIP44,
             );
@@ -1410,7 +1327,6 @@ mod tests {
             let result = managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
                 0,
                 FFIAccountType::StandardBIP44,
             );
@@ -1470,7 +1386,6 @@ mod tests {
             let result = managed_wallet_get_account(
                 manager,
                 wallet_ids_out,
-                FFINetwork::Testnet,
                 0,
                 FFIAccountType::StandardBIP44,
             );
@@ -1557,13 +1472,8 @@ mod tests {
             assert_eq!(count_out, 1);
 
             // Get CoinJoin account
-            let cj_result = managed_wallet_get_account(
-                manager,
-                wallet_ids_out,
-                FFINetwork::Testnet,
-                0,
-                FFIAccountType::CoinJoin,
-            );
+            let cj_result =
+                managed_wallet_get_account(manager, wallet_ids_out, 0, FFIAccountType::CoinJoin);
             assert!(!cj_result.account.is_null());
 
             let cj_account = cj_result.account;

--- a/key-wallet-ffi/src/managed_wallet.rs
+++ b/key-wallet-ffi/src/managed_wallet.rs
@@ -10,7 +10,6 @@ use std::ptr;
 
 use crate::error::{FFIError, FFIErrorCode};
 use crate::types::FFIWallet;
-use crate::FFINetwork;
 use key_wallet::managed_account::address_pool::KeySource;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use std::ffi::c_void;
@@ -54,7 +53,6 @@ impl FFIManagedWalletInfo {
 pub unsafe extern "C" fn managed_wallet_get_next_bip44_receive_address(
     managed_wallet: *mut FFIManagedWalletInfo,
     wallet: *const FFIWallet,
-    network: FFINetwork,
     account_index: std::os::raw::c_uint,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -74,53 +72,23 @@ pub unsafe extern "C" fn managed_wallet_get_next_bip44_receive_address(
 
     let managed_wallet = unsafe { &mut *managed_wallet };
     let wallet = unsafe { &*wallet };
-    let network = network.into();
-
-    // Get the account collection for the network
-    let account_collection = match managed_wallet.inner_mut().accounts.get_mut(&network) {
-        Some(collection) => collection,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::WalletError,
-                format!(
-                    "No accounts found for network {:?}, wallet has networks {:?}",
-                    network,
-                    managed_wallet.inner().networks_supported()
-                ),
-            );
-            return ptr::null_mut();
-        }
-    };
 
     // Get the specific managed account (default to BIP44)
-    let managed_account = match account_collection.standard_bip44_accounts.get_mut(&account_index) {
-        Some(account) => account,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::WalletError,
-                format!("Account {} not found", account_index),
-            );
-            return ptr::null_mut();
-        }
-    };
+    let managed_account =
+        match managed_wallet.inner_mut().accounts.standard_bip44_accounts.get_mut(&account_index) {
+            Some(account) => account,
+            None => {
+                FFIError::set_error(
+                    error,
+                    FFIErrorCode::WalletError,
+                    format!("Account {} not found", account_index),
+                );
+                return ptr::null_mut();
+            }
+        };
 
     // Get the account from the wallet to get the extended public key
-    // Need to get the account from the accounts collection
-    let wallet_accounts = match wallet.wallet.accounts.get(&network) {
-        Some(accounts) => accounts,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::WalletError,
-                format!("No accounts for network {:?}", network),
-            );
-            return ptr::null_mut();
-        }
-    };
-
-    let account = match wallet_accounts.standard_bip44_accounts.get(&account_index) {
+    let account = match wallet.wallet.accounts.standard_bip44_accounts.get(&account_index) {
         Some(account) => account,
         None => {
             FFIError::set_error(
@@ -178,7 +146,6 @@ pub unsafe extern "C" fn managed_wallet_get_next_bip44_receive_address(
 pub unsafe extern "C" fn managed_wallet_get_next_bip44_change_address(
     managed_wallet: *mut FFIManagedWalletInfo,
     wallet: *const FFIWallet,
-    network: FFINetwork,
     account_index: std::os::raw::c_uint,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -198,53 +165,23 @@ pub unsafe extern "C" fn managed_wallet_get_next_bip44_change_address(
 
     let managed_wallet = unsafe { &mut *managed_wallet };
     let wallet = unsafe { &*wallet };
-    let network = network.into();
-
-    // Get the account collection for the network
-    let account_collection = match managed_wallet.inner_mut().accounts.get_mut(&network) {
-        Some(collection) => collection,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::WalletError,
-                format!(
-                    "No accounts found for network {:?}, wallet has networks {:?}",
-                    network,
-                    managed_wallet.inner().networks_supported()
-                ),
-            );
-            return ptr::null_mut();
-        }
-    };
 
     // Get the specific managed account (default to BIP44)
-    let managed_account = match account_collection.standard_bip44_accounts.get_mut(&account_index) {
-        Some(account) => account,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::WalletError,
-                format!("Account {} not found", account_index),
-            );
-            return ptr::null_mut();
-        }
-    };
+    let managed_account =
+        match managed_wallet.inner_mut().accounts.standard_bip44_accounts.get_mut(&account_index) {
+            Some(account) => account,
+            None => {
+                FFIError::set_error(
+                    error,
+                    FFIErrorCode::WalletError,
+                    format!("Account {} not found", account_index),
+                );
+                return ptr::null_mut();
+            }
+        };
 
     // Get the account from the wallet to get the extended public key
-    // Need to get the account from the accounts collection
-    let wallet_accounts = match wallet.wallet.accounts.get(&network) {
-        Some(accounts) => accounts,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::WalletError,
-                format!("No accounts for network {:?}", network),
-            );
-            return ptr::null_mut();
-        }
-    };
-
-    let account = match wallet_accounts.standard_bip44_accounts.get(&account_index) {
+    let account = match wallet.wallet.accounts.standard_bip44_accounts.get(&account_index) {
         Some(account) => account,
         None => {
             FFIError::set_error(
@@ -304,7 +241,6 @@ pub unsafe extern "C" fn managed_wallet_get_next_bip44_change_address(
 pub unsafe extern "C" fn managed_wallet_get_bip_44_external_address_range(
     managed_wallet: *mut FFIManagedWalletInfo,
     wallet: *const FFIWallet,
-    network: FFINetwork,
     account_index: std::os::raw::c_uint,
     start_index: std::os::raw::c_uint,
     end_index: std::os::raw::c_uint,
@@ -341,58 +277,25 @@ pub unsafe extern "C" fn managed_wallet_get_bip_44_external_address_range(
 
     let managed_wallet = unsafe { &mut *managed_wallet };
     let wallet = unsafe { &*wallet };
-    let network = network.into();
-
-    // Get the account collection for the network
-    let account_collection = match managed_wallet.inner_mut().accounts.get_mut(&network) {
-        Some(collection) => collection,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::WalletError,
-                format!(
-                    "No accounts found for network {:?}, wallet has networks {:?}",
-                    network,
-                    managed_wallet.inner().networks_supported()
-                ),
-            );
-            *count_out = 0;
-            *addresses_out = ptr::null_mut();
-            return false;
-        }
-    };
 
     // Get the specific managed account (BIP44)
-    let managed_account = match account_collection.standard_bip44_accounts.get_mut(&account_index) {
-        Some(account) => account,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::WalletError,
-                format!("BIP44 account {} not found", account_index),
-            );
-            *count_out = 0;
-            *addresses_out = ptr::null_mut();
-            return false;
-        }
-    };
+    let managed_account =
+        match managed_wallet.inner_mut().accounts.standard_bip44_accounts.get_mut(&account_index) {
+            Some(account) => account,
+            None => {
+                FFIError::set_error(
+                    error,
+                    FFIErrorCode::WalletError,
+                    format!("BIP44 account {} not found", account_index),
+                );
+                *count_out = 0;
+                *addresses_out = ptr::null_mut();
+                return false;
+            }
+        };
 
     // Get the account from the wallet to get the extended public key
-    let wallet_accounts = match wallet.wallet.accounts.get(&network) {
-        Some(accounts) => accounts,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::WalletError,
-                format!("No accounts for network {:?}", network),
-            );
-            *count_out = 0;
-            *addresses_out = ptr::null_mut();
-            return false;
-        }
-    };
-
-    let account = match wallet_accounts.standard_bip44_accounts.get(&account_index) {
+    let account = match wallet.wallet.accounts.standard_bip44_accounts.get(&account_index) {
         Some(account) => account,
         None => {
             FFIError::set_error(
@@ -490,7 +393,6 @@ pub unsafe extern "C" fn managed_wallet_get_bip_44_external_address_range(
 pub unsafe extern "C" fn managed_wallet_get_bip_44_internal_address_range(
     managed_wallet: *mut FFIManagedWalletInfo,
     wallet: *const FFIWallet,
-    network: FFINetwork,
     account_index: std::os::raw::c_uint,
     start_index: std::os::raw::c_uint,
     end_index: std::os::raw::c_uint,
@@ -527,58 +429,25 @@ pub unsafe extern "C" fn managed_wallet_get_bip_44_internal_address_range(
 
     let managed_wallet = unsafe { &mut *managed_wallet };
     let wallet = unsafe { &*wallet };
-    let network = network.into();
-
-    // Get the account collection for the network
-    let account_collection = match managed_wallet.inner_mut().accounts.get_mut(&network) {
-        Some(collection) => collection,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::WalletError,
-                format!(
-                    "No accounts found for network {:?}, wallet has networks {:?}",
-                    network,
-                    managed_wallet.inner().networks_supported()
-                ),
-            );
-            *count_out = 0;
-            *addresses_out = ptr::null_mut();
-            return false;
-        }
-    };
 
     // Get the specific managed account (BIP44)
-    let managed_account = match account_collection.standard_bip44_accounts.get_mut(&account_index) {
-        Some(account) => account,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::WalletError,
-                format!("BIP44 account {} not found", account_index),
-            );
-            *count_out = 0;
-            *addresses_out = ptr::null_mut();
-            return false;
-        }
-    };
+    let managed_account =
+        match managed_wallet.inner_mut().accounts.standard_bip44_accounts.get_mut(&account_index) {
+            Some(account) => account,
+            None => {
+                FFIError::set_error(
+                    error,
+                    FFIErrorCode::WalletError,
+                    format!("BIP44 account {} not found", account_index),
+                );
+                *count_out = 0;
+                *addresses_out = ptr::null_mut();
+                return false;
+            }
+        };
 
     // Get the account from the wallet to get the extended public key
-    let wallet_accounts = match wallet.wallet.accounts.get(&network) {
-        Some(accounts) => accounts,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::WalletError,
-                format!("No accounts for network {:?}", network),
-            );
-            *count_out = 0;
-            *addresses_out = ptr::null_mut();
-            return false;
-        }
-    };
-
-    let account = match wallet_accounts.standard_bip44_accounts.get(&account_index) {
+    let account = match wallet.wallet.accounts.standard_bip44_accounts.get(&account_index) {
         Some(account) => account,
         None => {
             FFIError::set_error(
@@ -781,7 +650,6 @@ mod tests {
             managed_wallet_get_next_bip44_receive_address(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
                 0,
                 &mut error,
             )
@@ -800,7 +668,6 @@ mod tests {
             managed_wallet_get_next_bip44_change_address(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
                 0,
                 &mut error,
             )
@@ -821,7 +688,6 @@ mod tests {
             managed_wallet_get_bip_44_external_address_range(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
                 0,
                 0,
                 10,
@@ -848,7 +714,6 @@ mod tests {
             managed_wallet_get_bip_44_internal_address_range(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
                 0,
                 0,
                 10,
@@ -890,13 +755,7 @@ mod tests {
 
         // Test get_next_receive_address with valid pointers
         let receive_addr = unsafe {
-            managed_wallet_get_next_bip44_receive_address(
-                &mut ffi_managed,
-                wallet,
-                FFINetwork::Testnet,
-                0,
-                &mut error,
-            )
+            managed_wallet_get_next_bip44_receive_address(&mut ffi_managed, wallet, 0, &mut error)
         };
 
         if !receive_addr.is_null() {
@@ -917,13 +776,7 @@ mod tests {
 
         // Test get_next_change_address with valid pointers
         let change_addr = unsafe {
-            managed_wallet_get_next_bip44_change_address(
-                &mut ffi_managed,
-                wallet,
-                FFINetwork::Testnet,
-                0,
-                &mut error,
-            )
+            managed_wallet_get_next_bip44_change_address(&mut ffi_managed, wallet, 0, &mut error)
         };
 
         if !change_addr.is_null() {
@@ -1012,8 +865,9 @@ mod tests {
             false,
         );
 
-        managed_collection.standard_bip44_accounts.insert(0, managed_account);
-        managed_info.accounts.insert(network, managed_collection);
+        managed_collection.standard_bip44_accounts.insert(0, managed_account.clone());
+        // Insert the managed account directly into managed_info's accounts
+        managed_info.accounts.insert(managed_account);
 
         // Create wrapper for managed info
         let mut ffi_managed = FFIManagedWalletInfo::new(managed_info);
@@ -1026,7 +880,6 @@ mod tests {
             managed_wallet_get_next_bip44_receive_address(
                 &mut ffi_managed,
                 ffi_wallet_ptr,
-                FFINetwork::Testnet,
                 0,
                 &mut error,
             )
@@ -1045,7 +898,6 @@ mod tests {
             managed_wallet_get_next_bip44_change_address(
                 &mut ffi_managed,
                 ffi_wallet_ptr,
-                FFINetwork::Testnet,
                 0,
                 &mut error,
             )
@@ -1067,7 +919,6 @@ mod tests {
             managed_wallet_get_bip_44_external_address_range(
                 &mut ffi_managed,
                 ffi_wallet_ptr,
-                FFINetwork::Testnet,
                 0,
                 0,
                 5,
@@ -1101,7 +952,6 @@ mod tests {
             managed_wallet_get_bip_44_internal_address_range(
                 &mut ffi_managed,
                 ffi_wallet_ptr,
-                FFINetwork::Testnet,
                 0,
                 0,
                 3,
@@ -1238,7 +1088,6 @@ mod tests {
             managed_wallet_get_bip_44_external_address_range(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
                 0,
                 0,
                 10,
@@ -1257,7 +1106,6 @@ mod tests {
             managed_wallet_get_bip_44_internal_address_range(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
                 0,
                 0,
                 10,

--- a/key-wallet-ffi/src/transaction.rs
+++ b/key-wallet-ffi/src/transaction.rs
@@ -155,7 +155,6 @@ pub unsafe extern "C" fn wallet_sign_transaction(
 ///
 /// - `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo
 /// - `wallet` must be a valid pointer to an FFIWallet
-/// - `network` must be a valid FFINetwork
 /// - `outputs` must be a valid pointer to an array of FFITxOutput with at least `outputs_count` elements
 /// - `tx_bytes_out` must be a valid pointer to store the transaction bytes pointer
 /// - `tx_len_out` must be a valid pointer to store the transaction length
@@ -165,7 +164,6 @@ pub unsafe extern "C" fn wallet_sign_transaction(
 pub unsafe extern "C" fn wallet_build_and_sign_transaction(
     managed_wallet: *mut FFIManagedWalletInfo,
     wallet: *const FFIWallet,
-    network: FFINetwork,
     account_index: c_uint,
     outputs: *const FFITxOutput,
     outputs_count: usize,
@@ -202,61 +200,49 @@ pub unsafe extern "C" fn wallet_build_and_sign_transaction(
 
         let managed_wallet_ref = &mut *managed_wallet;
         let wallet_ref = &*wallet;
-        let network_rust: Network = network.into();
+        let network_rust = managed_wallet_ref.inner().network;
         let outputs_slice = slice::from_raw_parts(outputs, outputs_count);
 
-        // Get the managed account collection
-        let account_collection =
-            match managed_wallet_ref.inner_mut().accounts.get_mut(&network_rust) {
-                Some(collection) => collection,
-                None => {
-                    FFIError::set_error(
-                        error,
-                        FFIErrorCode::WalletError,
-                        format!("No accounts found for network {:?}", network_rust),
-                    );
-                    return false;
-                }
-            };
-
         // Get the managed account
-        let managed_account =
-            match account_collection.standard_bip44_accounts.get_mut(&account_index) {
-                Some(account) => account,
-                None => {
-                    FFIError::set_error(
-                        error,
-                        FFIErrorCode::WalletError,
-                        format!("Account {} not found", account_index),
-                    );
-                    return false;
-                }
-            };
-
-        // Get the wallet account (for getting extended keys)
-        let wallet_accounts = match wallet_ref.inner().accounts.get(&network_rust) {
-            Some(accounts) => accounts,
-            None => {
-                FFIError::set_error(
-                    error,
-                    FFIErrorCode::WalletError,
-                    format!("No wallet accounts for network {:?}", network_rust),
-                );
-                return false;
-            }
-        };
-
-        let wallet_account = match wallet_accounts.standard_bip44_accounts.get(&account_index) {
+        let managed_account = match managed_wallet_ref
+            .inner_mut()
+            .accounts
+            .standard_bip44_accounts
+            .get_mut(&account_index)
+        {
             Some(account) => account,
             None => {
                 FFIError::set_error(
                     error,
                     FFIErrorCode::WalletError,
-                    format!("Wallet account {} not found", account_index),
+                    format!("Account {} not found", account_index),
                 );
                 return false;
             }
         };
+
+        // Verify wallet and managed wallet have matching networks
+        if wallet_ref.inner().network != network_rust {
+            FFIError::set_error(
+                error,
+                FFIErrorCode::WalletError,
+                "Wallet and managed wallet have different networks".to_string(),
+            );
+            return false;
+        }
+
+        let wallet_account =
+            match wallet_ref.inner().accounts.standard_bip44_accounts.get(&account_index) {
+                Some(account) => account,
+                None => {
+                    FFIError::set_error(
+                        error,
+                        FFIErrorCode::WalletError,
+                        format!("Wallet account {} not found", account_index),
+                    );
+                    return false;
+                }
+            };
 
         // Convert FFI outputs to Rust outputs
         let mut tx_builder = TransactionBuilder::new();
@@ -465,7 +451,6 @@ pub struct FFITransactionCheckResult {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_check_transaction(
     wallet: *mut FFIWallet,
-    network: FFINetwork,
     tx_bytes: *const u8,
     tx_len: usize,
     context_type: FFITransactionContext,
@@ -483,7 +468,6 @@ pub unsafe extern "C" fn wallet_check_transaction(
 
     unsafe {
         let wallet = &mut *wallet;
-        let network_rust: Network = network.into();
         let tx_slice = slice::from_raw_parts(tx_bytes, tx_len);
 
         // Parse the transaction
@@ -566,9 +550,8 @@ pub unsafe extern "C" fn wallet_check_transaction(
         };
 
         // Block on the async check_transaction call
-        let check_result = tokio::runtime::Handle::current().block_on(
-            managed_info.check_transaction(&tx, network_rust, context, wallet_mut, update_state),
-        );
+        let check_result = tokio::runtime::Handle::current()
+            .block_on(managed_info.check_transaction(&tx, context, wallet_mut, update_state));
 
         // If we updated state, we need to update the wallet's managed info
         // Note: This would require storing ManagedWalletInfo in FFIWallet

--- a/key-wallet-ffi/src/utxo.rs
+++ b/key-wallet-ffi/src/utxo.rs
@@ -6,7 +6,7 @@ use std::ptr;
 
 use crate::error::{FFIError, FFIErrorCode};
 use crate::managed_wallet::FFIManagedWalletInfo;
-use crate::types::{FFINetwork, FFINetworks};
+use crate::types::FFINetworks;
 
 /// UTXO structure for FFI
 #[repr(C)]
@@ -88,7 +88,6 @@ impl FFIUTXO {
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_get_utxos(
     managed_info: *const FFIManagedWalletInfo,
-    network: FFINetwork,
     utxos_out: *mut *mut FFIUTXO,
     count_out: *mut usize,
     error: *mut FFIError,
@@ -99,10 +98,9 @@ pub unsafe extern "C" fn managed_wallet_get_utxos(
     }
 
     let managed_info = &*managed_info;
-    let network_rust: key_wallet::Network = network.into();
 
     // Get UTXOs from the managed wallet info
-    let utxos = managed_info.inner().get_utxos(network_rust);
+    let utxos = managed_info.inner().get_utxos();
 
     if utxos.is_empty() {
         *count_out = 0;

--- a/key-wallet-ffi/src/wallet_tests.rs
+++ b/key-wallet-ffi/src/wallet_tests.rs
@@ -5,7 +5,7 @@ mod wallet_tests {
     use crate::account::account_free;
     use crate::error::{FFIError, FFIErrorCode};
     use crate::types::{FFIAccountType, FFINetworks};
-    use crate::{wallet, FFINetwork};
+    use crate::wallet;
     use std::ffi::CString;
     use std::ptr;
 
@@ -290,14 +290,8 @@ mod wallet_tests {
         assert!(!wallet.is_null());
 
         // Test adding account - check if it succeeds or fails gracefully
-        let result = unsafe {
-            wallet::wallet_add_account(
-                wallet,
-                FFINetwork::Testnet,
-                FFIAccountType::StandardBIP44,
-                1,
-            )
-        };
+        let result =
+            unsafe { wallet::wallet_add_account(wallet, FFIAccountType::StandardBIP44, 1) };
         // Some implementations may not support adding accounts, so just verify it doesn't crash
         // and the error code is set appropriately
         assert!(!result.account.is_null() || result.error_code != 0);
@@ -326,12 +320,7 @@ mod wallet_tests {
     fn test_wallet_add_account_null() {
         // Test with null wallet
         let result = unsafe {
-            wallet::wallet_add_account(
-                ptr::null_mut(),
-                FFINetwork::Testnet,
-                FFIAccountType::StandardBIP44,
-                0,
-            )
+            wallet::wallet_add_account(ptr::null_mut(), FFIAccountType::StandardBIP44, 0)
         };
         assert!(result.account.is_null());
         assert_ne!(result.error_code, 0);
@@ -391,7 +380,7 @@ mod wallet_tests {
         assert!(!wallet.is_null());
 
         // Get xpub for account 0
-        let xpub = unsafe { wallet::wallet_get_xpub(wallet, FFINetwork::Testnet, 0, error) };
+        let xpub = unsafe { wallet::wallet_get_xpub(wallet, 0, error) };
         assert!(!xpub.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::Success);
 
@@ -412,7 +401,7 @@ mod wallet_tests {
         let error = &mut error as *mut FFIError;
 
         // Test with null wallet
-        let xpub = unsafe { wallet::wallet_get_xpub(ptr::null(), FFINetwork::Testnet, 0, error) };
+        let xpub = unsafe { wallet::wallet_get_xpub(ptr::null(), 0, error) };
         assert!(xpub.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidInput);
     }

--- a/key-wallet-ffi/tests/test_account_collection.rs
+++ b/key-wallet-ffi/tests/test_account_collection.rs
@@ -6,7 +6,6 @@ use key_wallet_ffi::types::{
     FFIAccountCreationOptionType, FFINetworks, FFIWalletAccountCreationOptions,
 };
 use key_wallet_ffi::wallet::{wallet_create_from_mnemonic_with_options, wallet_free};
-use key_wallet_ffi::FFINetwork;
 use std::ffi::CString;
 use std::ptr;
 
@@ -43,8 +42,7 @@ fn test_account_collection_comprehensive() {
         assert!(!wallet.is_null());
 
         // Get account collection for testnet
-        let collection =
-            wallet_get_account_collection(wallet, FFINetwork::Testnet, ptr::null_mut());
+        let collection = wallet_get_account_collection(wallet, ptr::null_mut());
         assert!(!collection.is_null());
 
         // Test account count
@@ -161,8 +159,7 @@ fn test_account_collection_minimal() {
         assert!(!wallet.is_null());
 
         // Get account collection
-        let collection =
-            wallet_get_account_collection(wallet, FFINetwork::Testnet, ptr::null_mut());
+        let collection = wallet_get_account_collection(wallet, ptr::null_mut());
         assert!(!collection.is_null());
 
         // Should have at least some default accounts

--- a/key-wallet-ffi/tests/test_passphrase_wallets.rs
+++ b/key-wallet-ffi/tests/test_passphrase_wallets.rs
@@ -3,7 +3,6 @@
 
 use key_wallet_ffi::error::{FFIError, FFIErrorCode};
 use key_wallet_ffi::types::FFINetworks;
-use key_wallet_ffi::FFINetwork;
 use std::ffi::CString;
 
 #[test]
@@ -176,21 +175,11 @@ fn test_demonstrate_passphrase_issue_with_account_creation() {
     assert!(!wallet_with_pass.is_null());
 
     // Try to get account count for both wallets
-    let count_no_pass = unsafe {
-        key_wallet_ffi::account::wallet_get_account_count(
-            wallet_no_pass,
-            FFINetwork::Testnet,
-            error,
-        )
-    };
+    let count_no_pass =
+        unsafe { key_wallet_ffi::account::wallet_get_account_count(wallet_no_pass, error) };
 
-    let count_with_pass = unsafe {
-        key_wallet_ffi::account::wallet_get_account_count(
-            wallet_with_pass,
-            FFINetwork::Testnet,
-            error,
-        )
-    };
+    let count_with_pass =
+        unsafe { key_wallet_ffi::account::wallet_get_account_count(wallet_with_pass, error) };
 
     println!("Account count without passphrase: {}", count_no_pass);
     println!("Account count with passphrase: {}", count_with_pass);

--- a/key-wallet-ffi/tests/test_valid_addr.rs
+++ b/key-wallet-ffi/tests/test_valid_addr.rs
@@ -11,10 +11,10 @@ fn test_valid_testnet_address() {
         Mnemonic::from_phrase(mnemonic_str, key_wallet::mnemonic::Language::English).unwrap();
 
     let wallet =
-        Wallet::from_mnemonic(mnemonic, &[Network::Testnet], WalletAccountCreationOptions::Default)
+        Wallet::from_mnemonic(mnemonic, Network::Testnet, WalletAccountCreationOptions::Default)
             .unwrap();
 
-    if let Some(account) = wallet.get_bip44_account(Network::Testnet, 0) {
+    if let Some(account) = wallet.get_bip44_account(0) {
         use key_wallet::ChildNumber;
         use secp256k1::Secp256k1;
         let secp = Secp256k1::new();

--- a/key-wallet-manager/examples/wallet_creation.rs
+++ b/key-wallet-manager/examples/wallet_creation.rs
@@ -46,7 +46,7 @@ fn main() {
     let result = manager.create_wallet_from_mnemonic(
         test_mnemonic,
         "", // No passphrase
-        &[Network::Testnet],
+        Network::Testnet,
         Some(100_000), // Birth height
         key_wallet::wallet::initialization::WalletAccountCreationOptions::Default,
     );
@@ -73,7 +73,6 @@ fn main() {
             index: 1,
             standard_account_type: StandardAccountType::BIP44Account,
         },
-        Network::Testnet,
         None,
     );
 
@@ -98,7 +97,6 @@ fn main() {
     // isn't properly initialized in the managed wallet info
     let address_result = manager.get_receive_address(
         &wallet_id,
-        Network::Testnet,
         0, // Account index
         AccountTypePreference::BIP44,
         false, // Don't advance index

--- a/key-wallet-manager/src/wallet_manager/process_block.rs
+++ b/key-wallet-manager/src/wallet_manager/process_block.rs
@@ -102,9 +102,11 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
         // Get all wallet addresses for this network
         for info in self.wallet_infos.values() {
-            let monitored = info.monitored_addresses(network);
-            for address in monitored {
-                script_bytes.push(address.script_pubkey().as_bytes().to_vec());
+            if info.network() == network {
+                let monitored = info.monitored_addresses();
+                for address in monitored {
+                    script_bytes.push(address.script_pubkey().as_bytes().to_vec());
+                }
             }
         }
 
@@ -139,7 +141,8 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         let mut is_relevant_any = false;
         for info in self.wallet_infos.values() {
             // Only consider wallets tracking this network
-            if let Some(collection) = info.accounts(network) {
+            if info.network() == network {
+                let collection = info.accounts();
                 // Reuse the same routing/check logic used in normal processing
                 let tx_type = TransactionRouter::classify_transaction(tx);
                 let account_types = TransactionRouter::get_relevant_account_types(&tx_type);
@@ -176,7 +179,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
         for info in self.wallet_infos.values() {
             // Only consider wallets that actually track this network AND have a known birth height
-            if info.accounts(network).is_some() {
+            if info.network() == network {
                 if let Some(birth_height) = info.birth_height() {
                     earliest = Some(match earliest {
                         Some(current) => current.min(birth_height),
@@ -205,7 +208,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
                 let _ = write!(&mut wallet_id_hex, "{:02x}", byte);
             }
 
-            let script_count = info.monitored_addresses(network).len();
+            let script_count = info.monitored_addresses().len();
             let summary = format!("{} scripts", script_count);
 
             details.push(format!("{} ({}): {}", name, wallet_id_hex, summary));

--- a/key-wallet-manager/src/wallet_manager/transaction_building.rs
+++ b/key-wallet-manager/src/wallet_manager/transaction_building.rs
@@ -7,7 +7,7 @@ use key_wallet::wallet::managed_wallet_info::transaction_building::{
     AccountTypePreference, TransactionError,
 };
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
-use key_wallet::{Address, Network};
+use key_wallet::Address;
 
 impl<T: WalletInfoInterface> WalletManager<T> {
     /// Creates an unsigned transaction from a specific wallet and account
@@ -18,7 +18,6 @@ impl<T: WalletInfoInterface> WalletManager<T> {
     pub fn create_unsigned_payment_transaction(
         &mut self,
         wallet_id: &WalletId,
-        network: Network,
         account_index: u32,
         account_type_pref: Option<AccountTypePreference>,
         recipients: Vec<(Address, u64)>,
@@ -36,7 +35,6 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         managed_info
             .create_unsigned_payment_transaction(
                 wallet,
-                network,
                 account_index,
                 account_type_pref,
                 recipients,

--- a/key-wallet-manager/tests/integration_test.rs
+++ b/key-wallet-manager/tests/integration_test.rs
@@ -29,7 +29,7 @@ fn test_wallet_manager_from_mnemonic() {
     let wallet_result = manager.create_wallet_from_mnemonic(
         &mnemonic.to_string(),
         "",
-        &[Network::Testnet],
+        Network::Testnet,
         None, // birth_height
         WalletAccountCreationOptions::Default,
     );
@@ -57,7 +57,6 @@ fn test_account_management() {
             index: 1,
             standard_account_type: key_wallet::account::StandardAccountType::BIP44Account,
         },
-        Network::Testnet,
         None,
     );
     assert!(result.is_ok());
@@ -84,13 +83,7 @@ fn test_address_generation() {
     // But the managed wallet info might not have the account collection initialized
 
     // Test address generation - it may fail if accounts aren't initialized
-    let address1 = manager.get_receive_address(
-        &wallet_id,
-        Network::Testnet,
-        0,
-        AccountTypePreference::BIP44,
-        false,
-    );
+    let address1 = manager.get_receive_address(&wallet_id, 0, AccountTypePreference::BIP44, false);
     // This might fail with InvalidNetwork if the account collection isn't initialized
     // We'll check if it's the expected error
     if let Err(ref e) = address1 {
@@ -104,13 +97,7 @@ fn test_address_generation() {
         }
     }
 
-    let change = manager.get_change_address(
-        &wallet_id,
-        Network::Testnet,
-        0,
-        AccountTypePreference::BIP44,
-        false,
-    );
+    let change = manager.get_change_address(&wallet_id, 0, AccountTypePreference::BIP44, false);
     // Same check for change address
     if let Err(ref e) = change {
         match e {

--- a/key-wallet-manager/tests/test_serialized_wallets.rs
+++ b/key-wallet-manager/tests/test_serialized_wallets.rs
@@ -16,7 +16,7 @@ mod tests {
         let result = manager.create_wallet_from_mnemonic_return_serialized_bytes(
             test_mnemonic,
             "",
-            &[Network::Testnet],
+            Network::Testnet,
             Some(100_000),
             WalletAccountCreationOptions::Default,
             false, // Don't downgrade
@@ -32,7 +32,7 @@ mod tests {
         let result = manager2.create_wallet_from_mnemonic_return_serialized_bytes(
             test_mnemonic,
             "",
-            &[Network::Testnet],
+            Network::Testnet,
             Some(100_000),
             WalletAccountCreationOptions::Default,
             true,  // Downgrade to pubkey wallet
@@ -51,7 +51,7 @@ mod tests {
         let result = manager3.create_wallet_from_mnemonic_return_serialized_bytes(
             test_mnemonic,
             "",
-            &[Network::Testnet],
+            Network::Testnet,
             Some(100_000),
             WalletAccountCreationOptions::Default,
             true, // Downgrade to pubkey wallet
@@ -80,7 +80,7 @@ mod tests {
         let result = manager.create_wallet_from_mnemonic_return_serialized_bytes(
             test_mnemonic,
             passphrase,
-            &[Network::Testnet],
+            Network::Testnet,
             None,
             WalletAccountCreationOptions::Default,
             false,
@@ -95,7 +95,7 @@ mod tests {
         let result2 = manager2.create_wallet_from_mnemonic_return_serialized_bytes(
             test_mnemonic,
             "", // No passphrase
-            &[Network::Testnet],
+            Network::Testnet,
             None,
             WalletAccountCreationOptions::Default,
             false,

--- a/key-wallet/src/address_metadata_tests.rs
+++ b/key-wallet/src/address_metadata_tests.rs
@@ -27,15 +27,15 @@ mod tests {
         // Basic test that wallet and accounts can be created
 
         let wallet = Wallet::new_random(
-            &[Network::Testnet],
+            Network::Testnet,
             crate::wallet::initialization::WalletAccountCreationOptions::Default,
         )
         .unwrap();
 
         // Verify wallet has a default account
-        assert!(wallet.get_bip44_account(Network::Testnet, 0).is_some());
+        assert!(wallet.get_bip44_account(0).is_some());
 
-        let account = wallet.get_bip44_account(Network::Testnet, 0).unwrap();
+        let account = wallet.get_bip44_account(0).unwrap();
         match &account.account_type {
             AccountType::Standard {
                 index,
@@ -48,7 +48,7 @@ mod tests {
     #[test]
     fn test_multiple_accounts() {
         let mut wallet = Wallet::new_random(
-            &[Network::Testnet],
+            Network::Testnet,
             crate::wallet::initialization::WalletAccountCreationOptions::Default,
         )
         .unwrap();
@@ -60,7 +60,6 @@ mod tests {
                     index: 1,
                     standard_account_type: StandardAccountType::BIP44Account,
                 },
-                Network::Testnet,
                 None,
             )
             .unwrap();
@@ -70,19 +69,18 @@ mod tests {
                     index: 2,
                     standard_account_type: StandardAccountType::BIP44Account,
                 },
-                Network::Testnet,
                 None,
             )
             .unwrap();
 
         // Verify accounts exist
-        assert!(wallet.get_bip44_account(Network::Testnet, 0).is_some());
-        assert!(wallet.get_bip44_account(Network::Testnet, 1).is_some());
-        assert!(wallet.get_bip44_account(Network::Testnet, 2).is_some());
+        assert!(wallet.get_bip44_account(0).is_some());
+        assert!(wallet.get_bip44_account(1).is_some());
+        assert!(wallet.get_bip44_account(2).is_some());
 
         // Verify account indices
         for i in 0..3 {
-            let account = wallet.get_bip44_account(Network::Testnet, i).unwrap();
+            let account = wallet.get_bip44_account(i).unwrap();
             match &account.account_type {
                 AccountType::Standard {
                     index,

--- a/key-wallet/src/tests/advanced_transaction_tests.rs
+++ b/key-wallet/src/tests/advanced_transaction_tests.rs
@@ -14,7 +14,7 @@ fn test_multi_account_transaction() {
     // Test transaction involving multiple accounts
 
     let mut wallet = Wallet::new_random(
-        &[Network::Testnet],
+        Network::Testnet,
         crate::wallet::initialization::WalletAccountCreationOptions::Default,
     )
     .unwrap();
@@ -27,7 +27,6 @@ fn test_multi_account_transaction() {
                     index: i,
                     standard_account_type: StandardAccountType::BIP44Account,
                 },
-                Network::Testnet,
                 None,
             )
             .unwrap();

--- a/key-wallet/src/tests/edge_case_tests.rs
+++ b/key-wallet/src/tests/edge_case_tests.rs
@@ -50,11 +50,12 @@ fn test_corrupted_wallet_data_recovery() {
     let mnemonic = Mnemonic::from_phrase(
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
         Language::English,
-    ).unwrap();
+    )
+    .unwrap();
 
     let wallet = Wallet::from_mnemonic(
         mnemonic.clone(),
-        &[Network::Testnet],
+        Network::Testnet,
         crate::wallet::initialization::WalletAccountCreationOptions::None,
     )
     .unwrap();
@@ -65,7 +66,7 @@ fn test_corrupted_wallet_data_recovery() {
     // Recovery: recreate from mnemonic
     let recovered_wallet = Wallet::from_mnemonic(
         mnemonic,
-        &[Network::Testnet],
+        Network::Testnet,
         crate::wallet::initialization::WalletAccountCreationOptions::None,
     )
     .unwrap();
@@ -77,12 +78,13 @@ fn test_network_mismatch_handling() {
     let mnemonic = Mnemonic::from_phrase(
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
         Language::English,
-    ).unwrap();
+    )
+    .unwrap();
 
     // Create wallet for testnet
     let testnet_wallet = Wallet::from_mnemonic(
         mnemonic.clone(),
-        &[Network::Testnet],
+        Network::Testnet,
         crate::wallet::initialization::WalletAccountCreationOptions::Default,
     )
     .unwrap();
@@ -90,7 +92,7 @@ fn test_network_mismatch_handling() {
     // Create wallet for mainnet with same mnemonic
     let mainnet_wallet = Wallet::from_mnemonic(
         mnemonic,
-        &[Network::Dash],
+        Network::Dash,
         crate::wallet::initialization::WalletAccountCreationOptions::Default,
     )
     .unwrap();
@@ -98,9 +100,9 @@ fn test_network_mismatch_handling() {
     // Wallet IDs should be the same (derived from same root key)
     assert_eq!(testnet_wallet.wallet_id, mainnet_wallet.wallet_id);
 
-    // But accounts should be network-specific
-    assert!(testnet_wallet.accounts.contains_key(&Network::Testnet));
-    assert!(mainnet_wallet.accounts.contains_key(&Network::Dash));
+    // But networks should be different
+    assert_eq!(testnet_wallet.network, Network::Testnet);
+    assert_eq!(mainnet_wallet.network, Network::Dash);
 }
 
 #[test]
@@ -134,7 +136,7 @@ fn test_zero_value_transaction_handling() {
 #[test]
 fn test_duplicate_account_handling() {
     let mut wallet = Wallet::new_random(
-        &[Network::Testnet],
+        Network::Testnet,
         crate::wallet::initialization::WalletAccountCreationOptions::None,
     )
     .unwrap();
@@ -146,10 +148,10 @@ fn test_duplicate_account_handling() {
     };
 
     // First addition should succeed (wallet was created with None, so no accounts exist)
-    let result1 = wallet.add_account(account_type, Network::Testnet, None);
+    let result1 = wallet.add_account(account_type, None);
 
     // Duplicate addition should be handled gracefully
-    let result2 = wallet.add_account(account_type, Network::Testnet, None);
+    let result2 = wallet.add_account(account_type, None);
 
     // First should succeed, second should fail due to duplicate
     assert!(result1.is_ok(), "First attempt to add account 0 should succeed");
@@ -239,7 +241,7 @@ fn test_concurrent_access_simulation() {
 
     let wallet = Arc::new(Mutex::new(
         Wallet::new_random(
-            &[Network::Testnet],
+            Network::Testnet,
             crate::wallet::initialization::WalletAccountCreationOptions::None,
         )
         .unwrap(),
@@ -274,12 +276,13 @@ fn test_passphrase_edge_cases() {
     let mnemonic = Mnemonic::from_phrase(
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
         Language::English,
-    ).unwrap();
+    )
+    .unwrap();
 
     // Test with empty passphrase - use regular from_mnemonic for empty passphrase
     let wallet1 = Wallet::from_mnemonic(
         mnemonic.clone(),
-        &[Network::Testnet],
+        Network::Testnet,
         crate::wallet::initialization::WalletAccountCreationOptions::None,
     )
     .unwrap();
@@ -289,7 +292,7 @@ fn test_passphrase_edge_cases() {
     let wallet2 = Wallet::from_mnemonic_with_passphrase(
         mnemonic.clone(),
         long_passphrase,
-        &[Network::Testnet],
+        Network::Testnet,
         crate::wallet::initialization::WalletAccountCreationOptions::None,
     )
     .unwrap();
@@ -299,7 +302,7 @@ fn test_passphrase_edge_cases() {
     let wallet3 = Wallet::from_mnemonic_with_passphrase(
         mnemonic,
         special_passphrase.to_string(),
-        &[Network::Testnet],
+        Network::Testnet,
         crate::wallet::initialization::WalletAccountCreationOptions::None,
     )
     .unwrap();
@@ -333,23 +336,23 @@ fn test_wallet_recovery_with_missing_accounts() {
     let mnemonic = Mnemonic::from_phrase(
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
         Language::English,
-    ).unwrap();
+    )
+    .unwrap();
 
     let mut wallet = Wallet::from_mnemonic(
         mnemonic.clone(),
-        &[Network::Testnet],
+        Network::Testnet,
         crate::wallet::initialization::WalletAccountCreationOptions::None,
     )
     .unwrap();
 
-    // Add accounts with gaps (0, 2, 5)
+    // Add accounts with gaps (2, 5)
     wallet
         .add_account(
             AccountType::Standard {
                 index: 2,
                 standard_account_type: StandardAccountType::BIP44Account,
             },
-            Network::Testnet,
             None,
         )
         .unwrap();
@@ -360,7 +363,6 @@ fn test_wallet_recovery_with_missing_accounts() {
                 index: 5,
                 standard_account_type: StandardAccountType::BIP44Account,
             },
-            Network::Testnet,
             None,
         )
         .unwrap();
@@ -368,7 +370,7 @@ fn test_wallet_recovery_with_missing_accounts() {
     // Recovery should handle gaps in account indices
     let recovered_wallet = Wallet::from_mnemonic(
         mnemonic,
-        &[Network::Testnet],
+        Network::Testnet,
         crate::wallet::initialization::WalletAccountCreationOptions::None,
     )
     .unwrap();

--- a/key-wallet/src/tests/performance_tests.rs
+++ b/key-wallet/src/tests/performance_tests.rs
@@ -89,7 +89,7 @@ fn test_key_derivation_performance() {
 #[test]
 fn test_account_creation_performance() {
     let mut wallet = Wallet::new_random(
-        &[Network::Testnet],
+        Network::Testnet,
         crate::wallet::initialization::WalletAccountCreationOptions::None,
     )
     .unwrap();
@@ -106,7 +106,6 @@ fn test_account_creation_performance() {
                     index: i as u32,
                     standard_account_type: StandardAccountType::BIP44Account,
                 },
-                Network::Testnet,
                 None,
             )
             .ok();
@@ -125,7 +124,8 @@ fn test_wallet_recovery_performance() {
     let mnemonic = Mnemonic::from_phrase(
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
         Language::English,
-    ).unwrap();
+    )
+    .unwrap();
 
     let iterations = 10;
     let mut times = Vec::new();
@@ -134,7 +134,7 @@ fn test_wallet_recovery_performance() {
         let start = Instant::now();
         let _wallet = Wallet::from_mnemonic(
             mnemonic.clone(),
-            &[Network::Testnet],
+            Network::Testnet,
             crate::wallet::initialization::WalletAccountCreationOptions::None,
         )
         .unwrap();
@@ -203,7 +203,7 @@ fn test_address_generation_batch_performance() {
 #[test]
 fn test_large_wallet_memory_usage() {
     let mut wallet = Wallet::new_random(
-        &[Network::Testnet],
+        Network::Testnet,
         crate::wallet::initialization::WalletAccountCreationOptions::None,
     )
     .unwrap();
@@ -218,7 +218,6 @@ fn test_large_wallet_memory_usage() {
                     index: i,
                     standard_account_type: StandardAccountType::BIP44Account,
                 },
-                Network::Testnet,
                 None,
             )
             .ok(); // OK if already exists
@@ -226,10 +225,7 @@ fn test_large_wallet_memory_usage() {
 
     // Memory usage would be measured with external tools
     // For now, just verify the wallet can handle many accounts
-    assert_eq!(
-        wallet.accounts.get(&Network::Testnet).unwrap().standard_bip44_accounts.len(),
-        num_accounts as usize
-    );
+    assert_eq!(wallet.accounts.standard_bip44_accounts.len(), num_accounts as usize);
 }
 
 #[test]
@@ -301,7 +297,7 @@ fn test_wallet_serialization_performance() {
     for _ in 0..iterations {
         let start = Instant::now();
         let _wallet = Wallet::new_random(
-            &[Network::Testnet],
+            Network::Testnet,
             crate::wallet::initialization::WalletAccountCreationOptions::None,
         )
         .unwrap();

--- a/key-wallet/src/transaction_checking/transaction_router/tests/asset_unlock.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/asset_unlock.rs
@@ -69,23 +69,22 @@ fn test_asset_unlock_classification() {
 
 #[tokio::test]
 async fn test_asset_unlock_transaction_routing() {
-    let network = Network::Testnet;
-    let mut wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut managed_wallet_info =
         ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
 
     // Get the BIP44 account
-    let account_collection = wallet.accounts.get(&network).expect("Failed to get network accounts");
-    let account = account_collection
+    let account = wallet
+        .accounts
         .standard_bip44_accounts
         .get(&0)
         .expect("Expected BIP44 account at index 0 to exist");
     let xpub = account.account_xpub;
 
     let managed_account = managed_wallet_info
-        .first_bip44_managed_account_mut(network)
+        .first_bip44_managed_account_mut()
         .expect("Failed to get first BIP44 managed account");
 
     // Get an address from standard account (where unlocked funds go)
@@ -134,8 +133,7 @@ async fn test_asset_unlock_transaction_routing() {
         timestamp: Some(1234567890),
     };
 
-    let result =
-        managed_wallet_info.check_transaction(&tx, network, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_transaction(&tx, context, &mut wallet, true).await;
 
     // The transaction should be recognized as relevant
     assert!(result.is_relevant, "Asset unlock transaction should be recognized as relevant");
@@ -159,10 +157,9 @@ async fn test_asset_unlock_transaction_routing() {
 #[tokio::test]
 async fn test_asset_unlock_routing_to_bip32_account() {
     // Test AssetUnlock routing to BIP32 accounts
-    let network = Network::Testnet;
 
     // Create wallet with default options (includes both BIP44 and BIP32)
-    let mut wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet");
 
     let mut managed_wallet_info =
@@ -170,15 +167,12 @@ async fn test_asset_unlock_routing_to_bip32_account() {
 
     // Get address from BIP44 account (we'll use BIP44 to test the routing)
     let managed_account = managed_wallet_info
-        .first_bip44_managed_account_mut(network)
+        .first_bip44_managed_account_mut()
         .expect("Failed to get first BIP44 managed account");
 
     // Get the account's xpub from wallet
-    let account_collection = wallet.accounts.get(&network).expect("Failed to get network accounts");
-    let account = account_collection
-        .standard_bip44_accounts
-        .get(&0)
-        .expect("Expected BIP44 account at index 0");
+    let account =
+        wallet.accounts.standard_bip44_accounts.get(&0).expect("Expected BIP44 account at index 0");
     let xpub = account.account_xpub;
 
     let address = managed_account
@@ -215,8 +209,7 @@ async fn test_asset_unlock_routing_to_bip32_account() {
         timestamp: Some(1234567890),
     };
 
-    let result =
-        managed_wallet_info.check_transaction(&tx, network, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_transaction(&tx, context, &mut wallet, true).await;
 
     // Should be recognized as relevant
     assert!(result.is_relevant, "Asset unlock transaction to BIP32 account should be relevant");

--- a/key-wallet/src/transaction_checking/transaction_router/tests/identity_transactions.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/identity_transactions.rs
@@ -57,26 +57,26 @@ fn test_identity_registration() {
 async fn test_identity_registration_account_routing() {
     let network = Network::Testnet;
 
-    let mut wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::None)
+    let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::None)
         .expect("Failed to create wallet without default accounts");
 
     // Add identity registration account
     let account_type = AccountType::IdentityRegistration;
-    wallet.add_account(account_type, network, None).expect("Failed to add account to wallet");
+    wallet.add_account(account_type, None).expect("Failed to add account to wallet");
 
     let mut managed_wallet_info =
         ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
 
     // Get the identity registration account
-    let account_collection = wallet.accounts.get(&network).expect("Failed to get network accounts");
-    let account = account_collection
+    let account = wallet
+        .accounts
         .identity_registration
         .as_ref()
         .expect("Expected identity registration account to exist");
     let xpub = account.account_xpub;
 
     let managed_account = managed_wallet_info
-        .identity_registration_managed_account_mut(network)
+        .identity_registration_managed_account_mut()
         .expect("Failed to get identity registration managed account");
 
     // Use the new next_address method for identity registration account
@@ -144,8 +144,7 @@ async fn test_identity_registration_account_routing() {
     };
 
     // First check without updating state
-    let result =
-        managed_wallet_info.check_transaction(&tx, network, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_transaction(&tx, context, &mut wallet, true).await;
 
     println!(
         "Identity registration transaction result: is_relevant={}, received={}, credit_conversion={}",
@@ -179,20 +178,20 @@ async fn test_identity_registration_account_routing() {
 async fn test_normal_payment_to_identity_address_not_detected() {
     let network = Network::Testnet;
 
-    let mut wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
     let mut managed_wallet_info =
         ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
 
-    let account_collection = wallet.accounts.get(&network).expect("Failed to get network accounts");
-    let account = account_collection
+    let account = wallet
+        .accounts
         .identity_registration
         .as_ref()
         .expect("Expected identity registration account to exist");
     let xpub = account.account_xpub;
 
     let managed_account = managed_wallet_info
-        .identity_registration_managed_account_mut(network)
+        .identity_registration_managed_account_mut()
         .expect("Failed to get identity registration managed account");
 
     // Get an identity registration address
@@ -223,7 +222,6 @@ async fn test_normal_payment_to_identity_address_not_detected() {
     let result = managed_wallet_info
         .check_transaction(
             &normal_tx,
-            network,
             context,
             &mut wallet,
             true, // update state

--- a/key-wallet/src/transaction_checking/transaction_router/tests/provider.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/provider.rs
@@ -125,10 +125,10 @@ async fn test_provider_registration_transaction_routing_check_owner_only() {
     let network = Network::Testnet;
 
     // We create another wallet that will hold keys not in our main wallet
-    let other_wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let other_wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
-    let mut wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut other_managed_wallet_info =
@@ -139,18 +139,18 @@ async fn test_provider_registration_transaction_routing_check_owner_only() {
 
     // Get addresses from provider accounts
     let managed_owner = managed_wallet_info
-        .provider_owner_keys_managed_account_mut(network)
+        .provider_owner_keys_managed_account_mut()
         .expect("Failed to get provider owner keys managed account");
     let owner_address = managed_owner.next_address(None, true).expect("expected owner address");
 
     let voting_address = other_managed_wallet_info
-        .provider_voting_keys_managed_account_mut(network)
+        .provider_voting_keys_managed_account_mut()
         .expect("Failed to get provider voting keys managed account")
         .next_address(None, true)
         .expect("expected voting address");
 
     let operator_public_key = other_managed_wallet_info
-        .provider_operator_keys_managed_account_mut(network)
+        .provider_operator_keys_managed_account_mut()
         .expect("Failed to get provider operator keys managed account")
         .next_bls_operator_key(None, true)
         .expect("expected voting address");
@@ -158,7 +158,7 @@ async fn test_provider_registration_transaction_routing_check_owner_only() {
     // Payout addresses for providers are just regular addresses, not a separate account
     // For testing, we'll use the first standard account's address
     let payout_address = other_managed_wallet_info
-        .first_bip44_managed_account_mut(network)
+        .first_bip44_managed_account_mut()
         .and_then(|acc| acc.next_receive_address(None, true).ok())
         .unwrap_or_else(|| {
             dashcore::Address::p2pkh(
@@ -229,8 +229,7 @@ async fn test_provider_registration_transaction_routing_check_owner_only() {
         timestamp: Some(1234567890),
     };
 
-    let result =
-        managed_wallet_info.check_transaction(&tx, network, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_transaction(&tx, context, &mut wallet, true).await;
 
     println!(
         "Provider registration transaction result: is_relevant={}, received={}",
@@ -262,10 +261,10 @@ async fn test_provider_registration_transaction_routing_check_voting_only() {
     let network = Network::Testnet;
 
     // We create another wallet that will hold keys not in our main wallet
-    let other_wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let other_wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
-    let mut wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut other_managed_wallet_info =
@@ -276,18 +275,18 @@ async fn test_provider_registration_transaction_routing_check_voting_only() {
 
     // Get addresses from provider accounts
     let owner_address = other_managed_wallet_info
-        .provider_owner_keys_managed_account_mut(network)
+        .provider_owner_keys_managed_account_mut()
         .expect("Failed to get provider owner keys managed account")
         .next_address(None, true)
         .expect("expected owner address");
 
     let managed_voting = managed_wallet_info
-        .provider_voting_keys_managed_account_mut(network)
+        .provider_voting_keys_managed_account_mut()
         .expect("Failed to get provider voting keys managed account");
     let voting_address = managed_voting.next_address(None, true).expect("expected voting address");
 
     let operator_public_key = other_managed_wallet_info
-        .provider_operator_keys_managed_account_mut(network)
+        .provider_operator_keys_managed_account_mut()
         .expect("Failed to get provider operator keys managed account")
         .next_bls_operator_key(None, true)
         .expect("expected operator key");
@@ -295,7 +294,7 @@ async fn test_provider_registration_transaction_routing_check_voting_only() {
     // Payout addresses for providers are just regular addresses, not a separate account
     // For testing, we'll use the first standard account's address
     let payout_address = other_managed_wallet_info
-        .first_bip44_managed_account_mut(network)
+        .first_bip44_managed_account_mut()
         .and_then(|acc| acc.next_receive_address(None, true).ok())
         .unwrap_or_else(|| {
             dashcore::Address::p2pkh(
@@ -366,8 +365,7 @@ async fn test_provider_registration_transaction_routing_check_voting_only() {
         timestamp: Some(1234567890),
     };
 
-    let result =
-        managed_wallet_info.check_transaction(&tx, network, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_transaction(&tx, context, &mut wallet, true).await;
 
     println!(
         "Provider registration transaction result (voting): is_relevant={}, received={}",
@@ -399,10 +397,10 @@ async fn test_provider_registration_transaction_routing_check_operator_only() {
     let network = Network::Testnet;
 
     // We create another wallet that will hold keys not in our main wallet
-    let other_wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let other_wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
-    let mut wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut other_managed_wallet_info =
@@ -413,19 +411,19 @@ async fn test_provider_registration_transaction_routing_check_operator_only() {
 
     // Get addresses from provider accounts
     let owner_address = other_managed_wallet_info
-        .provider_owner_keys_managed_account_mut(network)
+        .provider_owner_keys_managed_account_mut()
         .expect("Failed to get provider owner keys managed account")
         .next_address(None, true)
         .expect("expected owner address");
 
     let voting_address = other_managed_wallet_info
-        .provider_voting_keys_managed_account_mut(network)
+        .provider_voting_keys_managed_account_mut()
         .expect("Failed to get provider voting keys managed account")
         .next_address(None, true)
         .expect("expected voting address");
 
     let managed_operator = managed_wallet_info
-        .provider_operator_keys_managed_account_mut(network)
+        .provider_operator_keys_managed_account_mut()
         .expect("Failed to get provider operator keys managed account");
     let operator_public_key =
         managed_operator.next_bls_operator_key(None, true).expect("expected operator key");
@@ -433,7 +431,7 @@ async fn test_provider_registration_transaction_routing_check_operator_only() {
     // Payout addresses for providers are just regular addresses, not a separate account
     // For testing, we'll use the first standard account's address
     let payout_address = other_managed_wallet_info
-        .first_bip44_managed_account_mut(network)
+        .first_bip44_managed_account_mut()
         .and_then(|acc| acc.next_receive_address(None, true).ok())
         .unwrap_or_else(|| {
             dashcore::Address::p2pkh(
@@ -504,8 +502,7 @@ async fn test_provider_registration_transaction_routing_check_operator_only() {
         timestamp: Some(1234567890),
     };
 
-    let result =
-        managed_wallet_info.check_transaction(&tx, network, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_transaction(&tx, context, &mut wallet, true).await;
 
     println!(
         "Provider registration transaction result (operator): is_relevant={}, received={}",
@@ -582,10 +579,10 @@ async fn test_provider_registration_transaction_routing_check_platform_only() {
     let network = Network::Testnet;
 
     // We create another wallet that will hold keys not in our main wallet
-    let other_wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let other_wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
-    let mut wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut other_managed_wallet_info =
@@ -596,26 +593,26 @@ async fn test_provider_registration_transaction_routing_check_platform_only() {
 
     // Get addresses from provider accounts
     let owner_address = other_managed_wallet_info
-        .provider_owner_keys_managed_account_mut(network)
+        .provider_owner_keys_managed_account_mut()
         .expect("Failed to get provider owner keys managed account")
         .next_address(None, true)
         .expect("expected owner address");
 
     let voting_address = other_managed_wallet_info
-        .provider_voting_keys_managed_account_mut(network)
+        .provider_voting_keys_managed_account_mut()
         .expect("Failed to get provider voting keys managed account")
         .next_address(None, true)
         .expect("expected voting address");
 
     let operator_public_key = other_managed_wallet_info
-        .provider_operator_keys_managed_account_mut(network)
+        .provider_operator_keys_managed_account_mut()
         .expect("Failed to get provider operator keys managed account")
         .next_bls_operator_key(None, true)
         .expect("expected operator key");
 
     // Get platform key from our wallet
     let managed_platform = managed_wallet_info
-        .provider_platform_keys_managed_account_mut(network)
+        .provider_platform_keys_managed_account_mut()
         .expect("Failed to get provider platform keys managed account");
 
     // For platform keys, we need to get the EdDSA key and derive the node ID
@@ -633,7 +630,7 @@ async fn test_provider_registration_transaction_routing_check_platform_only() {
     // Payout addresses for providers are just regular addresses, not a separate account
     // For testing, we'll use the first standard account's address
     let payout_address = other_managed_wallet_info
-        .first_bip44_managed_account_mut(network)
+        .first_bip44_managed_account_mut()
         .and_then(|acc| acc.next_receive_address(None, true).ok())
         .unwrap_or_else(|| {
             dashcore::Address::p2pkh(
@@ -709,8 +706,7 @@ async fn test_provider_registration_transaction_routing_check_platform_only() {
         timestamp: Some(1234567890),
     };
 
-    let result =
-        managed_wallet_info.check_transaction(&tx, network, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_transaction(&tx, context, &mut wallet, true).await;
 
     println!(
         "Provider registration transaction result (platform): is_relevant={}, received={}",
@@ -784,8 +780,7 @@ fn test_provider_update_service_with_operator_key() {
 #[tokio::test]
 async fn test_provider_update_registrar_with_voting_and_operator() {
     // Test provider update registrar classification and routing
-    let network = Network::Testnet;
-    let mut wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut managed_wallet_info =
@@ -793,14 +788,14 @@ async fn test_provider_update_registrar_with_voting_and_operator() {
 
     // Get voting address
     let voting_address = managed_wallet_info
-        .provider_voting_keys_managed_account_mut(network)
+        .provider_voting_keys_managed_account_mut()
         .expect("Failed to get provider voting keys managed account")
         .next_address(None, true)
         .expect("expected voting address");
 
     // Get BLS operator key
     let operator_public_key = managed_wallet_info
-        .provider_operator_keys_managed_account_mut(network)
+        .provider_operator_keys_managed_account_mut()
         .expect("Failed to get provider operator keys managed account")
         .next_bls_operator_key(None, true)
         .expect("expected operator key");
@@ -832,8 +827,7 @@ async fn test_provider_update_registrar_with_voting_and_operator() {
         timestamp: Some(1234567890),
     };
 
-    let result =
-        managed_wallet_info.check_transaction(&tx, network, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_transaction(&tx, context, &mut wallet, true).await;
 
     // Should be recognized as relevant due to voting and operator keys
     assert!(result.is_relevant, "Provider update registrar should be relevant");
@@ -857,23 +851,22 @@ async fn test_provider_update_registrar_with_voting_and_operator() {
 #[tokio::test]
 async fn test_provider_revocation_classification_and_routing() {
     // Test that provider revocation transactions are properly classified and routed
-    let network = Network::Testnet;
-    let mut wallet = Wallet::new_random(&[network], WalletAccountCreationOptions::Default)
+    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut managed_wallet_info =
         ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
 
     // Get a standard address for collateral return
-    let account_collection = wallet.accounts.get(&network).expect("Failed to get network accounts");
-    let account = account_collection
+    let account = wallet
+        .accounts
         .standard_bip44_accounts
         .get(&0)
         .expect("Expected BIP44 account at index 0 to exist");
     let xpub = account.account_xpub;
 
     let managed_account = managed_wallet_info
-        .first_bip44_managed_account_mut(network)
+        .first_bip44_managed_account_mut()
         .expect("Failed to get first BIP44 managed account");
 
     let return_address = managed_account
@@ -927,8 +920,7 @@ async fn test_provider_revocation_classification_and_routing() {
         timestamp: Some(1234567890),
     };
 
-    let result =
-        managed_wallet_info.check_transaction(&tx, network, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_transaction(&tx, context, &mut wallet, true).await;
 
     // Should be recognized as relevant due to collateral return
     assert!(result.is_relevant, "Provider revocation with collateral return should be relevant");

--- a/key-wallet/src/wallet/backup.rs
+++ b/key-wallet/src/wallet/backup.rs
@@ -18,7 +18,7 @@ impl Wallet {
     /// use key_wallet::wallet::Wallet;
     ///
     /// let wallet = Wallet::new_random(
-    ///     &[key_wallet::Network::Testnet],
+    ///     key_wallet::Network::Testnet,
     ///     key_wallet::wallet::initialization::WalletAccountCreationOptions::Default,
     /// ).unwrap();
     ///
@@ -71,7 +71,7 @@ mod tests {
 
         let original = Wallet::from_mnemonic(
             mnemonic,
-            &[Network::Testnet],
+            Network::Testnet,
             WalletAccountCreationOptions::Default,
         )
         .unwrap();
@@ -85,7 +85,7 @@ mod tests {
 
         // Verify the restored wallet matches the original
         assert_eq!(original.wallet_id, restored.wallet_id);
-        assert_eq!(original.accounts.len(), restored.accounts.len());
+        assert_eq!(original.accounts.count(), restored.accounts.count());
     }
 
     #[test]

--- a/key-wallet/src/wallet/bip38.rs
+++ b/key-wallet/src/wallet/bip38.rs
@@ -36,7 +36,6 @@ impl Wallet {
     /// Export an account's private key as BIP38 encrypted
     pub fn export_bip44_account_key_bip38(
         &self,
-        network: Network,
         account_index: u32,
         password: &str,
     ) -> Result<Bip38EncryptedKey> {
@@ -47,14 +46,13 @@ impl Wallet {
         }
 
         // Verify account exists
-        let account =
-            self.get_bip44_account(network, account_index).ok_or(Error::InvalidParameter(
-                format!("Account {} not found for network {:?}", account_index, network),
-            ))?;
+        let account = self.get_bip44_account(account_index).ok_or(Error::InvalidParameter(
+            format!("Account {} not found for network {:?}", account_index, self.network),
+        ))?;
 
         // Derive the account key from the root key
         let root_key = self.root_extended_priv_key()?;
-        let master_key = root_key.to_extended_priv_key(network);
+        let master_key = root_key.to_extended_priv_key(self.network);
 
         use crate::account::AccountType;
         use crate::derivation::HDWallet;
@@ -75,7 +73,7 @@ impl Wallet {
         };
 
         let secret_key = account_key.private_key;
-        encrypt_private_key(&secret_key, password, true, network)
+        encrypt_private_key(&secret_key, password, true, self.network)
     }
 
     /// Import a BIP38 encrypted private key

--- a/key-wallet/src/wallet/helper.rs
+++ b/key-wallet/src/wallet/helper.rs
@@ -7,83 +7,54 @@ use super::root_extended_keys::RootExtendedPrivKey;
 use super::{Wallet, WalletType};
 use crate::account::{Account, AccountType, StandardAccountType};
 use crate::error::Result;
-use crate::{AccountCollection, Error, Network};
+use crate::Error;
 use alloc::vec::Vec;
 use hex;
 
 impl Wallet {
-    /// Get the networks supported for the wallet
-    pub fn networks_supported(&self) -> Vec<Network> {
-        self.accounts.keys().cloned().collect()
-    }
-    /// Get the collection of accounts on a network
-    pub fn accounts_on_network(&self, network: Network) -> Option<&AccountCollection> {
-        self.accounts.get(&network)
-    }
-    /// Get a bip44 account by network and index
-    pub fn get_bip44_account(&self, network: Network, index: u32) -> Option<&Account> {
-        self.accounts
-            .get(&network)
-            .and_then(|collection| collection.standard_bip44_accounts.get(&index))
+    /// Get a bip44 account and index
+    pub fn get_bip44_account(&self, index: u32) -> Option<&Account> {
+        self.accounts.standard_bip44_accounts.get(&index)
     }
 
-    /// Get a bip32 account by network and index
-    pub fn get_bip32_account(&self, network: Network, index: u32) -> Option<&Account> {
-        self.accounts
-            .get(&network)
-            .and_then(|collection| collection.standard_bip32_accounts.get(&index))
+    /// Get a bip32 account and index
+    pub fn get_bip32_account(&self, index: u32) -> Option<&Account> {
+        self.accounts.standard_bip32_accounts.get(&index)
     }
 
-    /// Get a coinjoin account by network and index
-    pub fn get_coinjoin_account(&self, network: Network, index: u32) -> Option<&Account> {
-        self.accounts.get(&network).and_then(|collection| collection.coinjoin_accounts.get(&index))
+    /// Get a coinjoin account and index
+    pub fn get_coinjoin_account(&self, index: u32) -> Option<&Account> {
+        self.accounts.coinjoin_accounts.get(&index)
     }
 
-    /// Get a mutable bip44 account by network and index
-    pub fn get_bip44_account_mut(&mut self, network: Network, index: u32) -> Option<&mut Account> {
-        self.accounts
-            .get_mut(&network)
-            .and_then(|collection| collection.standard_bip44_accounts.get_mut(&index))
+    /// Get a mutable bip44 account by index
+    pub fn get_bip44_account_mut(&mut self, index: u32) -> Option<&mut Account> {
+        self.accounts.standard_bip44_accounts.get_mut(&index)
     }
 
-    /// Get a mutable bip32 account by network and index
-    pub fn get_bip32_account_mut(&mut self, network: Network, index: u32) -> Option<&mut Account> {
-        self.accounts
-            .get_mut(&network)
-            .and_then(|collection| collection.standard_bip32_accounts.get_mut(&index))
+    /// Get a mutable bip32 account and index
+    pub fn get_bip32_account_mut(&mut self, index: u32) -> Option<&mut Account> {
+        self.accounts.standard_bip32_accounts.get_mut(&index)
     }
 
-    /// Get a mutable coinjoin account by network and index
-    pub fn get_coinjoin_account_mut(
-        &mut self,
-        network: Network,
-        index: u32,
-    ) -> Option<&mut Account> {
-        self.accounts
-            .get_mut(&network)
-            .and_then(|collection| collection.coinjoin_accounts.get_mut(&index))
+    /// Get a mutable coinjoin account by index
+    pub fn get_coinjoin_account_mut(&mut self, index: u32) -> Option<&mut Account> {
+        self.accounts.coinjoin_accounts.get_mut(&index)
     }
 
     /// Get all accounts (both standard and coinjoin)
     pub fn all_accounts(&self) -> Vec<&Account> {
-        let mut accounts = Vec::new();
-        for collection in self.accounts.values() {
-            accounts.extend(collection.all_accounts());
-        }
-        accounts
+        self.accounts.all_accounts()
     }
 
     /// Get the count of accounts (both standard and coinjoin)
     pub fn account_count(&self) -> usize {
-        self.accounts.values().map(|collection| collection.count()).sum()
+        self.accounts.count()
     }
 
-    /// Get all account indices for a network (both standard and coinjoin)
-    pub fn account_indices(&self, network: Network) -> Vec<u32> {
-        let mut indices = Vec::new();
-        if let Some(collection) = self.accounts.get(&network) {
-            indices.extend(collection.all_indices());
-        }
+    /// Get all account indices (both standard and coinjoin)
+    pub fn account_indices(&self) -> Vec<u32> {
+        let mut indices = self.accounts.all_indices();
         indices.sort();
         indices
     }
@@ -116,10 +87,8 @@ impl Wallet {
         watch_only.wallet_type = WalletType::WatchOnly(root_pub_key);
 
         // Convert all accounts to watch-only
-        for collection in watch_only.accounts.values_mut() {
-            for account in collection.all_accounts_mut() {
-                *account = account.to_watch_only();
-            }
+        for account in watch_only.accounts.all_accounts_mut() {
+            *account = account.to_watch_only();
         }
 
         watch_only
@@ -162,7 +131,6 @@ impl Wallet {
     pub(crate) fn create_accounts_from_options(
         &mut self,
         options: WalletAccountCreationOptions,
-        network: Network,
     ) -> Result<()> {
         if matches!(self.wallet_type, WalletType::MnemonicWithPassphrase { .. }) {
             return Err(Error::InvalidParameter(
@@ -177,7 +145,6 @@ impl Wallet {
                         index: 0,
                         standard_account_type: StandardAccountType::BIP32Account,
                     },
-                    network,
                     None,
                 )?;
 
@@ -187,7 +154,6 @@ impl Wallet {
                         index: 0,
                         standard_account_type: StandardAccountType::BIP44Account,
                     },
-                    network,
                     None,
                 )?;
 
@@ -196,12 +162,11 @@ impl Wallet {
                     AccountType::CoinJoin {
                         index: 0,
                     },
-                    network,
                     None,
                 )?;
 
                 // Create all special purpose accounts
-                self.create_special_purpose_accounts(network)?;
+                self.create_special_purpose_accounts()?;
             }
 
             WalletAccountCreationOptions::AllAccounts(
@@ -217,7 +182,6 @@ impl Wallet {
                             index,
                             standard_account_type: StandardAccountType::BIP44Account,
                         },
-                        network,
                         None,
                     )?;
                 }
@@ -229,7 +193,6 @@ impl Wallet {
                             index,
                             standard_account_type: StandardAccountType::BIP32Account,
                         },
-                        network,
                         None,
                     )?;
                 }
@@ -240,7 +203,6 @@ impl Wallet {
                         AccountType::CoinJoin {
                             index,
                         },
-                        network,
                         None,
                     )?;
                 }
@@ -251,13 +213,12 @@ impl Wallet {
                         AccountType::IdentityTopUp {
                             registration_index,
                         },
-                        network,
                         None,
                     )?;
                 }
 
                 // Create all special purpose accounts
-                self.create_special_purpose_accounts(network)?;
+                self.create_special_purpose_accounts()?;
             }
 
             WalletAccountCreationOptions::BIP44AccountsOnly(bip44_indices) => {
@@ -268,7 +229,6 @@ impl Wallet {
                             index,
                             standard_account_type: StandardAccountType::BIP44Account,
                         },
-                        network,
                         None,
                     )?;
                 }
@@ -288,7 +248,6 @@ impl Wallet {
                             index,
                             standard_account_type: StandardAccountType::BIP44Account,
                         },
-                        network,
                         None,
                     )?;
                 }
@@ -300,7 +259,6 @@ impl Wallet {
                             index,
                             standard_account_type: StandardAccountType::BIP32Account,
                         },
-                        network,
                         None,
                     )?;
                 }
@@ -311,7 +269,6 @@ impl Wallet {
                         AccountType::CoinJoin {
                             index,
                         },
-                        network,
                         None,
                     )?;
                 }
@@ -322,7 +279,6 @@ impl Wallet {
                         AccountType::IdentityTopUp {
                             registration_index,
                         },
-                        network,
                         None,
                     )?;
                 }
@@ -330,7 +286,7 @@ impl Wallet {
                 // Create any additional special accounts if provided
                 if let Some(special_types) = special_accounts {
                     for account_type in special_types {
-                        self.add_account(account_type, network, None)?;
+                        self.add_account(account_type, None)?;
                     }
                 }
             }
@@ -348,7 +304,6 @@ impl Wallet {
         &mut self,
         options: WalletAccountCreationOptions,
         passphrase: &str,
-        network: Network,
     ) -> Result<()> {
         if !matches!(self.wallet_type, WalletType::MnemonicWithPassphrase { .. }) {
             return Err(Error::InvalidParameter(
@@ -363,7 +318,6 @@ impl Wallet {
                         index: 0,
                         standard_account_type: StandardAccountType::BIP32Account,
                     },
-                    network,
                     passphrase,
                 )?;
 
@@ -373,7 +327,6 @@ impl Wallet {
                         index: 0,
                         standard_account_type: StandardAccountType::BIP44Account,
                     },
-                    network,
                     passphrase,
                 )?;
 
@@ -382,12 +335,11 @@ impl Wallet {
                     AccountType::CoinJoin {
                         index: 0,
                     },
-                    network,
                     passphrase,
                 )?;
 
                 // Create all special purpose accounts
-                self.create_special_purpose_accounts_with_passphrase(passphrase, network)?;
+                self.create_special_purpose_accounts_with_passphrase(passphrase)?;
             }
 
             WalletAccountCreationOptions::AllAccounts(
@@ -403,7 +355,6 @@ impl Wallet {
                             index,
                             standard_account_type: StandardAccountType::BIP44Account,
                         },
-                        network,
                         passphrase,
                     )?;
                 }
@@ -415,7 +366,6 @@ impl Wallet {
                             index,
                             standard_account_type: StandardAccountType::BIP32Account,
                         },
-                        network,
                         passphrase,
                     )?;
                 }
@@ -426,7 +376,6 @@ impl Wallet {
                         AccountType::CoinJoin {
                             index,
                         },
-                        network,
                         passphrase,
                     )?;
                 }
@@ -437,13 +386,12 @@ impl Wallet {
                         AccountType::IdentityTopUp {
                             registration_index,
                         },
-                        network,
                         passphrase,
                     )?;
                 }
 
                 // Create all special purpose accounts
-                self.create_special_purpose_accounts_with_passphrase(passphrase, network)?;
+                self.create_special_purpose_accounts_with_passphrase(passphrase)?;
             }
 
             WalletAccountCreationOptions::BIP44AccountsOnly(bip44_indices) => {
@@ -454,7 +402,6 @@ impl Wallet {
                             index,
                             standard_account_type: StandardAccountType::BIP44Account,
                         },
-                        network,
                         passphrase,
                     )?;
                 }
@@ -474,7 +421,6 @@ impl Wallet {
                             index,
                             standard_account_type: StandardAccountType::BIP44Account,
                         },
-                        network,
                         passphrase,
                     )?;
                 }
@@ -486,7 +432,6 @@ impl Wallet {
                             index,
                             standard_account_type: StandardAccountType::BIP32Account,
                         },
-                        network,
                         passphrase,
                     )?;
                 }
@@ -497,7 +442,6 @@ impl Wallet {
                         AccountType::CoinJoin {
                             index,
                         },
-                        network,
                         passphrase,
                     )?;
                 }
@@ -508,7 +452,6 @@ impl Wallet {
                         AccountType::IdentityTopUp {
                             registration_index,
                         },
-                        network,
                         passphrase,
                     )?;
                 }
@@ -516,7 +459,7 @@ impl Wallet {
                 // Create any additional special accounts if provided
                 if let Some(special_types) = special_accounts {
                     for account_type in special_types {
-                        self.add_account_with_passphrase(account_type, network, passphrase)?;
+                        self.add_account_with_passphrase(account_type, passphrase)?;
                     }
                 }
             }
@@ -530,61 +473,45 @@ impl Wallet {
     }
 
     /// Create all special purpose accounts
-    fn create_special_purpose_accounts(&mut self, network: Network) -> Result<()> {
+    fn create_special_purpose_accounts(&mut self) -> Result<()> {
         // Identity registration account
-        self.add_account(AccountType::IdentityRegistration, network, None)?;
+        self.add_account(AccountType::IdentityRegistration, None)?;
 
         // Identity invitation account
-        self.add_account(AccountType::IdentityInvitation, network, None)?;
+        self.add_account(AccountType::IdentityInvitation, None)?;
 
         // Identity top-up not bound to identity
-        self.add_account(AccountType::IdentityTopUpNotBoundToIdentity, network, None)?;
+        self.add_account(AccountType::IdentityTopUpNotBoundToIdentity, None)?;
 
         // Provider keys accounts
-        self.add_account(AccountType::ProviderVotingKeys, network, None)?;
-        self.add_account(AccountType::ProviderOwnerKeys, network, None)?;
+        self.add_account(AccountType::ProviderVotingKeys, None)?;
+        self.add_account(AccountType::ProviderOwnerKeys, None)?;
         #[cfg(feature = "bls")]
-        self.add_bls_account(AccountType::ProviderOperatorKeys, network, None)?;
+        self.add_bls_account(AccountType::ProviderOperatorKeys, None)?;
         #[cfg(feature = "eddsa")]
-        self.add_eddsa_account(AccountType::ProviderPlatformKeys, network, None)?;
+        self.add_eddsa_account(AccountType::ProviderPlatformKeys, None)?;
 
         Ok(())
     }
 
     /// Create all special purpose accounts
-    fn create_special_purpose_accounts_with_passphrase(
-        &mut self,
-        passphrase: &str,
-        network: Network,
-    ) -> Result<()> {
+    fn create_special_purpose_accounts_with_passphrase(&mut self, passphrase: &str) -> Result<()> {
         // Identity registration account
-        self.add_account_with_passphrase(AccountType::IdentityRegistration, network, passphrase)?;
+        self.add_account_with_passphrase(AccountType::IdentityRegistration, passphrase)?;
 
         // Identity invitation account
-        self.add_account_with_passphrase(AccountType::IdentityInvitation, network, passphrase)?;
+        self.add_account_with_passphrase(AccountType::IdentityInvitation, passphrase)?;
 
         // Identity top-up not bound to identity
-        self.add_account_with_passphrase(
-            AccountType::IdentityTopUpNotBoundToIdentity,
-            network,
-            passphrase,
-        )?;
+        self.add_account_with_passphrase(AccountType::IdentityTopUpNotBoundToIdentity, passphrase)?;
 
         // Provider keys accounts
-        self.add_account_with_passphrase(AccountType::ProviderVotingKeys, network, passphrase)?;
-        self.add_account_with_passphrase(AccountType::ProviderOwnerKeys, network, passphrase)?;
+        self.add_account_with_passphrase(AccountType::ProviderVotingKeys, passphrase)?;
+        self.add_account_with_passphrase(AccountType::ProviderOwnerKeys, passphrase)?;
         #[cfg(feature = "bls")]
-        self.add_bls_account_with_passphrase(
-            AccountType::ProviderOperatorKeys,
-            network,
-            passphrase,
-        )?;
+        self.add_bls_account_with_passphrase(AccountType::ProviderOperatorKeys, passphrase)?;
         #[cfg(feature = "eddsa")]
-        self.add_eddsa_account_with_passphrase(
-            AccountType::ProviderPlatformKeys,
-            network,
-            passphrase,
-        )?;
+        self.add_eddsa_account_with_passphrase(AccountType::ProviderPlatformKeys, passphrase)?;
 
         Ok(())
     }
@@ -596,7 +523,6 @@ impl Wallet {
     /// For MnemonicWithPassphrase wallets, you must provide the passphrase.
     ///
     /// # Arguments
-    /// * `network` - The network to derive for
     /// * `path` - The derivation path (e.g., "m/44'/5'/0'/0/0")
     /// * `passphrase` - Optional passphrase for MnemonicWithPassphrase wallets
     ///
@@ -604,7 +530,6 @@ impl Wallet {
     /// The extended private key, or an error if the wallet is watch-only or path is invalid
     pub fn derive_extended_private_key_with_passphrase(
         &self,
-        network: Network,
         path: &crate::DerivationPath,
         passphrase: Option<&str>,
     ) -> Result<crate::bip32::ExtendedPrivKey> {
@@ -616,7 +541,7 @@ impl Wallet {
             WalletType::Mnemonic {
                 root_extended_private_key,
                 ..
-            } => root_extended_private_key.to_extended_priv_key(network),
+            } => root_extended_private_key.to_extended_priv_key(self.network),
             WalletType::MnemonicWithPassphrase {
                 mnemonic,
                 ..
@@ -625,13 +550,13 @@ impl Wallet {
                     "Passphrase required for this wallet type".to_string(),
                 ))?;
                 let seed = mnemonic.to_seed(pass);
-                ExtendedPrivKey::new_master(network, &seed)?
+                ExtendedPrivKey::new_master(self.network, &seed)?
             }
             WalletType::Seed {
                 root_extended_private_key,
                 ..
-            } => root_extended_private_key.to_extended_priv_key(network),
-            WalletType::ExtendedPrivKey(root_priv) => root_priv.to_extended_priv_key(network),
+            } => root_extended_private_key.to_extended_priv_key(self.network),
+            WalletType::ExtendedPrivKey(root_priv) => root_priv.to_extended_priv_key(self.network),
             WalletType::ExternalSignable(_) | WalletType::WatchOnly(_) => {
                 return Err(Error::InvalidParameter(
                     "Cannot derive private keys from watch-only wallet".to_string(),
@@ -651,17 +576,15 @@ impl Wallet {
     /// For MnemonicWithPassphrase wallets, this will fail.
     ///
     /// # Arguments
-    /// * `network` - The network to derive for
     /// * `path` - The derivation path (e.g., "m/44'/5'/0'/0/0")
     ///
     /// # Returns
     /// The extended private key, or an error if the wallet is watch-only or path is invalid
     pub fn derive_extended_private_key(
         &self,
-        network: Network,
         path: &crate::DerivationPath,
     ) -> Result<crate::bip32::ExtendedPrivKey> {
-        self.derive_extended_private_key_with_passphrase(network, path, None)
+        self.derive_extended_private_key_with_passphrase(path, None)
     }
 
     /// Derive a private key at a specific derivation path
@@ -671,17 +594,12 @@ impl Wallet {
     /// For MnemonicWithPassphrase wallets, this will fail.
     ///
     /// # Arguments
-    /// * `network` - The network to derive for
     /// * `path` - The derivation path (e.g., "m/44'/5'/0'/0/0")
     ///
     /// # Returns
     /// The private key (SecretKey), or an error if the wallet is watch-only or path is invalid
-    pub fn derive_private_key(
-        &self,
-        network: Network,
-        path: &crate::DerivationPath,
-    ) -> Result<secp256k1::SecretKey> {
-        let extended = self.derive_extended_private_key(network, path)?;
+    pub fn derive_private_key(&self, path: &crate::DerivationPath) -> Result<secp256k1::SecretKey> {
+        let extended = self.derive_extended_private_key(path)?;
         Ok(extended.private_key)
     }
 
@@ -692,23 +610,18 @@ impl Wallet {
     /// For MnemonicWithPassphrase wallets, this will fail.
     ///
     /// # Arguments
-    /// * `network` - The network to derive for
     /// * `path` - The derivation path (e.g., "m/44'/5'/0'/0/0")
     ///
     /// # Returns
     /// The private key in WIF format, or an error if the wallet is watch-only or path is invalid
-    pub fn derive_private_key_as_wif(
-        &self,
-        network: Network,
-        path: &crate::DerivationPath,
-    ) -> Result<String> {
-        let private_key = self.derive_private_key(network, path)?;
+    pub fn derive_private_key_as_wif(&self, path: &crate::DerivationPath) -> Result<String> {
+        let private_key = self.derive_private_key(path)?;
 
         // Convert to WIF format
         use dashcore::PrivateKey as DashPrivateKey;
         let dash_key = DashPrivateKey {
             compressed: true,
-            network,
+            network: self.network,
             inner: private_key,
         };
         Ok(dash_key.to_wif())
@@ -720,14 +633,12 @@ impl Wallet {
     /// For non-hardened paths, this works with watch-only wallets.
     ///
     /// # Arguments
-    /// * `network` - The network to derive for
     /// * `path` - The derivation path (e.g., "m/44'/5'/0'/0/0")
     ///
     /// # Returns
     /// The extended public key, or an error if the path is invalid
     pub fn derive_extended_public_key(
         &self,
-        network: Network,
         path: &crate::DerivationPath,
     ) -> Result<crate::bip32::ExtendedPubKey> {
         use secp256k1::Secp256k1;
@@ -743,14 +654,14 @@ impl Wallet {
 
         if has_hardened {
             // For hardened paths, derive the extended private key first, then get extended public key
-            let extended_private = self.derive_extended_private_key(network, path)?;
+            let extended_private = self.derive_extended_private_key(path)?;
             use crate::bip32::ExtendedPubKey;
             let secp = Secp256k1::new();
             Ok(ExtendedPubKey::from_priv(&secp, &extended_private))
         } else {
             // For non-hardened paths, derive directly from public key
             let secp = Secp256k1::new();
-            let xpub = self.root_extended_pub_key().to_extended_pub_key(network);
+            let xpub = self.root_extended_pub_key().to_extended_pub_key(self.network);
             xpub.derive_pub(&secp, path).map_err(|e| e.into())
         }
     }
@@ -761,16 +672,11 @@ impl Wallet {
     /// For non-hardened paths, this works with watch-only wallets.
     ///
     /// # Arguments
-    /// * `network` - The network to derive for
     /// * `path` - The derivation path (e.g., "m/44'/5'/0'/0/0")
     ///
     /// # Returns
     /// The public key (secp256k1::PublicKey), or an error if the path is invalid
-    pub fn derive_public_key(
-        &self,
-        network: Network,
-        path: &crate::DerivationPath,
-    ) -> Result<secp256k1::PublicKey> {
+    pub fn derive_public_key(&self, path: &crate::DerivationPath) -> Result<secp256k1::PublicKey> {
         // Check if the path contains hardened derivation
         let has_hardened = path.into_iter().any(|child| child.is_hardened());
 
@@ -782,13 +688,13 @@ impl Wallet {
 
         if has_hardened {
             // For hardened paths, derive the private key first, then get public key
-            let private_key = self.derive_private_key(network, path)?;
+            let private_key = self.derive_private_key(path)?;
             use secp256k1::Secp256k1;
             let secp = Secp256k1::new();
             Ok(secp256k1::PublicKey::from_secret_key(&secp, &private_key))
         } else {
             // For non-hardened paths, derive directly from public key
-            let extended = self.derive_extended_public_key(network, path)?;
+            let extended = self.derive_extended_public_key(path)?;
             Ok(extended.public_key)
         }
     }
@@ -799,17 +705,12 @@ impl Wallet {
     /// For non-hardened paths, this works with watch-only wallets.
     ///
     /// # Arguments
-    /// * `network` - The network to derive for
     /// * `path` - The derivation path (e.g., "m/44'/5'/0'/0/0")
     ///
     /// # Returns
     /// The public key as hex string, or an error if the path is invalid
-    pub fn derive_public_key_as_hex(
-        &self,
-        network: Network,
-        path: &crate::DerivationPath,
-    ) -> Result<String> {
-        let public_key = self.derive_public_key(network, path)?;
+    pub fn derive_public_key_as_hex(&self, path: &crate::DerivationPath) -> Result<String> {
+        let public_key = self.derive_public_key(path)?;
 
         // Return as hex string
         let serialized = public_key.serialize(); // compressed
@@ -824,7 +725,6 @@ impl Wallet {
     /// # Arguments
     /// * `account_type` - The type of account to get the xpub for
     /// * `account_index` - The account index for indexed account types
-    /// * `network` - The network to look up accounts for
     ///
     /// # Returns
     /// The extended public key for the account, or None if not found
@@ -832,53 +732,51 @@ impl Wallet {
         &self,
         account_type: &crate::transaction_checking::transaction_router::AccountTypeToCheck,
         account_index: Option<u32>,
-        network: Network,
     ) -> Option<crate::bip32::ExtendedPubKey> {
-        self.accounts.get(&network).and_then(|coll| {
-            match account_type {
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::StandardBIP44 => {
-                    account_index.and_then(|idx| coll.standard_bip44_accounts.get(&idx).map(|a| a.account_xpub))
-                }
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::StandardBIP32 => {
-                    account_index.and_then(|idx| coll.standard_bip32_accounts.get(&idx).map(|a| a.account_xpub))
-                }
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::CoinJoin => {
-                    account_index.and_then(|idx| coll.coinjoin_accounts.get(&idx).map(|a| a.account_xpub))
-                }
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::IdentityRegistration => {
-                    coll.identity_registration.as_ref().map(|a| a.account_xpub)
-                }
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::IdentityTopUp => {
-                    account_index.and_then(|idx| coll.identity_topup.get(&idx).map(|a| a.account_xpub))
-                }
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::IdentityTopUpNotBound => {
-                    coll.identity_topup_not_bound.as_ref().map(|a| a.account_xpub)
-                }
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::IdentityInvitation => {
-                    coll.identity_invitation.as_ref().map(|a| a.account_xpub)
-                }
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::ProviderVotingKeys => {
-                    coll.provider_voting_keys.as_ref().map(|a| a.account_xpub)
-                }
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::ProviderOwnerKeys => {
-                    coll.provider_owner_keys.as_ref().map(|a| a.account_xpub)
-                }
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::ProviderOperatorKeys |
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::ProviderPlatformKeys => {
-                    // These use BLS/EdDSA keys, not regular xpubs
-                    None
-                }
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::DashpayReceivingFunds |
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::DashpayExternalAccount => {
-                    // Currently not retrieved via this helper
-                    None
-                }
-                crate::transaction_checking::transaction_router::AccountTypeToCheck::PlatformPayment => {
-                    // Platform Payment addresses are not used in Core chain transactions
-                    // and xpubs are not retrieved via this helper
-                    None
-                }
+        let coll = &self.accounts;
+        match account_type {
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::StandardBIP44 => {
+                account_index.and_then(|idx| coll.standard_bip44_accounts.get(&idx).map(|a| a.account_xpub))
             }
-        })
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::StandardBIP32 => {
+                account_index.and_then(|idx| coll.standard_bip32_accounts.get(&idx).map(|a| a.account_xpub))
+            }
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::CoinJoin => {
+                account_index.and_then(|idx| coll.coinjoin_accounts.get(&idx).map(|a| a.account_xpub))
+            }
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::IdentityRegistration => {
+                coll.identity_registration.as_ref().map(|a| a.account_xpub)
+            }
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::IdentityTopUp => {
+                account_index.and_then(|idx| coll.identity_topup.get(&idx).map(|a| a.account_xpub))
+            }
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::IdentityTopUpNotBound => {
+                coll.identity_topup_not_bound.as_ref().map(|a| a.account_xpub)
+            }
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::IdentityInvitation => {
+                coll.identity_invitation.as_ref().map(|a| a.account_xpub)
+            }
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::ProviderVotingKeys => {
+                coll.provider_voting_keys.as_ref().map(|a| a.account_xpub)
+            }
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::ProviderOwnerKeys => {
+                coll.provider_owner_keys.as_ref().map(|a| a.account_xpub)
+            }
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::ProviderOperatorKeys |
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::ProviderPlatformKeys => {
+                // These use BLS/EdDSA keys, not regular xpubs
+                None
+            }
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::DashpayReceivingFunds |
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::DashpayExternalAccount => {
+                // Currently not retrieved via this helper
+                None
+            }
+            crate::transaction_checking::transaction_router::AccountTypeToCheck::PlatformPayment => {
+                // Platform Payment addresses are not used in Core chain transactions
+                // and xpubs are not retrieved via this helper
+                None
+            }
+        }
     }
 }

--- a/key-wallet/src/wallet/initialization.rs
+++ b/key-wallet/src/wallet/initialization.rs
@@ -11,7 +11,6 @@ use crate::error::Result;
 use crate::mnemonic::{Language, Mnemonic};
 use crate::seed::Seed;
 use crate::Network;
-use alloc::collections::BTreeMap;
 use alloc::string::String;
 use std::collections::BTreeSet;
 
@@ -81,31 +80,31 @@ impl Wallet {
     /// Create a new wallet with a randomly generated mnemonic
     ///
     /// # Arguments
-    /// * `networks` - List of networks to create accounts for
+    /// * `network` - Network to create accounts for
     /// * `account_creation_options` - Specifies which accounts to create during initialization
     pub fn new_random(
-        networks: &[Network],
+        network: Network,
         account_creation_options: WalletAccountCreationOptions,
     ) -> Result<Self> {
         let mnemonic = Mnemonic::generate(12, Language::English)?;
         let seed = mnemonic.to_seed("");
         let root_extended_private_key = RootExtendedPrivKey::new_master(&seed)?;
 
-        let mut wallet = Self::from_wallet_type(WalletType::Mnemonic {
-            mnemonic,
-            root_extended_private_key,
-        });
+        let mut wallet = Self::from_wallet_type(
+            network,
+            WalletType::Mnemonic {
+                mnemonic,
+                root_extended_private_key,
+            },
+        );
 
-        // Create accounts for each network
-        for network in networks {
-            wallet.create_accounts_from_options(account_creation_options.clone(), *network)?;
-        }
+        wallet.create_accounts_from_options(account_creation_options.clone())?;
 
         Ok(wallet)
     }
 
     /// Create a wallet from a specific wallet type with no accounts
-    pub fn from_wallet_type(wallet_type: WalletType) -> Self {
+    pub fn from_wallet_type(network: Network, wallet_type: WalletType) -> Self {
         // Compute wallet ID from root public key
         let root_pub_key = match &wallet_type {
             WalletType::Mnemonic {
@@ -129,9 +128,10 @@ impl Wallet {
         let wallet_id = Self::compute_wallet_id_from_root_extended_pub_key(&root_pub_key);
 
         Self {
+            network,
             wallet_id,
             wallet_type,
-            accounts: BTreeMap::new(),
+            accounts: AccountCollection::new(),
         }
     }
 
@@ -139,25 +139,25 @@ impl Wallet {
     ///
     /// # Arguments
     /// * `mnemonic` - The mnemonic phrase
-    /// * `networks` - List of networks to create accounts for
+    /// * `network` - Network to create accounts for
     /// * `account_creation_options` - Specifies which accounts to create during initialization
     pub fn from_mnemonic(
         mnemonic: Mnemonic,
-        networks: &[Network],
+        network: Network,
         account_creation_options: WalletAccountCreationOptions,
     ) -> Result<Self> {
         let seed = mnemonic.to_seed("");
         let root_extended_private_key = RootExtendedPrivKey::new_master(&seed)?;
 
-        let mut wallet = Self::from_wallet_type(WalletType::Mnemonic {
-            mnemonic,
-            root_extended_private_key,
-        });
+        let mut wallet = Self::from_wallet_type(
+            network,
+            WalletType::Mnemonic {
+                mnemonic,
+                root_extended_private_key,
+            },
+        );
 
-        // Create accounts for each network
-        for network in networks {
-            wallet.create_accounts_from_options(account_creation_options.clone(), *network)?;
-        }
+        wallet.create_accounts_from_options(account_creation_options.clone())?;
 
         Ok(wallet)
     }
@@ -168,12 +168,12 @@ impl Wallet {
     /// # Arguments
     /// * `mnemonic` - The mnemonic phrase
     /// * `passphrase` - The BIP39 passphrase
-    /// * `networks` - List of networks to create accounts for
+    /// * `network` - Network to create accounts for
     /// * `account_creation_options` - Specifies which accounts to create during initialization
     pub fn from_mnemonic_with_passphrase(
         mnemonic: Mnemonic,
         passphrase: String,
-        networks: &[Network],
+        network: Network,
         account_creation_options: WalletAccountCreationOptions,
     ) -> Result<Self> {
         let seed = mnemonic.to_seed(&passphrase);
@@ -181,19 +181,18 @@ impl Wallet {
         let root_extended_public_key = root_extended_private_key.to_root_extended_pub_key();
 
         // Store only mnemonic and public key, not the passphrase or private key
-        let mut wallet = Self::from_wallet_type(WalletType::MnemonicWithPassphrase {
-            mnemonic,
-            root_extended_public_key,
-        });
+        let mut wallet = Self::from_wallet_type(
+            network,
+            WalletType::MnemonicWithPassphrase {
+                mnemonic,
+                root_extended_public_key,
+            },
+        );
 
-        // Create accounts for each network
-        for network in networks {
-            wallet.create_accounts_with_passphrase_from_options(
-                account_creation_options.clone(),
-                passphrase.as_str(),
-                *network,
-            )?;
-        }
+        wallet.create_accounts_with_passphrase_from_options(
+            account_creation_options.clone(),
+            passphrase.as_str(),
+        )?;
 
         Ok(wallet)
     }
@@ -206,9 +205,9 @@ impl Wallet {
     ///
     /// # Arguments
     /// * `master_xpub` - The master extended public key for the wallet
-    /// * `accounts` - Pre-created account collections mapped by network. Since watch-only wallets
-    ///   cannot derive private keys, all accounts must be provided with their extended
-    ///   public keys already initialized.
+    /// * `accounts` - Pre-created account collections. Since watch-only wallets cannot derive
+    ///   private keys, all accounts must be provided with their extended public keys already
+    ///   initialized.
     /// * `can_sign_externally` - If true, creates an externally signable wallet that supports
     ///   transaction creation for external signing. If false, creates a pure watch-only wallet.
     ///
@@ -217,18 +216,15 @@ impl Wallet {
     ///
     /// # Example
     /// ```ignore
-    /// let accounts = BTreeMap::from([
-    ///     (Network::Mainnet, account_collection),
-    /// ]);
     /// // Create a pure watch-only wallet
-    /// let watch_wallet = Wallet::from_xpub(master_xpub, accounts.clone(), false)?;
+    /// let watch_wallet = Wallet::from_xpub(master_xpub, account_collection, false)?;
     ///
     /// // Create an externally signable wallet (e.g., for hardware wallet)
     /// let hw_wallet = Wallet::from_xpub(master_xpub, accounts, true)?;
     /// ```
     pub fn from_xpub(
         master_xpub: ExtendedPubKey,
-        accounts: BTreeMap<Network, AccountCollection>,
+        accounts: AccountCollection,
         can_sign_externally: bool,
     ) -> Result<Self> {
         let root_extended_public_key = RootExtendedPubKey::from_extended_pub_key(&master_xpub);
@@ -237,7 +233,7 @@ impl Wallet {
         } else {
             WalletType::WatchOnly(root_extended_public_key)
         };
-        let mut wallet = Self::from_wallet_type(wallet_type);
+        let mut wallet = Self::from_wallet_type(master_xpub.network, wallet_type);
 
         wallet.accounts = accounts;
 
@@ -251,11 +247,10 @@ impl Wallet {
     /// hardware wallets, remote signing services, or other external signing mechanisms.
     ///
     /// # Arguments
-    /// * `master_xpub` - The master extended public key from the external signing device
-    /// * `config` - Optional wallet configuration (uses default if None)
-    /// * `accounts` - Pre-created account collections mapped by network. Since external signable
-    ///   wallets cannot derive private keys, all accounts must be provided with their
-    ///   extended public keys already initialized from the external device.
+    /// * `master_xpub` - The master extended public key from the external signing device.
+    /// * `accounts` - Pre-created account collections. Since external signable wallets cannot
+    ///   derive private keys, all accounts must be provided with their extended public keys
+    ///   already initialized from the external device.
     ///
     /// # Returns
     /// A new external signable wallet instance that can create transactions but requires
@@ -269,18 +264,20 @@ impl Wallet {
     /// // Create accounts with xpubs from hardware wallet
     /// let accounts = create_accounts_from_hardware_wallet(&hardware_wallet)?;
     ///
-    /// let wallet = Wallet::from_external_signable(master_xpub, None, accounts)?;
+    /// let wallet = Wallet::from_external_signable(master_xpub, accounts)?;
     ///
     /// // Later, when signing is needed:
     /// // let signature = hardware_wallet.sign_transaction(&tx)?;
     /// ```
     pub fn from_external_signable(
         master_xpub: ExtendedPubKey,
-        accounts: BTreeMap<Network, AccountCollection>,
+        accounts: AccountCollection,
     ) -> Result<Self> {
         let root_extended_public_key = RootExtendedPubKey::from_extended_pub_key(&master_xpub);
-        let mut wallet =
-            Self::from_wallet_type(WalletType::ExternalSignable(root_extended_public_key));
+        let mut wallet = Self::from_wallet_type(
+            master_xpub.network,
+            WalletType::ExternalSignable(root_extended_public_key),
+        );
 
         wallet.accounts = accounts;
 
@@ -291,24 +288,24 @@ impl Wallet {
     ///
     /// # Arguments
     /// * `seed` - The seed bytes
-    /// * `networks` - List of networks to create accounts for
+    /// * `network` - Network to create accounts for
     /// * `account_creation_options` - Specifies which accounts to create during initialization
     pub fn from_seed(
         seed: Seed,
-        networks: &[Network],
+        network: Network,
         account_creation_options: WalletAccountCreationOptions,
     ) -> Result<Self> {
         let root_extended_private_key = RootExtendedPrivKey::new_master(seed.as_slice())?;
 
-        let mut wallet = Self::from_wallet_type(WalletType::Seed {
-            seed,
-            root_extended_private_key,
-        });
+        let mut wallet = Self::from_wallet_type(
+            network,
+            WalletType::Seed {
+                seed,
+                root_extended_private_key,
+            },
+        );
 
-        // Create accounts for each network
-        for network in networks {
-            wallet.create_accounts_from_options(account_creation_options.clone(), *network)?;
-        }
+        wallet.create_accounts_from_options(account_creation_options.clone())?;
 
         Ok(wallet)
     }
@@ -317,35 +314,32 @@ impl Wallet {
     ///
     /// # Arguments
     /// * `seed_bytes` - The seed bytes array
-    /// * `networks` - List of networks to create accounts for
+    /// * `network` - Network to create accounts for
     /// * `account_creation_options` - Specifies which accounts to create during initialization
     pub fn from_seed_bytes(
         seed_bytes: [u8; 64],
-        networks: &[Network],
+        network: Network,
         account_creation_options: WalletAccountCreationOptions,
     ) -> Result<Self> {
-        Self::from_seed(Seed::new(seed_bytes), networks, account_creation_options)
+        Self::from_seed(Seed::new(seed_bytes), network, account_creation_options)
     }
 
     /// Create a wallet from an extended private key
     ///
     /// # Arguments
     /// * `master_key` - The extended private key
-    /// * `networks` - List of networks to create accounts for
     /// * `account_creation_options` - Specifies which accounts to create during initialization
     pub fn from_extended_key(
         master_key: ExtendedPrivKey,
-        networks: &[Network],
         account_creation_options: WalletAccountCreationOptions,
     ) -> Result<Self> {
         let root_extended_private_key = RootExtendedPrivKey::from_extended_priv_key(&master_key);
-        let mut wallet =
-            Self::from_wallet_type(WalletType::ExtendedPrivKey(root_extended_private_key));
+        let mut wallet = Self::from_wallet_type(
+            master_key.network,
+            WalletType::ExtendedPrivKey(root_extended_private_key),
+        );
 
-        // Create accounts for each network
-        for network in networks {
-            wallet.create_accounts_from_options(account_creation_options.clone(), *network)?;
-        }
+        wallet.create_accounts_from_options(account_creation_options.clone())?;
 
         Ok(wallet)
     }

--- a/key-wallet/src/wallet/managed_wallet_info/helpers.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/helpers.rs
@@ -2,281 +2,210 @@
 
 use super::ManagedWalletInfo;
 use crate::account::ManagedAccount;
-use crate::Network;
+use alloc::vec::Vec;
 
 impl ManagedWalletInfo {
-    /// Get the networks supported for the wallet
-    pub fn networks_supported(&self) -> Vec<Network> {
-        self.accounts.keys().cloned().collect()
-    }
     // BIP44 Account Helpers
 
-    /// Get the first BIP44 managed account for a given network
-    pub fn first_bip44_managed_account(&self, network: Network) -> Option<&ManagedAccount> {
-        self.bip44_managed_account_at_index(network, 0)
+    /// Get the first BIP44 managed account
+    pub fn first_bip44_managed_account(&self) -> Option<&ManagedAccount> {
+        self.bip44_managed_account_at_index(0)
     }
 
-    /// Get the first BIP44 managed account for a given network (mutable)
-    pub fn first_bip44_managed_account_mut(
-        &mut self,
-        network: Network,
-    ) -> Option<&mut ManagedAccount> {
-        self.bip44_managed_account_at_index_mut(network, 0)
+    /// Get the first BIP44 managed account (mutable)
+    pub fn first_bip44_managed_account_mut(&mut self) -> Option<&mut ManagedAccount> {
+        self.bip44_managed_account_at_index_mut(0)
     }
 
     /// Get a BIP44 managed account at a specific index
-    pub fn bip44_managed_account_at_index(
-        &self,
-        network: Network,
-        index: u32,
-    ) -> Option<&ManagedAccount> {
-        self.accounts.get(&network)?.standard_bip44_accounts.get(&index)
+    pub fn bip44_managed_account_at_index(&self, index: u32) -> Option<&ManagedAccount> {
+        self.accounts.standard_bip44_accounts.get(&index)
     }
 
     /// Get a BIP44 managed account at a specific index (mutable)
     pub fn bip44_managed_account_at_index_mut(
         &mut self,
-        network: Network,
         index: u32,
     ) -> Option<&mut ManagedAccount> {
-        self.accounts.get_mut(&network)?.standard_bip44_accounts.get_mut(&index)
+        self.accounts.standard_bip44_accounts.get_mut(&index)
     }
 
     // BIP32 Account Helpers
 
-    /// Get the first BIP32 managed account for a given network
-    pub fn first_bip32_managed_account(&self, network: Network) -> Option<&ManagedAccount> {
-        self.bip32_managed_account_at_index(network, 0)
+    /// Get the first BIP32 managed account
+    pub fn first_bip32_managed_account(&self) -> Option<&ManagedAccount> {
+        self.bip32_managed_account_at_index(0)
     }
 
-    /// Get the first BIP32 managed account for a given network (mutable)
-    pub fn first_bip32_managed_account_mut(
-        &mut self,
-        network: Network,
-    ) -> Option<&mut ManagedAccount> {
-        self.bip32_managed_account_at_index_mut(network, 0)
+    /// Get the first BIP32 managed account (mutable)
+    pub fn first_bip32_managed_account_mut(&mut self) -> Option<&mut ManagedAccount> {
+        self.bip32_managed_account_at_index_mut(0)
     }
 
     /// Get a BIP32 managed account at a specific index
-    pub fn bip32_managed_account_at_index(
-        &self,
-        network: Network,
-        index: u32,
-    ) -> Option<&ManagedAccount> {
-        self.accounts.get(&network)?.standard_bip32_accounts.get(&index)
+    pub fn bip32_managed_account_at_index(&self, index: u32) -> Option<&ManagedAccount> {
+        self.accounts.standard_bip32_accounts.get(&index)
     }
 
     /// Get a BIP32 managed account at a specific index (mutable)
     pub fn bip32_managed_account_at_index_mut(
         &mut self,
-        network: Network,
         index: u32,
     ) -> Option<&mut ManagedAccount> {
-        self.accounts.get_mut(&network)?.standard_bip32_accounts.get_mut(&index)
+        self.accounts.standard_bip32_accounts.get_mut(&index)
     }
 
     // CoinJoin Account Helpers
 
-    /// Get the first CoinJoin managed account for a given network
-    pub fn first_coinjoin_managed_account(&self, network: Network) -> Option<&ManagedAccount> {
-        self.coinjoin_managed_account_at_index(network, 0)
+    /// Get the first CoinJoin managed account
+    pub fn first_coinjoin_managed_account(&self) -> Option<&ManagedAccount> {
+        self.coinjoin_managed_account_at_index(0)
     }
 
-    /// Get the first CoinJoin managed account for a given network (mutable)
-    pub fn first_coinjoin_managed_account_mut(
-        &mut self,
-        network: Network,
-    ) -> Option<&mut ManagedAccount> {
-        self.coinjoin_managed_account_at_index_mut(network, 0)
+    /// Get the first CoinJoin managed account (mutable)
+    pub fn first_coinjoin_managed_account_mut(&mut self) -> Option<&mut ManagedAccount> {
+        self.coinjoin_managed_account_at_index_mut(0)
     }
 
     /// Get a CoinJoin managed account at a specific index
-    pub fn coinjoin_managed_account_at_index(
-        &self,
-        network: Network,
-        index: u32,
-    ) -> Option<&ManagedAccount> {
-        self.accounts.get(&network)?.coinjoin_accounts.get(&index)
+    pub fn coinjoin_managed_account_at_index(&self, index: u32) -> Option<&ManagedAccount> {
+        self.accounts.coinjoin_accounts.get(&index)
     }
 
     /// Get a CoinJoin managed account at a specific index (mutable)
     pub fn coinjoin_managed_account_at_index_mut(
         &mut self,
-        network: Network,
         index: u32,
     ) -> Option<&mut ManagedAccount> {
-        self.accounts.get_mut(&network)?.coinjoin_accounts.get_mut(&index)
+        self.accounts.coinjoin_accounts.get_mut(&index)
     }
 
     // TopUp Account Helpers
 
-    /// Get the first TopUp managed account for a given network
-    pub fn first_topup_managed_account(&self, network: Network) -> Option<&ManagedAccount> {
-        // TopUp accounts use registration_index, so we need to get the first one in the collection
-        self.accounts.get(&network)?.identity_topup.values().next()
+    /// Get the first TopUp managed account
+    pub fn first_topup_managed_account(&self) -> Option<&ManagedAccount> {
+        self.accounts.identity_topup.values().next()
     }
 
-    /// Get the first TopUp managed account for a given network (mutable)
-    pub fn first_topup_managed_account_mut(
-        &mut self,
-        network: Network,
-    ) -> Option<&mut ManagedAccount> {
-        // TopUp accounts use registration_index, so we need to get the first one in the collection
-        self.accounts.get_mut(&network)?.identity_topup.values_mut().next()
+    /// Get the first TopUp managed account (mutable)
+    pub fn first_topup_managed_account_mut(&mut self) -> Option<&mut ManagedAccount> {
+        self.accounts.identity_topup.values_mut().next()
     }
 
     /// Get a TopUp managed account at a specific registration index
     pub fn topup_managed_account_at_registration_index(
         &self,
-        network: Network,
         registration_index: u32,
     ) -> Option<&ManagedAccount> {
-        self.accounts.get(&network)?.identity_topup.get(&registration_index)
+        self.accounts.identity_topup.get(&registration_index)
     }
 
     /// Get a TopUp managed account at a specific registration index (mutable)
     pub fn topup_managed_account_at_registration_index_mut(
         &mut self,
-        network: Network,
         registration_index: u32,
     ) -> Option<&mut ManagedAccount> {
-        self.accounts.get_mut(&network)?.identity_topup.get_mut(&registration_index)
+        self.accounts.identity_topup.get_mut(&registration_index)
     }
 
     // Identity Registration Account Helper
 
-    /// Get the identity registration managed account for a given network
-    pub fn identity_registration_managed_account(
-        &self,
-        network: Network,
-    ) -> Option<&ManagedAccount> {
-        self.accounts.get(&network)?.identity_registration.as_ref()
+    /// Get the identity registration managed account
+    pub fn identity_registration_managed_account(&self) -> Option<&ManagedAccount> {
+        self.accounts.identity_registration.as_ref()
     }
 
-    /// Get the identity registration managed account for a given network (mutable)
-    pub fn identity_registration_managed_account_mut(
-        &mut self,
-        network: Network,
-    ) -> Option<&mut ManagedAccount> {
-        self.accounts.get_mut(&network)?.identity_registration.as_mut()
+    /// Get the identity registration managed account (mutable)
+    pub fn identity_registration_managed_account_mut(&mut self) -> Option<&mut ManagedAccount> {
+        self.accounts.identity_registration.as_mut()
     }
 
     // Identity TopUp Not Bound Account Helper
 
-    /// Get the identity top-up not bound managed account for a given network
-    pub fn identity_topup_not_bound_managed_account(
-        &self,
-        network: Network,
-    ) -> Option<&ManagedAccount> {
-        self.accounts.get(&network)?.identity_topup_not_bound.as_ref()
+    /// Get the identity top-up not bound managed account
+    pub fn identity_topup_not_bound_managed_account(&self) -> Option<&ManagedAccount> {
+        self.accounts.identity_topup_not_bound.as_ref()
     }
 
-    /// Get the identity top-up not bound managed account for a given network (mutable)
-    pub fn identity_topup_not_bound_managed_account_mut(
-        &mut self,
-        network: Network,
-    ) -> Option<&mut ManagedAccount> {
-        self.accounts.get_mut(&network)?.identity_topup_not_bound.as_mut()
+    /// Get the identity top-up not bound managed account (mutable)
+    pub fn identity_topup_not_bound_managed_account_mut(&mut self) -> Option<&mut ManagedAccount> {
+        self.accounts.identity_topup_not_bound.as_mut()
     }
 
     // Identity Invitation Account Helper
 
-    /// Get the identity invitation managed account for a given network
-    pub fn identity_invitation_managed_account(&self, network: Network) -> Option<&ManagedAccount> {
-        self.accounts.get(&network)?.identity_invitation.as_ref()
+    /// Get the identity invitation managed account
+    pub fn identity_invitation_managed_account(&self) -> Option<&ManagedAccount> {
+        self.accounts.identity_invitation.as_ref()
     }
 
-    /// Get the identity invitation managed account for a given network (mutable)
-    pub fn identity_invitation_managed_account_mut(
-        &mut self,
-        network: Network,
-    ) -> Option<&mut ManagedAccount> {
-        self.accounts.get_mut(&network)?.identity_invitation.as_mut()
+    /// Get the identity invitation managed account (mutable)
+    pub fn identity_invitation_managed_account_mut(&mut self) -> Option<&mut ManagedAccount> {
+        self.accounts.identity_invitation.as_mut()
     }
 
     // Provider Voting Keys Account Helper
 
-    /// Get the provider voting keys managed account for a given network
-    pub fn provider_voting_keys_managed_account(
-        &self,
-        network: Network,
-    ) -> Option<&ManagedAccount> {
-        self.accounts.get(&network)?.provider_voting_keys.as_ref()
+    /// Get the provider voting keys managed account
+    pub fn provider_voting_keys_managed_account(&self) -> Option<&ManagedAccount> {
+        self.accounts.provider_voting_keys.as_ref()
     }
 
-    /// Get the provider voting keys managed account for a given network (mutable)
-    pub fn provider_voting_keys_managed_account_mut(
-        &mut self,
-        network: Network,
-    ) -> Option<&mut ManagedAccount> {
-        self.accounts.get_mut(&network)?.provider_voting_keys.as_mut()
+    /// Get the provider voting keys managed account (mutable)
+    pub fn provider_voting_keys_managed_account_mut(&mut self) -> Option<&mut ManagedAccount> {
+        self.accounts.provider_voting_keys.as_mut()
     }
 
     // Provider Owner Keys Account Helper
 
-    /// Get the provider owner keys managed account for a given network
-    pub fn provider_owner_keys_managed_account(&self, network: Network) -> Option<&ManagedAccount> {
-        self.accounts.get(&network)?.provider_owner_keys.as_ref()
+    /// Get the provider owner keys managed account
+    pub fn provider_owner_keys_managed_account(&self) -> Option<&ManagedAccount> {
+        self.accounts.provider_owner_keys.as_ref()
     }
 
-    /// Get the provider owner keys managed account for a given network (mutable)
-    pub fn provider_owner_keys_managed_account_mut(
-        &mut self,
-        network: Network,
-    ) -> Option<&mut ManagedAccount> {
-        self.accounts.get_mut(&network)?.provider_owner_keys.as_mut()
+    /// Get the provider owner keys managed account (mutable)
+    pub fn provider_owner_keys_managed_account_mut(&mut self) -> Option<&mut ManagedAccount> {
+        self.accounts.provider_owner_keys.as_mut()
     }
 
     // Provider Operator Keys Account Helper
 
-    /// Get the provider operator keys managed account for a given network
-    pub fn provider_operator_keys_managed_account(
-        &self,
-        network: Network,
-    ) -> Option<&ManagedAccount> {
-        self.accounts.get(&network)?.provider_operator_keys.as_ref()
+    /// Get the provider operator keys managed account
+    pub fn provider_operator_keys_managed_account(&self) -> Option<&ManagedAccount> {
+        self.accounts.provider_operator_keys.as_ref()
     }
 
-    /// Get the provider operator keys managed account for a given network (mutable)
-    pub fn provider_operator_keys_managed_account_mut(
-        &mut self,
-        network: Network,
-    ) -> Option<&mut ManagedAccount> {
-        self.accounts.get_mut(&network)?.provider_operator_keys.as_mut()
+    /// Get the provider operator keys managed account (mutable)
+    pub fn provider_operator_keys_managed_account_mut(&mut self) -> Option<&mut ManagedAccount> {
+        self.accounts.provider_operator_keys.as_mut()
     }
 
     // Provider Platform Keys Account Helper
 
-    /// Get the provider platform keys managed account for a given network
-    pub fn provider_platform_keys_managed_account(
-        &self,
-        network: Network,
-    ) -> Option<&ManagedAccount> {
-        self.accounts.get(&network)?.provider_platform_keys.as_ref()
+    /// Get the provider platform keys managed account
+    pub fn provider_platform_keys_managed_account(&self) -> Option<&ManagedAccount> {
+        self.accounts.provider_platform_keys.as_ref()
     }
 
-    /// Get the provider platform keys managed account for a given network (mutable)
-    pub fn provider_platform_keys_managed_account_mut(
-        &mut self,
-        network: Network,
-    ) -> Option<&mut ManagedAccount> {
-        self.accounts.get_mut(&network)?.provider_platform_keys.as_mut()
+    /// Get the provider platform keys managed account (mutable)
+    pub fn provider_platform_keys_managed_account_mut(&mut self) -> Option<&mut ManagedAccount> {
+        self.accounts.provider_platform_keys.as_mut()
     }
 
     // General Helpers
 
-    /// Check if the wallet has any accounts for the given network
-    pub fn has_accounts(&self, network: Network) -> bool {
-        self.accounts.contains_key(&network)
+    /// Check if the wallet has any accounts
+    pub fn has_accounts(&self) -> bool {
+        !self.accounts.is_empty()
     }
 
-    /// Get the total number of accounts across all types for a given network
-    pub fn account_count(&self, network: Network) -> usize {
-        self.accounts.get(&network).map(|collection| collection.all_accounts().len()).unwrap_or(0)
+    /// Get the total number of accounts across all types
+    pub fn account_count(&self) -> usize {
+        self.accounts.all_accounts().len()
     }
 
-    /// Get the total number of accounts across all types for a given network
-    pub fn all_accounts(&self, network: Network) -> Vec<&ManagedAccount> {
-        self.accounts.get(&network).map(|collection| collection.all_accounts()).unwrap_or_default()
+    /// Get all accounts
+    pub fn all_managed_accounts(&self) -> Vec<&ManagedAccount> {
+        self.accounts.all_accounts()
     }
 }

--- a/key-wallet/src/wallet/managed_wallet_info/managed_account_operations.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/managed_account_operations.rs
@@ -6,7 +6,6 @@ use crate::account::AccountType;
 use crate::bip32::ExtendedPubKey;
 use crate::error::Result;
 use crate::wallet::Wallet;
-use crate::Network;
 
 /// Trait for managed account operations
 pub trait ManagedAccountOperations {
@@ -17,16 +16,10 @@ pub trait ManagedAccountOperations {
     /// # Arguments
     /// * `wallet` - The wallet containing the account
     /// * `account_type` - The type of account to manage
-    /// * `network` - The network for the account
     ///
     /// # Returns
     /// Ok(()) if the managed account was successfully added
-    fn add_managed_account(
-        &mut self,
-        wallet: &Wallet,
-        account_type: AccountType,
-        network: Network,
-    ) -> Result<()>;
+    fn add_managed_account(&mut self, wallet: &Wallet, account_type: AccountType) -> Result<()>;
 
     /// Add a new managed account with passphrase verification
     ///
@@ -36,7 +29,6 @@ pub trait ManagedAccountOperations {
     /// # Arguments
     /// * `wallet` - The wallet containing the account (must be MnemonicWithPassphrase type)
     /// * `account_type` - The type of account to manage
-    /// * `network` - The network for the account
     /// * `passphrase` - The passphrase to verify
     ///
     /// # Returns
@@ -45,7 +37,6 @@ pub trait ManagedAccountOperations {
         &mut self,
         wallet: &Wallet,
         account_type: AccountType,
-        network: Network,
         passphrase: &str,
     ) -> Result<()>;
 
@@ -56,7 +47,6 @@ pub trait ManagedAccountOperations {
     ///
     /// # Arguments
     /// * `account_type` - The type of account to create
-    /// * `network` - The network for the account
     /// * `account_xpub` - Extended public key for the account
     ///
     /// # Returns
@@ -64,7 +54,6 @@ pub trait ManagedAccountOperations {
     fn add_managed_account_from_xpub(
         &mut self,
         account_type: AccountType,
-        network: Network,
         account_xpub: ExtendedPubKey,
     ) -> Result<()>;
 
@@ -75,17 +64,12 @@ pub trait ManagedAccountOperations {
     /// # Arguments
     /// * `wallet` - The wallet containing the BLS account
     /// * `account_type` - The type of account (must be ProviderOperatorKeys)
-    /// * `network` - The network for the account
     ///
     /// # Returns
     /// Ok(()) if the managed BLS account was successfully added
     #[cfg(feature = "bls")]
-    fn add_managed_bls_account(
-        &mut self,
-        wallet: &Wallet,
-        account_type: AccountType,
-        network: Network,
-    ) -> Result<()>;
+    fn add_managed_bls_account(&mut self, wallet: &Wallet, account_type: AccountType)
+        -> Result<()>;
 
     /// Add a new managed BLS account with passphrase verification
     ///
@@ -95,7 +79,6 @@ pub trait ManagedAccountOperations {
     /// # Arguments
     /// * `wallet` - The wallet containing the BLS account (must be MnemonicWithPassphrase type)
     /// * `account_type` - The type of account (must be ProviderOperatorKeys)
-    /// * `network` - The network for the account
     /// * `passphrase` - The passphrase to verify
     ///
     /// # Returns
@@ -105,7 +88,6 @@ pub trait ManagedAccountOperations {
         &mut self,
         wallet: &Wallet,
         account_type: AccountType,
-        network: Network,
         passphrase: &str,
     ) -> Result<()>;
 
@@ -115,7 +97,6 @@ pub trait ManagedAccountOperations {
     ///
     /// # Arguments
     /// * `account_type` - The type of account (must be ProviderOperatorKeys)
-    /// * `network` - The network for the account
     /// * `bls_public_key` - 48-byte BLS public key
     ///
     /// # Returns
@@ -124,7 +105,6 @@ pub trait ManagedAccountOperations {
     fn add_managed_bls_account_from_public_key(
         &mut self,
         account_type: AccountType,
-        network: Network,
         bls_public_key: [u8; 48],
     ) -> Result<()>;
 
@@ -135,7 +115,6 @@ pub trait ManagedAccountOperations {
     /// # Arguments
     /// * `wallet` - The wallet containing the EdDSA account
     /// * `account_type` - The type of account (must be ProviderPlatformKeys)
-    /// * `network` - The network for the account
     ///
     /// # Returns
     /// Ok(()) if the managed EdDSA account was successfully added
@@ -144,7 +123,6 @@ pub trait ManagedAccountOperations {
         &mut self,
         wallet: &Wallet,
         account_type: AccountType,
-        network: Network,
     ) -> Result<()>;
 
     /// Add a new managed EdDSA account with passphrase verification
@@ -155,7 +133,6 @@ pub trait ManagedAccountOperations {
     /// # Arguments
     /// * `wallet` - The wallet containing the EdDSA account (must be MnemonicWithPassphrase type)
     /// * `account_type` - The type of account (must be ProviderPlatformKeys)
-    /// * `network` - The network for the account
     /// * `passphrase` - The passphrase to verify
     ///
     /// # Returns
@@ -165,7 +142,6 @@ pub trait ManagedAccountOperations {
         &mut self,
         wallet: &Wallet,
         account_type: AccountType,
-        network: Network,
         passphrase: &str,
     ) -> Result<()>;
 
@@ -175,7 +151,6 @@ pub trait ManagedAccountOperations {
     ///
     /// # Arguments
     /// * `account_type` - The type of account (must be ProviderPlatformKeys)
-    /// * `network` - The network for the account
     /// * `ed25519_public_key` - 32-byte Ed25519 public key
     ///
     /// # Returns
@@ -184,7 +159,6 @@ pub trait ManagedAccountOperations {
     fn add_managed_eddsa_account_from_public_key(
         &mut self,
         account_type: AccountType,
-        network: Network,
         ed25519_public_key: [u8; 32],
     ) -> Result<()>;
 }

--- a/key-wallet/src/wallet/managed_wallet_info/mod.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/mod.rs
@@ -20,7 +20,6 @@ use super::immature_transaction::ImmatureTransactionCollection;
 use super::metadata::WalletMetadata;
 use crate::account::ManagedAccountCollection;
 use crate::Network;
-use alloc::collections::BTreeMap;
 use alloc::string::String;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -33,6 +32,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ManagedWalletInfo {
+    /// Network this wallet info is associated with
+    pub network: Network,
     /// Unique wallet ID (SHA256 hash of root public key) - should match the Wallet's wallet_id
     pub wallet_id: [u8; 32],
     /// Wallet name
@@ -41,59 +42,53 @@ pub struct ManagedWalletInfo {
     pub description: Option<String>,
     /// Wallet metadata
     pub metadata: WalletMetadata,
-    /// All managed accounts organized by network
-    pub accounts: BTreeMap<Network, ManagedAccountCollection>,
-    /// Immature transactions organized by network
-    pub immature_transactions: BTreeMap<Network, ImmatureTransactionCollection>,
+    /// All managed accounts
+    pub accounts: ManagedAccountCollection,
+    /// Immature transactions
+    pub immature_transactions: ImmatureTransactionCollection,
     /// Cached wallet balance - should be updated when accounts change
     pub balance: WalletBalance,
 }
 
 impl ManagedWalletInfo {
-    /// Create new managed wallet info with wallet ID
-    pub fn new(wallet_id: [u8; 32]) -> Self {
+    /// Create new managed wallet info with network and wallet ID
+    pub fn new(network: Network, wallet_id: [u8; 32]) -> Self {
         Self {
+            network,
             wallet_id,
             name: None,
             description: None,
             metadata: WalletMetadata::default(),
-            accounts: BTreeMap::new(),
-            immature_transactions: BTreeMap::new(),
+            accounts: ManagedAccountCollection::new(),
+            immature_transactions: ImmatureTransactionCollection::new(),
             balance: WalletBalance::default(),
         }
     }
 
-    /// Create managed wallet info with wallet ID and name
-    pub fn with_name(wallet_id: [u8; 32], name: String) -> Self {
+    /// Create managed wallet info with network, wallet ID and name
+    pub fn with_name(network: Network, wallet_id: [u8; 32], name: String) -> Self {
         Self {
+            network,
             wallet_id,
             name: Some(name),
             description: None,
             metadata: WalletMetadata::default(),
-            accounts: BTreeMap::new(),
-            immature_transactions: BTreeMap::new(),
+            accounts: ManagedAccountCollection::new(),
+            immature_transactions: ImmatureTransactionCollection::new(),
             balance: WalletBalance::default(),
         }
     }
 
     /// Create managed wallet info from a Wallet
     pub fn from_wallet(wallet: &super::super::Wallet) -> Self {
-        let mut managed_accounts = BTreeMap::new();
-
-        // Initialize ManagedAccountCollection for each network that has accounts
-        for (network, account_collection) in &wallet.accounts {
-            let managed_collection =
-                ManagedAccountCollection::from_account_collection(account_collection);
-            managed_accounts.insert(*network, managed_collection);
-        }
-
         Self {
+            network: wallet.network,
             wallet_id: wallet.wallet_id,
             name: None,
             description: None,
             metadata: WalletMetadata::default(),
-            accounts: managed_accounts,
-            immature_transactions: BTreeMap::new(),
+            accounts: ManagedAccountCollection::from_account_collection(&wallet.accounts),
+            immature_transactions: ImmatureTransactionCollection::new(),
             balance: WalletBalance::default(),
         }
     }
@@ -106,10 +101,19 @@ impl ManagedWalletInfo {
     }
 
     /// Create managed wallet info with birth height
-    pub fn with_birth_height(wallet_id: [u8; 32], birth_height: Option<u32>) -> Self {
-        let mut info = Self::new(wallet_id);
+    pub fn with_birth_height(
+        network: Network,
+        wallet_id: [u8; 32],
+        birth_height: Option<u32>,
+    ) -> Self {
+        let mut info = Self::new(network, wallet_id);
         info.metadata.birth_height = birth_height;
         info
+    }
+
+    /// Get the network for this wallet info
+    pub fn network(&self) -> Network {
+        self.network
     }
 
     /// Increment the transaction count
@@ -124,17 +128,15 @@ impl ManagedWalletInfo {
         let mut locked = 0u64;
 
         // Sum balances from all accounts across all networks
-        for collection in self.accounts.values() {
-            for account in collection.all_accounts() {
-                for utxo in account.utxos.values() {
-                    let value = utxo.txout.value;
-                    if utxo.is_locked {
-                        locked += value;
-                    } else if utxo.is_confirmed {
-                        confirmed += value;
-                    } else {
-                        unconfirmed += value;
-                    }
+        for account in self.accounts.all_accounts() {
+            for utxo in account.utxos.values() {
+                let value = utxo.txout.value;
+                if utxo.is_locked {
+                    locked += value;
+                } else if utxo.is_confirmed {
+                    confirmed += value;
+                } else {
+                    unconfirmed += value;
                 }
             }
         }

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_building.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_building.rs
@@ -42,19 +42,24 @@ impl ManagedWalletInfo {
     pub(crate) fn create_unsigned_payment_transaction_internal(
         &mut self,
         wallet: &Wallet,
-        network: Network,
+        _network: Network,
         account_index: u32,
         account_type_pref: Option<AccountTypePreference>,
         recipients: Vec<(Address, u64)>,
         fee_level: FeeLevel,
         current_block_height: u32,
     ) -> Result<Transaction, TransactionError> {
-        // Get the wallet's account collection for this network
-        let wallet_collection = wallet.accounts.get(&network).ok_or(TransactionError::NoAccount)?;
+        // Validate network consistency
+        if wallet.network != self.network {
+            return Err(TransactionError::BuildFailed(format!(
+                "Network mismatch: wallet network {:?} does not match managed wallet info network {:?}",
+                wallet.network,
+                self.network
+            )));
+        }
 
-        // Get the mutable account collection from managed info
-        let managed_collection =
-            self.accounts.get_mut(&network).ok_or(TransactionError::NoAccount)?;
+        // Get the wallet's account collection
+        let wallet_collection = &wallet.accounts;
 
         // Use BIP44 as default if no preference specified
         let pref = account_type_pref.unwrap_or(AccountTypePreference::BIP44);
@@ -83,23 +88,27 @@ impl ManagedWalletInfo {
 
         // Get the mutable managed account for UTXO access
         let managed_account = match pref {
-            AccountTypePreference::BIP44 => managed_collection
+            AccountTypePreference::BIP44 => self
+                .accounts
                 .standard_bip44_accounts
                 .get_mut(&account_index)
                 .ok_or(TransactionError::NoAccount)?,
-            AccountTypePreference::BIP32 => managed_collection
+            AccountTypePreference::BIP32 => self
+                .accounts
                 .standard_bip32_accounts
                 .get_mut(&account_index)
                 .ok_or(TransactionError::NoAccount)?,
-            AccountTypePreference::PreferBIP44 => managed_collection
+            AccountTypePreference::PreferBIP44 => self
+                .accounts
                 .standard_bip44_accounts
                 .get_mut(&account_index)
-                .or_else(|| managed_collection.standard_bip32_accounts.get_mut(&account_index))
+                .or_else(|| self.accounts.standard_bip32_accounts.get_mut(&account_index))
                 .ok_or(TransactionError::NoAccount)?,
-            AccountTypePreference::PreferBIP32 => managed_collection
+            AccountTypePreference::PreferBIP32 => self
+                .accounts
                 .standard_bip32_accounts
                 .get_mut(&account_index)
-                .or_else(|| managed_collection.standard_bip44_accounts.get_mut(&account_index))
+                .or_else(|| self.accounts.standard_bip44_accounts.get_mut(&account_index))
                 .ok_or(TransactionError::NoAccount)?,
         };
 

--- a/key-wallet/src/wallet/managed_wallet_info/utxo.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/utxo.rs
@@ -3,7 +3,6 @@
 //! This module provides methods to retrieve UTXOs from managed wallet accounts.
 
 use crate::utxo::Utxo;
-use crate::Network;
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use dashcore::blockdata::transaction::OutPoint;
@@ -14,149 +13,124 @@ use super::ManagedWalletInfo;
 type UtxosByAccountType = BTreeMap<&'static str, Vec<(u32, Vec<(OutPoint, Utxo)>)>>;
 
 impl ManagedWalletInfo {
-    /// Get all UTXOs for a specific network
+    /// Get all UTXOs for the wallet
     ///
     /// Returns UTXOs from BIP44, BIP32, and CoinJoin accounts only.
     /// Does not include UTXOs from identity or provider accounts.
-    pub fn get_utxos(&self, network: Network) -> Vec<(OutPoint, Utxo)> {
+    pub fn get_utxos(&self) -> Vec<(OutPoint, Utxo)> {
         let mut all_utxos = Vec::new();
 
-        // Get the managed account collection for this network
-        if let Some(account_collection) = self.accounts.get(&network) {
-            // Collect UTXOs from standard BIP44 accounts
-            for account in account_collection.standard_bip44_accounts.values() {
-                for (outpoint, utxo) in &account.utxos {
-                    all_utxos.push((*outpoint, utxo.clone()));
-                }
+        // Collect UTXOs from standard BIP44 accounts
+        for account in self.accounts.standard_bip44_accounts.values() {
+            for (outpoint, utxo) in &account.utxos {
+                all_utxos.push((*outpoint, utxo.clone()));
             }
+        }
 
-            // Collect UTXOs from standard BIP32 accounts
-            for account in account_collection.standard_bip32_accounts.values() {
-                for (outpoint, utxo) in &account.utxos {
-                    all_utxos.push((*outpoint, utxo.clone()));
-                }
+        // Collect UTXOs from standard BIP32 accounts
+        for account in self.accounts.standard_bip32_accounts.values() {
+            for (outpoint, utxo) in &account.utxos {
+                all_utxos.push((*outpoint, utxo.clone()));
             }
+        }
 
-            // Collect UTXOs from CoinJoin accounts
-            for account in account_collection.coinjoin_accounts.values() {
-                for (outpoint, utxo) in &account.utxos {
-                    all_utxos.push((*outpoint, utxo.clone()));
-                }
+        // Collect UTXOs from CoinJoin accounts
+        for account in self.accounts.coinjoin_accounts.values() {
+            for (outpoint, utxo) in &account.utxos {
+                all_utxos.push((*outpoint, utxo.clone()));
             }
         }
 
         all_utxos
     }
 
-    /// Get UTXOs grouped by account type for a specific network
+    /// Get UTXOs grouped by account type
     ///
     /// Returns a map where:
     /// - Keys are account type strings ("bip44", "bip32", "coinjoin")
     /// - Values are vectors of (account_index, Vec<(OutPoint, Utxo)>) tuples
-    pub fn get_utxos_by_account_type(&self, network: Network) -> UtxosByAccountType {
+    pub fn get_utxos_by_account_type(&self) -> UtxosByAccountType {
         let mut utxos_by_type = BTreeMap::new();
 
-        if let Some(account_collection) = self.accounts.get(&network) {
-            // Collect BIP44 account UTXOs
-            let mut bip44_utxos = Vec::new();
-            for (index, account) in &account_collection.standard_bip44_accounts {
-                let account_utxos: Vec<(OutPoint, Utxo)> = account
-                    .utxos
-                    .iter()
-                    .map(|(outpoint, utxo)| (*outpoint, utxo.clone()))
-                    .collect();
-                if !account_utxos.is_empty() {
-                    bip44_utxos.push((*index, account_utxos));
-                }
+        // Collect BIP44 account UTXOs
+        let mut bip44_utxos = Vec::new();
+        for (index, account) in &self.accounts.standard_bip44_accounts {
+            let account_utxos: Vec<(OutPoint, Utxo)> =
+                account.utxos.iter().map(|(outpoint, utxo)| (*outpoint, utxo.clone())).collect();
+            if !account_utxos.is_empty() {
+                bip44_utxos.push((*index, account_utxos));
             }
-            if !bip44_utxos.is_empty() {
-                utxos_by_type.insert("bip44", bip44_utxos);
-            }
+        }
+        if !bip44_utxos.is_empty() {
+            utxos_by_type.insert("bip44", bip44_utxos);
+        }
 
-            // Collect BIP32 account UTXOs
-            let mut bip32_utxos = Vec::new();
-            for (index, account) in &account_collection.standard_bip32_accounts {
-                let account_utxos: Vec<(OutPoint, Utxo)> = account
-                    .utxos
-                    .iter()
-                    .map(|(outpoint, utxo)| (*outpoint, utxo.clone()))
-                    .collect();
-                if !account_utxos.is_empty() {
-                    bip32_utxos.push((*index, account_utxos));
-                }
+        // Collect BIP32 account UTXOs
+        let mut bip32_utxos = Vec::new();
+        for (index, account) in &self.accounts.standard_bip32_accounts {
+            let account_utxos: Vec<(OutPoint, Utxo)> =
+                account.utxos.iter().map(|(outpoint, utxo)| (*outpoint, utxo.clone())).collect();
+            if !account_utxos.is_empty() {
+                bip32_utxos.push((*index, account_utxos));
             }
-            if !bip32_utxos.is_empty() {
-                utxos_by_type.insert("bip32", bip32_utxos);
-            }
+        }
+        if !bip32_utxos.is_empty() {
+            utxos_by_type.insert("bip32", bip32_utxos);
+        }
 
-            // Collect CoinJoin account UTXOs
-            let mut coinjoin_utxos = Vec::new();
-            for (index, account) in &account_collection.coinjoin_accounts {
-                let account_utxos: Vec<(OutPoint, Utxo)> = account
-                    .utxos
-                    .iter()
-                    .map(|(outpoint, utxo)| (*outpoint, utxo.clone()))
-                    .collect();
-                if !account_utxos.is_empty() {
-                    coinjoin_utxos.push((*index, account_utxos));
-                }
+        // Collect CoinJoin account UTXOs
+        let mut coinjoin_utxos = Vec::new();
+        for (index, account) in &self.accounts.coinjoin_accounts {
+            let account_utxos: Vec<(OutPoint, Utxo)> =
+                account.utxos.iter().map(|(outpoint, utxo)| (*outpoint, utxo.clone())).collect();
+            if !account_utxos.is_empty() {
+                coinjoin_utxos.push((*index, account_utxos));
             }
-            if !coinjoin_utxos.is_empty() {
-                utxos_by_type.insert("coinjoin", coinjoin_utxos);
-            }
+        }
+        if !coinjoin_utxos.is_empty() {
+            utxos_by_type.insert("coinjoin", coinjoin_utxos);
         }
 
         utxos_by_type
     }
 
-    /// Get spendable UTXOs for a specific network at a given block height
+    /// Get spendable UTXOs at a given block height
     ///
     /// Returns only UTXOs that can be spent at the current height from
     /// BIP44, BIP32, and CoinJoin accounts.
-    pub fn get_spendable_utxos(
-        &self,
-        network: Network,
-        current_height: u32,
-    ) -> Vec<(OutPoint, Utxo)> {
-        self.get_utxos(network)
-            .into_iter()
-            .filter(|(_, utxo)| utxo.is_spendable(current_height))
-            .collect()
+    pub fn get_spendable_utxos(&self, current_height: u32) -> Vec<(OutPoint, Utxo)> {
+        self.get_utxos().into_iter().filter(|(_, utxo)| utxo.is_spendable(current_height)).collect()
     }
 
-    /// Get total value of all UTXOs for a specific network
+    /// Get total value of all UTXOs
     ///
     /// Returns the sum of all UTXO values from BIP44, BIP32, and CoinJoin accounts
-    pub fn get_total_utxo_value(&self, network: Network) -> u64 {
-        self.get_utxos(network).iter().map(|(_, utxo)| utxo.value()).sum()
+    pub fn get_total_utxo_value(&self) -> u64 {
+        self.get_utxos().iter().map(|(_, utxo)| utxo.value()).sum()
     }
 
-    /// Get UTXO count for a specific network
+    /// Get UTXO count
     ///
     /// Returns the total number of UTXOs from BIP44, BIP32, and CoinJoin accounts
-    pub fn get_utxo_count(&self, network: Network) -> usize {
-        if let Some(account_collection) = self.accounts.get(&network) {
-            let mut count = 0;
+    pub fn get_utxo_count(&self) -> usize {
+        let mut count = 0;
 
-            // Count BIP44 account UTXOs
-            for account in account_collection.standard_bip44_accounts.values() {
-                count += account.utxos.len();
-            }
-
-            // Count BIP32 account UTXOs
-            for account in account_collection.standard_bip32_accounts.values() {
-                count += account.utxos.len();
-            }
-
-            // Count CoinJoin account UTXOs
-            for account in account_collection.coinjoin_accounts.values() {
-                count += account.utxos.len();
-            }
-
-            count
-        } else {
-            0
+        // Count BIP44 account UTXOs
+        for account in self.accounts.standard_bip44_accounts.values() {
+            count += account.utxos.len();
         }
+
+        // Count BIP32 account UTXOs
+        for account in self.accounts.standard_bip32_accounts.values() {
+            count += account.utxos.len();
+        }
+
+        // Count CoinJoin account UTXOs
+        for account in self.accounts.coinjoin_accounts.values() {
+            count += account.utxos.len();
+        }
+
+        count
     }
 }
 
@@ -164,26 +138,23 @@ impl ManagedWalletInfo {
 mod tests {
     use super::*;
     use crate::bip32::DerivationPath;
-    use crate::managed_account::managed_account_collection::ManagedAccountCollection;
     use crate::managed_account::managed_account_type::ManagedAccountType;
     use crate::managed_account::ManagedAccount;
+    use crate::Network;
     use dashcore::{Address, PublicKey, ScriptBuf, TxOut, Txid};
     use dashcore_hashes::Hash;
     use std::str::FromStr;
 
     #[test]
     fn test_get_utxos_empty() {
-        let managed_info = ManagedWalletInfo::new([0u8; 32]);
-        let utxos = managed_info.get_utxos(Network::Testnet);
+        let managed_info = ManagedWalletInfo::new(Network::Testnet, [0u8; 32]);
+        let utxos = managed_info.get_utxos();
         assert_eq!(utxos.len(), 0);
     }
 
     #[test]
     fn test_get_utxos_with_accounts() {
-        let mut managed_info = ManagedWalletInfo::new([0u8; 32]);
-
-        // Create a managed account collection for testnet
-        let mut account_collection = ManagedAccountCollection::new();
+        let mut managed_info = ManagedWalletInfo::new(Network::Testnet, [0u8; 32]);
 
         // Create a BIP44 account with some UTXOs
         let base_path = DerivationPath::from_str("m/44'/5'/0'").unwrap();
@@ -235,12 +206,10 @@ mod tests {
         let utxo = Utxo::new(outpoint, txout, address, 0, false);
 
         bip44_account.utxos.insert(outpoint, utxo);
-        account_collection.standard_bip44_accounts.insert(0, bip44_account);
-
-        managed_info.accounts.insert(Network::Testnet, account_collection);
+        managed_info.accounts.standard_bip44_accounts.insert(0, bip44_account);
 
         // Test getting UTXOs
-        let utxos = managed_info.get_utxos(Network::Testnet);
+        let utxos = managed_info.get_utxos();
         assert_eq!(utxos.len(), 1);
         assert_eq!(utxos[0].1.value(), 100000);
     }

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -13,8 +13,9 @@ use crate::wallet::managed_wallet_info::transaction_building::{
 use crate::wallet::managed_wallet_info::TransactionRecord;
 use crate::wallet::ManagedWalletInfo;
 use crate::{Network, Utxo, Wallet, WalletBalance};
+use alloc::collections::BTreeSet;
+use alloc::vec::Vec;
 use dashcore::{Address as DashAddress, Address, Transaction};
-use std::collections::BTreeSet;
 
 /// Trait that wallet info types must implement to work with WalletManager
 pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccountOperations {
@@ -25,6 +26,9 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Create a wallet info from an existing wallet with proper account initialization
     /// Default implementation just uses with_name (backward compatibility)
     fn from_wallet_with_name(wallet: &Wallet, name: String) -> Self;
+
+    /// Get the wallet's network
+    fn network(&self) -> Network;
 
     /// Get the wallet's unique ID
     fn wallet_id(&self) -> [u8; 32];
@@ -56,8 +60,8 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Update last synced timestamp
     fn update_last_synced(&mut self, timestamp: u64);
 
-    /// Get all monitored addresses for a network
-    fn monitored_addresses(&self, network: Network) -> Vec<DashAddress>;
+    /// Get all monitored addresses
+    fn monitored_addresses(&self) -> Vec<DashAddress>;
 
     /// Get all UTXOs for the wallet
     fn utxos(&self) -> BTreeSet<&Utxo>;
@@ -74,33 +78,29 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Get transaction history
     fn transaction_history(&self) -> Vec<&TransactionRecord>;
 
-    /// Get accounts for a network (mutable)
-    fn accounts_mut(&mut self, network: Network) -> Option<&mut ManagedAccountCollection>;
+    /// Get accounts (mutable)
+    fn accounts_mut(&mut self) -> &mut ManagedAccountCollection;
 
-    /// Get accounts for a network (immutable)
-    fn accounts(&self, network: Network) -> Option<&ManagedAccountCollection>;
+    /// Get accounts (immutable)
+    fn accounts(&self) -> &ManagedAccountCollection;
 
     /// Process matured transactions for a given chain height
-    fn process_matured_transactions(
-        &mut self,
-        network: Network,
-        current_height: u32,
-    ) -> Vec<ImmatureTransaction>;
+    fn process_matured_transactions(&mut self, current_height: u32) -> Vec<ImmatureTransaction>;
 
     /// Add an immature transaction
-    fn add_immature_transaction(&mut self, network: Network, tx: ImmatureTransaction);
-    /// Get immature transactions for a network
-    fn immature_transactions(&self, network: Network) -> Option<&ImmatureTransactionCollection>;
+    fn add_immature_transaction(&mut self, tx: ImmatureTransaction);
 
-    /// Get immature balance for a specific network
-    fn network_immature_balance(&self, network: Network) -> u64;
+    /// Get immature transactions
+    fn immature_transactions(&self) -> &ImmatureTransactionCollection;
 
-    /// Get immature balance for a specific network
+    /// Get immature balance
+    fn immature_balance(&self) -> u64;
+
+    /// Create an unsigned payment transaction
     #[allow(clippy::too_many_arguments)]
     fn create_unsigned_payment_transaction(
         &mut self,
         wallet: &Wallet,
-        network: Network,
         account_index: u32,
         account_type_pref: Option<AccountTypePreference>,
         recipients: Vec<(Address, u64)>,
@@ -110,7 +110,7 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
 
     /// Update chain state and process any matured transactions
     /// This should be called when the chain tip advances to a new height
-    fn update_chain_height(&mut self, network: Network, current_height: u32);
+    fn update_chain_height(&mut self, current_height: u32);
 }
 
 /// Default implementation for ManagedWalletInfo
@@ -121,6 +121,10 @@ impl WalletInfoInterface for ManagedWalletInfo {
 
     fn from_wallet_with_name(wallet: &Wallet, name: String) -> Self {
         Self::from_wallet_with_name(wallet, name)
+    }
+
+    fn network(&self) -> Network {
+        self.network
     }
 
     fn wallet_id(&self) -> [u8; 32] {
@@ -163,29 +167,19 @@ impl WalletInfoInterface for ManagedWalletInfo {
         self.metadata.last_synced = Some(timestamp);
     }
 
-    fn monitored_addresses(&self, network: Network) -> Vec<DashAddress> {
+    fn monitored_addresses(&self) -> Vec<DashAddress> {
         let mut addresses = Vec::new();
-
-        if let Some(collection) = self.accounts.get(&network) {
-            // Collect from all accounts using the account's get_all_addresses method
-            for account in collection.all_accounts() {
-                addresses.extend(account.all_addresses());
-            }
+        for account in self.accounts.all_accounts() {
+            addresses.extend(account.all_addresses());
         }
-
         addresses
     }
 
     fn utxos(&self) -> BTreeSet<&Utxo> {
         let mut utxos = BTreeSet::new();
-
-        // Collect UTXOs from all accounts across all networks
-        for collection in self.accounts.values() {
-            for account in collection.all_accounts() {
-                utxos.extend(account.utxos.values());
-            }
+        for account in self.accounts.all_accounts() {
+            utxos.extend(account.utxos.values());
         }
-
         utxos
     }
     fn get_spendable_utxos(&self) -> BTreeSet<&Utxo> {
@@ -204,18 +198,15 @@ impl WalletInfoInterface for ManagedWalletInfo {
         let mut unconfirmed = 0u64;
         let mut locked = 0u64;
 
-        // Sum balances from all accounts across all networks
-        for collection in self.accounts.values() {
-            for account in collection.all_accounts() {
-                for utxo in account.utxos.values() {
-                    let value = utxo.txout.value;
-                    if utxo.is_locked {
-                        locked += value;
-                    } else if utxo.is_confirmed {
-                        confirmed += value;
-                    } else {
-                        unconfirmed += value;
-                    }
+        for account in self.accounts.all_accounts() {
+            for utxo in account.utxos.values() {
+                let value = utxo.txout.value;
+                if utxo.is_locked {
+                    locked += value;
+                } else if utxo.is_confirmed {
+                    confirmed += value;
+                } else {
+                    unconfirmed += value;
                 }
             }
         }
@@ -227,118 +218,92 @@ impl WalletInfoInterface for ManagedWalletInfo {
 
     fn transaction_history(&self) -> Vec<&TransactionRecord> {
         let mut transactions = Vec::new();
-
-        // Collect transactions from all accounts across all networks
-        for collection in self.accounts.values() {
-            for account in collection.all_accounts() {
-                transactions.extend(account.transactions.values());
-            }
+        for account in self.accounts.all_accounts() {
+            transactions.extend(account.transactions.values());
         }
-
         transactions
     }
 
-    fn accounts_mut(&mut self, network: Network) -> Option<&mut ManagedAccountCollection> {
-        self.accounts.get_mut(&network)
+    fn accounts_mut(&mut self) -> &mut ManagedAccountCollection {
+        &mut self.accounts
     }
 
-    fn accounts(&self, network: Network) -> Option<&ManagedAccountCollection> {
-        self.accounts.get(&network)
+    fn accounts(&self) -> &ManagedAccountCollection {
+        &self.accounts
     }
 
-    fn process_matured_transactions(
-        &mut self,
-        network: Network,
-        current_height: u32,
-    ) -> Vec<ImmatureTransaction> {
-        if let Some(collection) = self.immature_transactions.get_mut(&network) {
-            let matured = collection.remove_matured(current_height);
+    fn process_matured_transactions(&mut self, current_height: u32) -> Vec<ImmatureTransaction> {
+        let matured = self.immature_transactions.remove_matured(current_height);
 
-            // Update accounts with matured transactions
-            if let Some(account_collection) = self.accounts.get_mut(&network) {
-                for tx in &matured {
-                    // Process BIP44 accounts
-                    for &index in &tx.affected_accounts.bip44_accounts {
-                        if let Some(account) =
-                            account_collection.standard_bip44_accounts.get_mut(&index)
-                        {
-                            // Add transaction record as confirmed
-                            let tx_record = TransactionRecord::new_confirmed(
-                                tx.transaction.clone(),
-                                tx.height,
-                                tx.block_hash,
-                                tx.timestamp,
-                                tx.total_received as i64,
-                                false, // Not ours (we received)
-                            );
-                            account.transactions.insert(tx.txid, tx_record);
-                        }
-                    }
-
-                    // Process BIP32 accounts
-                    for &index in &tx.affected_accounts.bip32_accounts {
-                        if let Some(account) =
-                            account_collection.standard_bip32_accounts.get_mut(&index)
-                        {
-                            let tx_record = TransactionRecord::new_confirmed(
-                                tx.transaction.clone(),
-                                tx.height,
-                                tx.block_hash,
-                                tx.timestamp,
-                                tx.total_received as i64,
-                                false,
-                            );
-                            account.transactions.insert(tx.txid, tx_record);
-                        }
-                    }
-
-                    // Process CoinJoin accounts
-                    for &index in &tx.affected_accounts.coinjoin_accounts {
-                        if let Some(account) = account_collection.coinjoin_accounts.get_mut(&index)
-                        {
-                            let tx_record = TransactionRecord::new_confirmed(
-                                tx.transaction.clone(),
-                                tx.height,
-                                tx.block_hash,
-                                tx.timestamp,
-                                tx.total_received as i64,
-                                false,
-                            );
-                            account.transactions.insert(tx.txid, tx_record);
-                        }
-                    }
+        // Update accounts with matured transactions
+        for tx in &matured {
+            // Process BIP44 accounts
+            for &index in &tx.affected_accounts.bip44_accounts {
+                if let Some(account) = self.accounts.standard_bip44_accounts.get_mut(&index) {
+                    let tx_record = TransactionRecord::new_confirmed(
+                        tx.transaction.clone(),
+                        tx.height,
+                        tx.block_hash,
+                        tx.timestamp,
+                        tx.total_received as i64,
+                        false,
+                    );
+                    account.transactions.insert(tx.txid, tx_record);
                 }
             }
 
-            // Update balance after processing matured transactions
-            self.update_balance();
+            // Process BIP32 accounts
+            for &index in &tx.affected_accounts.bip32_accounts {
+                if let Some(account) = self.accounts.standard_bip32_accounts.get_mut(&index) {
+                    let tx_record = TransactionRecord::new_confirmed(
+                        tx.transaction.clone(),
+                        tx.height,
+                        tx.block_hash,
+                        tx.timestamp,
+                        tx.total_received as i64,
+                        false,
+                    );
+                    account.transactions.insert(tx.txid, tx_record);
+                }
+            }
 
-            matured
-        } else {
-            Vec::new()
+            // Process CoinJoin accounts
+            for &index in &tx.affected_accounts.coinjoin_accounts {
+                if let Some(account) = self.accounts.coinjoin_accounts.get_mut(&index) {
+                    let tx_record = TransactionRecord::new_confirmed(
+                        tx.transaction.clone(),
+                        tx.height,
+                        tx.block_hash,
+                        tx.timestamp,
+                        tx.total_received as i64,
+                        false,
+                    );
+                    account.transactions.insert(tx.txid, tx_record);
+                }
+            }
         }
+
+        // Update balance after processing matured transactions
+        self.update_balance();
+
+        matured
     }
 
-    /// Add an immature transaction
-    fn add_immature_transaction(&mut self, network: Network, tx: ImmatureTransaction) {
-        self.immature_transactions.entry(network).or_default().insert(tx);
+    fn add_immature_transaction(&mut self, tx: ImmatureTransaction) {
+        self.immature_transactions.insert(tx);
     }
 
-    fn immature_transactions(&self, network: Network) -> Option<&ImmatureTransactionCollection> {
-        self.immature_transactions.get(&network)
+    fn immature_transactions(&self) -> &ImmatureTransactionCollection {
+        &self.immature_transactions
     }
 
-    fn network_immature_balance(&self, network: Network) -> u64 {
-        self.immature_transactions
-            .get(&network)
-            .map(|collection| collection.total_immature_balance())
-            .unwrap_or(0)
+    fn immature_balance(&self) -> u64 {
+        self.immature_transactions.total_immature_balance()
     }
 
     fn create_unsigned_payment_transaction(
         &mut self,
         wallet: &Wallet,
-        network: Network,
         account_index: u32,
         account_type_pref: Option<AccountTypePreference>,
         recipients: Vec<(Address, u64)>,
@@ -347,7 +312,7 @@ impl WalletInfoInterface for ManagedWalletInfo {
     ) -> Result<Transaction, TransactionError> {
         self.create_unsigned_payment_transaction_internal(
             wallet,
-            network,
+            self.network,
             account_index,
             account_type_pref,
             recipients,
@@ -356,13 +321,12 @@ impl WalletInfoInterface for ManagedWalletInfo {
         )
     }
 
-    fn update_chain_height(&mut self, network: Network, current_height: u32) {
-        // Process any matured transactions for this network
-        let matured = self.process_matured_transactions(network, current_height);
+    fn update_chain_height(&mut self, current_height: u32) {
+        let matured = self.process_matured_transactions(current_height);
 
         if !matured.is_empty() {
             tracing::info!(
-                network = ?network,
+                network = ?self.network,
                 current_height = current_height,
                 matured_count = matured.len(),
                 "Processed matured coinbase transactions"

--- a/key-wallet/src/wallet/passphrase_test.rs
+++ b/key-wallet/src/wallet/passphrase_test.rs
@@ -21,7 +21,7 @@ mod tests {
         let wallet = Wallet::from_mnemonic_with_passphrase(
             mnemonic.clone(),
             passphrase.to_string(),
-            &[network],
+            network,
             WalletAccountCreationOptions::None,
         )
         .expect("Should create wallet with passphrase");
@@ -30,7 +30,7 @@ mod tests {
         // We can't easily check the wallet type from outside, but we know it's created
 
         // Try to get account 0 - should not exist yet
-        assert!(wallet.get_bip44_account(network, 0).is_none());
+        assert!(wallet.get_bip44_account(0).is_none());
 
         // Try to add account 0 without providing passphrase
         // THIS WILL FAIL because the wallet needs the passphrase to derive accounts
@@ -41,7 +41,7 @@ mod tests {
         };
 
         // This should fail with an error about needing the passphrase
-        let result = wallet_mut.add_account(account_type, network, None);
+        let result = wallet_mut.add_account(account_type, None);
 
         // EXPECTED: This will fail because we can't derive the account without the passphrase
         assert!(result.is_err());
@@ -70,7 +70,7 @@ mod tests {
         let wallet = Wallet::from_mnemonic_with_passphrase(
             mnemonic,
             passphrase.to_string(),
-            &[network],
+            network,
             WalletAccountCreationOptions::None,
         )
         .expect("Should create wallet");
@@ -104,13 +104,13 @@ mod tests {
         let mut wallet = Wallet::from_mnemonic_with_passphrase(
             mnemonic,
             passphrase.to_string(),
-            &[network],
+            network,
             WalletAccountCreationOptions::None,
         )
         .expect("Should create wallet");
 
         // Verify no accounts exist initially
-        assert!(wallet.get_bip44_account(network, 0).is_none());
+        assert!(wallet.get_bip44_account(0).is_none());
 
         // Add account using the new function with the correct passphrase
         let account_type = AccountType::Standard {
@@ -118,15 +118,14 @@ mod tests {
             standard_account_type: StandardAccountType::BIP44Account,
         };
 
-        let result = wallet.add_account_with_passphrase(account_type, network, passphrase);
+        let result = wallet.add_account_with_passphrase(account_type, passphrase);
         assert!(result.is_ok(), "Should successfully add account with correct passphrase");
 
         // Verify account was added
-        assert!(wallet.get_bip44_account(network, 0).is_some());
+        assert!(wallet.get_bip44_account(0).is_some());
 
         // Try to add the same account again - should fail
-        let duplicate_result =
-            wallet.add_account_with_passphrase(account_type, network, passphrase);
+        let duplicate_result = wallet.add_account_with_passphrase(account_type, passphrase);
         assert!(duplicate_result.is_err());
         assert!(duplicate_result.unwrap_err().to_string().contains("already exists"));
 
@@ -135,9 +134,9 @@ mod tests {
             index: 1,
             standard_account_type: StandardAccountType::BIP44Account,
         };
-        let result2 = wallet.add_account_with_passphrase(account_type_2, network, passphrase);
+        let result2 = wallet.add_account_with_passphrase(account_type_2, passphrase);
         assert!(result2.is_ok());
-        assert!(wallet.get_bip44_account(network, 1).is_some());
+        assert!(wallet.get_bip44_account(1).is_some());
     }
 
     #[test]
@@ -150,7 +149,7 @@ mod tests {
 
         // Create regular wallet WITHOUT passphrase
         let mut wallet =
-            Wallet::from_mnemonic(mnemonic, &[network], WalletAccountCreationOptions::Default)
+            Wallet::from_mnemonic(mnemonic, network, WalletAccountCreationOptions::Default)
                 .expect("Should create wallet");
 
         // Try to use add_account_with_passphrase - should fail
@@ -159,7 +158,7 @@ mod tests {
             standard_account_type: StandardAccountType::BIP44Account,
         };
 
-        let result = wallet.add_account_with_passphrase(account_type, network, "some_passphrase");
+        let result = wallet.add_account_with_passphrase(account_type, "some_passphrase");
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/key-wallet/src/wallet/stats.rs
+++ b/key-wallet/src/wallet/stats.rs
@@ -29,11 +29,8 @@ impl Wallet {
     /// Get wallet statistics
     /// Note: Address statistics would need to be implemented using ManagedAccounts
     pub fn stats(&self) -> WalletStats {
-        let total_accounts: usize =
-            self.accounts.values().map(|collection| collection.count()).sum();
-
-        let coinjoin_enabled_accounts: usize =
-            self.accounts.values().map(|collection| collection.coinjoin_accounts.len()).sum();
+        let total_accounts: usize = self.accounts.count();
+        let coinjoin_enabled_accounts: usize = self.accounts.coinjoin_accounts.len();
 
         // Address statistics would need to be retrieved from ManagedAccountCollection
         // For now, we return basic stats based on account counts


### PR DESCRIPTION
This will make the `Wallet` and `ManagedWalletInfo` single network instances. I think its a cleaner API and makes sense because we pass it to the `DashSpvClient` which is also running only on one specific network so instead of having a shared wallet between clients that are running on different networks we will have one wallet per client when the refactoring is done. This PR does the main part but i will have some follow up PRs to clean up few other places.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features & Breaking Changes**
  * Wallets are now single-network: wallets, accounts and address operations use a single network per wallet.
  * Per-call network arguments removed from creation, account, address, key derivation, transaction and UTXO APIs (including FFI), simplifying calls.
  * Account/address access moved to index- and wallet-scoped accessors instead of per-network maps.

* **Chores**
  * Tests and examples updated to the new single-network model and signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->