### PR TITLE
feat: add new `HeaderTip` cache to header storage

### DIFF
--- a/dash-spv/src/client/core.rs
+++ b/dash-spv/src/client/core.rs
@@ -185,11 +185,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
     /// Returns the current chain tip hash if available.
     pub async fn tip_hash(&self) -> Option<dashcore::BlockHash> {
         let storage = self.storage.lock().await;
-
-        let tip_height = storage.get_tip_height().await?;
-        let header = storage.get_header(tip_height).await.ok()??;
-
-        Some(header.block_hash())
+        storage.get_header_tip().await.map(|tip| tip.hash)
     }
 
     /// Returns the current chain tip height (absolute), accounting for checkpoint base.

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use tokio::sync::RwLock;
 
 use crate::error::StorageResult;
-use crate::storage::blocks::PersistentBlockHeaderStorage;
+use crate::storage::blocks::{HeaderTip, PersistentBlockHeaderStorage};
 use crate::storage::chainstate::PersistentChainStateStorage;
 use crate::storage::filters::{PersistentFilterHeaderStorage, PersistentFilterStorage};
 use crate::storage::lockfile::LockFile;
@@ -271,6 +271,10 @@ impl blocks::BlockHeaderStorage for DiskStorageManager {
 
     async fn get_tip_height(&self) -> Option<u32> {
         self.block_headers.read().await.get_tip_height().await
+    }
+
+    async fn get_header_tip(&self) -> Option<HeaderTip> {
+        self.block_headers.read().await.get_header_tip().await
     }
 
     async fn get_start_height(&self) -> Option<u32> {


### PR DESCRIPTION
Introduces a `HeaderTip` struct that caches height, header, and hash for the current block header tip. This consolidates two-step pattern of `get_tip_height()` followed by `get_header(tip_height)` into a single `get_tip()` call. I didn't adjust any of the other places where it's currently possible to be used since they are in the "old" sync code and this PR here is more like a preparation to be used by the sync rewrite.

I had this other more general version of this which is 4f799319c8883b92fa142d94677a7c6476e01605. Basically caching the tip height + item right inside the `SegmentCache` but i kind of liked the only in the header version more because we don't need the other segmented tip's to be cached.. not that this is a big deal but also having it cached in the block storage allows caching the block hash too which isn't possible if we go with the above alternative commit. Maybe it's worth coming back to this once we either get some usage for the other segmented storage tip items, or we store block hashes along with the headers in the block storage.

Also i think eventually we can get rid of this again once we implement proper for tracking (#291) since we then will have another layer on top of the storage (like `ChainState` currently) which will have the different tips cached. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized blockchain tip retrieval through implementation of caching mechanisms to eliminate redundant data lookups, reducing resource consumption and improving response times when accessing current chain tip information.

* **Refactor**
  * Simplified internal storage patterns and control flow logic to improve overall system efficiency while maintaining complete backward compatibility with existing applications and services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->