### PR TITLE
refactor: make wallet birth height non-optional

### DIFF
--- a/dash-spv-ffi/tests/test_wallet_manager.rs
+++ b/dash-spv-ffi/tests/test_wallet_manager.rs
@@ -64,7 +64,7 @@ mod tests {
                     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
                     "",
                     Network::Dash,
-                    None,
+                    0,
                     WalletAccountCreationOptions::Default,
                     false,
                     false,

--- a/dash-spv/src/main.rs
+++ b/dash-spv/src/main.rs
@@ -307,7 +307,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         mnemonic_phrase.as_str(),
         "",
         network,
-        None,
+        0,
         key_wallet::wallet::initialization::WalletAccountCreationOptions::default(),
     )?;
     let wallet = Arc::new(tokio::sync::RwLock::new(wallet_manager));

--- a/dash-spv/src/sync/manager.rs
+++ b/dash-spv/src/sync/manager.rs
@@ -9,6 +9,7 @@ use crate::storage::StorageManager;
 use crate::sync::{FilterSyncManager, HeaderSyncManager, MasternodeSyncManager, ReorgConfig};
 use crate::types::{SharedFilterHeights, SyncProgress};
 use crate::{SpvStats, SyncError};
+use dashcore::prelude::CoreBlockHeight;
 use dashcore::BlockHash;
 use key_wallet_manager::{wallet_interface::WalletInterface, Network as WalletNetwork};
 use std::sync::Arc;
@@ -158,14 +159,14 @@ impl<
     }
 
     /// Get the earliest wallet birth height hint for the configured network, if available.
-    pub async fn wallet_birth_height_hint(&self) -> Option<u32> {
+    pub async fn wallet_birth_height_hint(&self) -> CoreBlockHeight {
         // Map the dashcore network to wallet network, returning None for unknown variants
         let wallet_network = match self.config.network {
             dashcore::Network::Dash => WalletNetwork::Dash,
             dashcore::Network::Testnet => WalletNetwork::Testnet,
             dashcore::Network::Devnet => WalletNetwork::Devnet,
             dashcore::Network::Regtest => WalletNetwork::Regtest,
-            _ => return None, // Unknown network variant - return None instead of defaulting
+            _ => return 0, // Unknown network variant - return None instead of defaulting
         };
 
         // Only acquire the wallet lock if we have a valid network mapping

--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -3941,7 +3941,7 @@ bool wallet_manager_add_wallet_from_mnemonic(FFIWalletManager *manager,
  - `manager` must be a valid pointer to an FFIWalletManager instance
  - `mnemonic` must be a valid pointer to a null-terminated C string
  - `passphrase` must be a valid pointer to a null-terminated C string or null
- - `birth_height` is optional, pass 0 for default
+ - `birth_height` is the block height to start syncing from (0 = sync from genesis)
  - `account_options` must be a valid pointer to FFIWalletAccountCreationOptions or null
  - `downgrade_to_pubkey_wallet` if true, creates a watch-only or externally signable wallet
  - `allow_external_signing` if true AND downgrade_to_pubkey_wallet is true, creates an externally signable wallet

--- a/key-wallet-ffi/src/wallet_manager.rs
+++ b/key-wallet-ffi/src/wallet_manager.rs
@@ -215,7 +215,7 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic_with_options(
                 mnemonic_str,
                 passphrase_str,
                 network_rust,
-                None, // birth_height
+                0,
                 creation_options,
             )
         });
@@ -274,7 +274,7 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic(
 /// - `manager` must be a valid pointer to an FFIWalletManager instance
 /// - `mnemonic` must be a valid pointer to a null-terminated C string
 /// - `passphrase` must be a valid pointer to a null-terminated C string or null
-/// - `birth_height` is optional, pass 0 for default
+/// - `birth_height` is the block height to start syncing from (0 = sync from genesis)
 /// - `account_options` must be a valid pointer to FFIWalletAccountCreationOptions or null
 /// - `downgrade_to_pubkey_wallet` if true, creates a watch-only or externally signable wallet
 /// - `allow_external_signing` if true AND downgrade_to_pubkey_wallet is true, creates an externally signable wallet
@@ -368,13 +368,6 @@ pub unsafe extern "C" fn wallet_manager_add_wallet_from_mnemonic_return_serializ
 
     // Get the manager and call the proper method
     let manager_ref = unsafe { &*manager };
-
-    // Convert birth_height: 0 means None, any other value means Some(value)
-    let birth_height = if birth_height == 0 {
-        None
-    } else {
-        Some(birth_height)
-    };
 
     let result = manager_ref.runtime.block_on(async {
         let mut manager_guard = manager_ref.manager.write().await;

--- a/key-wallet-manager/examples/wallet_creation.rs
+++ b/key-wallet-manager/examples/wallet_creation.rs
@@ -47,7 +47,7 @@ fn main() {
         test_mnemonic,
         "", // No passphrase
         Network::Testnet,
-        Some(100_000), // Birth height
+        100_000,
         key_wallet::wallet::initialization::WalletAccountCreationOptions::Default,
     );
 

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -58,8 +58,8 @@ pub trait WalletInterface: Send + Sync {
     ///
     /// The default implementation returns `None`, which signals that the caller should
     /// fall back to its existing behaviour.
-    async fn earliest_required_height(&self, _network: Network) -> Option<CoreBlockHeight> {
-        None
+    async fn earliest_required_height(&self, _network: Network) -> CoreBlockHeight {
+        0
     }
 
     /// Provide a human-readable description of the wallet implementation.

--- a/key-wallet-manager/src/wallet_manager/mod.rs
+++ b/key-wallet-manager/src/wallet_manager/mod.rs
@@ -11,6 +11,7 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 use dashcore::blockdata::transaction::Transaction;
+use dashcore::prelude::CoreBlockHeight;
 use dashcore::{BlockHash, Txid};
 use key_wallet::account::AccountCollection;
 use key_wallet::transaction_checking::TransactionContext;
@@ -121,7 +122,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         mnemonic: &str,
         passphrase: &str,
         network: Network,
-        birth_height: Option<u32>,
+        birth_height: CoreBlockHeight,
         account_creation_options: key_wallet::wallet::initialization::WalletAccountCreationOptions,
     ) -> Result<WalletId, WalletError> {
         let mnemonic_obj = Mnemonic::from_phrase(mnemonic, key_wallet::mnemonic::Language::English)
@@ -178,7 +179,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
     /// * `mnemonic` - The mnemonic phrase
     /// * `passphrase` - Optional BIP39 passphrase (empty string for no passphrase)
     /// * `network` - The network for the wallet
-    /// * `birth_height` - Optional birth height for wallet scanning
+    /// * `birth_height` - Birth height for wallet scanning (0 to sync from genesis)
     /// * `account_creation_options` - Which accounts to create initially
     /// * `downgrade_to_pubkey_wallet` - If true, creates a wallet without private keys
     /// * `allow_external_signing` - If true and downgraded, creates an externally signable wallet (e.g., for hardware wallets)
@@ -198,7 +199,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         mnemonic: &str,
         passphrase: &str,
         network: Network,
-        birth_height: Option<u32>,
+        birth_height: CoreBlockHeight,
         account_creation_options: key_wallet::wallet::initialization::WalletAccountCreationOptions,
         downgrade_to_pubkey_wallet: bool,
         allow_external_signing: bool,
@@ -302,7 +303,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         // Create managed wallet info
         let mut managed_info = T::from_wallet(&wallet);
         let network_state = self.get_or_create_network_state(network);
-        managed_info.set_birth_height(Some(network_state.current_height));
+        managed_info.set_birth_height(network_state.current_height);
         managed_info.set_first_loaded_at(current_timestamp());
 
         self.wallets.insert(wallet_id, wallet);
@@ -396,8 +397,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
 
         // Create managed wallet info
         let mut managed_info = T::from_wallet(&wallet);
-        managed_info
-            .set_birth_height(Some(self.get_or_create_network_state(network).current_height));
+        managed_info.set_birth_height(self.get_or_create_network_state(network).current_height);
         managed_info.set_first_loaded_at(current_timestamp());
 
         self.wallets.insert(wallet_id, wallet);
@@ -446,8 +446,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
 
         // Create managed wallet info
         let mut managed_info = T::from_wallet(&wallet);
-        managed_info
-            .set_birth_height(Some(self.get_or_create_network_state(network).current_height));
+        managed_info.set_birth_height(self.get_or_create_network_state(network).current_height);
         managed_info.set_first_loaded_at(current_timestamp());
 
         self.wallets.insert(wallet_id, wallet);
@@ -492,7 +491,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
 
         // Use the current network's height as the birth height since we don't know when it was originally created
         let network_state = self.get_or_create_network_state(wallet.network);
-        managed_info.set_birth_height(Some(network_state.current_height));
+        managed_info.set_birth_height(network_state.current_height);
         managed_info.set_first_loaded_at(current_timestamp());
 
         self.wallets.insert(wallet_id, wallet);

--- a/key-wallet-manager/src/wallet_manager/process_block.rs
+++ b/key-wallet-manager/src/wallet_manager/process_block.rs
@@ -174,23 +174,13 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         }
     }
 
-    async fn earliest_required_height(&self, network: Network) -> Option<CoreBlockHeight> {
-        let mut earliest: Option<CoreBlockHeight> = None;
-
-        for info in self.wallet_infos.values() {
-            // Only consider wallets that actually track this network AND have a known birth height
-            if info.network() == network {
-                if let Some(birth_height) = info.birth_height() {
-                    earliest = Some(match earliest {
-                        Some(current) => current.min(birth_height),
-                        None => birth_height,
-                    });
-                }
-            }
-        }
-
-        // Return None if no wallets with known birth heights were found for this network
-        earliest
+    async fn earliest_required_height(&self, network: Network) -> CoreBlockHeight {
+        self.wallet_infos
+            .values()
+            .filter(|info| info.network() == network)
+            .map(|info| info.birth_height())
+            .min()
+            .unwrap_or(0)
     }
 
     async fn describe(&self, network: Network) -> String {

--- a/key-wallet-manager/tests/integration_test.rs
+++ b/key-wallet-manager/tests/integration_test.rs
@@ -30,7 +30,7 @@ fn test_wallet_manager_from_mnemonic() {
         &mnemonic.to_string(),
         "",
         Network::Testnet,
-        None, // birth_height
+        0,
         WalletAccountCreationOptions::Default,
     );
     assert!(wallet_result.is_ok(), "Failed to create wallet: {:?}", wallet_result);

--- a/key-wallet-manager/tests/test_serialized_wallets.rs
+++ b/key-wallet-manager/tests/test_serialized_wallets.rs
@@ -17,7 +17,7 @@ mod tests {
             test_mnemonic,
             "",
             Network::Testnet,
-            Some(100_000),
+            100_000,
             WalletAccountCreationOptions::Default,
             false, // Don't downgrade
             false,
@@ -33,7 +33,7 @@ mod tests {
             test_mnemonic,
             "",
             Network::Testnet,
-            Some(100_000),
+            100_000,
             WalletAccountCreationOptions::Default,
             true,  // Downgrade to pubkey wallet
             false, // Watch-only, not externally signable
@@ -52,7 +52,7 @@ mod tests {
             test_mnemonic,
             "",
             Network::Testnet,
-            Some(100_000),
+            100_000,
             WalletAccountCreationOptions::Default,
             true, // Downgrade to pubkey wallet
             true, // Externally signable (for hardware wallets)
@@ -81,7 +81,7 @@ mod tests {
             test_mnemonic,
             passphrase,
             Network::Testnet,
-            None,
+            0,
             WalletAccountCreationOptions::Default,
             false,
             false,
@@ -96,7 +96,7 @@ mod tests {
             test_mnemonic,
             "", // No passphrase
             Network::Testnet,
-            None,
+            0,
             WalletAccountCreationOptions::Default,
             false,
             false,

--- a/key-wallet/src/wallet/managed_wallet_info/mod.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/mod.rs
@@ -21,6 +21,7 @@ use super::metadata::WalletMetadata;
 use crate::account::ManagedAccountCollection;
 use crate::Network;
 use alloc::string::String;
+use dashcore::prelude::CoreBlockHeight;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -104,7 +105,7 @@ impl ManagedWalletInfo {
     pub fn with_birth_height(
         network: Network,
         wallet_id: [u8; 32],
-        birth_height: Option<u32>,
+        birth_height: CoreBlockHeight,
     ) -> Self {
         let mut info = Self::new(network, wallet_id);
         info.metadata.birth_height = birth_height;

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -15,6 +15,7 @@ use crate::wallet::ManagedWalletInfo;
 use crate::{Network, Utxo, Wallet, WalletBalance};
 use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
+use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address as DashAddress, Address, Transaction};
 
 /// Trait that wallet info types must implement to work with WalletManager
@@ -45,11 +46,11 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Set the wallet's description
     fn set_description(&mut self, description: Option<String>);
 
-    /// Get the birth height for tracking
-    fn birth_height(&self) -> Option<u32>;
+    /// Get the birth height of the wallet
+    fn birth_height(&self) -> CoreBlockHeight;
 
     /// Set the birth height
-    fn set_birth_height(&mut self, height: Option<u32>);
+    fn set_birth_height(&mut self, height: CoreBlockHeight);
 
     /// Get the timestamp when first loaded
     fn first_loaded_at(&self) -> u64;
@@ -147,11 +148,11 @@ impl WalletInfoInterface for ManagedWalletInfo {
         self.description = description;
     }
 
-    fn birth_height(&self) -> Option<u32> {
+    fn birth_height(&self) -> CoreBlockHeight {
         self.metadata.birth_height
     }
 
-    fn set_birth_height(&mut self, height: Option<u32>) {
+    fn set_birth_height(&mut self, height: CoreBlockHeight) {
         self.metadata.birth_height = height;
     }
 

--- a/key-wallet/src/wallet/metadata.rs
+++ b/key-wallet/src/wallet/metadata.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 pub struct WalletMetadata {
     /// Wallet creation timestamp
     pub first_loaded_at: u64,
-    /// Birth height (when wallet was created/restored) - None if unknown
-    pub birth_height: Option<CoreBlockHeight>,
+    /// Birth height (when wallet was created/restored) - 0 (genesis) if unknown
+    pub birth_height: CoreBlockHeight,
     /// Last sync timestamp
     pub last_synced: Option<u64>,
     /// Total transactions


### PR DESCRIPTION
Just a bit simpler as we define `None` to be `0` (unknown birth height start from genesis) anyway and there is not really any benefit of having an extra unknown state, i think.

Note: The birth height is currently not used by the sync process so its basically unused code at the moment but i will integrate it into the sync in a later PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified wallet birth height parameter handling in wallet creation methods. Birth height is now required instead of optional, with 0 representing the genesis block.

* **Documentation**
  * Clarified wallet creation documentation for birth height semantics.

* **Tests**
  * Updated wallet creation tests to reflect parameter changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->