### PR TITLE
fix: fail sync on timeout

### DIFF
--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -389,7 +389,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
             // Check for sync timeouts and handle recovery (only periodically, not every loop)
             if last_timeout_check.elapsed() >= timeout_check_interval {
                 let mut storage = self.storage.lock().await;
-                let _ = self.sync_manager.check_timeout(&mut self.network, &mut *storage).await;
+                self.sync_manager.check_timeout(&mut self.network, &mut *storage).await?;
                 drop(storage);
             }
 


### PR DESCRIPTION
We currently just discard the error if we fail to recover from timeouts for max retry attempts. It's probably a serious issue if this happens and it's probably better to fail the sync process then instead of silently ignore it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the network synchronization process to properly propagate timeout-related issues instead of silently skipping them, resulting in more reliable error detection and recovery during synchronization operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->