### PR TITLE
feat: bump `rs-x11-hash` to `0.1.9` for windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ version = "0.40.0"
 
 [patch.crates-io]
 dashcore_hashes = { path = "hashes" }
+# Use directly from GitHub while we don't have ownership of the crate on crates.io
+rs-x11-hash = { git = "https://github.com/dashpay/rs-x11-hash", tag = "0.1.9" }
 
 [profile.release]
 # Default to unwinding for most crates


### PR DESCRIPTION
Bumps `rs-x11-hash` to `0.1.9` which now supports windows build. This is one part of the puzzle for the Windows support in the CI overhaul PR #253.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to use an alternative source for a cryptographic library, improving compatibility and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->