### PR TITLE
refactor: Drop `FFINetworks` and use `FFINetwork` only

### DIFF
--- a/dash-spv-ffi/examples/wallet_manager_usage.rs
+++ b/dash-spv-ffi/examples/wallet_manager_usage.rs
@@ -51,7 +51,7 @@ fn main() {
         let affected = wallet_manager_process_transaction(
             wallet_manager,
             tx_hex.as_ptr() as *const i8,
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             100000, // block height
             &mut error
         );

--- a/key-wallet-ffi/FFI_API.md
+++ b/key-wallet-ffi/FFI_API.md
@@ -418,7 +418,7 @@ Free a managed account result's error message (if any) Note: This does NOT free 
 #### `wallet_manager_add_wallet_from_mnemonic`
 
 ```c
-wallet_manager_add_wallet_from_mnemonic(manager: *mut FFIWalletManager, mnemonic: *const c_char, passphrase: *const c_char, network: FFINetworks, error: *mut FFIError,) -> bool
+wallet_manager_add_wallet_from_mnemonic(manager: *mut FFIWalletManager, mnemonic: *const c_char, passphrase: *const c_char, network: FFINetwork, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -434,7 +434,7 @@ Add a wallet from mnemonic to the manager (backward compatibility)  # Safety  - 
 #### `wallet_manager_add_wallet_from_mnemonic_return_serialized_bytes`
 
 ```c
-wallet_manager_add_wallet_from_mnemonic_return_serialized_bytes(manager: *mut FFIWalletManager, mnemonic: *const c_char, passphrase: *const c_char, network: FFINetworks, birth_height: c_uint, account_options: *const crate::types::FFIWalletAccountCreationOptions, downgrade_to_pubkey_wallet: bool, allow_external_signing: bool, wallet_bytes_out: *mut *mut u8, wallet_bytes_len_out: *mut usize, wallet_id_out: *mut u8, error: *mut FFIError,) -> bool
+wallet_manager_add_wallet_from_mnemonic_return_serialized_bytes(manager: *mut FFIWalletManager, mnemonic: *const c_char, passphrase: *const c_char, network: FFINetwork, birth_height: c_uint, account_options: *const crate::types::FFIWalletAccountCreationOptions, downgrade_to_pubkey_wallet: bool, allow_external_signing: bool, wallet_bytes_out: *mut *mut u8, wallet_bytes_len_out: *mut usize, wallet_id_out: *mut u8, error: *mut FFIError,) -> bool
 ```
 
 **Module:** `wallet_manager`
@@ -444,7 +444,7 @@ wallet_manager_add_wallet_from_mnemonic_return_serialized_bytes(manager: *mut FF
 #### `wallet_manager_add_wallet_from_mnemonic_with_options`
 
 ```c
-wallet_manager_add_wallet_from_mnemonic_with_options(manager: *mut FFIWalletManager, mnemonic: *const c_char, passphrase: *const c_char, network: FFINetworks, account_options: *const crate::types::FFIWalletAccountCreationOptions, error: *mut FFIError,) -> bool
+wallet_manager_add_wallet_from_mnemonic_with_options(manager: *mut FFIWalletManager, mnemonic: *const c_char, passphrase: *const c_char, network: FFINetwork, account_options: *const crate::types::FFIWalletAccountCreationOptions, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -1219,7 +1219,7 @@ Build and sign a transaction using the wallet's managed info  This is the recomm
 #### `wallet_build_transaction`
 
 ```c
-wallet_build_transaction(wallet: *mut FFIWallet, _network: FFINetworks, account_index: c_uint, outputs: *const FFITxOutput, outputs_count: usize, fee_per_kb: u64, tx_bytes_out: *mut *mut u8, tx_len_out: *mut usize, error: *mut FFIError,) -> bool
+wallet_build_transaction(wallet: *mut FFIWallet, account_index: c_uint, outputs: *const FFITxOutput, outputs_count: usize, fee_per_kb: u64, tx_bytes_out: *mut *mut u8, tx_len_out: *mut usize, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -1251,7 +1251,7 @@ Check if a transaction belongs to the wallet using ManagedWalletInfo  # Safety  
 #### `wallet_create_from_mnemonic`
 
 ```c
-wallet_create_from_mnemonic(mnemonic: *const c_char, passphrase: *const c_char, network: FFINetworks, error: *mut FFIError,) -> *mut FFIWallet
+wallet_create_from_mnemonic(mnemonic: *const c_char, passphrase: *const c_char, network: FFINetwork, error: *mut FFIError,) -> *mut FFIWallet
 ```
 
 **Description:**
@@ -1267,7 +1267,7 @@ Create a new wallet from mnemonic (backward compatibility - single network)  # S
 #### `wallet_create_from_mnemonic_with_options`
 
 ```c
-wallet_create_from_mnemonic_with_options(mnemonic: *const c_char, passphrase: *const c_char, networks: FFINetworks, account_options: *const FFIWalletAccountCreationOptions, error: *mut FFIError,) -> *mut FFIWallet
+wallet_create_from_mnemonic_with_options(mnemonic: *const c_char, passphrase: *const c_char, network: FFINetwork, account_options: *const FFIWalletAccountCreationOptions, error: *mut FFIError,) -> *mut FFIWallet
 ```
 
 **Description:**
@@ -1283,7 +1283,7 @@ Create a new wallet from mnemonic with options  # Safety  - `mnemonic` must be a
 #### `wallet_create_from_seed`
 
 ```c
-wallet_create_from_seed(seed: *const u8, seed_len: usize, network: FFINetworks, error: *mut FFIError,) -> *mut FFIWallet
+wallet_create_from_seed(seed: *const u8, seed_len: usize, network: FFINetwork, error: *mut FFIError,) -> *mut FFIWallet
 ```
 
 **Description:**
@@ -1299,7 +1299,7 @@ Create a new wallet from seed (backward compatibility)  # Safety  - `seed` must 
 #### `wallet_create_from_seed_with_options`
 
 ```c
-wallet_create_from_seed_with_options(seed: *const u8, seed_len: usize, networks: FFINetworks, account_options: *const FFIWalletAccountCreationOptions, error: *mut FFIError,) -> *mut FFIWallet
+wallet_create_from_seed_with_options(seed: *const u8, seed_len: usize, network: FFINetwork, account_options: *const FFIWalletAccountCreationOptions, error: *mut FFIError,) -> *mut FFIWallet
 ```
 
 **Description:**
@@ -1331,7 +1331,7 @@ Create a managed wallet from a regular wallet  This creates a ManagedWalletInfo 
 #### `wallet_create_random`
 
 ```c
-wallet_create_random(network: FFINetworks, error: *mut FFIError,) -> *mut FFIWallet
+wallet_create_random(network: FFINetwork, error: *mut FFIError,) -> *mut FFIWallet
 ```
 
 **Description:**
@@ -1347,7 +1347,7 @@ Create a new random wallet (backward compatibility)  # Safety  - `error` must be
 #### `wallet_create_random_with_options`
 
 ```c
-wallet_create_random_with_options(networks: FFINetworks, account_options: *const FFIWalletAccountCreationOptions, error: *mut FFIError,) -> *mut FFIWallet
+wallet_create_random_with_options(network: FFINetwork, account_options: *const FFIWalletAccountCreationOptions, error: *mut FFIError,) -> *mut FFIWallet
 ```
 
 **Description:**
@@ -1603,7 +1603,7 @@ Get an IdentityTopUp account handle with a specific registration index This is u
 #### `wallet_get_utxos`
 
 ```c
-wallet_get_utxos(_wallet: *const crate::types::FFIWallet, _network: FFINetworks, utxos_out: *mut *mut FFIUTXO, count_out: *mut usize, error: *mut FFIError,) -> bool
+wallet_get_utxos(_wallet: *const crate::types::FFIWallet, utxos_out: *mut *mut FFIUTXO, count_out: *mut usize, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -1667,7 +1667,7 @@ Check if wallet is watch-only  # Safety  - `wallet` must be a valid pointer to a
 #### `wallet_sign_transaction`
 
 ```c
-wallet_sign_transaction(wallet: *const FFIWallet, _network: FFINetworks, tx_bytes: *const u8, tx_len: usize, signed_tx_out: *mut *mut u8, signed_len_out: *mut usize, error: *mut FFIError,) -> bool
+wallet_sign_transaction(wallet: *const FFIWallet, tx_bytes: *const u8, tx_len: usize, signed_tx_out: *mut *mut u8, signed_len_out: *mut usize, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -2293,14 +2293,14 @@ Check if an account is watch-only  # Safety  - `account` must be a valid pointer
 #### `account_get_network`
 
 ```c
-account_get_network(account: *const FFIAccount) -> FFINetworks
+account_get_network(account: *const FFIAccount) -> FFINetwork
 ```
 
 **Description:**
-Get the network of an account  # Safety  - `account` must be a valid pointer to an FFIAccount instance - Returns FFINetwork::NoNetworks if the account is null
+Get the network of an account  # Safety  - `account` must be a valid pointer to an FFIAccount instance - Returns `FFINetwork::Dash` if the account is null
 
 **Safety:**
-- `account` must be a valid pointer to an FFIAccount instance - Returns FFINetwork::NoNetworks if the account is null
+- `account` must be a valid pointer to an FFIAccount instance - Returns `FFINetwork::Dash` if the account is null
 
 **Module:** `account`
 
@@ -2369,7 +2369,7 @@ bls_account_get_is_watch_only(account: *const FFIBLSAccount) -> bool
 #### `bls_account_get_network`
 
 ```c
-bls_account_get_network(account: *const FFIBLSAccount) -> FFINetworks
+bls_account_get_network(account: *const FFIBLSAccount) -> FFINetwork
 ```
 
 **Module:** `account`
@@ -2452,7 +2452,7 @@ eddsa_account_get_is_watch_only(account: *const FFIEdDSAAccount) -> bool
 #### `eddsa_account_get_network`
 
 ```c
-eddsa_account_get_network(account: *const FFIEdDSAAccount) -> FFINetworks
+eddsa_account_get_network(account: *const FFIEdDSAAccount) -> FFINetwork
 ```
 
 **Module:** `account`
@@ -3042,10 +3042,10 @@ managed_account_get_network(account: *const FFIManagedAccount,) -> FFINetwork
 ```
 
 **Description:**
-Get the network of a managed account  # Safety  - `account` must be a valid pointer to an FFIManagedAccount instance
+Get the network of a managed account  # Safety  - `account` must be a valid pointer to an FFIManagedAccount instance - Returns `FFINetwork::Dash` if the account is null
 
 **Safety:**
-- `account` must be a valid pointer to an FFIManagedAccount instance
+- `account` must be a valid pointer to an FFIManagedAccount instance - Returns `FFINetwork::Dash` if the account is null
 
 **Module:** `managed_account`
 
@@ -3505,7 +3505,7 @@ This function is unsafe because it dereferences raw pointers: - `encrypted_key` 
 #### `bip38_encrypt_private_key`
 
 ```c
-bip38_encrypt_private_key(private_key: *const c_char, passphrase: *const c_char, _network: FFINetworks, error: *mut FFIError,) -> *mut c_char
+bip38_encrypt_private_key(private_key: *const c_char, passphrase: *const c_char, error: *mut FFIError,) -> *mut c_char
 ```
 
 **Description:**
@@ -4080,7 +4080,7 @@ Free a string  # Safety  - `s` must be a valid pointer created by C string creat
 - `FFIWalletManager` - Wallet manager handle
 - `FFIBalance` - Balance information
 - `FFIUTXO` - Unspent transaction output
-- `FFINetworks` - Network enumeration
+- `FFINetwork` - Network enumeration
 
 ## Memory Management
 

--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -89,16 +89,14 @@ typedef enum {
 } FFIAccountType;
 
 /*
- FFI Network type (bit flags for multiple networks)
+ FFI Network type (single network)
  */
 typedef enum {
-    NO_NETWORKS = 0,
-    DASH_FLAG = 1,
-    TESTNET_FLAG = 2,
-    REGTEST_FLAG = 4,
-    DEVNET_FLAG = 8,
-    ALL_NETWORKS = 15,
-} FFINetworks;
+    DASH = 0,
+    TESTNET = 1,
+    REGTEST = 2,
+    DEVNET = 3,
+} FFINetwork;
 
 /*
  FFI Error code
@@ -118,16 +116,6 @@ typedef enum {
     INVALID_STATE = 11,
     INTERNAL_ERROR = 12,
 } FFIErrorCode;
-
-/*
- FFI Network type (single network)
- */
-typedef enum {
-    DASH = 0,
-    TESTNET = 1,
-    REGTEST = 2,
-    DEVNET = 3,
-} FFINetwork;
 
 /*
  Address pool type
@@ -897,9 +885,9 @@ FFIAccountResult wallet_get_top_up_account_with_registration_index(const FFIWall
  # Safety
 
  - `account` must be a valid pointer to an FFIAccount instance
- - Returns FFINetwork::NoNetworks if the account is null
+ - Returns `FFINetwork::Dash` if the account is null
  */
- FFINetworks account_get_network(const FFIAccount *account) ;
+ FFINetwork account_get_network(const FFIAccount *account) ;
 
 /*
  Get the parent wallet ID of an account
@@ -951,9 +939,9 @@ FFIAccountResult wallet_get_top_up_account_with_registration_index(const FFIWall
  # Safety
 
  - `account` must be a valid pointer to an FFIBLSAccount instance
- - Returns FFINetwork::NoNetworks if the account is null
+ - Returns `FFINetwork::Dash` if the account is null
  */
- FFINetworks bls_account_get_network(const FFIBLSAccount *account) ;
+ FFINetwork bls_account_get_network(const FFIBLSAccount *account) ;
 
 /*
  Get the parent wallet ID of a BLS account
@@ -1008,9 +996,9 @@ FFIAccountType bls_account_get_account_type(const FFIBLSAccount *account,
  # Safety
 
  - `account` must be a valid pointer to an FFIEdDSAAccount instance
- - Returns FFINetwork::NoNetworks if the account is null
+ - Returns `FFINetwork::Dash` if the account is null
  */
- FFINetworks eddsa_account_get_network(const FFIEdDSAAccount *account) ;
+ FFINetwork eddsa_account_get_network(const FFIEdDSAAccount *account) ;
 
 /*
  Get the parent wallet ID of an EdDSA account
@@ -2433,6 +2421,7 @@ FFIManagedAccountResult managed_wallet_get_dashpay_external_account(const FFIWal
  # Safety
 
  - `account` must be a valid pointer to an FFIManagedAccount instance
+ - Returns `FFINetwork::Dash` if the account is null
  */
  FFINetwork managed_account_get_network(const FFIManagedAccount *account) ;
 
@@ -3200,7 +3189,6 @@ bool mnemonic_to_seed(const char *mnemonic,
  */
 
 bool wallet_build_transaction(FFIWallet *wallet,
-                              FFINetworks _network,
                               unsigned int account_index,
                               const FFITxOutput *outputs,
                               size_t outputs_count,
@@ -3224,7 +3212,6 @@ bool wallet_build_transaction(FFIWallet *wallet,
  */
 
 bool wallet_sign_transaction(const FFIWallet *wallet,
-                             FFINetworks _network,
                              const uint8_t *tx_bytes,
                              size_t tx_len,
                              uint8_t **signed_tx_out,
@@ -3589,7 +3576,6 @@ bool managed_wallet_get_utxos(const FFIManagedWalletInfo *managed_info,
  */
 
 bool wallet_get_utxos(const FFIWallet *_wallet,
-                      FFINetworks _network,
                       FFIUTXO **utxos_out,
                       size_t *count_out,
                       FFIError *error)
@@ -3622,7 +3608,7 @@ bool wallet_get_utxos(const FFIWallet *_wallet,
 
 FFIWallet *wallet_create_from_mnemonic_with_options(const char *mnemonic,
                                                     const char *passphrase,
-                                                    FFINetworks networks,
+                                                    FFINetwork network,
                                                     const FFIWalletAccountCreationOptions *account_options,
                                                     FFIError *error)
 ;
@@ -3641,7 +3627,7 @@ FFIWallet *wallet_create_from_mnemonic_with_options(const char *mnemonic,
 
 FFIWallet *wallet_create_from_mnemonic(const char *mnemonic,
                                        const char *passphrase,
-                                       FFINetworks network,
+                                       FFINetwork network,
                                        FFIError *error)
 ;
 
@@ -3658,7 +3644,7 @@ FFIWallet *wallet_create_from_mnemonic(const char *mnemonic,
 
 FFIWallet *wallet_create_from_seed_with_options(const uint8_t *seed,
                                                 size_t seed_len,
-                                                FFINetworks networks,
+                                                FFINetwork network,
                                                 const FFIWalletAccountCreationOptions *account_options,
                                                 FFIError *error)
 ;
@@ -3675,7 +3661,7 @@ FFIWallet *wallet_create_from_seed_with_options(const uint8_t *seed,
 
 FFIWallet *wallet_create_from_seed(const uint8_t *seed,
                                    size_t seed_len,
-                                   FFINetworks network,
+                                   FFINetwork network,
                                    FFIError *error)
 ;
 
@@ -3689,7 +3675,7 @@ FFIWallet *wallet_create_from_seed(const uint8_t *seed,
  - The caller must ensure all pointers remain valid for the duration of this call
  */
 
-FFIWallet *wallet_create_random_with_options(FFINetworks networks,
+FFIWallet *wallet_create_random_with_options(FFINetwork network,
                                              const FFIWalletAccountCreationOptions *account_options,
                                              FFIError *error)
 ;
@@ -3702,7 +3688,7 @@ FFIWallet *wallet_create_random_with_options(FFINetworks networks,
  - `error` must be a valid pointer to an FFIError structure or null
  - The caller must ensure the pointer remains valid for the duration of this call
  */
- FFIWallet *wallet_create_random(FFINetworks network, FFIError *error) ;
+ FFIWallet *wallet_create_random(FFINetwork network, FFIError *error) ;
 
 /*
  Get wallet ID (32-byte hash)
@@ -3906,7 +3892,7 @@ char *wallet_manager_describe(const FFIWalletManager *manager,
 bool wallet_manager_add_wallet_from_mnemonic_with_options(FFIWalletManager *manager,
                                                           const char *mnemonic,
                                                           const char *passphrase,
-                                                          FFINetworks network,
+                                                          FFINetwork network,
                                                           const FFIWalletAccountCreationOptions *account_options,
                                                           FFIError *error)
 ;
@@ -3926,7 +3912,7 @@ bool wallet_manager_add_wallet_from_mnemonic_with_options(FFIWalletManager *mana
 bool wallet_manager_add_wallet_from_mnemonic(FFIWalletManager *manager,
                                              const char *mnemonic,
                                              const char *passphrase,
-                                             FFINetworks network,
+                                             FFINetwork network,
                                              FFIError *error)
 ;
 
@@ -3956,7 +3942,7 @@ bool wallet_manager_add_wallet_from_mnemonic(FFIWalletManager *manager,
 bool wallet_manager_add_wallet_from_mnemonic_return_serialized_bytes(FFIWalletManager *manager,
                                                                      const char *mnemonic,
                                                                      const char *passphrase,
-                                                                     FFINetworks network,
+                                                                     FFINetwork network,
                                                                      unsigned int birth_height,
                                                                      const FFIWalletAccountCreationOptions *account_options,
                                                                      bool downgrade_to_pubkey_wallet,
@@ -4201,12 +4187,7 @@ void wallet_manager_free_addresses(char **addresses,
  - `passphrase` must be a valid, null-terminated C string
  - `error` must be a valid pointer to an FFIError or null
  */
-
-char *bip38_encrypt_private_key(const char *private_key,
-                                const char *passphrase,
-                                FFINetworks _network,
-                                FFIError *error)
-;
+ char *bip38_encrypt_private_key(const char *private_key, const char *passphrase, FFIError *error) ;
 
 /*
  Decrypt a BIP38 encrypted private key

--- a/key-wallet-ffi/scripts/generate_ffi_docs.py
+++ b/key-wallet-ffi/scripts/generate_ffi_docs.py
@@ -257,7 +257,7 @@ def generate_markdown(functions: List[FFIFunction]) -> str:
     md.append("- `FFIWalletManager` - Wallet manager handle")
     md.append("- `FFIBalance` - Balance information")
     md.append("- `FFIUTXO` - Unspent transaction output")
-    md.append("- `FFINetworks` - Network enumeration")
+    md.append("- `FFINetwork` - Network enumeration")
     md.append("")
 
     # Memory Management

--- a/key-wallet-ffi/src/account.rs
+++ b/key-wallet-ffi/src/account.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_uint;
 use std::sync::Arc;
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFIAccountResult, FFIAccountType, FFINetworks, FFIWallet};
+use crate::types::{FFIAccountResult, FFIAccountType, FFINetwork, FFIWallet};
 #[cfg(feature = "bls")]
 use key_wallet::account::BLSAccount;
 #[cfg(feature = "eddsa")]
@@ -231,11 +231,11 @@ pub unsafe extern "C" fn account_get_extended_public_key_as_string(
 /// # Safety
 ///
 /// - `account` must be a valid pointer to an FFIAccount instance
-/// - Returns FFINetwork::NoNetworks if the account is null
+/// - Returns `FFINetwork::Dash` if the account is null
 #[no_mangle]
-pub unsafe extern "C" fn account_get_network(account: *const FFIAccount) -> FFINetworks {
+pub unsafe extern "C" fn account_get_network(account: *const FFIAccount) -> FFINetwork {
     if account.is_null() {
-        return FFINetworks::NoNetworks;
+        return FFINetwork::Dash;
     }
 
     let account = &*account;
@@ -342,12 +342,12 @@ pub unsafe extern "C" fn bls_account_get_extended_public_key_as_string(
 /// # Safety
 ///
 /// - `account` must be a valid pointer to an FFIBLSAccount instance
-/// - Returns FFINetwork::NoNetworks if the account is null
+/// - Returns `FFINetwork::Dash` if the account is null
 #[cfg(feature = "bls")]
 #[no_mangle]
-pub unsafe extern "C" fn bls_account_get_network(account: *const FFIBLSAccount) -> FFINetworks {
+pub unsafe extern "C" fn bls_account_get_network(account: *const FFIBLSAccount) -> FFINetwork {
     if account.is_null() {
-        return FFINetworks::NoNetworks;
+        return FFINetwork::Dash;
     }
 
     let account = &*account;
@@ -459,12 +459,12 @@ pub unsafe extern "C" fn eddsa_account_get_extended_public_key_as_string(
 /// # Safety
 ///
 /// - `account` must be a valid pointer to an FFIEdDSAAccount instance
-/// - Returns FFINetwork::NoNetworks if the account is null
+/// - Returns `FFINetwork::Dash` if the account is null
 #[cfg(feature = "eddsa")]
 #[no_mangle]
-pub unsafe extern "C" fn eddsa_account_get_network(account: *const FFIEdDSAAccount) -> FFINetworks {
+pub unsafe extern "C" fn eddsa_account_get_network(account: *const FFIEdDSAAccount) -> FFINetwork {
     if account.is_null() {
-        return FFINetworks::NoNetworks;
+        return FFINetwork::Dash;
     }
 
     let account = &*account;

--- a/key-wallet-ffi/src/account_collection.rs
+++ b/key-wallet-ffi/src/account_collection.rs
@@ -1074,7 +1074,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetworks::TestnetFlag,
+                crate::types::FFINetwork::Testnet,
                 ptr::null(),
                 ptr::null_mut(),
             );
@@ -1128,7 +1128,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetworks::TestnetFlag,
+                crate::types::FFINetwork::Testnet,
                 &options,
                 ptr::null_mut(),
             );
@@ -1174,7 +1174,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetworks::TestnetFlag,
+                crate::types::FFINetwork::Testnet,
                 &options,
                 ptr::null_mut(),
             );
@@ -1244,7 +1244,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetworks::TestnetFlag,
+                crate::types::FFINetwork::Testnet,
                 &options,
                 ptr::null_mut(),
             );
@@ -1296,7 +1296,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetworks::TestnetFlag,
+                crate::types::FFINetwork::Testnet,
                 &options,
                 ptr::null_mut(),
             );
@@ -1380,7 +1380,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetworks::TestnetFlag,
+                crate::types::FFINetwork::Testnet,
                 &options,
                 ptr::null_mut(),
             );
@@ -1466,7 +1466,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetworks::TestnetFlag,
+                crate::types::FFINetwork::Testnet,
                 &options,
                 ptr::null_mut(),
             );
@@ -1536,7 +1536,7 @@ mod tests {
             let wallet = wallet_create_from_mnemonic_with_options(
                 mnemonic.as_ptr(),
                 ptr::null(),
-                crate::types::FFINetworks::TestnetFlag,
+                crate::types::FFINetwork::Testnet,
                 ptr::null(),
                 ptr::null_mut(),
             );

--- a/key-wallet-ffi/src/account_derivation_tests.rs
+++ b/key-wallet-ffi/src/account_derivation_tests.rs
@@ -7,7 +7,7 @@ mod tests {
     use crate::derivation::*;
     use crate::error::{FFIError, FFIErrorCode};
     use crate::keys::{extended_private_key_free, private_key_free};
-    use crate::types::{FFIAccountType, FFINetworks};
+    use crate::types::FFIAccountType;
     use crate::wallet;
     use std::ffi::CString;
     use std::os::raw::c_char;
@@ -20,7 +20,7 @@ mod tests {
         let mut error = FFIError::success();
 
         // Create wallet on testnet with default accounts
-        let wallet = unsafe { wallet::wallet_create_from_mnemonic(c_str(MNEMONIC), c_str(""), FFINetworks::TestnetFlag, &mut error) };
+        let wallet = unsafe { wallet::wallet_create_from_mnemonic(c_str(MNEMONIC), c_str(""), FFINetwork::Testnet, &mut error) };
         assert!(!wallet.is_null());
         assert_eq!(unsafe { (*(&mut error)).code }, FFIErrorCode::Success);
 
@@ -104,7 +104,7 @@ mod tests {
         let mut error = FFIError::success();
 
         // Create wallet on testnet with default accounts
-        let wallet = unsafe { wallet::wallet_create_from_mnemonic(c_str(MNEMONIC), c_str(""), FFINetworks::TestnetFlag, &mut error) };
+        let wallet = unsafe { wallet::wallet_create_from_mnemonic(c_str(MNEMONIC), c_str(""), FFINetwork::Testnet, &mut error) };
         assert!(!wallet.is_null());
 
         // Get account 0 (BIP44)
@@ -142,7 +142,7 @@ mod tests {
         let mut error = FFIError::success();
 
         // Create wallet and get account 0
-        let wallet = unsafe { wallet::wallet_create_from_mnemonic(c_str(MNEMONIC), c_str(""), FFINetworks::TestnetFlag, &mut error) };
+        let wallet = unsafe { wallet::wallet_create_from_mnemonic(c_str(MNEMONIC), c_str(""), FFINetwork::Testnet, &mut error) };
         assert!(!wallet.is_null());
         let account = unsafe {
             crate::account::wallet_get_account(wallet, crate::FFINetwork::Testnet, 0, FFIAccountType::StandardBIP44)

--- a/key-wallet-ffi/src/account_tests.rs
+++ b/key-wallet-ffi/src/account_tests.rs
@@ -3,8 +3,9 @@
 mod tests {
     use super::super::*;
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::{FFIAccountType, FFINetworks};
+    use crate::types::FFIAccountType;
     use crate::wallet;
+    use crate::FFINetwork;
     use std::ffi::CString;
     use std::ptr;
 
@@ -36,7 +37,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -90,7 +91,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -135,7 +136,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -158,7 +159,7 @@ mod tests {
 
                 // Test get network
                 let network = account_get_network(result.account);
-                assert_eq!(network as u32, FFINetworks::TestnetFlag as u32);
+                assert_eq!(network, FFINetwork::Testnet);
 
                 // Test get parent wallet id (may be null)
                 let _wallet_id = account_get_parent_wallet_id(result.account);
@@ -200,7 +201,7 @@ mod tests {
             assert!(xpub.is_null());
 
             let network = account_get_network(ptr::null());
-            assert_eq!(network as u32, FFINetworks::NoNetworks as u32);
+            assert_eq!(network, crate::FFINetwork::Dash);
 
             let wallet_id = account_get_parent_wallet_id(ptr::null());
             assert!(wallet_id.is_null());

--- a/key-wallet-ffi/src/address_pool.rs
+++ b/key-wallet-ffi/src/address_pool.rs
@@ -964,7 +964,7 @@ pub unsafe extern "C" fn address_info_array_free(infos: *mut *mut FFIAddressInfo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::FFINetworks;
+    use crate::FFINetwork;
 
     #[test]
     fn test_address_pool_type_values() {
@@ -1069,7 +1069,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1169,7 +1169,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 ptr::null(),
                 &mut error,
             );

--- a/key-wallet-ffi/src/bip38.rs
+++ b/key-wallet-ffi/src/bip38.rs
@@ -5,7 +5,6 @@ use std::os::raw::c_char;
 use std::ptr;
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::FFINetworks;
 
 /// Encrypt a private key with BIP38
 ///
@@ -19,7 +18,6 @@ use crate::types::FFINetworks;
 pub unsafe extern "C" fn bip38_encrypt_private_key(
     private_key: *const c_char,
     passphrase: *const c_char,
-    _network: FFINetworks,
     error: *mut FFIError,
 ) -> *mut c_char {
     #[cfg(feature = "bip38")]

--- a/key-wallet-ffi/src/keys_tests.rs
+++ b/key-wallet-ffi/src/keys_tests.rs
@@ -5,7 +5,7 @@
 mod tests {
     use crate::error::{FFIError, FFIErrorCode};
     use crate::keys::*;
-    use crate::types::{FFINetwork, FFINetworks};
+    use crate::types::FFINetwork;
     use crate::wallet;
     use std::ffi::{CStr, CString};
     use std::ptr;
@@ -21,7 +21,7 @@ mod tests {
             let wallet = wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             );
             assert!(!wallet.is_null());
@@ -111,7 +111,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -142,7 +142,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -177,7 +177,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -225,7 +225,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -279,7 +279,7 @@ mod tests {
             let wallet = wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             );
             assert!(!wallet.is_null());
@@ -427,7 +427,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -561,7 +561,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -606,7 +606,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };

--- a/key-wallet-ffi/src/lib.rs
+++ b/key-wallet-ffi/src/lib.rs
@@ -31,7 +31,7 @@ pub mod bip38;
 
 // Re-export main types for convenience
 pub use error::{FFIError, FFIErrorCode};
-pub use types::{FFIBalance, FFINetwork, FFINetworks, FFIWallet};
+pub use types::{FFIBalance, FFINetwork, FFIWallet};
 pub use utxo::FFIUTXO;
 pub use wallet_manager::{
     wallet_manager_create, wallet_manager_describe, wallet_manager_free,

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -384,6 +384,7 @@ pub unsafe extern "C" fn managed_wallet_get_dashpay_external_account(
 /// # Safety
 ///
 /// - `account` must be a valid pointer to an FFIManagedAccount instance
+/// - Returns `FFINetwork::Dash` if the account is null
 #[no_mangle]
 pub unsafe extern "C" fn managed_account_get_network(
     account: *const FFIManagedAccount,
@@ -969,7 +970,7 @@ mod tests {
         wallet_manager_add_wallet_from_mnemonic_with_options, wallet_manager_create,
         wallet_manager_free, wallet_manager_free_wallet_ids, wallet_manager_get_wallet_ids,
     };
-    use crate::FFINetworks;
+    use crate::FFINetwork;
     use std::ffi::CString;
     use std::ptr;
 
@@ -993,7 +994,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1061,7 +1062,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &options,
                 &mut error,
             );
@@ -1136,7 +1137,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &options,
                 &mut error,
             );
@@ -1185,7 +1186,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1271,7 +1272,7 @@ mod tests {
     #[test]
     fn test_managed_account_getter_edge_cases() {
         unsafe {
-            // Test null account
+            // Test null account for get_network
             let network = managed_account_get_network(ptr::null());
             assert_eq!(network, FFINetwork::Dash);
 
@@ -1305,7 +1306,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1361,7 +1362,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1455,7 +1456,7 @@ mod tests {
                 manager,
                 mnemonic2.as_ptr(),
                 passphrase2.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &options,
                 &mut error,
             );

--- a/key-wallet-ffi/src/managed_wallet.rs
+++ b/key-wallet-ffi/src/managed_wallet.rs
@@ -622,8 +622,8 @@ pub unsafe extern "C" fn managed_wallet_info_free(wallet_info: *mut FFIManagedWa
 mod tests {
     use crate::error::{FFIError, FFIErrorCode};
     use crate::managed_wallet::*;
-    use crate::types::FFINetworks;
     use crate::wallet;
+    use crate::FFINetwork;
     use key_wallet::managed_account::managed_account_type::ManagedAccountType;
     use std::ffi::{CStr, CString};
     use std::ptr;
@@ -741,7 +741,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -815,7 +815,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -998,7 +998,7 @@ mod tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };

--- a/key-wallet-ffi/src/transaction.rs
+++ b/key-wallet-ffi/src/transaction.rs
@@ -13,7 +13,7 @@ use secp256k1::{Message, Secp256k1, SecretKey};
 
 use crate::error::{FFIError, FFIErrorCode};
 use crate::managed_wallet::FFIManagedWalletInfo;
-use crate::types::{FFINetwork, FFINetworks, FFITransactionContext, FFIWallet};
+use crate::types::{FFINetwork, FFITransactionContext, FFIWallet};
 
 // MARK: - Transaction Types
 
@@ -71,7 +71,6 @@ pub struct FFITxOutput {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_build_transaction(
     wallet: *mut FFIWallet,
-    _network: FFINetworks,
     account_index: c_uint,
     outputs: *const FFITxOutput,
     outputs_count: usize,
@@ -116,7 +115,6 @@ pub unsafe extern "C" fn wallet_build_transaction(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_sign_transaction(
     wallet: *const FFIWallet,
-    _network: FFINetworks,
     tx_bytes: *const u8,
     tx_len: usize,
     signed_tx_out: *mut *mut u8,

--- a/key-wallet-ffi/src/transaction_tests.rs
+++ b/key-wallet-ffi/src/transaction_tests.rs
@@ -3,8 +3,8 @@
 mod transaction_tests {
     use super::super::*;
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::FFINetworks;
     use crate::wallet;
+    use crate::FFINetwork;
     use std::ffi::CString;
     use std::os::raw::c_char;
     use std::ptr;
@@ -24,7 +24,6 @@ mod transaction_tests {
         let success = unsafe {
             wallet_build_transaction(
                 ptr::null_mut(),
-                FFINetworks::TestnetFlag,
                 0,
                 &output,
                 1,
@@ -56,7 +55,7 @@ mod transaction_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -67,7 +66,6 @@ mod transaction_tests {
         let success = unsafe {
             wallet_build_transaction(
                 wallet,
-                FFINetworks::TestnetFlag,
                 0,
                 ptr::null(),
                 0,
@@ -98,7 +96,6 @@ mod transaction_tests {
         let success = unsafe {
             wallet_sign_transaction(
                 ptr::null(),
-                FFINetworks::TestnetFlag,
                 tx_bytes.as_ptr(),
                 tx_bytes.len(),
                 &mut signed_tx_out,
@@ -123,7 +120,7 @@ mod transaction_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -134,7 +131,6 @@ mod transaction_tests {
         let success = unsafe {
             wallet_sign_transaction(
                 wallet,
-                FFINetworks::TestnetFlag,
                 ptr::null(),
                 0,
                 &mut signed_tx_out,
@@ -172,7 +168,7 @@ mod transaction_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -188,7 +184,6 @@ mod transaction_tests {
         let success = unsafe {
             wallet_build_transaction(
                 wallet,
-                FFINetworks::TestnetFlag,
                 0,
                 &output,
                 1,
@@ -222,7 +217,7 @@ mod transaction_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 &mut error,
             )
         };
@@ -234,7 +229,6 @@ mod transaction_tests {
         let success = unsafe {
             wallet_sign_transaction(
                 wallet,
-                FFINetworks::TestnetFlag,
                 tx_bytes.as_ptr(),
                 tx_bytes.len(),
                 &mut signed_tx_out,

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -4,64 +4,6 @@ use key_wallet::{Network, Wallet};
 use std::os::raw::{c_char, c_uint};
 use std::sync::Arc;
 
-/// FFI Network type (bit flags for multiple networks)
-#[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum FFINetworks {
-    NoNetworks = 0,
-    DashFlag = 1,
-    TestnetFlag = 2,
-    RegtestFlag = 4,
-    DevnetFlag = 8,
-    AllNetworks = 15, // DashFlag | TestnetFlag | RegtestFlag | DevnetFlag
-}
-
-impl FFINetworks {
-    /// Parse bit flags into a vector of networks
-    pub fn parse_networks(&self) -> Vec<Network> {
-        // Handle special cases
-        if self == &FFINetworks::NoNetworks {
-            return vec![];
-        }
-
-        let flags = *self as c_uint;
-
-        let mut networks = Vec::new();
-
-        if flags & (FFINetworks::DashFlag as c_uint) != 0 {
-            networks.push(Network::Dash);
-        }
-        if flags & (FFINetworks::TestnetFlag as c_uint) != 0 {
-            networks.push(Network::Testnet);
-        }
-        if flags & (FFINetworks::RegtestFlag as c_uint) != 0 {
-            networks.push(Network::Regtest);
-        }
-        if flags & (FFINetworks::DevnetFlag as c_uint) != 0 {
-            networks.push(Network::Devnet);
-        }
-
-        networks
-    }
-}
-
-impl FFINetworks {
-    /// Try to convert to a single Network
-    /// Returns None if multiple networks are set or if NoNetworks is set
-    pub fn try_into_single_network(&self) -> Option<Network> {
-        let flags = *self as c_uint;
-
-        // Check if it's a single network
-        match flags {
-            x if x == FFINetworks::DashFlag as c_uint => Some(Network::Dash),
-            x if x == FFINetworks::TestnetFlag as c_uint => Some(Network::Testnet),
-            x if x == FFINetworks::RegtestFlag as c_uint => Some(Network::Regtest),
-            x if x == FFINetworks::DevnetFlag as c_uint => Some(Network::Devnet),
-            _ => None, // Multiple networks or NoNetworks
-        }
-    }
-}
-
 /// FFI Network type (single network)
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -101,31 +43,6 @@ impl From<Network> for FFINetwork {
             Network::Regtest => FFINetwork::Regtest,
             Network::Devnet => FFINetwork::Devnet,
             _ => FFINetwork::Dash,
-        }
-    }
-}
-
-use std::convert::TryFrom;
-
-impl TryFrom<FFINetworks> for Network {
-    type Error = &'static str;
-
-    fn try_from(value: FFINetworks) -> Result<Self, Self::Error> {
-        match value.try_into_single_network() {
-            Some(network) => Ok(network),
-            None => Err("FFINetwork must represent exactly one network"),
-        }
-    }
-}
-
-impl From<Network> for FFINetworks {
-    fn from(n: Network) -> Self {
-        match n {
-            Network::Dash => FFINetworks::DashFlag,
-            Network::Testnet => FFINetworks::TestnetFlag,
-            Network::Regtest => FFINetworks::RegtestFlag,
-            Network::Devnet => FFINetworks::DevnetFlag,
-            _ => FFINetworks::DashFlag, // Default to Dash for unknown networks
         }
     }
 }

--- a/key-wallet-ffi/src/utxo.rs
+++ b/key-wallet-ffi/src/utxo.rs
@@ -6,7 +6,6 @@ use std::ptr;
 
 use crate::error::{FFIError, FFIErrorCode};
 use crate::managed_wallet::FFIManagedWalletInfo;
-use crate::types::FFINetworks;
 
 /// UTXO structure for FFI
 #[repr(C)]
@@ -161,7 +160,6 @@ pub unsafe extern "C" fn managed_wallet_get_utxos(
 #[deprecated(note = "Use managed_wallet_get_utxos with ManagedWalletInfo instead")]
 pub unsafe extern "C" fn wallet_get_utxos(
     _wallet: *const crate::types::FFIWallet,
-    _network: FFINetworks,
     utxos_out: *mut *mut FFIUTXO,
     count_out: *mut usize,
     error: *mut FFIError,

--- a/key-wallet-ffi/src/utxo_tests.rs
+++ b/key-wallet-ffi/src/utxo_tests.rs
@@ -2,7 +2,6 @@
 mod utxo_tests {
     use super::super::*;
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::FFINetworks;
     use key_wallet::managed_account::managed_account_type::ManagedAccountType;
     use std::ffi::CStr;
     use std::ptr;
@@ -81,13 +80,7 @@ mod utxo_tests {
         // The deprecated function should always return an empty list
         let success = unsafe {
             #[allow(deprecated)]
-            wallet_get_utxos(
-                ptr::null(),
-                FFINetworks::TestnetFlag,
-                &mut utxos_out,
-                &mut count_out,
-                error,
-            )
+            wallet_get_utxos(ptr::null(), &mut utxos_out, &mut count_out, error)
         };
 
         assert!(success);

--- a/key-wallet-ffi/src/wallet.rs
+++ b/key-wallet-ffi/src/wallet.rs
@@ -14,7 +14,9 @@ use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::{Mnemonic, Seed, Wallet};
 
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFINetworks, FFIWallet, FFIWalletAccountCreationOptions};
+use crate::types::{FFIWallet, FFIWalletAccountCreationOptions};
+use crate::FFINetwork;
+use key_wallet::Network;
 
 /// Create a new wallet from mnemonic with options
 ///
@@ -30,7 +32,7 @@ use crate::types::{FFINetworks, FFIWallet, FFIWalletAccountCreationOptions};
 pub unsafe extern "C" fn wallet_create_from_mnemonic_with_options(
     mnemonic: *const c_char,
     passphrase: *const c_char,
-    networks: FFINetworks,
+    network: FFINetwork,
     account_options: *const FFIWalletAccountCreationOptions,
     error: *mut FFIError,
 ) -> *mut FFIWallet {
@@ -84,19 +86,7 @@ pub unsafe extern "C" fn wallet_create_from_mnemonic_with_options(
         }
     };
 
-    // Convert networks bit flags to single network
-    let networks_rust = networks.parse_networks();
-    let network_rust = match networks_rust.first() {
-        Some(n) => *n,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::InvalidInput,
-                "No network specified".to_string(),
-            );
-            return ptr::null_mut();
-        }
-    };
+    let network_rust: Network = network.into();
 
     // Convert account creation options
     let creation_options = if account_options.is_null() {
@@ -155,7 +145,7 @@ pub unsafe extern "C" fn wallet_create_from_mnemonic_with_options(
 pub unsafe extern "C" fn wallet_create_from_mnemonic(
     mnemonic: *const c_char,
     passphrase: *const c_char,
-    network: FFINetworks,
+    network: FFINetwork,
     error: *mut FFIError,
 ) -> *mut FFIWallet {
     wallet_create_from_mnemonic_with_options(
@@ -179,7 +169,7 @@ pub unsafe extern "C" fn wallet_create_from_mnemonic(
 pub unsafe extern "C" fn wallet_create_from_seed_with_options(
     seed: *const u8,
     seed_len: usize,
-    networks: FFINetworks,
+    network: FFINetwork,
     account_options: *const FFIWalletAccountCreationOptions,
     error: *mut FFIError,
 ) -> *mut FFIWallet {
@@ -202,19 +192,7 @@ pub unsafe extern "C" fn wallet_create_from_seed_with_options(
     seed_array.copy_from_slice(seed_bytes);
     let seed = Seed::new(seed_array);
 
-    // Convert networks bit flags to single network
-    let networks_rust = networks.parse_networks();
-    let network_rust = match networks_rust.first() {
-        Some(n) => *n,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::InvalidInput,
-                "No network specified".to_string(),
-            );
-            return ptr::null_mut();
-        }
-    };
+    let network_rust: Network = network.into();
 
     // Convert account creation options
     let creation_options = if account_options.is_null() {
@@ -250,7 +228,7 @@ pub unsafe extern "C" fn wallet_create_from_seed_with_options(
 pub unsafe extern "C" fn wallet_create_from_seed(
     seed: *const u8,
     seed_len: usize,
-    network: FFINetworks,
+    network: FFINetwork,
     error: *mut FFIError,
 ) -> *mut FFIWallet {
     wallet_create_from_seed_with_options(
@@ -271,23 +249,11 @@ pub unsafe extern "C" fn wallet_create_from_seed(
 /// - The caller must ensure all pointers remain valid for the duration of this call
 #[no_mangle]
 pub unsafe extern "C" fn wallet_create_random_with_options(
-    networks: FFINetworks,
+    network: FFINetwork,
     account_options: *const FFIWalletAccountCreationOptions,
     error: *mut FFIError,
 ) -> *mut FFIWallet {
-    // Convert networks bit flags to single network
-    let networks_rust = networks.parse_networks();
-    let network_rust = match networks_rust.first() {
-        Some(n) => *n,
-        None => {
-            FFIError::set_error(
-                error,
-                FFIErrorCode::InvalidInput,
-                "No network specified".to_string(),
-            );
-            return ptr::null_mut();
-        }
-    };
+    let network_rust: Network = network.into();
 
     // Convert account creation options
     let creation_options = if account_options.is_null() {
@@ -320,7 +286,7 @@ pub unsafe extern "C" fn wallet_create_random_with_options(
 /// - The caller must ensure the pointer remains valid for the duration of this call
 #[no_mangle]
 pub unsafe extern "C" fn wallet_create_random(
-    network: FFINetworks,
+    network: FFINetwork,
     error: *mut FFIError,
 ) -> *mut FFIWallet {
     wallet_create_random_with_options(

--- a/key-wallet-ffi/src/wallet_manager_serialization_tests.rs
+++ b/key-wallet-ffi/src/wallet_manager_serialization_tests.rs
@@ -3,8 +3,9 @@
 #[cfg(all(test, feature = "bincode"))]
 mod tests {
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::{FFINetworks, FFIWalletAccountCreationOptions};
+    use crate::types::FFIWalletAccountCreationOptions;
     use crate::wallet_manager;
+    use crate::FFINetwork;
     use std::ffi::CString;
     use std::ptr;
 
@@ -32,7 +33,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 0,           // birth_height
                 ptr::null(), // default account options
                 false,       // don't downgrade to pubkey wallet
@@ -84,7 +85,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 true,  // downgrade to pubkey wallet
@@ -133,7 +134,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 true, // downgrade to pubkey wallet
@@ -182,7 +183,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -231,7 +232,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -298,7 +299,7 @@ mod tests {
                 manager,
                 invalid_mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -334,7 +335,7 @@ mod tests {
                 manager,
                 ptr::null(),
                 ptr::null(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -390,7 +391,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 0,
                 &account_options,
                 false,

--- a/key-wallet-ffi/src/wallet_manager_tests.rs
+++ b/key-wallet-ffi/src/wallet_manager_tests.rs
@@ -4,7 +4,6 @@
 #[allow(clippy::module_inception)]
 mod tests {
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::FFINetworks;
     use crate::{wallet, wallet_manager, FFINetwork};
     use std::ffi::{CStr, CString};
     use std::ptr;
@@ -53,7 +52,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag, // Create 3 accounts
+                FFINetwork::Testnet, // Create 3 accounts
                 error,
             )
         };
@@ -91,7 +90,7 @@ mod tests {
                     manager,
                     mnemonic.as_ptr(),
                     ptr::null(), // No passphrase
-                    FFINetworks::TestnetFlag,
+                    FFINetwork::Testnet,
                     error,
                 );
                 if !success {
@@ -164,7 +163,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 ptr::null(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -268,7 +267,7 @@ mod tests {
                 manager,
                 invalid_mnemonic.as_ptr(),
                 ptr::null(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -300,7 +299,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag, // account_count
+                FFINetwork::Testnet, // account_count
                 error,
             )
         };
@@ -332,7 +331,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -387,7 +386,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -468,7 +467,7 @@ mod tests {
                 ptr::null_mut(),
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag, // account_count
+                FFINetwork::Testnet, // account_count
                 error,
             )
         };
@@ -536,7 +535,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -656,7 +655,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -823,7 +822,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -938,7 +937,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 0,           // birth_height
                 ptr::null(), // default account options
                 false,       // don't downgrade to pubkey wallet
@@ -980,7 +979,7 @@ mod tests {
                 manager2,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 true,  // downgrade to pubkey wallet
@@ -1051,7 +1050,7 @@ mod tests {
                 manager4,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 true, // downgrade to pubkey wallet
@@ -1091,7 +1090,7 @@ mod tests {
                 manager5,
                 invalid_mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -1139,7 +1138,7 @@ mod tests {
                 manager1,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 100,         // birth_height
                 ptr::null(), // default account options
                 false,       // don't downgrade to pubkey wallet

--- a/key-wallet-ffi/src/wallet_tests.rs
+++ b/key-wallet-ffi/src/wallet_tests.rs
@@ -4,8 +4,9 @@
 mod wallet_tests {
     use crate::account::account_free;
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::{FFIAccountType, FFINetworks};
+    use crate::types::FFIAccountType;
     use crate::wallet;
+    use crate::FFINetwork;
     use std::ffi::CString;
     use std::ptr;
 
@@ -23,7 +24,7 @@ mod wallet_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -45,12 +46,7 @@ mod wallet_tests {
         let seed = [0x01u8; 64];
 
         let wallet = unsafe {
-            wallet::wallet_create_from_seed(
-                seed.as_ptr(),
-                seed.len(),
-                FFINetworks::TestnetFlag,
-                error,
-            )
+            wallet::wallet_create_from_seed(seed.as_ptr(), seed.len(), FFINetwork::Testnet, error)
         };
 
         assert!(!wallet.is_null());
@@ -68,8 +64,7 @@ mod wallet_tests {
         let error = &mut error as *mut FFIError;
 
         // Test random wallet creation
-        let random_wallet =
-            unsafe { wallet::wallet_create_random(FFINetworks::TestnetFlag, error) };
+        let random_wallet = unsafe { wallet::wallet_create_random(FFINetwork::Testnet, error) };
         assert!(!random_wallet.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::Success);
 
@@ -96,7 +91,7 @@ mod wallet_tests {
                 let wallet = wallet::wallet_create_from_seed(
                     seed.as_ptr(),
                     seed.len(),
-                    FFINetworks::TestnetFlag,
+                    FFINetwork::Testnet,
                     error,
                 );
 
@@ -121,7 +116,7 @@ mod wallet_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -145,7 +140,7 @@ mod wallet_tests {
             wallet::wallet_create_from_mnemonic(
                 ptr::null(),
                 ptr::null(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -158,7 +153,7 @@ mod wallet_tests {
             wallet::wallet_create_from_mnemonic(
                 invalid_mnemonic.as_ptr(),
                 ptr::null(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -166,9 +161,8 @@ mod wallet_tests {
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidMnemonic);
 
         // Test with null seed
-        let wallet = unsafe {
-            wallet::wallet_create_from_seed(ptr::null(), 64, FFINetworks::TestnetFlag, error)
-        };
+        let wallet =
+            unsafe { wallet::wallet_create_from_seed(ptr::null(), 64, FFINetwork::Testnet, error) };
         assert!(wallet.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidInput);
     }
@@ -178,7 +172,7 @@ mod wallet_tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let wallet = unsafe { wallet::wallet_create_random(FFINetworks::TestnetFlag, error) };
+        let wallet = unsafe { wallet::wallet_create_random(FFINetwork::Testnet, error) };
         assert!(!wallet.is_null());
 
         // Get wallet ID
@@ -212,7 +206,7 @@ mod wallet_tests {
             wallet::wallet_create_from_seed(
                 seed_bytes.as_ptr(),
                 seed_bytes.len(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -232,9 +226,8 @@ mod wallet_tests {
         let error = &mut error as *mut FFIError;
 
         // Test with null seed bytes
-        let wallet = unsafe {
-            wallet::wallet_create_from_seed(ptr::null(), 64, FFINetworks::TestnetFlag, error)
-        };
+        let wallet =
+            unsafe { wallet::wallet_create_from_seed(ptr::null(), 64, FFINetwork::Testnet, error) };
 
         assert!(wallet.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidInput);
@@ -253,7 +246,7 @@ mod wallet_tests {
             wallet::wallet_create_from_mnemonic(
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -286,7 +279,7 @@ mod wallet_tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let wallet = unsafe { wallet::wallet_create_random(FFINetworks::TestnetFlag, error) };
+        let wallet = unsafe { wallet::wallet_create_random(FFINetwork::Testnet, error) };
         assert!(!wallet.is_null());
 
         // Test adding account - check if it succeeds or fails gracefully
@@ -344,7 +337,7 @@ mod wallet_tests {
             wallet::wallet_create_from_seed(
                 normal_seed.as_ptr(),
                 normal_seed.len(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -359,7 +352,7 @@ mod wallet_tests {
             wallet::wallet_create_from_seed(
                 large_seed.as_ptr(),
                 large_seed.len(),
-                FFINetworks::TestnetFlag,
+                FFINetwork::Testnet,
                 error,
             )
         };
@@ -376,7 +369,7 @@ mod wallet_tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let wallet = unsafe { wallet::wallet_create_random(FFINetworks::TestnetFlag, error) };
+        let wallet = unsafe { wallet::wallet_create_random(FFINetwork::Testnet, error) };
         assert!(!wallet.is_null());
 
         // Get xpub for account 0

--- a/key-wallet-ffi/tests/debug_wallet_add.rs
+++ b/key-wallet-ffi/tests/debug_wallet_add.rs
@@ -1,8 +1,8 @@
 #[test]
 fn test_debug_wallet_add() {
     use key_wallet_ffi::error::FFIError;
-    use key_wallet_ffi::types::FFINetworks;
     use key_wallet_ffi::wallet_manager;
+    use key_wallet_ffi::FFINetwork;
     use std::ffi::CString;
 
     let mut error = FFIError::success();
@@ -21,7 +21,7 @@ fn test_debug_wallet_add() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             error,
         )
     };

--- a/key-wallet-ffi/tests/integration_test.rs
+++ b/key-wallet-ffi/tests/integration_test.rs
@@ -3,7 +3,6 @@
 //! These tests verify the interaction between different FFI modules
 
 use key_wallet_ffi::error::{FFIError, FFIErrorCode};
-use key_wallet_ffi::types::FFINetworks;
 use key_wallet_ffi::FFINetwork;
 use std::ffi::CString;
 use std::ptr;
@@ -36,7 +35,7 @@ fn test_full_wallet_workflow() {
             manager,
             mnemonic,
             passphrase.as_ptr(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             error,
         )
     };
@@ -111,7 +110,7 @@ fn test_seed_to_wallet_workflow() {
         key_wallet_ffi::wallet::wallet_create_from_seed(
             seed.as_ptr(),
             seed_len,
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             error,
         )
     };
@@ -182,7 +181,7 @@ fn test_error_handling() {
         key_wallet_ffi::wallet::wallet_create_from_mnemonic(
             invalid_mnemonic.as_ptr(),
             ptr::null(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             error,
         )
     };
@@ -194,7 +193,7 @@ fn test_error_handling() {
         key_wallet_ffi::wallet::wallet_create_from_mnemonic(
             ptr::null(),
             ptr::null(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             error,
         )
     };
@@ -207,7 +206,7 @@ fn test_error_handling() {
         key_wallet_ffi::wallet::wallet_create_from_seed(
             invalid_seed.as_ptr(),
             invalid_seed.len(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             error,
         )
     };

--- a/key-wallet-ffi/tests/test_account_collection.rs
+++ b/key-wallet-ffi/tests/test_account_collection.rs
@@ -2,10 +2,9 @@
 
 use key_wallet_ffi::account::account_free;
 use key_wallet_ffi::account_collection::*;
-use key_wallet_ffi::types::{
-    FFIAccountCreationOptionType, FFINetworks, FFIWalletAccountCreationOptions,
-};
+use key_wallet_ffi::types::{FFIAccountCreationOptionType, FFIWalletAccountCreationOptions};
 use key_wallet_ffi::wallet::{wallet_create_from_mnemonic_with_options, wallet_free};
+use key_wallet_ffi::FFINetwork;
 use std::ffi::CString;
 use std::ptr;
 
@@ -35,7 +34,7 @@ fn test_account_collection_comprehensive() {
         let wallet = wallet_create_from_mnemonic_with_options(
             mnemonic.as_ptr(),
             ptr::null(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             &account_options,
             ptr::null_mut(),
         );
@@ -152,7 +151,7 @@ fn test_account_collection_minimal() {
         let wallet = wallet_create_from_mnemonic_with_options(
             mnemonic.as_ptr(),
             ptr::null(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             ptr::null(), // Use default options
             ptr::null_mut(),
         );

--- a/key-wallet-ffi/tests/test_addr_simple.rs
+++ b/key-wallet-ffi/tests/test_addr_simple.rs
@@ -1,7 +1,7 @@
 #[test]
 fn test_address_simple() {
     use key_wallet_ffi::error::FFIError;
-    use key_wallet_ffi::types::FFINetworks;
+    use key_wallet_ffi::FFINetwork;
 
     let mut error = FFIError::success();
     let error = &mut error as *mut FFIError;
@@ -12,7 +12,7 @@ fn test_address_simple() {
         key_wallet_ffi::wallet::wallet_create_from_seed(
             seed.as_ptr(),
             seed.len(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             error,
         )
     };

--- a/key-wallet-ffi/tests/test_import_wallet.rs
+++ b/key-wallet-ffi/tests/test_import_wallet.rs
@@ -4,8 +4,8 @@
 #[cfg(test)]
 mod tests {
     use key_wallet_ffi::error::{FFIError, FFIErrorCode};
-    use key_wallet_ffi::types::FFINetworks;
     use key_wallet_ffi::wallet_manager::*;
+    use key_wallet_ffi::FFINetwork;
     use std::os::raw::c_char;
     use std::ptr;
 
@@ -26,7 +26,7 @@ mod tests {
                 manager,
                 mnemonic.as_ptr() as *const c_char,
                 passphrase.as_ptr() as *const c_char,
-                FFINetworks::DashFlag,
+                FFINetwork::Dash,
                 &mut error,
             );
             assert!(success);

--- a/key-wallet-ffi/tests/test_managed_account_collection.rs
+++ b/key-wallet-ffi/tests/test_managed_account_collection.rs
@@ -2,13 +2,12 @@
 
 use key_wallet_ffi::error::{FFIError, FFIErrorCode};
 use key_wallet_ffi::managed_account_collection::*;
-use key_wallet_ffi::types::{
-    FFIAccountCreationOptionType, FFINetworks, FFIWalletAccountCreationOptions,
-};
+use key_wallet_ffi::types::{FFIAccountCreationOptionType, FFIWalletAccountCreationOptions};
 use key_wallet_ffi::wallet_manager::{
     wallet_manager_add_wallet_from_mnemonic_with_options, wallet_manager_create,
     wallet_manager_free, wallet_manager_free_wallet_ids, wallet_manager_get_wallet_ids,
 };
+use key_wallet_ffi::FFINetwork;
 use std::ffi::CString;
 use std::ptr;
 
@@ -33,7 +32,7 @@ fn test_managed_account_collection_basic() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             ptr::null(), // Use default options
             &mut error,
         );
@@ -133,7 +132,7 @@ fn test_managed_account_collection_with_special_accounts() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             &options,
             &mut error,
         );
@@ -253,7 +252,7 @@ fn test_managed_account_collection_summary() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             &options,
             &mut error,
         );
@@ -342,7 +341,7 @@ fn test_managed_account_collection_summary_data() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             &options,
             &mut error,
         );
@@ -439,7 +438,7 @@ fn test_managed_account_collection_nonexistent_accounts() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             ptr::null(), // Default options
             &mut error,
         );

--- a/key-wallet-ffi/tests/test_passphrase_wallets.rs
+++ b/key-wallet-ffi/tests/test_passphrase_wallets.rs
@@ -2,7 +2,7 @@
 //! These tests demonstrate current issues with passphrase handling in the FFI layer
 
 use key_wallet_ffi::error::{FFIError, FFIErrorCode};
-use key_wallet_ffi::types::FFINetworks;
+use key_wallet_ffi::FFINetwork;
 use std::ffi::CString;
 
 #[test]
@@ -20,7 +20,7 @@ fn test_ffi_wallet_create_from_mnemonic_with_passphrase() {
         key_wallet_ffi::wallet::wallet_create_from_mnemonic(
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             error,
         )
     };
@@ -69,7 +69,7 @@ fn test_ffi_wallet_manager_add_wallet_with_passphrase() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetworks::TestnetFlag, // account_count (ignored)
+            FFINetwork::Testnet,
             error,
         )
     };
@@ -118,7 +118,7 @@ fn test_ffi_wallet_with_passphrase_ideal_workflow() {
         key_wallet_ffi::wallet::wallet_create_from_mnemonic(
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             error,
         )
     };
@@ -157,7 +157,7 @@ fn test_demonstrate_passphrase_issue_with_account_creation() {
         key_wallet_ffi::wallet::wallet_create_from_mnemonic(
             mnemonic.as_ptr(),
             empty_passphrase.as_ptr(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             error,
         )
     };
@@ -168,7 +168,7 @@ fn test_demonstrate_passphrase_issue_with_account_creation() {
         key_wallet_ffi::wallet::wallet_create_from_mnemonic(
             mnemonic.as_ptr(),
             actual_passphrase.as_ptr(),
-            FFINetworks::TestnetFlag,
+            FFINetwork::Testnet,
             error,
         )
     };


### PR DESCRIPTION
This drops the `FFINetworks` enum which was supposed to be used by the FFI layer to provide multiple networks via bitflag combinations. Since im working away from having multi network support in the wallet this PR removes it and uses `FFINetwork` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API now exposes a single-network enum (FFINetwork) instead of multi-network flags.

* **Bug Fixes**
  * Network getters now report success/failure and return network via out-parameter with explicit error reporting for clearer diagnostics.

* **Breaking Changes**
  * Many public FFI signatures and exports changed to the single-network form; callers must use the new enum and the out-parameter/error pattern.

* **Tests & Docs**
  * Tests and generated FFI documentation updated to reflect the new enum and signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->