### PR TITLE
fix: unify immature balance tracking with remaining balances

### DIFF
--- a/key-wallet-ffi/FFI_API.md
+++ b/key-wallet-ffi/FFI_API.md
@@ -915,14 +915,14 @@ Get address pool information for an account  # Safety  - `managed_wallet` must b
 #### `managed_wallet_get_balance`
 
 ```c
-managed_wallet_get_balance(managed_wallet: *const FFIManagedWalletInfo, confirmed_out: *mut u64, unconfirmed_out: *mut u64, locked_out: *mut u64, total_out: *mut u64, error: *mut FFIError,) -> bool
+managed_wallet_get_balance(managed_wallet: *const FFIManagedWalletInfo, confirmed_out: *mut u64, unconfirmed_out: *mut u64, immature_out: *mut u64, locked_out: *mut u64, total_out: *mut u64, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
-Get wallet balance from managed wallet info  Returns the balance breakdown including confirmed, unconfirmed, locked, and total amounts.  # Safety  - `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo - `confirmed_out` must be a valid pointer to store the confirmed balance - `unconfirmed_out` must be a valid pointer to store the unconfirmed balance - `locked_out` must be a valid pointer to store the locked balance - `total_out` must be a valid pointer to store the total balance - `error` must be a valid pointer to an FFIError
+Get wallet balance from managed wallet info  Returns the balance breakdown including confirmed, unconfirmed, immature, locked, and total amounts.  # Safety  - `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo - `confirmed_out` must be a valid pointer to store the confirmed balance - `unconfirmed_out` must be a valid pointer to store the unconfirmed balance - `immature_out` must be a valid pointer to store the immature balance - `locked_out` must be a valid pointer to store the locked balance - `total_out` must be a valid pointer to store the total balance - `error` must be a valid pointer to an FFIError
 
 **Safety:**
-- `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo - `confirmed_out` must be a valid pointer to store the confirmed balance - `unconfirmed_out` must be a valid pointer to store the unconfirmed balance - `locked_out` must be a valid pointer to store the locked balance - `total_out` must be a valid pointer to store the total balance - `error` must be a valid pointer to an FFIError
+- `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo - `confirmed_out` must be a valid pointer to store the confirmed balance - `unconfirmed_out` must be a valid pointer to store the unconfirmed balance - `immature_out` must be a valid pointer to store the immature balance - `locked_out` must be a valid pointer to store the locked balance - `total_out` must be a valid pointer to store the total balance - `error` must be a valid pointer to an FFIError
 
 **Module:** `managed_wallet`
 

--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -516,11 +516,15 @@ typedef struct {
      */
     uint64_t unconfirmed;
     /*
-     Immature balance in duffs (e.g., mining rewards)
+     Immature balance in duffs (e.g., mining rewards not yet mature)
      */
     uint64_t immature;
     /*
-     Total balance (confirmed + unconfirmed) in duffs
+     Locked balance in duffs (e.g., CoinJoin reserves)
+     */
+    uint64_t locked;
+    /*
+     Total balance in duffs
      */
     uint64_t total;
 } FFIBalance;
@@ -3069,13 +3073,14 @@ bool managed_wallet_get_bip_44_internal_address_range(FFIManagedWalletInfo *mana
 /*
  Get wallet balance from managed wallet info
 
- Returns the balance breakdown including confirmed, unconfirmed, locked, and total amounts.
+ Returns the balance breakdown including confirmed, unconfirmed, immature, locked, and total amounts.
 
  # Safety
 
  - `managed_wallet` must be a valid pointer to an FFIManagedWalletInfo
  - `confirmed_out` must be a valid pointer to store the confirmed balance
  - `unconfirmed_out` must be a valid pointer to store the unconfirmed balance
+ - `immature_out` must be a valid pointer to store the immature balance
  - `locked_out` must be a valid pointer to store the locked balance
  - `total_out` must be a valid pointer to store the total balance
  - `error` must be a valid pointer to an FFIError
@@ -3084,6 +3089,7 @@ bool managed_wallet_get_bip_44_internal_address_range(FFIManagedWalletInfo *mana
 bool managed_wallet_get_balance(const FFIManagedWalletInfo *managed_wallet,
                                 uint64_t *confirmed_out,
                                 uint64_t *unconfirmed_out,
+                                uint64_t *immature_out,
                                 uint64_t *locked_out,
                                 uint64_t *total_out,
                                 FFIError *error)

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -515,7 +515,8 @@ pub unsafe extern "C" fn managed_account_get_balance(
     *balance_out = crate::types::FFIBalance {
         confirmed: balance.spendable(),
         unconfirmed: balance.unconfirmed(),
-        immature: 0, // WalletBalance doesn't have immature field
+        immature: balance.immature(),
+        locked: balance.locked(),
         total: balance.total(),
     };
 
@@ -1236,6 +1237,7 @@ mod tests {
                 confirmed: 999,
                 unconfirmed: 999,
                 immature: 999,
+                locked: 999,
                 total: 999,
             };
             let success = managed_account_get_balance(account, &mut balance_out);
@@ -1244,6 +1246,7 @@ mod tests {
             assert_eq!(balance_out.confirmed, 0);
             assert_eq!(balance_out.unconfirmed, 0);
             assert_eq!(balance_out.immature, 0);
+            assert_eq!(balance_out.locked, 0);
             assert_eq!(balance_out.total, 0);
 
             // Test get_transaction_count

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -55,9 +55,11 @@ pub struct FFIBalance {
     pub confirmed: u64,
     /// Unconfirmed balance in duffs
     pub unconfirmed: u64,
-    /// Immature balance in duffs (e.g., mining rewards)
+    /// Immature balance in duffs (e.g., mining rewards not yet mature)
     pub immature: u64,
-    /// Total balance (confirmed + unconfirmed) in duffs
+    /// Locked balance in duffs (e.g., CoinJoin reserves)
+    pub locked: u64,
+    /// Total balance in duffs
     pub total: u64,
 }
 
@@ -66,7 +68,8 @@ impl From<key_wallet::WalletBalance> for FFIBalance {
         FFIBalance {
             confirmed: balance.spendable(),
             unconfirmed: balance.unconfirmed(),
-            immature: balance.locked(), // Map locked to immature for now
+            immature: balance.immature(),
+            locked: balance.locked(),
             total: balance.total(),
         }
     }

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -268,18 +268,21 @@ impl ManagedAccount {
     pub fn update_balance(&mut self, synced_height: u32) {
         let mut spendable = 0;
         let mut unconfirmed = 0;
+        let mut immature = 0;
         let mut locked = 0;
         for utxo in self.utxos.values() {
             let value = utxo.txout.value;
             if utxo.is_locked {
                 locked += value;
+            } else if !utxo.is_mature(synced_height) {
+                immature += value;
             } else if utxo.is_spendable(synced_height) {
                 spendable += value;
             } else {
                 unconfirmed += value;
             }
         }
-        self.balance = WalletBalance::new(spendable, unconfirmed, locked);
+        self.balance = WalletBalance::new(spendable, unconfirmed, immature, locked);
         self.metadata.last_used = Some(Self::current_timestamp());
     }
 

--- a/key-wallet/src/test_utils/account.rs
+++ b/key-wallet/src/test_utils/account.rs
@@ -1,0 +1,39 @@
+use crate::account::StandardAccountType;
+use crate::managed_account::address_pool::{AddressPool, AddressPoolType, KeySource};
+use crate::managed_account::managed_account_type::ManagedAccountType;
+use crate::managed_account::ManagedAccount;
+use crate::{DerivationPath, Network};
+
+impl ManagedAccount {
+    /// Create a test managed account with a standard BIP44 type and empty address pools
+    pub fn new_test_bip44(network: Network) -> Self {
+        let base_path = DerivationPath::master();
+
+        let external_pool = AddressPool::new(
+            base_path.clone(),
+            AddressPoolType::External,
+            20,
+            network,
+            &KeySource::NoKeySource,
+        )
+        .expect("Failed to create external address pool");
+
+        let internal_pool = AddressPool::new(
+            base_path,
+            AddressPoolType::Internal,
+            20,
+            network,
+            &KeySource::NoKeySource,
+        )
+        .expect("Failed to create internal address pool");
+
+        let account_type = ManagedAccountType::Standard {
+            index: 0,
+            standard_account_type: StandardAccountType::BIP44Account,
+            external_addresses: external_pool,
+            internal_addresses: internal_pool,
+        };
+
+        ManagedAccount::new(account_type, network, false)
+    }
+}

--- a/key-wallet/src/test_utils/mod.rs
+++ b/key-wallet/src/test_utils/mod.rs
@@ -1,3 +1,4 @@
+mod account;
 mod address;
 mod utxo;
 

--- a/key-wallet/src/tests/balance_tests.rs
+++ b/key-wallet/src/tests/balance_tests.rs
@@ -1,0 +1,81 @@
+//! Tests for update_balance() UTXO categorization.
+
+use crate::managed_account::ManagedAccount;
+use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+use crate::wallet::managed_wallet_info::ManagedWalletInfo;
+use crate::{Network, Utxo, WalletBalance};
+
+#[test]
+fn test_balance_with_mixed_utxo_types() {
+    let mut wallet_info = ManagedWalletInfo::new(Network::Regtest, [1u8; 32]);
+    let mut account = ManagedAccount::new_test_bip44(Network::Regtest);
+
+    // Regular confirmed UTXO
+    let utxo1 = Utxo::new_test(1, 100_000, 1000, false, true);
+    account.utxos.insert(utxo1.outpoint, utxo1);
+    // Mature coinbase (100+ confirmations at height 1100)
+    let utxo2 = Utxo::new_test(2, 10_000_000, 1000, true, true);
+    account.utxos.insert(utxo2.outpoint, utxo2);
+    // Immature coinbase (<100 confirmations at height 1100)
+    let utxo3 = Utxo::new_test(3, 20_000_000, 1050, true, true);
+    account.utxos.insert(utxo3.outpoint, utxo3);
+    wallet_info.accounts.insert(account);
+
+    assert_eq!(wallet_info.balance(), WalletBalance::default());
+    wallet_info.update_synced_height(1100);
+    let expected = WalletBalance::new(10_100_000, 0, 20_000_000, 0);
+    assert_eq!(wallet_info.balance(), expected);
+}
+
+#[test]
+fn test_coinbase_maturity_boundary() {
+    let mut wallet_info = ManagedWalletInfo::new(Network::Regtest, [2u8; 32]);
+    let mut account = ManagedAccount::new_test_bip44(Network::Regtest);
+
+    // Coinbase at height 1000
+    let utxo = Utxo::new_test(1, 50_000_000, 1000, true, true);
+    account.utxos.insert(utxo.outpoint, utxo);
+    wallet_info.accounts.insert(account);
+
+    assert_eq!(wallet_info.balance(), WalletBalance::default());
+    // 99 confirmations: immature
+    wallet_info.update_synced_height(1099);
+    let expected_immature = WalletBalance::new(0, 0, 50_000_000, 0);
+    assert_eq!(wallet_info.balance(), expected_immature);
+
+    // 100 confirmations: mature
+    wallet_info.update_synced_height(1100);
+    let expected_mature = WalletBalance::new(50_000_000, 0, 0, 0);
+    assert_eq!(wallet_info.balance(), expected_mature);
+}
+
+#[test]
+fn test_locked_utxos_in_locked_balance() {
+    let mut wallet_info = ManagedWalletInfo::new(Network::Regtest, [3u8; 32]);
+    let mut account = ManagedAccount::new_test_bip44(Network::Regtest);
+
+    let mut utxo = Utxo::new_test(1, 100_000, 1000, false, true);
+    utxo.is_locked = true;
+    account.utxos.insert(utxo.outpoint, utxo);
+    wallet_info.accounts.insert(account);
+
+    assert_eq!(wallet_info.balance(), WalletBalance::default());
+    wallet_info.update_synced_height(1100);
+    let expected = WalletBalance::new(0, 0, 0, 100_000);
+    assert_eq!(wallet_info.balance(), expected);
+}
+
+#[test]
+fn test_unconfirmed_utxos_in_unconfirmed_balance() {
+    let mut wallet_info = ManagedWalletInfo::new(Network::Regtest, [4u8; 32]);
+    let mut account = ManagedAccount::new_test_bip44(Network::Regtest);
+
+    let utxo = Utxo::new_test(1, 100_000, 0, false, false);
+    account.utxos.insert(utxo.outpoint, utxo);
+    wallet_info.accounts.insert(account);
+
+    assert_eq!(wallet_info.balance(), WalletBalance::default());
+    wallet_info.update_synced_height(1100);
+    let expected = WalletBalance::new(0, 100_000, 0, 0);
+    assert_eq!(wallet_info.balance(), expected);
+}

--- a/key-wallet/src/tests/mod.rs
+++ b/key-wallet/src/tests/mod.rs
@@ -4,6 +4,8 @@
 
 mod account_tests;
 
+mod balance_tests;
+
 mod address_pool_tests;
 
 mod advanced_transaction_tests;

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -91,9 +91,6 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Get immature transactions
     fn immature_transactions(&self) -> Vec<Transaction>;
 
-    /// Get immature balance
-    fn immature_balance(&self) -> u64;
-
     /// Create an unsigned payment transaction
     #[allow(clippy::too_many_arguments)]
     fn create_unsigned_payment_transaction(
@@ -242,14 +239,6 @@ impl WalletInfoInterface for ManagedWalletInfo {
         transactions
     }
 
-    fn immature_balance(&self) -> u64 {
-        self.utxos()
-            .iter()
-            .filter(|utxo| utxo.is_coinbase && !utxo.is_mature(self.synced_height()))
-            .map(|utxo| utxo.value())
-            .sum()
-    }
-
     fn create_unsigned_payment_transaction(
         &mut self,
         wallet: &Wallet,
@@ -272,5 +261,7 @@ impl WalletInfoInterface for ManagedWalletInfo {
 
     fn update_synced_height(&mut self, current_height: u32) {
         self.metadata.synced_height = current_height;
+        // Update cached balance
+        self.update_balance();
     }
 }


### PR DESCRIPTION
We currently keep track of immature balance separately from other balances with the `immature_balance` function. This PR drops the extra function, adds `WalletBalance.immature` and changes the balance tracking so that we have all balances in one place. It also fixes a mix-up between locked and immature balance in FFI.

Based on: 

- #307 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Balance breakdown now includes an immature component and exposes it in the public balance retrieval surface.
  * Added locked balance visibility alongside existing categories.

* **Tests**
  * Added unit and integration tests covering immature and locked UTXO handling and coinbase maturity transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->