### PR TITLE
chore: Drop unused `lookahead`

### DIFF
--- a/key-wallet/CLAUDE.md
+++ b/key-wallet/CLAUDE.md
@@ -187,7 +187,7 @@ let managed_account = ManagedAccount::from_account(&account);
 ```rust
 // Pre-generate addresses for performance
 let pool = &mut managed_account.account_type.receive_pool_mut()?;
-pool.ensure_addresses_generated(current_index + lookahead)?;
+pool.ensure_addresses_generated(current_index + gap_limit)?;
 ```
 
 ### 3. Transaction Checking Pattern

--- a/key-wallet/src/derivation.rs
+++ b/key-wallet/src/derivation.rs
@@ -363,8 +363,6 @@ pub struct DerivationStrategy {
     base_path: DerivationPath,
     /// Gap limit for address discovery
     gap_limit: u32,
-    /// Lookahead window
-    lookahead: u32,
 }
 
 impl DerivationStrategy {
@@ -373,19 +371,12 @@ impl DerivationStrategy {
         Self {
             base_path,
             gap_limit: 20,
-            lookahead: 20,
         }
     }
 
     /// Set the gap limit
     pub fn with_gap_limit(mut self, limit: u32) -> Self {
         self.gap_limit = limit;
-        self
-    }
-
-    /// Set the lookahead window
-    pub fn with_lookahead(mut self, lookahead: u32) -> Self {
-        self.lookahead = lookahead;
         self
     }
 


### PR DESCRIPTION
Thats basically what the gap limit is doing already and its not used anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed lookahead configuration options from address derivation and pool management.
  * Updated address pre-generation mechanism to use gap limit parameter instead of lookahead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->