### PR TITLE
fix: Rework sync state validation

### DIFF
--- a/dash-spv/src/error.rs
+++ b/dash-spv/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for the Dash SPV client.
 
+use crate::storage::RecoverySuggestion;
 use std::io;
 use thiserror::Error;
 
@@ -127,8 +128,8 @@ pub enum StorageError {
     #[error("Serialization error: {0}")]
     Serialization(String),
 
-    #[error("Inconsistent state: {0}")]
-    InconsistentState(String),
+    #[error("Inconsistent state: {0}, recovery suggestion: {1:?}")]
+    InconsistentState(String, RecoverySuggestion),
 
     #[error("Lock poisoned: {0}")]
     LockPoisoned(String),
@@ -146,7 +147,9 @@ impl Clone for StorageError {
             StorageError::ReadFailed(s) => StorageError::ReadFailed(s.clone()),
             StorageError::Io(err) => StorageError::Io(io::Error::new(err.kind(), err.to_string())),
             StorageError::Serialization(s) => StorageError::Serialization(s.clone()),
-            StorageError::InconsistentState(s) => StorageError::InconsistentState(s.clone()),
+            StorageError::InconsistentState(s, r) => {
+                StorageError::InconsistentState(s.clone(), r.clone())
+            }
             StorageError::LockPoisoned(s) => StorageError::LockPoisoned(s.clone()),
             StorageError::DirectoryLocked(s) => StorageError::DirectoryLocked(s.clone()),
         }

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -18,7 +18,7 @@ use crate::types::{ChainState, MempoolState, UnconfirmedTransaction};
 
 pub use disk::DiskStorageManager;
 pub use memory::MemoryStorageManager;
-pub use sync_state::{PersistentSyncState, RecoverySuggestion, SyncStateValidation};
+pub use sync_state::{PersistentSyncState, RecoverySuggestion};
 pub use sync_storage::MemoryStorage;
 pub use types::*;
 

--- a/dash-spv/tests/error_types_test.rs
+++ b/dash-spv/tests/error_types_test.rs
@@ -11,6 +11,7 @@ use dashcore_hashes::Hash;
 use std::io;
 
 use dash_spv::error::*;
+use dash_spv::storage::RecoverySuggestion;
 
 #[test]
 fn test_network_error_from_io_error() {
@@ -174,8 +175,11 @@ fn test_storage_error_variants() {
             "Serialization error: Invalid encoding",
         ),
         (
-            StorageError::InconsistentState("Height mismatch".to_string()),
-            "Inconsistent state: Height mismatch",
+            StorageError::InconsistentState(
+                "Height mismatch".to_string(),
+                RecoverySuggestion::StartFresh,
+            ),
+            "Inconsistent state: Height mismatch, recovery suggestion: StartFresh",
         ),
         (
             StorageError::LockPoisoned("Mutex poisoned by panic".to_string()),


### PR DESCRIPTION
This PR reworks the sync state validation a bit. Before the "recovery suggestion" system provided via `SyncStateValidation ` didn't work as expected anyway because `recovery_suggestion` was overwritten within the validation by whatever triggered last. All this is still not quite what it should be but at least it gets rid of the faulty checkpointing system which created thousands of pointless checkpoints and failed validation on restart because they were not sorted. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, storage-centric error messages with explicit recovery suggestions for inconsistent sync states.
  * Recovery flows made more consistent: rollbacks and corrupt-state handling now yield actionable errors instead of ambiguous signals.
  * First-run (no saved state) is now explicitly recognized and logged instead of treated as an error.

* **Improvements**
  * Validation simplified to fail fast with direct error guidance, improving sync reliability and diagnostics.
  * Save/restore behavior clarified: saves no-op when chain tip is unavailable and restored state handling is more predictable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->