### PR TITLE
fix: `maintain_gap_limit` target calculation off by one 

### DIFF
--- a/key-wallet/src/managed_account/address_pool.rs
+++ b/key-wallet/src/managed_account/address_pool.rs
@@ -885,8 +885,8 @@ impl AddressPool {
     /// Generate addresses to maintain the gap limit
     pub fn maintain_gap_limit(&mut self, key_source: &KeySource) -> Result<Vec<Address>> {
         let target = match self.highest_used {
-            None => self.gap_limit,
-            Some(highest) => highest + self.gap_limit + 1,
+            None => self.gap_limit - 1,
+            Some(highest) => highest + self.gap_limit,
         };
 
         let mut new_addresses = Vec::new();
@@ -1233,9 +1233,14 @@ mod tests {
         let gap_limit = 5;
 
         // Create pool with gap_limit addresses already generated
-        let mut pool =
-            AddressPool::new(base_path, AddressPoolType::External, gap_limit, Network::Testnet, &key_source)
-                .unwrap();
+        let mut pool = AddressPool::new(
+            base_path,
+            AddressPoolType::External,
+            gap_limit,
+            Network::Testnet,
+            &key_source,
+        )
+        .unwrap();
 
         // Verify gap_limit addresses generated, none used
         assert_eq!(pool.highest_generated, Some(gap_limit - 1));


### PR DESCRIPTION
The target index was calculated incorrectly, causing one extra address to be generated.

See the adjusted test in 0f33cb2fdd385b92a2acb70ca983f2d12feabd13 which fails without the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined address generation behavior in account pool maintenance to more conservatively manage gap limits, reducing unnecessary address generation in certain scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->