### PR TITLE
chore: use separate target dirs for pre-commit

### DIFF
--- a/contrib/run_clippy.py
+++ b/contrib/run_clippy.py
@@ -9,6 +9,7 @@ cmd = [
     "--workspace",
     "--all-features",
     "--all-targets",
+    "--target-dir", "target/clippy",
 ]
 
 # Exclude dash-fuzz on Windows (honggfuzz doesn't support Windows)

--- a/contrib/verify_ffi.py
+++ b/contrib/verify_ffi.py
@@ -13,7 +13,8 @@ def build_ffi_crates(repo_root: Path) -> bool:
     """Build all FFI crates to regenerate headers."""
     print("  Building FFI crates...")
     result = subprocess.run(
-        ["cargo", "build", "--quiet"] + [f"-p={crate}" for crate in FFI_CRATES],
+        ["cargo", "build", "--quiet", "--target-dir", "target/verify-ffi"]
+        + [f"-p={crate}" for crate in FFI_CRATES],
         cwd=repo_root,
         capture_output=True,
         text=True


### PR DESCRIPTION
Right now the clippy and verify-ffi steps in pre-commit are forced to rebuild all dependencies every time you switch between running tests or CLI and running pre-commit because of different configurations, which makes running clippy and verify-ffi quite slow. Having separate target dirs prevents those rebuilds by keeping the caches for the different build configurations alive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build artifact management for internal development and verification processes by configuring dedicated target directories for build tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->