### PR TITLE
refactor: unify validation with a `Validator` trait

### DIFF
--- a/dash-spv/src/client/chainlock.rs
+++ b/dash-spv/src/client/chainlock.rs
@@ -12,6 +12,7 @@ use crate::error::{Result, SpvError};
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use crate::types::SpvEvent;
+use crate::validation::{InstantLockValidator, Validator};
 use key_wallet_manager::wallet_interface::WalletInterface;
 
 use super::DashSpvClient;
@@ -99,8 +100,8 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
 
         // Validate the InstantLock (structure + BLS signature)
         // This is REQUIRED for security - never accept InstantLocks without signature verification
-        let validator = crate::validation::InstantLockValidator::new();
-        if let Err(e) = validator.validate(&islock, masternode_engine) {
+        let validator = InstantLockValidator::new(masternode_engine);
+        if let Err(e) = validator.validate(&islock) {
             // Penalize the peer that relayed the invalid InstantLock
             let reason = format!("Invalid InstantLock: {}", e);
             tracing::warn!("{}", reason);

--- a/dash-spv/src/sync/headers/manager.rs
+++ b/dash-spv/src/sync/headers/manager.rs
@@ -12,8 +12,8 @@ use crate::client::ClientConfig;
 use crate::error::{SyncError, SyncResult};
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
-use crate::sync::headers::validate_headers;
 use crate::types::{ChainState, HashedBlockHeader};
+use crate::validation::{BlockHeaderValidator, Validator};
 use crate::ValidationMode;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -180,7 +180,7 @@ impl<S: StorageManager, N: NetworkManager> HeaderSyncManager<S, N> {
         }
 
         if self.config.validation_mode != ValidationMode::None {
-            validate_headers(&cached_headers).map_err(|e| {
+            BlockHeaderValidator::new().validate(&cached_headers).map_err(|e| {
                 let error = format!("Header validation failed: {}", e);
                 tracing::error!(error);
                 SyncError::Validation(error)

--- a/dash-spv/src/sync/headers/mod.rs
+++ b/dash-spv/src/sync/headers/mod.rs
@@ -1,7 +1,5 @@
 //! Header synchronization with fork detection and reorganization handling.
 
 mod manager;
-pub mod validation;
 
 pub use manager::{HeaderSyncManager, ReorgConfig};
-pub use validation::validate_headers;

--- a/dash-spv/src/validation/mod.rs
+++ b/dash-spv/src/validation/mod.rs
@@ -1,5 +1,13 @@
 //! Validation functionality for the Dash SPV client.
 
+mod header;
 mod instantlock;
 
+pub use header::BlockHeaderValidator;
 pub use instantlock::InstantLockValidator;
+
+use crate::error::ValidationResult;
+
+pub trait Validator<T> {
+    fn validate(&self, data: T) -> ValidationResult<()>;
+}


### PR DESCRIPTION
Currently, validation logic for different structs is spread in the codebase without following a consistent pattern. Sometimes it is a ValidatorStruct, logic inside a method, an independant method, etc, making them hard to locate. The idea of this branch is to move all the validation logic into the same module and implementing the same trait as I made in the first commit with the headers and the  instantlock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Validation system redesigned to use instantiated, trait-based validators for headers and instant-locks; tests updated to match.
* **Breaking Changes**
  * Several previously exported validation helpers and re-exports were removed or replaced, reducing the public API surface and requiring callers to use the new validator types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->