### PR TITLE
feat: storing block hashes along with the headers in segments

### DIFF
--- a/dash-spv/src/storage/segments.rs
+++ b/dash-spv/src/storage/segments.rs
@@ -17,7 +17,9 @@ use dashcore::{
 };
 use dashcore_hashes::Hash;
 
-use crate::{error::StorageResult, storage::io::atomic_write, types::CachedHeader, StorageError};
+use crate::{
+    error::StorageResult, storage::io::atomic_write, types::HashedBlockHeader, StorageError,
+};
 
 pub trait Persistable: Sized + Encodable + Decodable + PartialEq + Clone {
     const SEGMENT_PREFIX: &'static str = "segment";
@@ -36,7 +38,7 @@ impl Persistable for Vec<u8> {
     }
 }
 
-impl Persistable for CachedHeader {
+impl Persistable for HashedBlockHeader {
     fn sentinel() -> Self {
         let header = BlockHeader {
             version: Version::from_consensus(i32::MAX), // Invalid version
@@ -47,7 +49,7 @@ impl Persistable for CachedHeader {
             nonce: u32::MAX,
         };
 
-        Self::new_with_hash(header, header.block_hash())
+        Self::from(header)
     }
 }
 


### PR DESCRIPTION
The main idea of this change is to avoid persisting the reverse index hashmap in the file system, what could lead to inconsistencies if corruption occurs.

Right now the HeaderStorage API remains the same to avoid conflicts with the sync rewrite but in a future would be nice to return the header+hash and ask for the CachedHeader when storing BlockHeaders to avoid rehasing by mistake.

CachedHeader had some changes to make this possible without affecting any other line of code. Also, the struct name is not really good imo, I would appreciate suggestions.

Note: I removed the complexity of lazily calculating the hash in CachedHash for three reasons:
 - Reduced struct complexity making it easier to read
 - We only use CachedHeader once handling headers message where we need all the hashes so lazy calculating them decreases performance
 - The objective of CachedHeader is caching the hash, if we are using the struct is because we WANT to reuse the hash, now the fields better represent that idea IMO.
 
Maybe having BlockHeader lazily cache its own hash would be a better approach but thats another PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced block header storage efficiency by dynamically rebuilding the header index at startup instead of loading from persistent storage, resulting in improved startup performance and reduced storage overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->