### PR TITLE
refactor: move `Send + Sync + 'static` bounds into trait definitions

### DIFF
--- a/dash-spv/src/client/block_processor.rs
+++ b/dash-spv/src/client/block_processor.rs
@@ -38,9 +38,7 @@ pub struct BlockProcessor<W: WalletInterface, S: StorageManager> {
     failed: bool,
 }
 
-impl<W: WalletInterface + Send + Sync + 'static, S: StorageManager + Send + Sync + 'static>
-    BlockProcessor<W, S>
-{
+impl<W: WalletInterface, S: StorageManager> BlockProcessor<W, S> {
     /// Create a new block processor.
     pub fn new(
         receiver: mpsc::UnboundedReceiver<BlockProcessingTask>,

--- a/dash-spv/src/client/chainlock.rs
+++ b/dash-spv/src/client/chainlock.rs
@@ -16,12 +16,7 @@ use key_wallet_manager::wallet_interface::WalletInterface;
 
 use super::DashSpvClient;
 
-impl<
-        W: WalletInterface + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        S: StorageManager + Send + Sync + 'static,
-    > DashSpvClient<W, N, S>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     /// Process and validate a ChainLock.
     pub async fn process_chainlock(
         &mut self,

--- a/dash-spv/src/client/core.rs
+++ b/dash-spv/src/client/core.rs
@@ -146,12 +146,7 @@ pub struct DashSpvClient<W: WalletInterface, N: NetworkManager, S: StorageManage
     pub(super) mempool_filter: Option<Arc<MempoolFilter>>,
 }
 
-impl<
-        W: WalletInterface + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        S: StorageManager + Send + Sync + 'static,
-    > DashSpvClient<W, N, S>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     // ============ Simple Getters ============
 
     /// Get a reference to the wallet.

--- a/dash-spv/src/client/events.rs
+++ b/dash-spv/src/client/events.rs
@@ -13,12 +13,7 @@ use key_wallet_manager::wallet_interface::WalletInterface;
 
 use super::DashSpvClient;
 
-impl<
-        W: WalletInterface + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        S: StorageManager + Send + Sync + 'static,
-    > DashSpvClient<W, N, S>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     /// Take the event receiver for external consumption.
     pub fn take_event_receiver(&mut self) -> Option<mpsc::UnboundedReceiver<SpvEvent>> {
         self.event_rx.take()

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -25,12 +25,7 @@ use key_wallet_manager::wallet_interface::WalletInterface;
 
 use super::{BlockProcessor, ClientConfig, DashSpvClient};
 
-impl<
-        W: WalletInterface + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        S: StorageManager + Send + Sync + 'static,
-    > DashSpvClient<W, N, S>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     /// Create a new SPV client with the given configuration, network, storage, and wallet.
     pub async fn new(
         config: ClientConfig,

--- a/dash-spv/src/client/mempool.rs
+++ b/dash-spv/src/client/mempool.rs
@@ -17,12 +17,7 @@ use key_wallet_manager::wallet_interface::WalletInterface;
 
 use super::{config, DashSpvClient};
 
-impl<
-        W: WalletInterface + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        S: StorageManager + Send + Sync + 'static,
-    > DashSpvClient<W, N, S>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     /// Enable mempool tracking with the specified strategy.
     pub async fn enable_mempool_tracking(
         &mut self,

--- a/dash-spv/src/client/message_handler.rs
+++ b/dash-spv/src/client/message_handler.rs
@@ -24,13 +24,7 @@ pub struct MessageHandler<'a, S: StorageManager, N: NetworkManager, W: WalletInt
     event_tx: &'a tokio::sync::mpsc::UnboundedSender<SpvEvent>,
 }
 
-impl<
-        'a,
-        S: StorageManager + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        W: WalletInterface,
-    > MessageHandler<'a, S, N, W>
-{
+impl<'a, S: StorageManager, N: NetworkManager, W: WalletInterface> MessageHandler<'a, S, N, W> {
     /// Create a new message handler.
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/dash-spv/src/client/progress.rs
+++ b/dash-spv/src/client/progress.rs
@@ -14,12 +14,7 @@ use key_wallet_manager::wallet_interface::WalletInterface;
 
 use super::DashSpvClient;
 
-impl<
-        W: WalletInterface + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        S: StorageManager + Send + Sync + 'static,
-    > DashSpvClient<W, N, S>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     /// Get current sync progress.
     pub async fn sync_progress(&self) -> Result<SyncProgress> {
         let display = self.create_status_display().await;

--- a/dash-spv/src/client/queries.rs
+++ b/dash-spv/src/client/queries.rs
@@ -19,12 +19,7 @@ use key_wallet_manager::wallet_interface::WalletInterface;
 
 use super::DashSpvClient;
 
-impl<
-        W: WalletInterface + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        S: StorageManager + Send + Sync + 'static,
-    > DashSpvClient<W, N, S>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     // ============ Peer Queries ============
 
     /// Get the number of connected peers.

--- a/dash-spv/src/client/status_display.rs
+++ b/dash-spv/src/client/status_display.rs
@@ -23,9 +23,7 @@ pub struct StatusDisplay<'a, S: StorageManager, W: WalletInterface> {
     config: &'a ClientConfig,
 }
 
-impl<'a, S: StorageManager + Send + Sync + 'static, W: WalletInterface + Send + Sync + 'static>
-    StatusDisplay<'a, S, W>
-{
+impl<'a, S: StorageManager, W: WalletInterface> StatusDisplay<'a, S, W> {
     /// Create a new status display manager.
     #[cfg(feature = "terminal-ui")]
     pub fn new(

--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -23,12 +23,7 @@ use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio_util::sync::CancellationToken;
 
-impl<
-        W: WalletInterface + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        S: StorageManager + Send + Sync + 'static,
-    > DashSpvClient<W, N, S>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     /// Synchronize to the tip of the blockchain.
     pub async fn sync_to_tip(&mut self) -> Result<SyncProgress> {
         let running = self.running.read().await;

--- a/dash-spv/src/client/transactions.rs
+++ b/dash-spv/src/client/transactions.rs
@@ -8,12 +8,7 @@ use key_wallet_manager::wallet_interface::WalletInterface;
 
 use super::DashSpvClient;
 
-impl<
-        W: WalletInterface + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        S: StorageManager + Send + Sync + 'static,
-    > DashSpvClient<W, N, S>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     /// Broadcast a transaction to all connected peers.
     pub async fn broadcast_transaction(&self, tx: &dashcore::Transaction) -> Result<()> {
         let network = self

--- a/dash-spv/src/main.rs
+++ b/dash-spv/src/main.rs
@@ -347,7 +347,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-async fn run_client<S: dash_spv::storage::StorageManager + Send + Sync + 'static>(
+async fn run_client<S: dash_spv::storage::StorageManager>(
     config: ClientConfig,
     network_manager: dash_spv::network::manager::PeerNetworkManager,
     storage_manager: S,

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -28,7 +28,7 @@ pub use peer::Peer;
 
 /// Network manager trait for abstracting network operations.
 #[async_trait]
-pub trait NetworkManager: Send + Sync {
+pub trait NetworkManager: Send + Sync + 'static {
     /// Convert to Any for downcasting.
     fn as_any(&self) -> &dyn std::any::Any;
 

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -70,7 +70,7 @@ pub use types::*;
 /// Note that the `&mut self` requirement means only one thread can be mutating the storage
 /// at a time when using external synchronization, which naturally provides consistency.
 #[async_trait]
-pub trait StorageManager: Send + Sync {
+pub trait StorageManager: Send + Sync + 'static {
     /// Store block headers.
     async fn store_headers(&mut self, headers: &[BlockHeader]) -> StorageResult<()>;
 

--- a/dash-spv/src/sync/filters/download.rs
+++ b/dash-spv/src/sync/filters/download.rs
@@ -21,9 +21,7 @@ use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use crate::types::SyncProgress;
 
-impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync + 'static>
-    super::manager::FilterSyncManager<S, N>
-{
+impl<S: StorageManager, N: NetworkManager> super::manager::FilterSyncManager<S, N> {
     pub async fn verify_cfilter_against_headers(
         &self,
         filter_data: &[u8],

--- a/dash-spv/src/sync/filters/headers.rs
+++ b/dash-spv/src/sync/filters/headers.rs
@@ -26,9 +26,7 @@ use crate::error::{SyncError, SyncResult};
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 
-impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync + 'static>
-    super::manager::FilterSyncManager<S, N>
-{
+impl<S: StorageManager, N: NetworkManager> super::manager::FilterSyncManager<S, N> {
     pub(super) async fn find_available_header_at_or_before(
         &self,
         abs_height: u32,

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -86,9 +86,7 @@ pub struct FilterSyncManager<S: StorageManager, N: NetworkManager> {
     pub(super) cfheader_request_timeout: std::time::Duration,
 }
 
-impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync + 'static>
-    FilterSyncManager<S, N>
-{
+impl<S: StorageManager, N: NetworkManager> FilterSyncManager<S, N> {
     /// Verify that the received compact filter hashes to the expected filter header
     pub fn new(config: &ClientConfig, received_filter_heights: SharedFilterHeights) -> Self {
         Self {

--- a/dash-spv/src/sync/filters/matching.rs
+++ b/dash-spv/src/sync/filters/matching.rs
@@ -19,9 +19,7 @@ use crate::error::{SyncError, SyncResult};
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 
-impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync + 'static>
-    super::manager::FilterSyncManager<S, N>
-{
+impl<S: StorageManager, N: NetworkManager> super::manager::FilterSyncManager<S, N> {
     pub async fn check_filter_for_matches<
         W: key_wallet_manager::wallet_interface::WalletInterface,
     >(

--- a/dash-spv/src/sync/filters/requests.rs
+++ b/dash-spv/src/sync/filters/requests.rs
@@ -11,9 +11,7 @@ use crate::error::{SyncError, SyncResult};
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 
-impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync + 'static>
-    super::manager::FilterSyncManager<S, N>
-{
+impl<S: StorageManager, N: NetworkManager> super::manager::FilterSyncManager<S, N> {
     /// Build a queue of filter requests covering the specified range.
     ///
     /// If start_height is None, defaults to (filter_header_tip - DEFAULT_FILTER_SYNC_RANGE).

--- a/dash-spv/src/sync/filters/retry.rs
+++ b/dash-spv/src/sync/filters/retry.rs
@@ -12,9 +12,7 @@ use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use dashcore::BlockHash;
 
-impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync + 'static>
-    super::manager::FilterSyncManager<S, N>
-{
+impl<S: StorageManager, N: NetworkManager> super::manager::FilterSyncManager<S, N> {
     /// Check if filter header sync has timed out (no progress for SYNC_TIMEOUT_SECONDS).
     ///
     /// If timeout is detected, attempts recovery by re-sending the current batch request.

--- a/dash-spv/src/sync/filters/stats.rs
+++ b/dash-spv/src/sync/filters/stats.rs
@@ -4,9 +4,7 @@ use super::types::*;
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 
-impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync + 'static>
-    super::manager::FilterSyncManager<S, N>
-{
+impl<S: StorageManager, N: NetworkManager> super::manager::FilterSyncManager<S, N> {
     /// Get state (pending count, active count).
     pub fn get_filter_sync_state(&self) -> (usize, usize) {
         (self.pending_filter_requests.len(), self.active_filter_requests.len())

--- a/dash-spv/src/sync/headers/manager.rs
+++ b/dash-spv/src/sync/headers/manager.rs
@@ -61,9 +61,7 @@ pub struct HeaderSyncManager<S: StorageManager, N: NetworkManager> {
     cached_sync_base_height: u32,
 }
 
-impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync + 'static>
-    HeaderSyncManager<S, N>
-{
+impl<S: StorageManager, N: NetworkManager> HeaderSyncManager<S, N> {
     /// Create a new header sync manager
     pub fn new(
         config: &ClientConfig,

--- a/dash-spv/src/sync/manager.rs
+++ b/dash-spv/src/sync/manager.rs
@@ -100,12 +100,7 @@ pub struct SyncManager<S: StorageManager, N: NetworkManager, W: WalletInterface>
     pub(super) stats: std::sync::Arc<tokio::sync::RwLock<crate::types::SpvStats>>,
 }
 
-impl<
-        S: StorageManager + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        W: WalletInterface,
-    > SyncManager<S, N, W>
-{
+impl<S: StorageManager, N: NetworkManager, W: WalletInterface> SyncManager<S, N, W> {
     /// Create a new sequential sync manager
     pub fn new(
         config: &ClientConfig,

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -51,9 +51,7 @@ pub struct MasternodeSyncManager<S: StorageManager, N: NetworkManager> {
     mnlistdiff_retry_count: u8,
 }
 
-impl<S: StorageManager + Send + Sync + 'static, N: NetworkManager + Send + Sync + 'static>
-    MasternodeSyncManager<S, N>
-{
+impl<S: StorageManager, N: NetworkManager> MasternodeSyncManager<S, N> {
     /// Create a new masternode sync manager.
     pub fn new(config: &ClientConfig) -> Self {
         let (engine, mnlist_diffs) = if config.enable_masternodes {

--- a/dash-spv/src/sync/message_handlers.rs
+++ b/dash-spv/src/sync/message_handlers.rs
@@ -16,12 +16,7 @@ use key_wallet_manager::wallet_interface::WalletInterface;
 use super::manager::SyncManager;
 use super::phases::SyncPhase;
 
-impl<
-        S: StorageManager + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        W: WalletInterface,
-    > SyncManager<S, N, W>
-{
+impl<S: StorageManager, N: NetworkManager, W: WalletInterface> SyncManager<S, N, W> {
     /// Handle incoming network messages with phase filtering
     pub async fn handle_message(
         &mut self,

--- a/dash-spv/src/sync/phase_execution.rs
+++ b/dash-spv/src/sync/phase_execution.rs
@@ -10,12 +10,7 @@ use key_wallet_manager::wallet_interface::WalletInterface;
 use super::manager::SyncManager;
 use super::phases::SyncPhase;
 
-impl<
-        S: StorageManager + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        W: WalletInterface,
-    > SyncManager<S, N, W>
-{
+impl<S: StorageManager, N: NetworkManager, W: WalletInterface> SyncManager<S, N, W> {
     /// Execute the current sync phase
     pub(super) async fn execute_current_phase(
         &mut self,

--- a/dash-spv/src/sync/post_sync.rs
+++ b/dash-spv/src/sync/post_sync.rs
@@ -13,12 +13,7 @@ use key_wallet_manager::wallet_interface::WalletInterface;
 use super::manager::{SyncManager, CHAINLOCK_VALIDATION_MASTERNODE_OFFSET};
 use super::phases::SyncPhase;
 
-impl<
-        S: StorageManager + Send + Sync + 'static,
-        N: NetworkManager + Send + Sync + 'static,
-        W: WalletInterface,
-    > SyncManager<S, N, W>
-{
+impl<S: StorageManager, N: NetworkManager, W: WalletInterface> SyncManager<S, N, W> {
     /// Handle inventory messages for sequential sync
     pub async fn handle_inventory(
         &mut self,

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -10,7 +10,7 @@ use dashcore::{Block, Transaction, Txid};
 
 /// Trait for wallet implementations to receive SPV events
 #[async_trait]
-pub trait WalletInterface: Send + Sync {
+pub trait WalletInterface: Send + Sync + 'static {
     /// Called when a new block is received that may contain relevant transactions
     /// Returns transaction IDs that were relevant to the wallet
     async fn process_block(&mut self, block: &Block, height: CoreBlockHeight) -> Vec<Txid>;


### PR DESCRIPTION
These bounds are required almost everywhere anyway, so making them explicit in the trait definitions reduces lots of repetitions.

- Add `'static` to `StorageManager`, `NetworkManager`, and `WalletInterface` traits
- Remove redundant bounds where traits are used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured trait bound requirements across core components to consolidate constraints at the trait definition level rather than impl blocks.

* **Bug Fixes**
  * Updated method signature in transaction handling to properly pass required parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->