### PR TITLE
chore: ignore `bincode` unmaintained advisory `RUSTSEC-2025-0141`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,9 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
     # serde_cbor is unmaintained but only used in fuzz targets
     "RUSTSEC-2021-0127",
+    # bincode is unmaintained but used throughout the codebase, need to find a solution here.
+    # https://rustsec.org/advisories/RUSTSEC-2025-0141.html
+    "RUSTSEC-2025-0141",
 ]
 
 [licenses]


### PR DESCRIPTION
CI currently fails because `bincode` was just recently flagged by the security audit. See https://rustsec.org/advisories/RUSTSEC-2025-0141.html.

Ignore it for now since its currently used all over the codebase. 

See the issue https://github.com/dashpay/rust-dashcore/issues/344.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security advisory management configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->