### PR TITLE
fix: store checkpoints at checkpoint height not 0

### DIFF
--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -324,7 +324,9 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
                         // Update storage with chain state including sync_base_height
                         {
                             let mut storage = self.storage.lock().await;
-                            storage.store_headers(&[checkpoint_header]).await?;
+                            storage
+                                .store_headers_at_height(&[checkpoint_header], checkpoint.height)
+                                .await?;
                             storage
                                 .store_chain_state(&chain_state_for_storage)
                                 .await


### PR DESCRIPTION
Fix checkpoint sync after #292. Before that PR the checkpoint header was stored via `ChainState::store_chain_state` like below making use of `sync_base_height`:

```rust
// First store all headers
// For checkpoint sync, we need to store headers starting from the checkpoint height
self.store_headers_at_height(&state.headers, state.sync_base_height).await?;
```

After that PR its stored at height 0 via:

```rust
storage.store_headers(&[checkpoint_header]).await?;
```

So this PR fixes it by using `store_headers_at_height` again with the actual checkpoint height.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced checkpoint header storage system with height-aware tracking to improve blockchain synchronization reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->