### PR TITLE
fix: use `from_byte_array` for dummy block hash in tests

### DIFF
--- a/dash/src/bip152.rs
+++ b/dash/src/bip152.rs
@@ -412,7 +412,7 @@ mod test {
         Block {
             header: block::Header {
                 version: block::Version::ONE,
-                prev_blockhash: BlockHash::hash(&[0]),
+                prev_blockhash: BlockHash::from_byte_array([0; 32]),
                 merkle_root: TxMerkleNode::hash(&[1]),
                 time: 2,
                 bits: CompactTarget::from_consensus(3),


### PR DESCRIPTION
Using `BlockHash::hash(&[0])` causes heap buffer overflow in sanitizer step in the CI overhaul #253 because it tries to X11 hash a 1 byte input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test code to modernize dummy block header construction patterns.

---

**Note:** This release contains no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->