### PR TITLE
feat: add `network` to `FFIWalletManager` struct

### DIFF
--- a/dash-spv-ffi/tests/test_wallet_manager.rs
+++ b/dash-spv-ffi/tests/test_wallet_manager.rs
@@ -8,7 +8,7 @@ mod tests {
             wallet_manager_free_wallet_ids, wallet_manager_get_wallet_ids,
             wallet_manager_import_wallet_from_bytes, wallet_manager_wallet_count,
         },
-        FFIError, FFIWalletManager,
+        FFIError, FFINetwork, FFIWalletManager,
     };
     use key_wallet_manager::wallet_manager::WalletManager;
     use std::ffi::CStr;
@@ -27,6 +27,8 @@ mod tests {
             // Get wallet manager
             let wallet_manager = dash_spv_ffi_client_get_wallet_manager(client);
             assert!(!wallet_manager.is_null());
+            let wallet_manager_ptr = wallet_manager as *mut FFIWalletManager;
+            assert_eq!((*wallet_manager_ptr).network(), FFINetwork::Testnet);
 
             // Get wallet count (should be 0 initially)
             let mut error = FFIError::success();
@@ -55,6 +57,7 @@ mod tests {
             let wallet_manager = dash_spv_ffi_client_get_wallet_manager(client);
             assert!(!wallet_manager.is_null());
             let wallet_manager_ptr = wallet_manager as *mut key_wallet_ffi::FFIWalletManager;
+            assert_eq!((*wallet_manager_ptr).network(), FFINetwork::Testnet);
 
             // Prepare a serialized wallet using the native manager so we can import it
             let mut native_manager =

--- a/key-wallet-ffi/src/wallet_manager_tests.rs
+++ b/key-wallet-ffi/src/wallet_manager_tests.rs
@@ -21,6 +21,7 @@ mod tests {
 
         // Create a wallet manager
         let manager = wallet_manager::wallet_manager_create(FFINetwork::Testnet, error);
+        assert_eq!(unsafe { (*manager).network() }, FFINetwork::Testnet);
 
         assert!(!manager.is_null());
         assert_eq!(unsafe { (*error).code }, FFIErrorCode::Success);

--- a/key-wallet-manager/src/wallet_manager/mod.rs
+++ b/key-wallet-manager/src/wallet_manager/mod.rs
@@ -925,6 +925,11 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         Ok(())
     }
 
+    /// Get the network this manager is configured for
+    pub fn network(&self) -> Network {
+        self.network
+    }
+
     /// Get current block height for a specific network
     pub fn current_height(&self) -> u32 {
         self.current_height


### PR DESCRIPTION
Adds a new field to the wallet manager FFI struct to get the network the manager is configured for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Wallet managers now expose the current network setting, allowing you to query which network (e.g., Testnet) your wallet is connected to.

* **Tests**
  * Added comprehensive tests to verify that wallet managers correctly report their network configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->