### PR TITLE
feat: implement parallel filter matching

### DIFF
--- a/dash-spv/src/sync/legacy/filters/matching.rs
+++ b/dash-spv/src/sync/legacy/filters/matching.rs
@@ -20,27 +20,6 @@ use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 
 impl<S: StorageManager, N: NetworkManager> super::manager::FilterSyncManager<S, N> {
-    pub async fn check_filter_for_matches<
-        W: key_wallet_manager::wallet_interface::WalletInterface,
-    >(
-        &self,
-        filter_data: &[u8],
-        block_hash: &BlockHash,
-        wallet: &mut W,
-    ) -> SyncResult<bool> {
-        // Create the BlockFilter from the raw data
-        let filter = dashcore::bip158::BlockFilter::new(filter_data);
-
-        // Use wallet's check_compact_filter method
-        let matches = wallet.check_compact_filter(&filter, block_hash).await;
-        if matches {
-            tracing::info!("🎯 Filter match found for block {}", block_hash);
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-
     /// Check if filter matches any of the provided scripts using BIP158 GCS filter.
     #[allow(dead_code)]
     fn filter_matches_scripts(

--- a/key-wallet-manager/Cargo.toml
+++ b/key-wallet-manager/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 async-trait = "0.1"
 bincode = { version = "2.0.1", optional = true }
 zeroize = { version = "1.8", features = ["derive"] }
+rayon = "1.11"
 tokio = { version = "1.32", features = ["full"] }
 
 [dev-dependencies]

--- a/key-wallet-manager/src/test_utils/wallet.rs
+++ b/key-wallet-manager/src/test_utils/wallet.rs
@@ -1,9 +1,7 @@
-use std::{collections::BTreeMap, sync::Arc};
-
-use dashcore::{Block, Transaction, Txid};
-use tokio::sync::Mutex;
-
 use crate::{wallet_interface::WalletInterface, BlockProcessingResult};
+use dashcore::{Address, Block, Transaction, Txid};
+use std::{collections::BTreeMap, sync::Arc};
+use tokio::sync::Mutex;
 
 // Type alias for transaction effects map
 type TransactionEffectsMap = Arc<Mutex<BTreeMap<Txid, (i64, Vec<String>)>>>;
@@ -57,15 +55,6 @@ impl WalletInterface for MockWallet {
         processed.push(tx.txid());
     }
 
-    async fn check_compact_filter(
-        &mut self,
-        _filter: &dashcore::bip158::BlockFilter,
-        _block_hash: &dashcore::BlockHash,
-    ) -> bool {
-        // Return true for all filters in test
-        true
-    }
-
     async fn describe(&self) -> String {
         "MockWallet (test implementation)".to_string()
     }
@@ -73,6 +62,10 @@ impl WalletInterface for MockWallet {
     async fn transaction_effect(&self, tx: &Transaction) -> Option<(i64, Vec<String>)> {
         let map = self.effects.lock().await;
         map.get(&tx.txid()).cloned()
+    }
+
+    fn monitored_addresses(&self) -> Vec<Address> {
+        Vec::new()
     }
 }
 
@@ -94,13 +87,8 @@ impl WalletInterface for NonMatchingMockWallet {
 
     async fn process_mempool_transaction(&mut self, _tx: &Transaction) {}
 
-    async fn check_compact_filter(
-        &mut self,
-        _filter: &dashcore::bip158::BlockFilter,
-        _block_hash: &dashcore::BlockHash,
-    ) -> bool {
-        // Always return false - filter doesn't match
-        false
+    fn monitored_addresses(&self) -> Vec<Address> {
+        Vec::new()
     }
 
     async fn describe(&self) -> String {

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -5,7 +5,6 @@
 use alloc::string::String;
 use alloc::vec::Vec;
 use async_trait::async_trait;
-use dashcore::bip158::BlockFilter;
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, Block, Transaction, Txid};
 
@@ -47,13 +46,8 @@ pub trait WalletInterface: Send + Sync + 'static {
     /// Called when a transaction is seen in the mempool
     async fn process_mempool_transaction(&mut self, tx: &Transaction);
 
-    /// Check if a compact filter matches any watched items
-    /// Returns true if the block should be downloaded
-    async fn check_compact_filter(
-        &mut self,
-        filter: &BlockFilter,
-        block_hash: &dashcore::BlockHash,
-    ) -> bool;
+    /// Get all addresses the wallet is monitoring for incoming transactions
+    fn monitored_addresses(&self) -> Vec<Address>;
 
     /// Return the wallet's per-transaction net change and involved addresses if known.
     /// Returns (net_amount, addresses) where net_amount is received - sent in satoshis.

--- a/key-wallet-manager/src/wallet_manager/matching.rs
+++ b/key-wallet-manager/src/wallet_manager/matching.rs
@@ -1,0 +1,166 @@
+use alloc::vec::Vec;
+use dashcore::bip158::BlockFilter;
+use dashcore::prelude::CoreBlockHeight;
+use dashcore::{Address, BlockHash};
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+use std::collections::{BTreeSet, HashMap};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FilterMatchKey {
+    height: CoreBlockHeight,
+    hash: BlockHash,
+}
+
+impl FilterMatchKey {
+    pub fn new(height: CoreBlockHeight, hash: BlockHash) -> Self {
+        Self {
+            height,
+            hash,
+        }
+    }
+    pub fn height(&self) -> CoreBlockHeight {
+        self.height
+    }
+    pub fn hash(&self) -> &BlockHash {
+        &self.hash
+    }
+}
+
+/// Check compact filters for addresses and return the keys that matched.
+pub fn check_compact_filters_for_addresses(
+    input: &HashMap<FilterMatchKey, BlockFilter>,
+    addresses: Vec<Address>,
+) -> BTreeSet<FilterMatchKey> {
+    let script_pubkey_bytes: Vec<Vec<u8>> =
+        addresses.iter().map(|address| address.script_pubkey().to_bytes()).collect();
+
+    input
+        .into_par_iter()
+        .filter_map(|(key, filter)| {
+            filter
+                .match_any(key.hash(), script_pubkey_bytes.iter().map(|v| v.as_slice()))
+                .unwrap_or(false)
+                .then_some(key.clone())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Network;
+    use dashcore::{Block, Transaction};
+
+    #[test]
+    fn test_empty_input_returns_empty() {
+        let result = check_compact_filters_for_addresses(&HashMap::new(), vec![]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_empty_addresses_returns_empty() {
+        let address = Address::dummy(Network::Regtest, 1);
+        let tx = Transaction::dummy(&address, 0..0, &[1]);
+        let block = Block::dummy(100, vec![tx]);
+        let filter = BlockFilter::dummy(&block);
+        let key = FilterMatchKey::new(100, block.block_hash());
+
+        let mut input = HashMap::new();
+        input.insert(key.clone(), filter);
+
+        let output = check_compact_filters_for_addresses(&input, vec![]);
+        assert!(!output.contains(&key));
+    }
+
+    #[test]
+    fn test_matching_filter() {
+        let address = Address::dummy(Network::Regtest, 1);
+        let tx = Transaction::dummy(&address, 0..0, &[1]);
+        let block = Block::dummy(100, vec![tx]);
+        let filter = BlockFilter::dummy(&block);
+        let key = FilterMatchKey::new(100, block.block_hash());
+
+        let mut input = HashMap::new();
+        input.insert(key.clone(), filter);
+
+        let output = check_compact_filters_for_addresses(&input, vec![address]);
+        assert!(output.contains(&key));
+    }
+
+    #[test]
+    fn test_non_matching_filter() {
+        let address = Address::dummy(Network::Regtest, 1);
+        let address_other = Address::dummy(Network::Regtest, 2);
+
+        let tx = Transaction::dummy(&address_other, 0..0, &[1]);
+        let block = Block::dummy(100, vec![tx]);
+        let filter = BlockFilter::dummy(&block);
+        let key = FilterMatchKey::new(100, block.block_hash());
+
+        let mut input = HashMap::new();
+        input.insert(key.clone(), filter);
+
+        let output = check_compact_filters_for_addresses(&input, vec![address]);
+        assert!(!output.contains(&key));
+    }
+
+    #[test]
+    fn test_batch_mixed_results() {
+        let unrelated_address = Address::dummy(Network::Regtest, 0);
+        let address_1 = Address::dummy(Network::Regtest, 1);
+        let address_2 = Address::dummy(Network::Regtest, 2);
+
+        let tx_1 = Transaction::dummy(&address_1, 0..0, &[1]);
+        let block_1 = Block::dummy(100, vec![tx_1]);
+        let filter_1 = BlockFilter::dummy(&block_1);
+        let key_1 = FilterMatchKey::new(100, block_1.block_hash());
+
+        let tx_2 = Transaction::dummy(&address_2, 0..0, &[2]);
+        let block_2 = Block::dummy(200, vec![tx_2]);
+        let filter_2 = BlockFilter::dummy(&block_2);
+        let key_2 = FilterMatchKey::new(200, block_2.block_hash());
+
+        let tx_3 = Transaction::dummy(&unrelated_address, 0..0, &[10]);
+        let block_3 = Block::dummy(300, vec![tx_3]);
+        let filter_3 = BlockFilter::dummy(&block_3);
+        let key_3 = FilterMatchKey::new(300, block_3.block_hash());
+
+        let mut input = HashMap::new();
+        input.insert(key_1.clone(), filter_1);
+        input.insert(key_2.clone(), filter_2);
+        input.insert(key_3.clone(), filter_3);
+
+        let output = check_compact_filters_for_addresses(&input, vec![address_1, address_2]);
+        assert_eq!(output.len(), 2);
+        assert!(output.contains(&key_1));
+        assert!(output.contains(&key_2));
+        assert!(!output.contains(&key_3));
+    }
+
+    #[test]
+    fn test_output_sorted_by_height() {
+        let address = Address::dummy(Network::Regtest, 1);
+
+        // Create blocks at different heights (inserted in non-sorted order)
+        let heights = [500, 100, 300, 200, 400];
+        let mut input = HashMap::new();
+
+        for (i, &height) in heights.iter().enumerate() {
+            let tx = Transaction::dummy(&address, 0..0, &[i as u64]);
+            let block = Block::dummy(height, vec![tx]);
+            let filter = BlockFilter::dummy(&block);
+            let key = FilterMatchKey::new(height, block.block_hash());
+            input.insert(key, filter);
+        }
+
+        let output = check_compact_filters_for_addresses(&input, vec![address]);
+
+        // Verify output is sorted by height (ascending)
+        let heights_out: Vec<CoreBlockHeight> = output.iter().map(|k| k.height()).collect();
+        let mut sorted_heights = heights_out.clone();
+        sorted_heights.sort();
+
+        assert_eq!(heights_out, sorted_heights);
+        assert_eq!(heights_out, vec![100, 200, 300, 400, 500]);
+    }
+}

--- a/key-wallet-manager/src/wallet_manager/mod.rs
+++ b/key-wallet-manager/src/wallet_manager/mod.rs
@@ -4,9 +4,11 @@
 //! each of which can have multiple accounts. This follows the architecture
 //! pattern where a manager oversees multiple distinct wallets.
 
+mod matching;
 mod process_block;
 mod transaction_building;
 
+pub use crate::wallet_manager::matching::{check_compact_filters_for_addresses, FilterMatchKey};
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;


### PR DESCRIPTION
Introduce parallel filter matching for the wallet, not currently in use in this PR but preparation for follow up sync improvements. This leverages `rayon` to match filters in parallel. This brings batch processing of 5000 filters in #257 from ~16s down to ~2s. I did some benchmarking on this and it appears to be the filter size which slows things down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added address-based compact-filter matching with parallel processing for faster filter checks.
  * Wallet interface now exposes monitored addresses plus optional metadata (description, earliest required height, transaction effect).

* **Behavior Changes**
  * Replaced direct wallet-based filter checks with address-driven matching; syncing now handles filter matches by explicit match results and phase-aware processing.

* **Tests**
  * Removed integration tests covering wallet filter-checking and filter caching.

* **Chores**
  * Added a parallel-processing dependency to improve performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->