### PR TITLE
feat: track `synced_height` per `ManagedWalletInfo`

### DIFF
--- a/key-wallet-ffi/FFI_API.md
+++ b/key-wallet-ffi/FFI_API.md
@@ -42,7 +42,7 @@ Functions: 3
 
 ### Wallet Manager
 
-Functions: 19
+Functions: 18
 
 | Function | Description | Module |
 |----------|-------------|--------|
@@ -63,12 +63,11 @@ Functions: 19
 | `wallet_manager_get_wallet_ids` | Get wallet IDs  # Safety  - `manager` must be a valid pointer to an... | wallet_manager |
 | `wallet_manager_import_wallet_from_bytes` | No description | wallet_manager |
 | `wallet_manager_process_transaction` | Process a transaction through all wallets  Checks a transaction against all... | wallet_manager |
-| `wallet_manager_update_height` | Update block height for a network  # Safety  - `manager` must be a valid... | wallet_manager |
 | `wallet_manager_wallet_count` | Get wallet count  # Safety  - `manager` must be a valid pointer to an... | wallet_manager |
 
 ### Wallet Operations
 
-Functions: 62
+Functions: 63
 
 | Function | Description | Module |
 |----------|-------------|--------|
@@ -99,6 +98,7 @@ Functions: 62
 | `managed_wallet_info_free` | Free managed wallet info returned by wallet_manager_get_managed_wallet_info ... | managed_wallet |
 | `managed_wallet_mark_address_used` | Mark an address as used in the pool  This updates the pool's tracking of... | address_pool |
 | `managed_wallet_set_gap_limit` | Set the gap limit for an address pool  The gap limit determines how many... | address_pool |
+| `managed_wallet_synced_height` | Get current synced height from wallet info  # Safety  - `managed_wallet`... | managed_wallet |
 | `wallet_add_account` | Add an account to the wallet without xpub  # Safety  This function... | wallet |
 | `wallet_add_account_with_string_xpub` | Add an account to the wallet with xpub as string  # Safety  This function... | wallet |
 | `wallet_add_account_with_xpub_bytes` | Add an account to the wallet with xpub as byte array  # Safety  This... | wallet |
@@ -666,22 +666,6 @@ Process a transaction through all wallets  Checks a transaction against all wall
 
 ---
 
-#### `wallet_manager_update_height`
-
-```c
-wallet_manager_update_height(manager: *mut FFIWalletManager, height: c_uint, error: *mut FFIError,) -> bool
-```
-
-**Description:**
-Update block height for a network  # Safety  - `manager` must be a valid pointer to an FFIWalletManager - `error` must be a valid pointer to an FFIError structure or null - The caller must ensure all pointers remain valid for the duration of this call
-
-**Safety:**
-- `manager` must be a valid pointer to an FFIWalletManager - `error` must be a valid pointer to an FFIError structure or null - The caller must ensure all pointers remain valid for the duration of this call
-
-**Module:** `wallet_manager`
-
----
-
 #### `wallet_manager_wallet_count`
 
 ```c
@@ -1117,6 +1101,22 @@ Set the gap limit for an address pool  The gap limit determines how many unused 
 - `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo - `error` must be a valid pointer to an FFIError or null
 
 **Module:** `address_pool`
+
+---
+
+#### `managed_wallet_synced_height`
+
+```c
+managed_wallet_synced_height(managed_wallet: *const FFIManagedWalletInfo, error: *mut FFIError,) -> c_uint
+```
+
+**Description:**
+Get current synced height from wallet info  # Safety  - `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo - `error` must be a valid pointer to an FFIError structure or null - The caller must ensure all pointers remain valid for the duration of this call
+
+**Safety:**
+- `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo - `error` must be a valid pointer to an FFIError structure or null - The caller must ensure all pointers remain valid for the duration of this call
+
+**Module:** `managed_wallet`
 
 ---
 

--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -3090,6 +3090,20 @@ bool managed_wallet_get_balance(const FFIManagedWalletInfo *managed_wallet,
 ;
 
 /*
+ Get current synced height from wallet info
+
+ # Safety
+
+ - `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo
+ - `error` must be a valid pointer to an FFIError structure or null
+ - The caller must ensure all pointers remain valid for the duration of this call
+ */
+
+unsigned int managed_wallet_synced_height(const FFIManagedWalletInfo *managed_wallet,
+                                          FFIError *error)
+;
+
+/*
  Free managed wallet info
 
  # Safety
@@ -4085,21 +4099,6 @@ bool wallet_manager_process_transaction(FFIWalletManager *manager,
                                         const FFITransactionContextDetails *context,
                                         bool update_state_if_found,
                                         FFIError *error)
-;
-
-/*
- Update block height for a network
-
- # Safety
-
- - `manager` must be a valid pointer to an FFIWalletManager
- - `error` must be a valid pointer to an FFIError structure or null
- - The caller must ensure all pointers remain valid for the duration of this call
- */
-
-bool wallet_manager_update_height(FFIWalletManager *manager,
-                                  unsigned int height,
-                                  FFIError *error)
 ;
 
 /*

--- a/key-wallet-ffi/src/managed_wallet.rs
+++ b/key-wallet-ffi/src/managed_wallet.rs
@@ -5,12 +5,13 @@
 //!
 
 use std::ffi::CString;
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_uint};
 use std::ptr;
 
 use crate::error::{FFIError, FFIErrorCode};
 use crate::types::FFIWallet;
 use key_wallet::managed_account::address_pool::KeySource;
+use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use std::ffi::c_void;
 
@@ -583,6 +584,31 @@ pub unsafe extern "C" fn managed_wallet_get_balance(
 
     FFIError::set_success(error);
     true
+}
+
+/// Get current synced height from wallet info
+///
+/// # Safety
+///
+/// - `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo
+/// - `error` must be a valid pointer to an FFIError structure or null
+/// - The caller must ensure all pointers remain valid for the duration of this call
+#[no_mangle]
+pub unsafe extern "C" fn managed_wallet_synced_height(
+    managed_wallet: *const FFIManagedWalletInfo,
+    error: *mut FFIError,
+) -> c_uint {
+    if managed_wallet.is_null() {
+        FFIError::set_error(
+            error,
+            FFIErrorCode::InvalidInput,
+            "Managed wallet is null".to_string(),
+        );
+        return 0;
+    }
+    let managed_wallet = unsafe { &*managed_wallet };
+    FFIError::set_success(error);
+    managed_wallet.inner().synced_height()
 }
 
 /// Free managed wallet info

--- a/key-wallet-ffi/src/wallet_manager.rs
+++ b/key-wallet-ffi/src/wallet_manager.rs
@@ -787,35 +787,6 @@ pub unsafe extern "C" fn wallet_manager_process_transaction(
     !relevant_wallets.is_empty()
 }
 
-/// Update block height for a network
-///
-/// # Safety
-///
-/// - `manager` must be a valid pointer to an FFIWalletManager
-/// - `error` must be a valid pointer to an FFIError structure or null
-/// - The caller must ensure all pointers remain valid for the duration of this call
-#[no_mangle]
-pub unsafe extern "C" fn wallet_manager_update_height(
-    manager: *mut FFIWalletManager,
-    height: c_uint,
-    error: *mut FFIError,
-) -> bool {
-    if manager.is_null() {
-        FFIError::set_error(error, FFIErrorCode::InvalidInput, "Manager is null".to_string());
-        return false;
-    }
-
-    let manager_ref = &*manager;
-
-    manager_ref.runtime.block_on(async {
-        let mut manager_guard = manager_ref.manager.write().await;
-        manager_guard.update_height(height);
-    });
-
-    FFIError::set_success(error);
-    true
-}
-
 /// Get current height for a network
 ///
 /// # Safety

--- a/key-wallet-manager/src/wallet_manager/mod.rs
+++ b/key-wallet-manager/src/wallet_manager/mod.rs
@@ -935,9 +935,12 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         self.current_height
     }
 
-    /// Update current block height for a specific network
+    /// Update current block height and propagate to all wallet infos
     pub fn update_height(&mut self, height: u32) {
-        self.current_height = height
+        self.current_height = height;
+        for info in self.wallet_infos.values_mut() {
+            info.update_synced_height(height);
+        }
     }
 
     /// Get monitored addresses for all wallets for a specific network

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -827,7 +827,7 @@ mod tests {
 
         // Now advance the chain height past maturity (100 blocks)
         let mature_height = block_height + 100;
-        managed_wallet.update_chain_height(mature_height);
+        managed_wallet.update_synced_height(mature_height);
 
         // Verify transaction moved from immature to regular
         let managed_account =

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -61,6 +61,9 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Update last synced timestamp
     fn update_last_synced(&mut self, timestamp: u64);
 
+    /// Get the synced height
+    fn synced_height(&self) -> CoreBlockHeight;
+
     /// Get all monitored addresses
     fn monitored_addresses(&self) -> Vec<DashAddress>;
 
@@ -111,7 +114,7 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
 
     /// Update chain state and process any matured transactions
     /// This should be called when the chain tip advances to a new height
-    fn update_chain_height(&mut self, current_height: u32);
+    fn update_synced_height(&mut self, current_height: u32);
 }
 
 /// Default implementation for ManagedWalletInfo
@@ -154,6 +157,10 @@ impl WalletInfoInterface for ManagedWalletInfo {
 
     fn set_birth_height(&mut self, height: CoreBlockHeight) {
         self.metadata.birth_height = height;
+    }
+
+    fn synced_height(&self) -> CoreBlockHeight {
+        self.metadata.synced_height
     }
 
     fn first_loaded_at(&self) -> u64 {
@@ -322,7 +329,9 @@ impl WalletInfoInterface for ManagedWalletInfo {
         )
     }
 
-    fn update_chain_height(&mut self, current_height: u32) {
+    fn update_synced_height(&mut self, current_height: u32) {
+        self.metadata.synced_height = current_height;
+
         let matured = self.process_matured_transactions(current_height);
 
         if !matured.is_empty() {

--- a/key-wallet/src/wallet/metadata.rs
+++ b/key-wallet/src/wallet/metadata.rs
@@ -16,6 +16,8 @@ pub struct WalletMetadata {
     pub first_loaded_at: u64,
     /// Birth height (when wallet was created/restored) - 0 (genesis) if unknown
     pub birth_height: CoreBlockHeight,
+    /// Synced to block height
+    pub synced_height: CoreBlockHeight,
     /// Last sync timestamp
     pub last_synced: Option<u64>,
     /// Total transactions


### PR DESCRIPTION
This adds `synced_height` to the metadata of the `ManagedWalletInfo` which allows to keep track of the synced height of each individual wallet and also allows to leverage the synced height within wallet info for things like confirmation calculations. 

Few kind of related things included in this PR: 
- Drop `wallet_manager_update_height` from the wallet FFI since it's internal and i think we shouldn't be able to modify it from the FFI. 
- Drop a duplicated test in regard to the wallet height stuff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API to retrieve the current synced block height for individual managed wallets.

* **Improvements**
  * Wallet metadata now records per-wallet synced heights.
  * Global height updates now propagate to all managed wallets; wallets can still maintain individual synced heights.

* **Breaking Changes**
  * Removed the external API to directly set the wallet/network height; height updates are now managed internally.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->