### PR TITLE
refactor: Single network `WalletManager`

### DIFF
--- a/dash-spv-ffi/src/client.rs
+++ b/dash-spv-ffi/src/client.rs
@@ -183,7 +183,7 @@ pub unsafe extern "C" fn dash_spv_ffi_client_new(
         let storage = DiskStorageManager::new(storage_path.clone()).await;
         let wallet = key_wallet_manager::wallet_manager::WalletManager::<
             key_wallet::wallet::managed_wallet_info::ManagedWalletInfo,
-        >::new();
+        >::new(client_config.network);
         let wallet = std::sync::Arc::new(tokio::sync::RwLock::new(wallet));
 
         match (network, storage) {

--- a/dash-spv-ffi/tests/test_wallet_manager.rs
+++ b/dash-spv-ffi/tests/test_wallet_manager.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod tests {
     use dash_spv_ffi::*;
-    use dashcore::Network;
     use key_wallet::wallet::initialization::WalletAccountCreationOptions;
     use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
     use key_wallet_ffi::{
@@ -9,7 +8,7 @@ mod tests {
             wallet_manager_free_wallet_ids, wallet_manager_get_wallet_ids,
             wallet_manager_import_wallet_from_bytes, wallet_manager_wallet_count,
         },
-        FFIError, FFINetwork, FFIWalletManager,
+        FFIError, FFIWalletManager,
     };
     use key_wallet_manager::wallet_manager::WalletManager;
     use std::ffi::CStr;
@@ -58,12 +57,12 @@ mod tests {
             let wallet_manager_ptr = wallet_manager as *mut key_wallet_ffi::FFIWalletManager;
 
             // Prepare a serialized wallet using the native manager so we can import it
-            let mut native_manager = WalletManager::<ManagedWalletInfo>::new();
+            let mut native_manager =
+                WalletManager::<ManagedWalletInfo>::new((*config).get_inner().network);
             let (serialized_wallet, expected_wallet_id) = native_manager
                 .create_wallet_from_mnemonic_return_serialized_bytes(
                     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
                     "",
-                    Network::Dash,
                     0,
                     WalletAccountCreationOptions::Default,
                     false,
@@ -105,7 +104,6 @@ mod tests {
             let mut description_error = FFIError::success();
             let description_ptr = key_wallet_ffi::wallet_manager_describe(
                 wallet_manager_ptr as *const FFIWalletManager,
-                FFINetwork::Dash,
                 &mut description_error as *mut FFIError,
             );
             assert!(!description_ptr.is_null(), "describe should succeed: {:?}", description_error);

--- a/dash-spv/examples/filter_sync.rs
+++ b/dash-spv/examples/filter_sync.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DiskStorageManager::new("./.tmp/filter-sync-example-storage".into()).await?;
 
     // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     // Create the client
     let mut client = DashSpvClient::new(config, network_manager, storage_manager, wallet).await?;

--- a/dash-spv/examples/simple_sync.rs
+++ b/dash-spv/examples/simple_sync.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DiskStorageManager::new("./.tmp/simple-sync-example-storage".into()).await?;
 
     // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     // Create the client
     let mut client = DashSpvClient::new(config, network_manager, storage_manager, wallet).await?;

--- a/dash-spv/examples/spv_with_wallet.rs
+++ b/dash-spv/examples/spv_with_wallet.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         DiskStorageManager::new("./.tmp/spv-with-wallet-example-storage".into()).await?;
 
     // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     // Create the SPV client with all components
     let mut client = DashSpvClient::new(config, network_manager, storage_manager, wallet).await?;

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -148,7 +148,6 @@ impl<
             self.storage.clone(),
             self.stats.clone(),
             self.event_tx.clone(),
-            self.config.network,
         );
 
         tokio::spawn(async move {

--- a/dash-spv/src/client/mod.rs
+++ b/dash-spv/src/client/mod.rs
@@ -97,7 +97,7 @@ mod tests {
         let network_manager = MockNetworkManager::new();
         let storage =
             DiskStorageManager::with_temp_dir().await.expect("Failed to create tmp storage");
-        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
         let client = DashSpvClient::new(config, network_manager, storage, wallet)
             .await
@@ -125,7 +125,7 @@ mod tests {
         let network_manager = MockNetworkManager::new();
         let storage =
             DiskStorageManager::with_temp_dir().await.expect("Failed to create tmp storage");
-        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
         let mut client = DashSpvClient::new(config, network_manager, storage, wallet)
             .await

--- a/dash-spv/src/lib.rs
+++ b/dash-spv/src/lib.rs
@@ -31,7 +31,7 @@
 //!     // Create the required components
 //!     let network = PeerNetworkManager::new(&config).await?;
 //!     let storage = DiskStorageManager::new("./.tmp/example-storage".into()).await?;
-//!     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+//!     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 //!
 //!     // Create and start the client
 //!     let mut client = DashSpvClient::new(config.clone(), network, storage, wallet).await?;

--- a/dash-spv/src/sync/filters/matching.rs
+++ b/dash-spv/src/sync/filters/matching.rs
@@ -29,13 +29,12 @@ impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync 
         filter_data: &[u8],
         block_hash: &BlockHash,
         wallet: &mut W,
-        network: dashcore::Network,
     ) -> SyncResult<bool> {
         // Create the BlockFilter from the raw data
         let filter = dashcore::bip158::BlockFilter::new(filter_data);
 
         // Use wallet's check_compact_filter method
-        let matches = wallet.check_compact_filter(&filter, block_hash, network).await;
+        let matches = wallet.check_compact_filter(&filter, block_hash).await;
         if matches {
             tracing::info!("🎯 Filter match found for block {}", block_hash);
             Ok(true)

--- a/dash-spv/src/sync/manager.rs
+++ b/dash-spv/src/sync/manager.rs
@@ -11,7 +11,7 @@ use crate::types::{SharedFilterHeights, SyncProgress};
 use crate::{SpvStats, SyncError};
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::BlockHash;
-use key_wallet_manager::{wallet_interface::WalletInterface, Network as WalletNetwork};
+use key_wallet_manager::wallet_interface::WalletInterface;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
@@ -160,18 +160,9 @@ impl<
 
     /// Get the earliest wallet birth height hint for the configured network, if available.
     pub async fn wallet_birth_height_hint(&self) -> CoreBlockHeight {
-        // Map the dashcore network to wallet network, returning None for unknown variants
-        let wallet_network = match self.config.network {
-            dashcore::Network::Dash => WalletNetwork::Dash,
-            dashcore::Network::Testnet => WalletNetwork::Testnet,
-            dashcore::Network::Devnet => WalletNetwork::Devnet,
-            dashcore::Network::Regtest => WalletNetwork::Regtest,
-            _ => return 0, // Unknown network variant - return None instead of defaulting
-        };
-
         // Only acquire the wallet lock if we have a valid network mapping
         let wallet_guard = self.wallet.read().await;
-        let result = wallet_guard.earliest_required_height(wallet_network).await;
+        let result = wallet_guard.earliest_required_height().await;
         drop(wallet_guard);
         result
     }

--- a/dash-spv/src/sync/message_handlers.rs
+++ b/dash-spv/src/sync/message_handlers.rs
@@ -606,12 +606,7 @@ impl<
 
         let matches = self
             .filter_sync
-            .check_filter_for_matches(
-                &cfilter.filter,
-                &cfilter.block_hash,
-                wallet.deref_mut(),
-                self.config.network,
-            )
+            .check_filter_for_matches(&cfilter.filter, &cfilter.block_hash, wallet.deref_mut())
             .await?;
 
         drop(wallet);
@@ -755,7 +750,7 @@ impl<
             .map_err(|e| SyncError::Storage(format!("Failed to get block height: {}", e)))?
             .unwrap_or(0);
 
-        let relevant_txids = wallet.process_block(block, block_height, self.config.network).await;
+        let relevant_txids = wallet.process_block(block, block_height).await;
 
         drop(wallet);
 

--- a/dash-spv/tests/chainlock_simple_test.rs
+++ b/dash-spv/tests/chainlock_simple_test.rs
@@ -51,7 +51,7 @@ async fn test_chainlock_validation_flow() {
         DiskStorageManager::new(config.storage_path.clone().unwrap()).await.unwrap();
 
     // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     // Create the SPV client
     let client =
@@ -101,7 +101,7 @@ async fn test_chainlock_manager_initialization() {
         DiskStorageManager::new(config.storage_path.clone().unwrap()).await.unwrap();
 
     // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     // Create the SPV client
     let client =

--- a/dash-spv/tests/chainlock_validation_test.rs
+++ b/dash-spv/tests/chainlock_validation_test.rs
@@ -169,9 +169,6 @@ async fn test_chainlock_validation_with_masternode_engine() {
     let chain_lock = create_test_chainlock(0, genesis.block_hash());
     network.add_chain_lock(chain_lock.clone());
 
-    // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
-
     // Create client config with masternodes enabled
     let config = ClientConfig {
         network: Network::Dash,
@@ -180,6 +177,9 @@ async fn test_chainlock_validation_with_masternode_engine() {
         validation_mode: ValidationMode::Basic,
         ..Default::default()
     };
+
+    // Create wallet manager
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     // Create the SPV client
     let client = DashSpvClient::new(config, network, storage, wallet).await.unwrap();
@@ -222,9 +222,6 @@ async fn test_chainlock_queue_and_process_flow() {
     let storage = DiskStorageManager::new(storage_path).await.unwrap();
     let network = MockNetworkManager::new();
 
-    // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
-
     // Create client config
     let config = ClientConfig {
         network: Network::Dash,
@@ -233,6 +230,9 @@ async fn test_chainlock_queue_and_process_flow() {
         validation_mode: ValidationMode::Basic,
         ..Default::default()
     };
+
+    // Create wallet manager
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     // Create the SPV client
     let client = DashSpvClient::new(config, network, storage, wallet).await.unwrap();
@@ -275,9 +275,6 @@ async fn test_chainlock_manager_cache_operations() {
     let storage = DiskStorageManager::new(storage_path).await.unwrap();
     let network = MockNetworkManager::new();
 
-    // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
-
     // Create client config
     let config = ClientConfig {
         network: Network::Dash,
@@ -286,6 +283,9 @@ async fn test_chainlock_manager_cache_operations() {
         validation_mode: ValidationMode::Basic,
         ..Default::default()
     };
+
+    // Create wallet manager
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     // Create the SPV client
     let client = DashSpvClient::new(config, network, storage, wallet).await.unwrap();
@@ -327,9 +327,6 @@ async fn test_client_chainlock_update_flow() {
     let storage = DiskStorageManager::new(storage_path).await.unwrap();
     let network = MockNetworkManager::new();
 
-    // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
-
     // Create client config with masternodes enabled
     let config = ClientConfig {
         network: Network::Dash,
@@ -338,6 +335,9 @@ async fn test_client_chainlock_update_flow() {
         validation_mode: ValidationMode::Basic,
         ..Default::default()
     };
+
+    // Create wallet manager
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     // Create the SPV client
     let client = DashSpvClient::new(config, network, storage, wallet).await.unwrap();

--- a/dash-spv/tests/header_sync_test.rs
+++ b/dash-spv/tests/header_sync_test.rs
@@ -278,7 +278,7 @@ async fn test_header_sync_with_client_integration() {
             .expect("Failed to create tmp storage");
 
     // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     let client = DashSpvClient::new(config, network_manager, storage_manager, wallet).await;
     assert!(client.is_ok(), "Client creation should succeed");

--- a/dash-spv/tests/integration_real_node_test.rs
+++ b/dash-spv/tests/integration_real_node_test.rs
@@ -40,7 +40,7 @@ async fn create_test_client(
             .await?;
 
     // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     Ok(DashSpvClient::new(config, network_manager, storage_manager, wallet).await?)
 }

--- a/dash-spv/tests/peer_test.rs
+++ b/dash-spv/tests/peer_test.rs
@@ -44,7 +44,7 @@ async fn test_peer_connection() {
     let storage_manager = DiskStorageManager::new(temp_path).await.unwrap();
 
     // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     let mut client =
         DashSpvClient::new(config, network_manager, storage_manager, wallet).await.unwrap();
@@ -91,7 +91,7 @@ async fn test_peer_persistence() {
         let storage_manager = DiskStorageManager::new(temp_path.clone()).await.unwrap();
 
         // Create wallet manager
-        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
         let mut client =
             DashSpvClient::new(config, network_manager, storage_manager, wallet).await.unwrap();
@@ -117,7 +117,7 @@ async fn test_peer_persistence() {
         let storage_manager = DiskStorageManager::new(temp_path).await.unwrap();
 
         // Create wallet manager
-        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
         let mut client =
             DashSpvClient::new(config, network_manager, storage_manager, wallet).await.unwrap();
@@ -157,7 +157,7 @@ async fn test_peer_disconnection() {
     let storage_manager = DiskStorageManager::new(temp_path).await.unwrap();
 
     // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     let client =
         DashSpvClient::new(config, network_manager, storage_manager, wallet).await.unwrap();
@@ -195,7 +195,7 @@ async fn test_max_peer_limit() {
             .expect("Failed to create tmp storage");
 
     // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     let _client =
         DashSpvClient::new(config, network_manager, storage_manager, wallet).await.unwrap();

--- a/dash-spv/tests/simple_header_test.rs
+++ b/dash-spv/tests/simple_header_test.rs
@@ -64,7 +64,7 @@ async fn test_simple_header_sync() {
         PeerNetworkManager::new(&config).await.expect("Failed to create network manager");
 
     // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     let mut client = DashSpvClient::new(config.clone(), network_manager, storage, wallet)
         .await

--- a/dash-spv/tests/wallet_integration_test.rs
+++ b/dash-spv/tests/wallet_integration_test.rs
@@ -27,7 +27,7 @@ async fn create_test_client(
             .expect("Failed to create tmp storage");
 
     // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new()));
+    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
     DashSpvClient::new(config, network_manager, storage_manager, wallet).await.unwrap()
 }
@@ -64,7 +64,7 @@ async fn test_spv_client_start_stop() {
 #[tokio::test]
 async fn test_wallet_manager_basic_operations() {
     // Test basic wallet manager operations
-    let wallet_manager = WalletManager::<ManagedWalletInfo>::new();
+    let wallet_manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
     // Test that we can create a wallet manager
     // Check wallet count

--- a/key-wallet-ffi/FFI_API.md
+++ b/key-wallet-ffi/FFI_API.md
@@ -418,7 +418,7 @@ Free a managed account result's error message (if any) Note: This does NOT free 
 #### `wallet_manager_add_wallet_from_mnemonic`
 
 ```c
-wallet_manager_add_wallet_from_mnemonic(manager: *mut FFIWalletManager, mnemonic: *const c_char, passphrase: *const c_char, network: FFINetwork, error: *mut FFIError,) -> bool
+wallet_manager_add_wallet_from_mnemonic(manager: *mut FFIWalletManager, mnemonic: *const c_char, passphrase: *const c_char, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -434,7 +434,7 @@ Add a wallet from mnemonic to the manager (backward compatibility)  # Safety  - 
 #### `wallet_manager_add_wallet_from_mnemonic_return_serialized_bytes`
 
 ```c
-wallet_manager_add_wallet_from_mnemonic_return_serialized_bytes(manager: *mut FFIWalletManager, mnemonic: *const c_char, passphrase: *const c_char, network: FFINetwork, birth_height: c_uint, account_options: *const crate::types::FFIWalletAccountCreationOptions, downgrade_to_pubkey_wallet: bool, allow_external_signing: bool, wallet_bytes_out: *mut *mut u8, wallet_bytes_len_out: *mut usize, wallet_id_out: *mut u8, error: *mut FFIError,) -> bool
+wallet_manager_add_wallet_from_mnemonic_return_serialized_bytes(manager: *mut FFIWalletManager, mnemonic: *const c_char, passphrase: *const c_char, birth_height: c_uint, account_options: *const crate::types::FFIWalletAccountCreationOptions, downgrade_to_pubkey_wallet: bool, allow_external_signing: bool, wallet_bytes_out: *mut *mut u8, wallet_bytes_len_out: *mut usize, wallet_id_out: *mut u8, error: *mut FFIError,) -> bool
 ```
 
 **Module:** `wallet_manager`
@@ -444,7 +444,7 @@ wallet_manager_add_wallet_from_mnemonic_return_serialized_bytes(manager: *mut FF
 #### `wallet_manager_add_wallet_from_mnemonic_with_options`
 
 ```c
-wallet_manager_add_wallet_from_mnemonic_with_options(manager: *mut FFIWalletManager, mnemonic: *const c_char, passphrase: *const c_char, network: FFINetwork, account_options: *const crate::types::FFIWalletAccountCreationOptions, error: *mut FFIError,) -> bool
+wallet_manager_add_wallet_from_mnemonic_with_options(manager: *mut FFIWalletManager, mnemonic: *const c_char, passphrase: *const c_char, account_options: *const crate::types::FFIWalletAccountCreationOptions, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -460,7 +460,7 @@ Add a wallet from mnemonic to the manager with options  # Safety  - `manager` mu
 #### `wallet_manager_create`
 
 ```c
-wallet_manager_create(error: *mut FFIError) -> *mut FFIWalletManager
+wallet_manager_create(network: FFINetwork, error: *mut FFIError,) -> *mut FFIWalletManager
 ```
 
 **Description:**
@@ -473,7 +473,7 @@ Create a new wallet manager
 #### `wallet_manager_current_height`
 
 ```c
-wallet_manager_current_height(manager: *const FFIWalletManager, network: FFINetwork, error: *mut FFIError,) -> c_uint
+wallet_manager_current_height(manager: *const FFIWalletManager, error: *mut FFIError,) -> c_uint
 ```
 
 **Description:**
@@ -489,7 +489,7 @@ Get current height for a network  # Safety  - `manager` must be a valid pointer 
 #### `wallet_manager_describe`
 
 ```c
-wallet_manager_describe(manager: *const FFIWalletManager, network: crate::FFINetwork, error: *mut FFIError,) -> *mut c_char
+wallet_manager_describe(manager: *const FFIWalletManager, error: *mut FFIError,) -> *mut c_char
 ```
 
 **Description:**
@@ -653,14 +653,14 @@ wallet_manager_import_wallet_from_bytes(manager: *mut FFIWalletManager, wallet_b
 #### `wallet_manager_process_transaction`
 
 ```c
-wallet_manager_process_transaction(manager: *mut FFIWalletManager, tx_bytes: *const u8, tx_len: usize, network: FFINetwork, context: *const crate::types::FFITransactionContextDetails, update_state_if_found: bool, error: *mut FFIError,) -> bool
+wallet_manager_process_transaction(manager: *mut FFIWalletManager, tx_bytes: *const u8, tx_len: usize, context: *const crate::types::FFITransactionContextDetails, update_state_if_found: bool, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
-Process a transaction through all wallets  Checks a transaction against all wallets and updates their states if relevant. Returns true if the transaction was relevant to at least one wallet.  # Safety  - `manager` must be a valid pointer to an FFIWalletManager instance - `tx_bytes` must be a valid pointer to transaction bytes - `tx_len` must be the length of the transaction bytes - `network` is the network type - `context` must be a valid pointer to FFITransactionContextDetails - `update_state_if_found` indicates whether to update wallet state when transaction is relevant - `error` must be a valid pointer to an FFIError structure or null - The caller must ensure all pointers remain valid for the duration of this call
+Process a transaction through all wallets  Checks a transaction against all wallets and updates their states if relevant. Returns true if the transaction was relevant to at least one wallet.  # Safety  - `manager` must be a valid pointer to an FFIWalletManager instance - `tx_bytes` must be a valid pointer to transaction bytes - `tx_len` must be the length of the transaction bytes - `context` must be a valid pointer to FFITransactionContextDetails - `update_state_if_found` indicates whether to update wallet state when transaction is relevant - `error` must be a valid pointer to an FFIError structure or null - The caller must ensure all pointers remain valid for the duration of this call
 
 **Safety:**
-- `manager` must be a valid pointer to an FFIWalletManager instance - `tx_bytes` must be a valid pointer to transaction bytes - `tx_len` must be the length of the transaction bytes - `network` is the network type - `context` must be a valid pointer to FFITransactionContextDetails - `update_state_if_found` indicates whether to update wallet state when transaction is relevant - `error` must be a valid pointer to an FFIError structure or null - The caller must ensure all pointers remain valid for the duration of this call
+- `manager` must be a valid pointer to an FFIWalletManager instance - `tx_bytes` must be a valid pointer to transaction bytes - `tx_len` must be the length of the transaction bytes - `context` must be a valid pointer to FFITransactionContextDetails - `update_state_if_found` indicates whether to update wallet state when transaction is relevant - `error` must be a valid pointer to an FFIError structure or null - The caller must ensure all pointers remain valid for the duration of this call
 
 **Module:** `wallet_manager`
 
@@ -669,7 +669,7 @@ Process a transaction through all wallets  Checks a transaction against all wall
 #### `wallet_manager_update_height`
 
 ```c
-wallet_manager_update_height(manager: *mut FFIWalletManager, network: FFINetwork, height: c_uint, error: *mut FFIError,) -> bool
+wallet_manager_update_height(manager: *mut FFIWalletManager, height: c_uint, error: *mut FFIError,) -> bool
 ```
 
 **Description:**

--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -3854,11 +3854,7 @@ FFIAccountResult wallet_add_account_with_string_xpub(FFIWallet *wallet,
  - `manager` must be a valid pointer to an `FFIWalletManager`
  - Callers must free the returned string with `wallet_manager_free_string`
  */
-
-char *wallet_manager_describe(const FFIWalletManager *manager,
-                              FFINetwork network,
-                              FFIError *error)
-;
+ char *wallet_manager_describe(const FFIWalletManager *manager, FFIError *error) ;
 
 /*
  Free a string previously returned by wallet manager APIs.
@@ -3874,7 +3870,7 @@ char *wallet_manager_describe(const FFIWalletManager *manager,
 /*
  Create a new wallet manager
  */
- FFIWalletManager *wallet_manager_create(FFIError *error) ;
+ FFIWalletManager *wallet_manager_create(FFINetwork network, FFIError *error) ;
 
 /*
  Add a wallet from mnemonic to the manager with options
@@ -3892,7 +3888,6 @@ char *wallet_manager_describe(const FFIWalletManager *manager,
 bool wallet_manager_add_wallet_from_mnemonic_with_options(FFIWalletManager *manager,
                                                           const char *mnemonic,
                                                           const char *passphrase,
-                                                          FFINetwork network,
                                                           const FFIWalletAccountCreationOptions *account_options,
                                                           FFIError *error)
 ;
@@ -3912,7 +3907,6 @@ bool wallet_manager_add_wallet_from_mnemonic_with_options(FFIWalletManager *mana
 bool wallet_manager_add_wallet_from_mnemonic(FFIWalletManager *manager,
                                              const char *mnemonic,
                                              const char *passphrase,
-                                             FFINetwork network,
                                              FFIError *error)
 ;
 
@@ -3942,7 +3936,6 @@ bool wallet_manager_add_wallet_from_mnemonic(FFIWalletManager *manager,
 bool wallet_manager_add_wallet_from_mnemonic_return_serialized_bytes(FFIWalletManager *manager,
                                                                      const char *mnemonic,
                                                                      const char *passphrase,
-                                                                     FFINetwork network,
                                                                      unsigned int birth_height,
                                                                      const FFIWalletAccountCreationOptions *account_options,
                                                                      bool downgrade_to_pubkey_wallet,
@@ -4080,7 +4073,6 @@ bool wallet_manager_get_wallet_balance(const FFIWalletManager *manager,
  - `manager` must be a valid pointer to an FFIWalletManager instance
  - `tx_bytes` must be a valid pointer to transaction bytes
  - `tx_len` must be the length of the transaction bytes
- - `network` is the network type
  - `context` must be a valid pointer to FFITransactionContextDetails
  - `update_state_if_found` indicates whether to update wallet state when transaction is relevant
  - `error` must be a valid pointer to an FFIError structure or null
@@ -4090,7 +4082,6 @@ bool wallet_manager_get_wallet_balance(const FFIWalletManager *manager,
 bool wallet_manager_process_transaction(FFIWalletManager *manager,
                                         const uint8_t *tx_bytes,
                                         size_t tx_len,
-                                        FFINetwork network,
                                         const FFITransactionContextDetails *context,
                                         bool update_state_if_found,
                                         FFIError *error)
@@ -4107,7 +4098,6 @@ bool wallet_manager_process_transaction(FFIWalletManager *manager,
  */
 
 bool wallet_manager_update_height(FFIWalletManager *manager,
-                                  FFINetwork network,
                                   unsigned int height,
                                   FFIError *error)
 ;
@@ -4121,11 +4111,7 @@ bool wallet_manager_update_height(FFIWalletManager *manager,
  - `error` must be a valid pointer to an FFIError structure or null
  - The caller must ensure all pointers remain valid for the duration of this call
  */
-
-unsigned int wallet_manager_current_height(const FFIWalletManager *manager,
-                                           FFINetwork network,
-                                           FFIError *error)
-;
+ unsigned int wallet_manager_current_height(const FFIWalletManager *manager, FFIError *error) ;
 
 /*
  Get wallet count

--- a/key-wallet-ffi/src/address_pool.rs
+++ b/key-wallet-ffi/src/address_pool.rs
@@ -1057,7 +1057,7 @@ mod tests {
             let mut error = FFIError::success();
 
             // Create wallet manager
-            let manager = wallet_manager_create(&mut error);
+            let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
             assert!(!manager.is_null());
             assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -1069,7 +1069,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1157,7 +1156,7 @@ mod tests {
             let mut error = FFIError::success();
 
             // Create wallet manager
-            let manager = wallet_manager_create(&mut error);
+            let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
             assert!(!manager.is_null());
             assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -1169,7 +1168,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 ptr::null(),
                 &mut error,
             );

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -982,7 +982,7 @@ mod tests {
             let mut error = FFIError::success();
 
             // Create wallet manager
-            let manager = wallet_manager_create(&mut error);
+            let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
             assert!(!manager.is_null());
             assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -994,7 +994,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1045,7 +1044,7 @@ mod tests {
             let mut error = FFIError::success();
 
             // Create wallet manager
-            let manager = wallet_manager_create(&mut error);
+            let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
             assert!(!manager.is_null());
 
             // Add a wallet with minimal accounts
@@ -1062,7 +1061,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 &options,
                 &mut error,
             );
@@ -1112,7 +1110,7 @@ mod tests {
             let mut error = FFIError::success();
 
             // Create wallet manager
-            let manager = wallet_manager_create(&mut error);
+            let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
             assert!(!manager.is_null());
 
             // Add a wallet with multiple accounts
@@ -1137,7 +1135,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 &options,
                 &mut error,
             );
@@ -1174,7 +1171,7 @@ mod tests {
             let mut error = FFIError::success();
 
             // Create wallet manager
-            let manager = wallet_manager_create(&mut error);
+            let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
             assert!(!manager.is_null());
             assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -1186,7 +1183,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1295,7 +1291,7 @@ mod tests {
 
             // Test null balance_out
             let mut error = FFIError::success();
-            let manager = wallet_manager_create(&mut error);
+            let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
             assert!(!manager.is_null());
 
             // Add a wallet
@@ -1306,7 +1302,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1350,7 +1345,7 @@ mod tests {
             let mut error = FFIError::success();
 
             // Create wallet manager
-            let mut manager = wallet_manager_create(&mut error);
+            let mut manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
             assert!(!manager.is_null());
             assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -1362,7 +1357,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 ptr::null(),
                 &mut error,
             );
@@ -1440,7 +1434,7 @@ mod tests {
             wallet_manager_free(manager);
 
             // Create a new manager
-            manager = wallet_manager_create(&mut error);
+            manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
             assert!(!manager.is_null());
 
             // Create wallet with CoinJoin account
@@ -1456,7 +1450,6 @@ mod tests {
                 manager,
                 mnemonic2.as_ptr(),
                 passphrase2.as_ptr(),
-                FFINetwork::Testnet,
                 &options,
                 &mut error,
             );

--- a/key-wallet-ffi/src/wallet_manager.rs
+++ b/key-wallet-ffi/src/wallet_manager.rs
@@ -17,7 +17,6 @@ use tokio::sync::RwLock;
 use crate::error::{FFIError, FFIErrorCode};
 use crate::FFINetwork;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
-use key_wallet::Network;
 use key_wallet_manager::wallet_interface::WalletInterface;
 use key_wallet_manager::wallet_manager::WalletManager;
 
@@ -53,7 +52,6 @@ impl FFIWalletManager {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_manager_describe(
     manager: *const FFIWalletManager,
-    network: crate::FFINetwork,
     error: *mut FFIError,
 ) -> *mut c_char {
     if manager.is_null() {
@@ -67,7 +65,7 @@ pub unsafe extern "C" fn wallet_manager_describe(
 
     let description = runtime.block_on(async {
         let guard = manager_arc.read().await;
-        guard.describe(network.into()).await
+        guard.describe().await
     });
 
     match CString::new(description) {
@@ -104,8 +102,11 @@ pub unsafe extern "C" fn wallet_manager_free_string(value: *mut c_char) {
 
 /// Create a new wallet manager
 #[no_mangle]
-pub extern "C" fn wallet_manager_create(error: *mut FFIError) -> *mut FFIWalletManager {
-    let manager = WalletManager::new();
+pub extern "C" fn wallet_manager_create(
+    network: FFINetwork,
+    error: *mut FFIError,
+) -> *mut FFIWalletManager {
+    let manager = WalletManager::new(network.into());
     let runtime = match tokio::runtime::Runtime::new() {
         Ok(rt) => Arc::new(rt),
         Err(e) => {
@@ -139,7 +140,6 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic_with_options(
     manager: *mut FFIWalletManager,
     mnemonic: *const c_char,
     passphrase: *const c_char,
-    network: FFINetwork,
     account_options: *const crate::types::FFIWalletAccountCreationOptions,
     error: *mut FFIError,
 ) -> bool {
@@ -180,8 +180,6 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic_with_options(
         }
     };
 
-    let network_rust: Network = network.into();
-
     unsafe {
         let manager_ref = &*manager;
 
@@ -200,7 +198,6 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic_with_options(
             manager_guard.create_wallet_from_mnemonic(
                 mnemonic_str,
                 passphrase_str,
-                network_rust,
                 0,
                 creation_options,
             )
@@ -237,14 +234,12 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic(
     manager: *mut FFIWalletManager,
     mnemonic: *const c_char,
     passphrase: *const c_char,
-    network: FFINetwork,
     error: *mut FFIError,
 ) -> bool {
     wallet_manager_add_wallet_from_mnemonic_with_options(
         manager,
         mnemonic,
         passphrase,
-        network,
         ptr::null(), // Use default options
         error,
     )
@@ -276,7 +271,6 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic_return_serializ
     manager: *mut FFIWalletManager,
     mnemonic: *const c_char,
     passphrase: *const c_char,
-    network: FFINetwork,
     birth_height: c_uint,
     account_options: *const crate::types::FFIWalletAccountCreationOptions,
     downgrade_to_pubkey_wallet: bool,
@@ -331,8 +325,6 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic_return_serializ
         }
     };
 
-    let network_rust: Network = network.into();
-
     // Convert account creation options
     let creation_options = if account_options.is_null() {
         key_wallet::wallet::initialization::WalletAccountCreationOptions::Default
@@ -349,7 +341,6 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic_return_serializ
         manager_guard.create_wallet_from_mnemonic_return_serialized_bytes(
             mnemonic_str,
             passphrase_str,
-            network_rust,
             birth_height,
             creation_options,
             downgrade_to_pubkey_wallet,
@@ -727,7 +718,6 @@ pub unsafe extern "C" fn wallet_manager_get_wallet_balance(
 /// - `manager` must be a valid pointer to an FFIWalletManager instance
 /// - `tx_bytes` must be a valid pointer to transaction bytes
 /// - `tx_len` must be the length of the transaction bytes
-/// - `network` is the network type
 /// - `context` must be a valid pointer to FFITransactionContextDetails
 /// - `update_state_if_found` indicates whether to update wallet state when transaction is relevant
 /// - `error` must be a valid pointer to an FFIError structure or null
@@ -737,7 +727,6 @@ pub unsafe extern "C" fn wallet_manager_process_transaction(
     manager: *mut FFIWalletManager,
     tx_bytes: *const u8,
     tx_len: usize,
-    network: FFINetwork,
     context: *const crate::types::FFITransactionContextDetails,
     update_state_if_found: bool,
     error: *mut FFIError,
@@ -770,9 +759,6 @@ pub unsafe extern "C" fn wallet_manager_process_transaction(
         }
     };
 
-    // Convert FFINetwork to Network
-    let network = network.into();
-
     // Convert FFI context to native TransactionContext
     let context = unsafe { (*context).to_transaction_context() };
 
@@ -782,9 +768,7 @@ pub unsafe extern "C" fn wallet_manager_process_transaction(
     // Process the transaction using async runtime
     let relevant_wallets = manager_ref.runtime.block_on(async {
         let mut manager_guard = manager_ref.manager.write().await;
-        manager_guard
-            .check_transaction_in_all_wallets(&tx, network, context, update_state_if_found)
-            .await
+        manager_guard.check_transaction_in_all_wallets(&tx, context, update_state_if_found).await
     });
 
     FFIError::set_success(error);
@@ -801,7 +785,6 @@ pub unsafe extern "C" fn wallet_manager_process_transaction(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_manager_update_height(
     manager: *mut FFIWalletManager,
-    network: FFINetwork,
     height: c_uint,
     error: *mut FFIError,
 ) -> bool {
@@ -812,11 +795,9 @@ pub unsafe extern "C" fn wallet_manager_update_height(
 
     let manager_ref = &*manager;
 
-    let network_rust: Network = network.into();
-
     manager_ref.runtime.block_on(async {
         let mut manager_guard = manager_ref.manager.write().await;
-        manager_guard.update_height(network_rust, height);
+        manager_guard.update_height(height);
     });
 
     FFIError::set_success(error);
@@ -833,7 +814,6 @@ pub unsafe extern "C" fn wallet_manager_update_height(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_manager_current_height(
     manager: *const FFIWalletManager,
-    network: FFINetwork,
     error: *mut FFIError,
 ) -> c_uint {
     if manager.is_null() {
@@ -843,12 +823,10 @@ pub unsafe extern "C" fn wallet_manager_current_height(
 
     let manager_ref = &*manager;
 
-    let network_rust: Network = network.into();
-
     // Get current height from network state if it exists
     let height = manager_ref.runtime.block_on(async {
         let manager_guard = manager_ref.manager.read().await;
-        manager_guard.get_network_state(network_rust).map(|state| state.current_height).unwrap_or(0)
+        manager_guard.current_height()
     });
 
     FFIError::set_success(error);

--- a/key-wallet-ffi/src/wallet_manager_serialization_tests.rs
+++ b/key-wallet-ffi/src/wallet_manager_serialization_tests.rs
@@ -17,7 +17,7 @@ mod tests {
         let error = &mut error as *mut FFIError;
 
         // Create a wallet manager
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
@@ -33,7 +33,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 0,           // birth_height
                 ptr::null(), // default account options
                 false,       // don't downgrade to pubkey wallet
@@ -69,7 +68,7 @@ mod tests {
         let error = &mut error as *mut FFIError;
 
         // Create a wallet manager
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
@@ -85,7 +84,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 true,  // downgrade to pubkey wallet
@@ -118,7 +116,7 @@ mod tests {
         let error = &mut error as *mut FFIError;
 
         // Create a wallet manager
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
@@ -134,7 +132,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 true, // downgrade to pubkey wallet
@@ -167,7 +164,7 @@ mod tests {
         let error = &mut error as *mut FFIError;
 
         // Create a wallet manager
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
@@ -183,7 +180,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -216,7 +212,7 @@ mod tests {
         let error = &mut error as *mut FFIError;
 
         // Create a wallet manager
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
@@ -232,7 +228,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -248,7 +243,7 @@ mod tests {
         assert!(!wallet_bytes_out.is_null());
 
         // Now import the wallet into a new manager
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         let mut imported_wallet_id = [0u8; 32];
@@ -284,7 +279,7 @@ mod tests {
         let error = &mut error as *mut FFIError;
 
         // Create a wallet manager
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         let invalid_mnemonic = CString::new("invalid mnemonic phrase").unwrap();
@@ -299,7 +294,6 @@ mod tests {
                 manager,
                 invalid_mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -323,7 +317,7 @@ mod tests {
         let error = &mut error as *mut FFIError;
 
         // Create a wallet manager
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         let mut wallet_bytes_out: *mut u8 = ptr::null_mut();
@@ -335,7 +329,6 @@ mod tests {
                 manager,
                 ptr::null(),
                 ptr::null(),
-                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -359,7 +352,7 @@ mod tests {
         let error = &mut error as *mut FFIError;
 
         // Create a wallet manager
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
@@ -391,7 +384,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 0,
                 &account_options,
                 false,

--- a/key-wallet-ffi/src/wallet_manager_tests.rs
+++ b/key-wallet-ffi/src/wallet_manager_tests.rs
@@ -20,7 +20,7 @@ mod tests {
         let error = &mut error as *mut FFIError;
 
         // Create a wallet manager
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
 
         assert!(!manager.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::Success);
@@ -40,7 +40,7 @@ mod tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         // Add a wallet from mnemonic
@@ -52,7 +52,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet, // Create 3 accounts
                 error,
             )
         };
@@ -75,7 +74,7 @@ mod tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         // Add multiple wallets
@@ -90,7 +89,6 @@ mod tests {
                     manager,
                     mnemonic.as_ptr(),
                     ptr::null(), // No passphrase
-                    FFINetwork::Testnet,
                     error,
                 );
                 if !success {
@@ -153,7 +151,7 @@ mod tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         // Add a wallet
@@ -163,7 +161,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 ptr::null(),
-                FFINetwork::Testnet,
                 error,
             )
         };
@@ -215,30 +212,20 @@ mod tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         // Get initial height
-        let height = unsafe {
-            wallet_manager::wallet_manager_current_height(manager, FFINetwork::Testnet, error)
-        };
+        let height = unsafe { wallet_manager::wallet_manager_current_height(manager, error) };
         assert_eq!(height, 0);
 
         // Update height
-        let success = unsafe {
-            wallet_manager::wallet_manager_update_height(
-                manager,
-                FFINetwork::Testnet,
-                100000,
-                error,
-            )
-        };
+        let success =
+            unsafe { wallet_manager::wallet_manager_update_height(manager, 100000, error) };
         assert!(success);
 
         // Verify height was updated
-        let height = unsafe {
-            wallet_manager::wallet_manager_current_height(manager, FFINetwork::Testnet, error)
-        };
+        let height = unsafe { wallet_manager::wallet_manager_current_height(manager, error) };
         assert_eq!(height, 100000);
 
         // Clean up
@@ -258,7 +245,7 @@ mod tests {
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::InvalidInput);
 
         // Test with invalid mnemonic
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         let invalid_mnemonic = CString::new("invalid mnemonic").unwrap();
@@ -267,7 +254,6 @@ mod tests {
                 manager,
                 invalid_mnemonic.as_ptr(),
                 ptr::null(),
-                FFINetwork::Testnet,
                 error,
             )
         };
@@ -287,7 +273,7 @@ mod tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         // Add a wallet with account count
@@ -299,7 +285,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet, // account_count
                 error,
             )
         };
@@ -320,7 +305,7 @@ mod tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         // Add a wallet
@@ -331,7 +316,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 error,
             )
         };
@@ -375,7 +359,7 @@ mod tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         // Add wallet
@@ -386,7 +370,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 error,
             )
         };
@@ -467,7 +450,6 @@ mod tests {
                 ptr::null_mut(),
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet, // account_count
                 error,
             )
         };
@@ -487,29 +469,21 @@ mod tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         // Get initial height
-        let _height = unsafe {
-            wallet_manager::wallet_manager_current_height(manager, FFINetwork::Testnet, error)
-        };
+        let _height = unsafe { wallet_manager::wallet_manager_current_height(manager, error) };
 
         // Update height
         let new_height = 12345;
         unsafe {
-            wallet_manager::wallet_manager_update_height(
-                manager,
-                FFINetwork::Testnet,
-                new_height,
-                error,
-            );
+            wallet_manager::wallet_manager_update_height(manager, new_height, error);
         }
 
         // Get updated height
-        let current_height = unsafe {
-            wallet_manager::wallet_manager_current_height(manager, FFINetwork::Testnet, error)
-        };
+        let current_height =
+            unsafe { wallet_manager::wallet_manager_current_height(manager, error) };
         assert_eq!(current_height, new_height);
 
         // Clean up
@@ -523,7 +497,7 @@ mod tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         // Add a wallet from mnemonic
@@ -535,7 +509,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 error,
             )
         };
@@ -643,7 +616,7 @@ mod tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         // Add a wallet from mnemonic
@@ -655,7 +628,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 error,
             )
         };
@@ -691,7 +663,6 @@ mod tests {
                 manager,
                 tx_bytes.as_ptr(),
                 tx_bytes.len(),
-                FFINetwork::Testnet,
                 &mempool_context,
                 false,
                 error,
@@ -708,7 +679,6 @@ mod tests {
                 manager,
                 tx_bytes.as_ptr(),
                 tx_bytes.len(),
-                FFINetwork::Testnet,
                 &block_context,
                 false,
                 error,
@@ -729,7 +699,6 @@ mod tests {
                 manager,
                 tx_bytes.as_ptr(),
                 tx_bytes.len(),
-                FFINetwork::Testnet,
                 &chain_locked_context,
                 true,
                 error,
@@ -744,7 +713,6 @@ mod tests {
                 ptr::null_mut(),
                 tx_bytes.as_ptr(),
                 tx_bytes.len(),
-                FFINetwork::Testnet,
                 &mempool_context,
                 false,
                 error,
@@ -759,7 +727,6 @@ mod tests {
                 manager,
                 ptr::null(),
                 10,
-                FFINetwork::Testnet,
                 &mempool_context,
                 false,
                 error,
@@ -774,7 +741,6 @@ mod tests {
                 manager,
                 tx_bytes.as_ptr(),
                 0,
-                FFINetwork::Testnet,
                 &mempool_context,
                 false,
                 error,
@@ -790,7 +756,6 @@ mod tests {
                 manager,
                 invalid_tx.as_ptr(),
                 invalid_tx.len(),
-                FFINetwork::Testnet,
                 &mempool_context,
                 false,
                 error,
@@ -810,7 +775,7 @@ mod tests {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
-        let manager = wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         // Add a wallet from mnemonic
@@ -822,7 +787,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 error,
             )
         };
@@ -921,7 +885,7 @@ mod tests {
         let error = &mut error as *mut FFIError;
 
         // Create a wallet manager
-        let manager = crate::wallet_manager::wallet_manager_create(error);
+        let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager.is_null());
 
         // Test basic wallet creation and serialization
@@ -937,7 +901,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 0,           // birth_height
                 ptr::null(), // default account options
                 false,       // don't downgrade to pubkey wallet
@@ -967,7 +930,7 @@ mod tests {
         }
 
         // Test with downgrade to watch-only wallet (create new manager to avoid duplicate wallet ID)
-        let manager2 = crate::wallet_manager::wallet_manager_create(error);
+        let manager2 = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager2.is_null());
 
         let mut wallet_bytes_out: *mut u8 = ptr::null_mut();
@@ -979,7 +942,6 @@ mod tests {
                 manager2,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 true,  // downgrade to pubkey wallet
@@ -1007,7 +969,7 @@ mod tests {
         assert_eq!(wallet_id_out, original_wallet_id);
 
         // Import the watch-only wallet to verify it works (create third manager for import)
-        let manager3 = crate::wallet_manager::wallet_manager_create(error);
+        let manager3 = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager3.is_null());
 
         let wallet_bytes_slice =
@@ -1038,7 +1000,7 @@ mod tests {
         }
 
         // Test with externally signable wallet (create fourth manager)
-        let manager4 = crate::wallet_manager::wallet_manager_create(error);
+        let manager4 = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager4.is_null());
 
         let mut wallet_bytes_out: *mut u8 = ptr::null_mut();
@@ -1050,7 +1012,6 @@ mod tests {
                 manager4,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 true, // downgrade to pubkey wallet
@@ -1077,7 +1038,7 @@ mod tests {
         }
 
         // Test with invalid mnemonic (create fifth manager)
-        let manager5 = crate::wallet_manager::wallet_manager_create(error);
+        let manager5 = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager5.is_null());
 
         let invalid_mnemonic = CString::new("invalid mnemonic phrase").unwrap();
@@ -1090,7 +1051,6 @@ mod tests {
                 manager5,
                 invalid_mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 0,
                 ptr::null(),
                 false,
@@ -1122,7 +1082,7 @@ mod tests {
         let error = &mut error as *mut FFIError;
 
         // Create first wallet manager
-        let manager1 = crate::wallet_manager::wallet_manager_create(error);
+        let manager1 = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager1.is_null());
 
         let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
@@ -1138,7 +1098,6 @@ mod tests {
                 manager1,
                 mnemonic.as_ptr(),
                 passphrase.as_ptr(),
-                FFINetwork::Testnet,
                 100,         // birth_height
                 ptr::null(), // default account options
                 false,       // don't downgrade to pubkey wallet
@@ -1172,7 +1131,7 @@ mod tests {
         }
 
         // Create a completely new wallet manager
-        let manager2 = crate::wallet_manager::wallet_manager_create(error);
+        let manager2 = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
         assert!(!manager2.is_null());
 
         // Import the wallet using the serialized bytes in the new manager

--- a/key-wallet-ffi/tests/debug_wallet_add.rs
+++ b/key-wallet-ffi/tests/debug_wallet_add.rs
@@ -8,7 +8,7 @@ fn test_debug_wallet_add() {
     let mut error = FFIError::success();
     let error = &mut error as *mut FFIError;
 
-    let manager = wallet_manager::wallet_manager_create(error);
+    let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
     assert!(!manager.is_null());
     println!("Manager created successfully");
 
@@ -21,7 +21,6 @@ fn test_debug_wallet_add() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
             error,
         )
     };

--- a/key-wallet-ffi/tests/integration_test.rs
+++ b/key-wallet-ffi/tests/integration_test.rs
@@ -25,7 +25,7 @@ fn test_full_wallet_workflow() {
     assert!(is_valid);
 
     // 3. Create wallet manager
-    let manager = key_wallet_ffi::wallet_manager::wallet_manager_create(error);
+    let manager = key_wallet_ffi::wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
     assert!(!manager.is_null());
 
     // 4. Add wallet to manager
@@ -35,7 +35,6 @@ fn test_full_wallet_workflow() {
             manager,
             mnemonic,
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
             error,
         )
     };

--- a/key-wallet-ffi/tests/test_import_wallet.rs
+++ b/key-wallet-ffi/tests/test_import_wallet.rs
@@ -14,7 +14,7 @@ mod tests {
         unsafe {
             // Create a wallet manager
             let mut error = FFIError::success();
-            let manager = wallet_manager_create(&mut error);
+            let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
             assert_eq!(error.code, FFIErrorCode::Success);
             assert!(!manager.is_null());
 
@@ -26,7 +26,6 @@ mod tests {
                 manager,
                 mnemonic.as_ptr() as *const c_char,
                 passphrase.as_ptr() as *const c_char,
-                FFINetwork::Dash,
                 &mut error,
             );
             assert!(success);
@@ -50,7 +49,7 @@ mod tests {
             // For now, we'll just test that the import function exists and compiles
 
             // Create a second manager to test import
-            let manager2 = wallet_manager_create(&mut error);
+            let manager2 = wallet_manager_create(FFINetwork::Testnet, &mut error);
             assert_eq!(error.code, FFIErrorCode::Success);
             assert!(!manager2.is_null());
 

--- a/key-wallet-ffi/tests/test_managed_account_collection.rs
+++ b/key-wallet-ffi/tests/test_managed_account_collection.rs
@@ -20,7 +20,7 @@ fn test_managed_account_collection_basic() {
         let mut error = FFIError::success();
 
         // Create wallet manager
-        let manager = wallet_manager_create(&mut error);
+        let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
         assert!(!manager.is_null());
         assert_eq!(error.code, FFIErrorCode::Success);
 
@@ -32,7 +32,6 @@ fn test_managed_account_collection_basic() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
             ptr::null(), // Use default options
             &mut error,
         );
@@ -90,7 +89,7 @@ fn test_managed_account_collection_with_special_accounts() {
         let mut error = FFIError::success();
 
         // Create wallet manager
-        let manager = wallet_manager_create(&mut error);
+        let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
         assert!(!manager.is_null());
 
         // Create wallet with special accounts
@@ -132,7 +131,6 @@ fn test_managed_account_collection_with_special_accounts() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
             &options,
             &mut error,
         );
@@ -219,7 +217,7 @@ fn test_managed_account_collection_summary() {
         let mut error = FFIError::success();
 
         // Create wallet manager
-        let manager = wallet_manager_create(&mut error);
+        let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
         assert!(!manager.is_null());
 
         // Create wallet with multiple account types
@@ -252,7 +250,6 @@ fn test_managed_account_collection_summary() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
             &options,
             &mut error,
         );
@@ -301,7 +298,7 @@ fn test_managed_account_collection_summary_data() {
         let mut error = FFIError::success();
 
         // Create wallet manager
-        let manager = wallet_manager_create(&mut error);
+        let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
         assert!(!manager.is_null());
 
         // Create wallet with various account types
@@ -341,7 +338,6 @@ fn test_managed_account_collection_summary_data() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
             &options,
             &mut error,
         );
@@ -427,7 +423,7 @@ fn test_managed_account_collection_nonexistent_accounts() {
         let mut error = FFIError::success();
 
         // Create wallet manager
-        let manager = wallet_manager_create(&mut error);
+        let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
         assert!(!manager.is_null());
 
         // Create wallet with minimal accounts
@@ -438,7 +434,6 @@ fn test_managed_account_collection_nonexistent_accounts() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
             ptr::null(), // Default options
             &mut error,
         );

--- a/key-wallet-ffi/tests/test_passphrase_wallets.rs
+++ b/key-wallet-ffi/tests/test_passphrase_wallets.rs
@@ -57,7 +57,7 @@ fn test_ffi_wallet_manager_add_wallet_with_passphrase() {
     let error = &mut error as *mut FFIError;
 
     // Create wallet manager
-    let manager = key_wallet_ffi::wallet_manager::wallet_manager_create(error);
+    let manager = key_wallet_ffi::wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
     assert!(!manager.is_null());
 
     let mnemonic = CString::new("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about").unwrap();
@@ -69,7 +69,6 @@ fn test_ffi_wallet_manager_add_wallet_with_passphrase() {
             manager,
             mnemonic.as_ptr(),
             passphrase.as_ptr(),
-            FFINetwork::Testnet,
             error,
         )
     };

--- a/key-wallet-manager/examples/wallet_creation.rs
+++ b/key-wallet-manager/examples/wallet_creation.rs
@@ -18,12 +18,9 @@ fn main() {
     // Example 1: Basic wallet creation with WalletManager
     println!("1. Creating a basic wallet with WalletManager...");
 
-    let mut manager = WalletManager::<ManagedWalletInfo>::new();
+    let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
-    let result = manager.create_wallet_with_random_mnemonic(
-        WalletAccountCreationOptions::Default,
-        Network::Testnet,
-    );
+    let result = manager.create_wallet_with_random_mnemonic(WalletAccountCreationOptions::Default);
 
     let wallet_id = match result {
         Ok(wallet_id) => {
@@ -46,7 +43,6 @@ fn main() {
     let result = manager.create_wallet_from_mnemonic(
         test_mnemonic,
         "", // No passphrase
-        Network::Testnet,
         100_000,
         key_wallet::wallet::initialization::WalletAccountCreationOptions::Default,
     );
@@ -145,11 +141,11 @@ fn main() {
     // Example 7: Block height tracking
     println!("\n7. Block height tracking...");
 
-    println!("   Current height (Testnet): {}", manager.current_height(Network::Testnet));
+    println!("   Current height (Testnet): {}", manager.current_height());
 
     // Update height
-    manager.update_height(Network::Testnet, 850_000);
-    println!("   Updated height to: {}", manager.current_height(Network::Testnet));
+    manager.update_height(850_000);
+    println!("   Updated height to: {}", manager.current_height());
 
     println!("\n=== Summary ===");
     println!("Total wallets created: {}", manager.wallet_count());

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -7,30 +7,16 @@ use async_trait::async_trait;
 use dashcore::bip158::BlockFilter;
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Block, Transaction, Txid};
-use key_wallet::Network;
 
 /// Trait for wallet implementations to receive SPV events
 #[async_trait]
 pub trait WalletInterface: Send + Sync {
     /// Called when a new block is received that may contain relevant transactions
     /// Returns transaction IDs that were relevant to the wallet
-    async fn process_block(
-        &mut self,
-        block: &Block,
-        height: CoreBlockHeight,
-        network: Network,
-    ) -> Vec<Txid>;
+    async fn process_block(&mut self, block: &Block, height: CoreBlockHeight) -> Vec<Txid>;
 
     /// Called when a transaction is seen in the mempool
-    async fn process_mempool_transaction(&mut self, tx: &Transaction, network: Network);
-
-    /// Called when a reorg occurs and blocks need to be rolled back
-    async fn handle_reorg(
-        &mut self,
-        from_height: CoreBlockHeight,
-        to_height: CoreBlockHeight,
-        network: Network,
-    );
+    async fn process_mempool_transaction(&mut self, tx: &Transaction);
 
     /// Check if a compact filter matches any watched items
     /// Returns true if the block should be downloaded
@@ -38,7 +24,6 @@ pub trait WalletInterface: Send + Sync {
         &mut self,
         filter: &BlockFilter,
         block_hash: &dashcore::BlockHash,
-        network: Network,
     ) -> bool;
 
     /// Return the wallet's per-transaction net change and involved addresses if known.
@@ -47,7 +32,6 @@ pub trait WalletInterface: Send + Sync {
     async fn transaction_effect(
         &self,
         _tx: &Transaction,
-        _network: Network,
     ) -> Option<(i64, alloc::vec::Vec<alloc::string::String>)> {
         None
     }
@@ -58,7 +42,7 @@ pub trait WalletInterface: Send + Sync {
     ///
     /// The default implementation returns `None`, which signals that the caller should
     /// fall back to its existing behaviour.
-    async fn earliest_required_height(&self, _network: Network) -> CoreBlockHeight {
+    async fn earliest_required_height(&self) -> CoreBlockHeight {
         0
     }
 
@@ -66,7 +50,7 @@ pub trait WalletInterface: Send + Sync {
     ///
     /// Implementations are encouraged to include high-level state such as the
     /// number of managed wallets, networks, or tracked scripts.
-    async fn describe(&self, _network: Network) -> String {
+    async fn describe(&self) -> String {
         "Wallet interface description unavailable".to_string()
     }
 }

--- a/key-wallet-manager/src/wallet_manager/process_block.rs
+++ b/key-wallet-manager/src/wallet_manager/process_block.rs
@@ -1,5 +1,5 @@
 use crate::wallet_interface::WalletInterface;
-use crate::{Network, WalletManager};
+use crate::WalletManager;
 use alloc::string::String;
 use alloc::vec::Vec;
 use async_trait::async_trait;
@@ -13,12 +13,7 @@ use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoIn
 
 #[async_trait]
 impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletManager<T> {
-    async fn process_block(
-        &mut self,
-        block: &Block,
-        height: CoreBlockHeight,
-        network: Network,
-    ) -> Vec<Txid> {
+    async fn process_block(&mut self, block: &Block, height: CoreBlockHeight) -> Vec<Txid> {
         let mut relevant_txids = Vec::new();
         let block_hash = Some(block.block_hash());
         let timestamp = block.header.time;
@@ -33,7 +28,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
             let affected_wallets = self
                 .check_transaction_in_all_wallets(
-                    tx, network, context, true, // update state
+                    tx, context, true, // update state
                 )
                 .await;
 
@@ -42,71 +37,30 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             }
         }
 
-        // Update network state height
-        if let Some(state) = self.network_states.get_mut(&network) {
-            state.current_height = height;
-        }
+        self.current_height = height;
 
         relevant_txids
     }
 
-    async fn process_mempool_transaction(&mut self, tx: &Transaction, network: Network) {
+    async fn process_mempool_transaction(&mut self, tx: &Transaction) {
         let context = TransactionContext::Mempool;
 
         // Check transaction against all wallets
         self.check_transaction_in_all_wallets(
-            tx, network, context, true, // update state
+            tx, context, true, // update state
         )
         .await;
     }
 
-    async fn handle_reorg(
-        &mut self,
-        from_height: CoreBlockHeight,
-        to_height: CoreBlockHeight,
-        network: Network,
-    ) {
-        if let Some(state) = self.network_states.get_mut(&network) {
-            // Roll back to the reorg point
-            if state.current_height >= from_height {
-                // Remove transactions above the reorg height
-                state.transactions.retain(|_, record| {
-                    if let Some(height) = record.height {
-                        height < from_height
-                    } else {
-                        true // Keep mempool transactions
-                    }
-                });
-
-                // Update current height
-                state.current_height = to_height;
-            }
-        }
-    }
-
-    async fn check_compact_filter(
-        &mut self,
-        filter: &BlockFilter,
-        block_hash: &BlockHash,
-        network: Network,
-    ) -> bool {
-        // Check if we've already evaluated this filter
-        if let Some(network_cache) = self.filter_matches.get(&network) {
-            if let Some(&matched) = network_cache.get(block_hash) {
-                return matched;
-            }
-        }
-
+    async fn check_compact_filter(&mut self, filter: &BlockFilter, block_hash: &BlockHash) -> bool {
         // Collect all scripts we're watching
         let mut script_bytes = Vec::new();
 
         // Get all wallet addresses for this network
         for info in self.wallet_infos.values() {
-            if info.network() == network {
-                let monitored = info.monitored_addresses();
-                for address in monitored {
-                    script_bytes.push(address.script_pubkey().as_bytes().to_vec());
-                }
+            let monitored = info.monitored_addresses();
+            for address in monitored {
+                script_bytes.push(address.script_pubkey().as_bytes().to_vec());
             }
         }
 
@@ -121,17 +75,10 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
                 .unwrap_or(false)
         };
 
-        // Cache the result
-        self.filter_matches.entry(network).or_default().insert(*block_hash, hit);
-
         hit
     }
 
-    async fn transaction_effect(
-        &self,
-        tx: &Transaction,
-        network: Network,
-    ) -> Option<(i64, Vec<String>)> {
+    async fn transaction_effect(&self, tx: &Transaction) -> Option<(i64, Vec<String>)> {
         // Aggregate across all managed wallets. If any wallet considers it relevant,
         // compute net = total_received - total_sent and collect involved addresses.
         let mut total_received: u64 = 0;
@@ -140,24 +87,21 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
         let mut is_relevant_any = false;
         for info in self.wallet_infos.values() {
-            // Only consider wallets tracking this network
-            if info.network() == network {
-                let collection = info.accounts();
-                // Reuse the same routing/check logic used in normal processing
-                let tx_type = TransactionRouter::classify_transaction(tx);
-                let account_types = TransactionRouter::get_relevant_account_types(&tx_type);
-                let result = collection.check_transaction(tx, &account_types);
+            let collection = info.accounts();
+            // Reuse the same routing/check logic used in normal processing
+            let tx_type = TransactionRouter::classify_transaction(tx);
+            let account_types = TransactionRouter::get_relevant_account_types(&tx_type);
+            let result = collection.check_transaction(tx, &account_types);
 
-                if result.is_relevant {
-                    is_relevant_any = true;
-                    total_received = total_received.saturating_add(result.total_received);
-                    total_sent = total_sent.saturating_add(result.total_sent);
+            if result.is_relevant {
+                is_relevant_any = true;
+                total_received = total_received.saturating_add(result.total_received);
+                total_sent = total_sent.saturating_add(result.total_sent);
 
-                    // Collect involved addresses from affected accounts
-                    for account_match in result.affected_accounts {
-                        for addr_info in account_match.account_type_match.all_involved_addresses() {
-                            addresses.push(addr_info.address.to_string());
-                        }
+                // Collect involved addresses from affected accounts
+                for account_match in result.affected_accounts {
+                    for addr_info in account_match.account_type_match.all_involved_addresses() {
+                        addresses.push(addr_info.address.to_string());
                     }
                 }
             }
@@ -174,19 +118,14 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         }
     }
 
-    async fn earliest_required_height(&self, network: Network) -> CoreBlockHeight {
-        self.wallet_infos
-            .values()
-            .filter(|info| info.network() == network)
-            .map(|info| info.birth_height())
-            .min()
-            .unwrap_or(0)
+    async fn earliest_required_height(&self) -> CoreBlockHeight {
+        self.wallet_infos.values().map(|info| info.birth_height()).min().unwrap_or(0)
     }
 
-    async fn describe(&self, network: Network) -> String {
+    async fn describe(&self) -> String {
         let wallet_count = self.wallet_infos.len();
         if wallet_count == 0 {
-            return format!("WalletManager: 0 wallets (network {})", network);
+            return format!("WalletManager: 0 wallets (network {})", self.network);
         }
 
         let mut details = Vec::with_capacity(wallet_count);
@@ -204,6 +143,11 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             details.push(format!("{} ({}): {}", name, wallet_id_hex, summary));
         }
 
-        format!("WalletManager: {} wallet(s) on {}\n{}", wallet_count, network, details.join("\n"))
+        format!(
+            "WalletManager: {} wallet(s) on {}\n{}",
+            wallet_count,
+            self.network,
+            details.join("\n")
+        )
     }
 }

--- a/key-wallet-manager/tests/integration_test.rs
+++ b/key-wallet-manager/tests/integration_test.rs
@@ -12,10 +12,10 @@ use key_wallet_manager::wallet_manager::{WalletError, WalletManager};
 #[test]
 fn test_wallet_manager_creation() {
     // Create a wallet manager
-    let manager = WalletManager::<ManagedWalletInfo>::new();
+    let manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
     // WalletManager::new returns Self, not Result
-    assert_eq!(manager.current_height(Network::Testnet), 0);
+    assert_eq!(manager.current_height(), 0);
     assert_eq!(manager.wallet_count(), 0); // No wallets created yet
 }
 
@@ -23,13 +23,12 @@ fn test_wallet_manager_creation() {
 fn test_wallet_manager_from_mnemonic() {
     // Create from a test mnemonic
     let mnemonic = Mnemonic::generate(12, Language::English).unwrap();
-    let mut manager = WalletManager::<ManagedWalletInfo>::new();
+    let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
     // Create a wallet from mnemonic
     let wallet_result = manager.create_wallet_from_mnemonic(
         &mnemonic.to_string(),
         "",
-        Network::Testnet,
         0,
         WalletAccountCreationOptions::Default,
     );
@@ -39,13 +38,11 @@ fn test_wallet_manager_from_mnemonic() {
 
 #[test]
 fn test_account_management() {
-    let mut manager = WalletManager::<ManagedWalletInfo>::new();
+    let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
     // Create a wallet first
-    let wallet_result = manager.create_wallet_with_random_mnemonic(
-        WalletAccountCreationOptions::Default,
-        Network::Testnet,
-    );
+    let wallet_result =
+        manager.create_wallet_with_random_mnemonic(WalletAccountCreationOptions::Default);
     assert!(wallet_result.is_ok(), "Failed to create wallet: {:?}", wallet_result);
     let wallet_id = wallet_result.unwrap();
 
@@ -69,13 +66,11 @@ fn test_account_management() {
 
 #[test]
 fn test_address_generation() {
-    let mut manager = WalletManager::<ManagedWalletInfo>::new();
+    let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
     // Create a wallet first
-    let wallet_result = manager.create_wallet_with_random_mnemonic(
-        WalletAccountCreationOptions::Default,
-        Network::Testnet,
-    );
+    let wallet_result =
+        manager.create_wallet_with_random_mnemonic(WalletAccountCreationOptions::Default);
     assert!(wallet_result.is_ok(), "Failed to create wallet: {:?}", wallet_result);
     let wallet_id = wallet_result.unwrap();
 
@@ -111,13 +106,11 @@ fn test_address_generation() {
 fn test_utxo_management() {
     // Unused imports removed - UTXOs are created by processing transactions
 
-    let mut manager = WalletManager::<ManagedWalletInfo>::new();
+    let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
     // Create a wallet first
-    let wallet_result = manager.create_wallet_with_random_mnemonic(
-        WalletAccountCreationOptions::Default,
-        Network::Testnet,
-    );
+    let wallet_result =
+        manager.create_wallet_with_random_mnemonic(WalletAccountCreationOptions::Default);
     assert!(wallet_result.is_ok(), "Failed to create wallet: {:?}", wallet_result);
     let wallet_id = wallet_result.unwrap();
 
@@ -137,13 +130,11 @@ fn test_utxo_management() {
 
 #[test]
 fn test_balance_calculation() {
-    let mut manager = WalletManager::<ManagedWalletInfo>::new();
+    let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
     // Create a wallet first
-    let wallet_result = manager.create_wallet_with_random_mnemonic(
-        WalletAccountCreationOptions::Default,
-        Network::Testnet,
-    );
+    let wallet_result =
+        manager.create_wallet_with_random_mnemonic(WalletAccountCreationOptions::Default);
     assert!(wallet_result.is_ok(), "Failed to create wallet: {:?}", wallet_result);
     let wallet_id = wallet_result.unwrap();
 
@@ -162,10 +153,10 @@ fn test_balance_calculation() {
 
 #[test]
 fn test_block_height_tracking() {
-    let mut manager = WalletManager::<ManagedWalletInfo>::new();
+    let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
-    assert_eq!(manager.current_height(Network::Testnet), 0);
+    assert_eq!(manager.current_height(), 0);
 
-    manager.update_height(Network::Testnet, 12345);
-    assert_eq!(manager.current_height(Network::Testnet), 12345);
+    manager.update_height(12345);
+    assert_eq!(manager.current_height(), 12345);
 }

--- a/key-wallet-manager/tests/spv_integration_tests.rs
+++ b/key-wallet-manager/tests/spv_integration_tests.rs
@@ -67,13 +67,13 @@ fn create_mock_filter(block: &Block) -> BlockFilter {
 
 #[tokio::test]
 async fn test_filter_checking() {
-    let mut manager = WalletManager::<ManagedWalletInfo>::new();
+    let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
     // Add a test address to monitor - simplified for testing
     // In reality, addresses would be generated from wallet accounts
 
     let _wallet_id = manager
-        .create_wallet_with_random_mnemonic(WalletAccountCreationOptions::Default, Network::Testnet)
+        .create_wallet_with_random_mnemonic(WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet");
 
     // Create a test block with a transaction
@@ -83,8 +83,7 @@ async fn test_filter_checking() {
     let block_hash = block.block_hash();
 
     // Check the filter
-    let should_download =
-        manager.check_compact_filter(&filter, &block_hash, Network::Testnet).await;
+    let should_download = manager.check_compact_filter(&filter, &block_hash).await;
 
     // The filter matching depends on whether the wallet has any addresses
     // being watched. Since we just created an empty wallet, it may or may not match.
@@ -92,18 +91,17 @@ async fn test_filter_checking() {
     let _ = should_download;
 
     // Test filter caching - calling again should use cached result
-    let should_download_cached =
-        manager.check_compact_filter(&filter, &block_hash, Network::Testnet).await;
+    let should_download_cached = manager.check_compact_filter(&filter, &block_hash).await;
     assert_eq!(should_download, should_download_cached, "Cached result should match original");
 }
 
 #[tokio::test]
 async fn test_block_processing() {
-    let mut manager = WalletManager::<ManagedWalletInfo>::new();
+    let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
     // Create a test wallet
     let _wallet_id = manager
-        .create_wallet_with_random_mnemonic(WalletAccountCreationOptions::Default, Network::Testnet)
+        .create_wallet_with_random_mnemonic(WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet");
 
     // Create a transaction
@@ -113,7 +111,7 @@ async fn test_block_processing() {
     let block = create_test_block(100, vec![tx.clone()]);
 
     // Process the block
-    let result = manager.process_block(&block, 100, Network::Testnet).await;
+    let result = manager.process_block(&block, 100).await;
 
     // Since we're not watching specific addresses, no transactions should be relevant
     assert_eq!(result.len(), 0);
@@ -121,11 +119,11 @@ async fn test_block_processing() {
 
 #[tokio::test]
 async fn test_filter_caching() {
-    let mut manager = WalletManager::<ManagedWalletInfo>::new();
+    let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
     // Create a wallet with some addresses
     let _wallet_id = manager
-        .create_wallet_with_random_mnemonic(WalletAccountCreationOptions::Default, Network::Testnet)
+        .create_wallet_with_random_mnemonic(WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet");
 
     // Create multiple blocks with different hashes
@@ -139,12 +137,12 @@ async fn test_filter_caching() {
     let hash2 = block2.block_hash();
 
     // Check filters for both blocks
-    let result1 = manager.check_compact_filter(&filter1, &hash1, Network::Testnet).await;
-    let result2 = manager.check_compact_filter(&filter2, &hash2, Network::Testnet).await;
+    let result1 = manager.check_compact_filter(&filter1, &hash1).await;
+    let result2 = manager.check_compact_filter(&filter2, &hash2).await;
 
     // Check again - should use cached results
-    let cached1 = manager.check_compact_filter(&filter1, &hash1, Network::Testnet).await;
-    let cached2 = manager.check_compact_filter(&filter2, &hash2, Network::Testnet).await;
+    let cached1 = manager.check_compact_filter(&filter1, &hash1).await;
+    let cached2 = manager.check_compact_filter(&filter2, &hash2).await;
 
     // Cached results should match originals
     assert_eq!(result1, cached1, "Cached result for block1 should match");

--- a/key-wallet-manager/tests/test_serialized_wallets.rs
+++ b/key-wallet-manager/tests/test_serialized_wallets.rs
@@ -8,7 +8,7 @@ mod tests {
 
     #[test]
     fn test_create_wallet_return_serialized_bytes() {
-        let mut manager = WalletManager::<ManagedWalletInfo>::new();
+        let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
         let test_mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
@@ -16,7 +16,6 @@ mod tests {
         let result = manager.create_wallet_from_mnemonic_return_serialized_bytes(
             test_mnemonic,
             "",
-            Network::Testnet,
             100_000,
             WalletAccountCreationOptions::Default,
             false, // Don't downgrade
@@ -28,11 +27,10 @@ mod tests {
         println!("Full wallet ID: {}", hex::encode(wallet_id));
 
         // Test 2: Create watch-only wallet (no private keys)
-        let mut manager2 = WalletManager::<ManagedWalletInfo>::new();
+        let mut manager2 = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
         let result = manager2.create_wallet_from_mnemonic_return_serialized_bytes(
             test_mnemonic,
             "",
-            Network::Testnet,
             100_000,
             WalletAccountCreationOptions::Default,
             true,  // Downgrade to pubkey wallet
@@ -47,11 +45,10 @@ mod tests {
         println!("Watch-only wallet ID: {}", hex::encode(wallet_id2));
 
         // Test 3: Create externally signable wallet (for hardware wallets)
-        let mut manager3 = WalletManager::<ManagedWalletInfo>::new();
+        let mut manager3 = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
         let result = manager3.create_wallet_from_mnemonic_return_serialized_bytes(
             test_mnemonic,
             "",
-            Network::Testnet,
             100_000,
             WalletAccountCreationOptions::Default,
             true, // Downgrade to pubkey wallet
@@ -64,7 +61,7 @@ mod tests {
         println!("Externally signable wallet ID: {}", hex::encode(wallet_id3));
 
         // Test 4: Import the serialized wallet back
-        let mut manager4 = WalletManager::<ManagedWalletInfo>::new();
+        let mut manager4 = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
         let import_result = manager4.import_wallet_from_bytes(&bytes);
         assert!(import_result.is_ok());
         assert_eq!(import_result.unwrap(), wallet_id);
@@ -72,7 +69,7 @@ mod tests {
 
     #[test]
     fn test_wallet_with_passphrase() {
-        let mut manager = WalletManager::<ManagedWalletInfo>::new();
+        let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
         let test_mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
         let passphrase = "test_passphrase";
@@ -80,7 +77,6 @@ mod tests {
         let result = manager.create_wallet_from_mnemonic_return_serialized_bytes(
             test_mnemonic,
             passphrase,
-            Network::Testnet,
             0,
             WalletAccountCreationOptions::Default,
             false,
@@ -91,11 +87,10 @@ mod tests {
         assert!(!bytes.is_empty());
 
         // Wallet ID with passphrase should be different
-        let mut manager2 = WalletManager::<ManagedWalletInfo>::new();
+        let mut manager2 = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
         let result2 = manager2.create_wallet_from_mnemonic_return_serialized_bytes(
             test_mnemonic,
             "", // No passphrase
-            Network::Testnet,
             0,
             WalletAccountCreationOptions::Default,
             false,


### PR DESCRIPTION
Refactors the `WalletManager` to be a single network wallet only. Follow up to finalize the refactoring started in:

- #271
- #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Refactor**
  * Simplified wallet manager API by moving network configuration to initialization time instead of per-method calls.
  * Updated wallet interface methods to remove redundant network parameters, reducing API complexity.
  * Streamlined FFI function signatures for wallet operations by centralizing network context management.
  * Consolidated network state handling in wallet manager for improved performance and reduced parameter passing overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->