### PR TITLE
fix: address Windows filename issues

### DIFF
--- a/dash-spv/src/chain/chainlock_manager.rs
+++ b/dash-spv/src/chain/chainlock_manager.rs
@@ -333,7 +333,7 @@ impl ChainLockManager {
         }
 
         // Store persistently
-        let key = format!("chainlock:{}", chain_lock.block_height);
+        let key = format!("chainlock_{}", chain_lock.block_height);
         let data = bincode::serialize(&chain_lock)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
         storage.store_metadata(&key, &data).await?;
@@ -414,7 +414,7 @@ impl ChainLockManager {
         let mut chain_locks = Vec::new();
 
         for height in start_height..=end_height {
-            let key = format!("chainlock:{}", height);
+            let key = format!("chainlock_{}", height);
             if let Some(data) = storage.load_metadata(&key).await? {
                 match bincode::deserialize::<ChainLock>(&data) {
                     Ok(chain_lock) => {


### PR DESCRIPTION
Use underscore instead of colon since its not allowed in filenames in Windows.

This is are some of the fixes required for Windows support which gets introduced/tested in the CI overhaul PR #253.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal storage key format for chain lock entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->