### PR TITLE
ci: exclude `dash-fuzz` from clippy on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
       - id: clippy
         name: clippy (workspace strict)
         description: Strict clippy on entire workspace - deny all warnings
-        entry: cargo clippy --workspace --all-features --all-targets -- -D warnings
+        entry: python3 contrib/run_clippy.py
         language: system
         types: [rust]
         pass_filenames: false

--- a/contrib/run_clippy.py
+++ b/contrib/run_clippy.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Run clippy."""
+
+import subprocess
+import sys
+
+cmd = [
+    "cargo", "clippy",
+    "--workspace",
+    "--all-features",
+    "--all-targets",
+]
+
+# Exclude dash-fuzz on Windows (honggfuzz doesn't support Windows)
+if sys.platform == "win32":
+    cmd.extend(["--exclude", "dash-fuzz"])
+
+cmd.extend(["--", "-D", "warnings"])
+
+sys.exit(subprocess.call(cmd))


### PR DESCRIPTION
`honggfuzz` doesn't support Windows, causing the `pre-commit` clippy step in #253 to fail. This excludes `dash-fuzz` from clippy on Windows only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated pre-commit hook configuration to delegate Rust code linting invocation to a dedicated helper script.
- New helper script orchestrates Rust linting across the entire workspace with all features enabled. It handles platform-specific target exclusions and enforces a warnings-as-errors policy for stricter code quality validation during the development cycle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->