### PR TITLE
chore: add explicit UTF-8 encoding for FFI doc generation

### DIFF
--- a/contrib/verify_ffi.py
+++ b/contrib/verify_ffi.py
@@ -35,7 +35,10 @@ def generate_ffi_docs(crate_dir: Path) -> tuple[str, int, str]:
         capture_output=True,
         text=True
     )
-    return crate_dir.name, result.returncode, result.stdout
+    output = result.stdout
+    if result.returncode != 0 and result.stderr:
+        output = result.stderr
+    return crate_dir.name, result.returncode, output
 
 
 def main():

--- a/dash-spv-ffi/scripts/generate_ffi_docs.py
+++ b/dash-spv-ffi/scripts/generate_ffi_docs.py
@@ -29,7 +29,7 @@ def extract_ffi_functions(file_path: Path) -> List[FFIFunction]:
     """
     functions: List[FFIFunction] = []
 
-    with open(file_path, 'r') as f:
+    with open(file_path, 'r', encoding='utf-8') as f:
         content = f.read()
 
     # Iterate over all #[no_mangle] attribute occurrences
@@ -370,7 +370,7 @@ def main():
 
     # Write to file
     output_file = Path(__file__).parent.parent / "FFI_API.md"
-    with open(output_file, 'w') as f:
+    with open(output_file, 'w', encoding='utf-8') as f:
         f.write(markdown)
 
     print(f"Generated FFI documentation with {len(all_functions)} functions")

--- a/key-wallet-ffi/scripts/generate_ffi_docs.py
+++ b/key-wallet-ffi/scripts/generate_ffi_docs.py
@@ -28,7 +28,7 @@ def extract_ffi_functions(file_path: Path) -> List[FFIFunction]:
     """
     functions: List[FFIFunction] = []
 
-    with open(file_path, 'r') as f:
+    with open(file_path, 'r', encoding='utf-8') as f:
         content = f.read()
 
     for m in re.finditer(r'(?m)^\s*#\[no_mangle\]\s*$', content):
@@ -309,7 +309,7 @@ def main():
 
     # Write to file
     output_file = Path(__file__).parent.parent / "FFI_API.md"
-    with open(output_file, 'w') as f:
+    with open(output_file, 'w', encoding='utf-8') as f:
         f.write(markdown)
 
     print(f"Generated FFI documentation with {len(all_functions)} functions")


### PR DESCRIPTION
Add `encoding='utf-8'` to all file open operations in the FFI documentation generation scripts since the default Windows encoding doesnt seem to go well with it and lets the relevant `pre-commit` step fail for Windows in #253.

Also improved error visibility in `verify_ffi.py` by capturing stderr when the subprocess fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting to capture and display failure messages during documentation generation processes.
  * Ensured proper UTF-8 text encoding to guarantee consistent character handling across all platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->