### PR TITLE
build(deps): bump bincode to 2.0.1

### DIFF
--- a/dash-network/Cargo.toml
+++ b/dash-network/Cargo.toml
@@ -14,10 +14,7 @@ readme = "README.md"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 # Optional dependencies for serialization
-serde = { version = "1.0", default-features = false, optional = true, features = [
-    "derive",
-    "alloc",
-] }
+serde = { version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
 bincode = { version = "2.0.1", optional = true, default-features = false }
 bincode_derive = { version = "2.0.1", optional = true }
 

--- a/dash-network/Cargo.toml
+++ b/dash-network/Cargo.toml
@@ -14,9 +14,12 @@ readme = "README.md"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 # Optional dependencies for serialization
-serde = { version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
-bincode = { version = "=2.0.0-rc.3", optional = true, default-features = false }
-bincode_derive = { version= "=2.0.0-rc.3", optional = true }
+serde = { version = "1.0", default-features = false, optional = true, features = [
+    "derive",
+    "alloc",
+] }
+bincode = { version = "2.0.1", optional = true, default-features = false }
+bincode_derive = { version = "2.0.1", optional = true }
 
 [features]
 default = ["std"]

--- a/dash-spv/Cargo.toml
+++ b/dash-spv/Cargo.toml
@@ -33,7 +33,7 @@ anyhow = "1.0"
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-bincode = "1.3"
+bincode = "2.0.1"
 
 # Logging
 tracing = "0.1"

--- a/dash-spv/src/chain/chainlock_manager.rs
+++ b/dash-spv/src/chain/chainlock_manager.rs
@@ -334,7 +334,7 @@ impl ChainLockManager {
 
         // Store persistently
         let key = format!("chainlock:{}", chain_lock.block_height);
-        let data = bincode::serialize(&chain_lock)
+        let data = bincode::encode_to_vec(&chain_lock, bincode::config::standard())
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
         storage.store_metadata(&key, &data).await?;
 
@@ -416,8 +416,9 @@ impl ChainLockManager {
         for height in start_height..=end_height {
             let key = format!("chainlock:{}", height);
             if let Some(data) = storage.load_metadata(&key).await? {
-                match bincode::deserialize::<ChainLock>(&data) {
-                    Ok(chain_lock) => {
+                match bincode::decode_from_slice::<ChainLock, _>(&data, bincode::config::standard())
+                {
+                    Ok((chain_lock, _)) => {
                         // Cache it
                         let entry = ChainLockEntry {
                             chain_lock: chain_lock.clone(),

--- a/dash/Cargo.toml
+++ b/dash/Cargo.toml
@@ -61,8 +61,8 @@ bitcoinconsensus = { version = "0.20.2-0.5.0", default-features = false, optiona
 hex_lit = "0.1.1"
 anyhow = { version= "1.0" }
 hex = { version= "0.4" }
-bincode = { version= "=2.0.0-rc.3", optional = true }
-bincode_derive = { version= "=2.0.0-rc.3", optional = true }
+bincode = { version = "2.0.1", optional = true }
+bincode_derive = { version = "2.0.1", optional = true }
 blsful = { git = "https://github.com/dashpay/agora-blsful", rev = "0c34a7a488a0bd1c9a9a2196e793b303ad35c900", optional = true }
 ed25519-dalek = { version = "2.1", features = ["rand_core"], optional = true }
 blake3 = "1.8.1"
@@ -75,7 +75,7 @@ serde_json = "1.0.140"
 serde_test = "1.0.177"
 serde_derive = "1.0.219"
 secp256k1 = { features = [ "recovery", "rand", "hashes" ], version="0.30.0" }
-bincode = { version= "=2.0.0-rc.3" }
+bincode = { version = "2.0.1" }
 assert_matches = "1.5.0"
 dashcore = { path = ".", features = ["core-block-hash-use-x11", "message_verification", "quorum_validation", "signer"] }
 criterion = "0.5"

--- a/dash/src/address.rs
+++ b/dash/src/address.rs
@@ -863,8 +863,8 @@ impl bincode::Encode for Address {
 }
 
 #[cfg(feature = "bincode")]
-impl bincode::Decode for Address {
-    fn decode<D: bincode::de::Decoder>(
+impl<C> bincode::Decode<C> for Address {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         use core::str::FromStr;
@@ -876,8 +876,8 @@ impl bincode::Decode for Address {
 }
 
 #[cfg(feature = "bincode")]
-impl<'de> bincode::BorrowDecode<'de> for Address {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+impl<'de, C> bincode::BorrowDecode<'de, C> for Address {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         use core::str::FromStr;
@@ -899,8 +899,8 @@ impl bincode::Encode for AddressType {
 }
 
 #[cfg(feature = "bincode")]
-impl bincode::Decode for AddressType {
-    fn decode<D: bincode::de::Decoder>(
+impl<C> bincode::Decode<C> for AddressType {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let val = u8::decode(decoder)?;
@@ -916,8 +916,8 @@ impl bincode::Decode for AddressType {
 }
 
 #[cfg(feature = "bincode")]
-impl<'de> bincode::BorrowDecode<'de> for AddressType {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+impl<'de, C> bincode::BorrowDecode<'de, C> for AddressType {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let val = u8::borrow_decode(decoder)?;

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -35,7 +35,7 @@ actual-schemars = { package = "schemars", version = "1.0", optional = true }
 secp256k1 = { default-features = false, features = ["hashes"], version= "0.30.0" }
 
 rs-x11-hash = { version = "0.1.8", optional = true }
-bincode = { version= "=2.0.0-rc.3", optional = true }
+bincode = { version = "2.0.1", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/hashes/src/bincode_macros.rs
+++ b/hashes/src/bincode_macros.rs
@@ -32,16 +32,16 @@ macro_rules! bincode_impl {
             }
         }
 
-        impl<$($gen: $gent),*> bincode::Decode for $t<$($gen),*> {
-            fn decode<D: bincode::de::Decoder>(decoder: &mut D) -> Result<Self, bincode::error::DecodeError> {
+        impl<C $(, $gen: $gent)*> bincode::Decode<C> for $t<$($gen),*> {
+            fn decode<D: bincode::de::Decoder<Context = C>>(decoder: &mut D) -> Result<Self, bincode::error::DecodeError> {
                 // Decode a fixed-length byte array and then reconstruct via from_byte_array
                 let bytes: [u8; $len] = <[u8; $len]>::decode(decoder)?;
                 Ok(Self::from_byte_array(bytes))
             }
         }
 
-        impl<'de, $($gen: $gent),*> bincode::BorrowDecode<'de> for $t<$($gen),*> {
-            fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, bincode::error::DecodeError> {
+        impl<'de, C $(, $gen: $gent)*> bincode::BorrowDecode<'de, C> for $t<$($gen),*> {
+            fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(decoder: &mut D) -> Result<Self, bincode::error::DecodeError> {
                 // Decode a borrowed reference, then use from_bytes_ref (and clone, since our type is Copy)
                 use std::convert::TryInto;
 

--- a/hashes/src/internal_macros.rs
+++ b/hashes/src/internal_macros.rs
@@ -148,8 +148,8 @@ macro_rules! hash_trait_impls {
         }
 
         #[cfg(feature = "bincode")]
-        impl<$($gen: $gent),*> bincode::Decode for Hash<$($gen),*> {
-            fn decode<D: bincode::de::Decoder>(decoder: &mut D) -> Result<Self, bincode::error::DecodeError> {
+        impl<C $(, $gen: $gent)*> bincode::Decode<C> for Hash<$($gen),*> {
+            fn decode<D: bincode::de::Decoder<Context = C>>(decoder: &mut D) -> Result<Self, bincode::error::DecodeError> {
                 use crate::Hash;
                 // Decode a fixed-length byte array and then create the Hash
                 let bytes: [u8; $bits / 8] = <[u8; $bits / 8]>::decode(decoder)?;
@@ -158,8 +158,8 @@ macro_rules! hash_trait_impls {
         }
 
         #[cfg(feature = "bincode")]
-        impl<'de, $($gen: $gent),*> bincode::BorrowDecode<'de> for Hash<$($gen),*> {
-            fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, bincode::error::DecodeError> {
+        impl<'de, C $(, $gen: $gent)*> bincode::BorrowDecode<'de, C> for Hash<$($gen),*> {
+            fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(decoder: &mut D) -> Result<Self, bincode::error::DecodeError> {
                 use std::convert::TryInto;
                 // Decode a borrowed reference to a byte slice
                 let bytes: &[u8] = bincode::BorrowDecode::borrow_decode(decoder)?;

--- a/key-wallet-ffi/IMPORT_WALLET_FFI.md
+++ b/key-wallet-ffi/IMPORT_WALLET_FFI.md
@@ -84,7 +84,7 @@ cargo build --features bincode
 
 ## Serialization Format
 
-The wallet bytes must be in bincode format (version 2.0.0-rc.3). The serialization includes:
+The wallet bytes must be in bincode format (version 2.0). The serialization includes:
 - Wallet seed and key material
 - Account information
 - Address pools and indices

--- a/key-wallet-manager/Cargo.toml
+++ b/key-wallet-manager/Cargo.toml
@@ -13,7 +13,7 @@ default = ["std", "bincode"]
 std = ["key-wallet/std", "dashcore/std", "dashcore_hashes/std", "secp256k1/std"]
 serde = ["dep:serde", "key-wallet/serde", "dashcore/serde"]
 getrandom = ["key-wallet/getrandom"]
-bincode = ["dep:bincode","key-wallet/bincode"]
+bincode = ["dep:bincode", "key-wallet/bincode"]
 
 [dependencies]
 key-wallet = { path = "../key-wallet", default-features = false }
@@ -22,7 +22,7 @@ dashcore_hashes = { path = "../hashes", default-features = false }
 secp256k1 = { version = "0.30.0", default-features = false, features = ["recovery"] }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 async-trait = "0.1"
-bincode = { version = "=2.0.0-rc.3", optional = true }
+bincode = { version = "2.0.1", optional = true }
 zeroize = { version = "1.8", features = ["derive"] }
 
 [dev-dependencies]

--- a/key-wallet/Cargo.toml
+++ b/key-wallet/Cargo.toml
@@ -35,8 +35,8 @@ sha2 = { version = "0.10", default-features = false }
 bs58 = { version = "0.5", default-features = false, features = ["check", "alloc"], optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
 # Serialization
-bincode = { version = "=2.0.0-rc.3", optional = true }
-bincode_derive = { version = "=2.0.0-rc.3", optional = true }
+bincode = { version = "2.0.1", optional = true }
+bincode_derive = { version = "2.0.1", optional = true }
 base64 = { version = "0.22", optional = true }
 serde_json = { version = "1.0", optional = true }
 hex = { version = "0.4"}

--- a/key-wallet/src/bip32.rs
+++ b/key-wallet/src/bip32.rs
@@ -375,8 +375,8 @@ impl bincode::Encode for ExtendedPrivKey {
 }
 
 #[cfg(feature = "bincode")]
-impl bincode::Decode for ExtendedPrivKey {
-    fn decode<D: bincode::de::Decoder>(
+impl<C> bincode::Decode<C> for ExtendedPrivKey {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let network = Network::decode(decoder)?;
@@ -402,8 +402,8 @@ impl bincode::Decode for ExtendedPrivKey {
 }
 
 #[cfg(feature = "bincode")]
-impl<'de> bincode::BorrowDecode<'de> for ExtendedPrivKey {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+impl<'de, C> bincode::BorrowDecode<'de, C> for ExtendedPrivKey {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let network = Network::borrow_decode(decoder)?;
@@ -498,8 +498,8 @@ impl bincode::Encode for ExtendedPubKey {
 }
 
 #[cfg(feature = "bincode")]
-impl bincode::Decode for ExtendedPubKey {
-    fn decode<D: bincode::de::Decoder>(
+impl<C> bincode::Decode<C> for ExtendedPubKey {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let network = Network::decode(decoder)?;
@@ -525,8 +525,8 @@ impl bincode::Decode for ExtendedPubKey {
 }
 
 #[cfg(feature = "bincode")]
-impl<'de> bincode::BorrowDecode<'de> for ExtendedPubKey {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+impl<'de, C> bincode::BorrowDecode<'de, C> for ExtendedPubKey {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let network = Network::borrow_decode(decoder)?;
@@ -956,8 +956,8 @@ impl bincode::Encode for DerivationPath {
 }
 
 #[cfg(feature = "bincode")]
-impl bincode::Decode for DerivationPath {
-    fn decode<D: bincode::de::Decoder>(
+impl<C> bincode::Decode<C> for DerivationPath {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         Ok(DerivationPath(Vec::<ChildNumber>::decode(decoder)?))
@@ -965,8 +965,8 @@ impl bincode::Decode for DerivationPath {
 }
 
 #[cfg(feature = "bincode")]
-impl<'de> bincode::BorrowDecode<'de> for DerivationPath {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+impl<'de, C> bincode::BorrowDecode<'de, C> for DerivationPath {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         Ok(DerivationPath(Vec::<ChildNumber>::borrow_decode(decoder)?))

--- a/key-wallet/src/derivation_bls_bip32.rs
+++ b/key-wallet/src/derivation_bls_bip32.rs
@@ -528,8 +528,8 @@ impl bincode::Encode for ExtendedBLSPrivKey {
 }
 
 #[cfg(feature = "bincode")]
-impl bincode::Decode for ExtendedBLSPrivKey {
-    fn decode<D: bincode::de::Decoder>(
+impl<C> bincode::Decode<C> for ExtendedBLSPrivKey {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let network = Network::decode(decoder)?;
@@ -556,11 +556,11 @@ impl bincode::Decode for ExtendedBLSPrivKey {
 }
 
 #[cfg(feature = "bincode")]
-impl<'de> bincode::BorrowDecode<'de> for ExtendedBLSPrivKey {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+impl<'de, C> bincode::BorrowDecode<'de, C> for ExtendedBLSPrivKey {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
-        <Self as bincode::Decode>::decode(decoder)
+        <Self as bincode::Decode<C>>::decode(decoder)
     }
 }
 
@@ -584,8 +584,8 @@ impl bincode::Encode for ExtendedBLSPubKey {
 }
 
 #[cfg(feature = "bincode")]
-impl bincode::Decode for ExtendedBLSPubKey {
-    fn decode<D: bincode::de::Decoder>(
+impl<C> bincode::Decode<C> for ExtendedBLSPubKey {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let network = Network::decode(decoder)?;
@@ -614,11 +614,11 @@ impl bincode::Decode for ExtendedBLSPubKey {
 }
 
 #[cfg(feature = "bincode")]
-impl<'de> bincode::BorrowDecode<'de> for ExtendedBLSPubKey {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+impl<'de, C> bincode::BorrowDecode<'de, C> for ExtendedBLSPubKey {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
-        <Self as bincode::Decode>::decode(decoder)
+        <Self as bincode::Decode<C>>::decode(decoder)
     }
 }
 

--- a/key-wallet/src/derivation_slip10.rs
+++ b/key-wallet/src/derivation_slip10.rs
@@ -523,8 +523,8 @@ impl bincode::Encode for ExtendedEd25519PrivKey {
 }
 
 #[cfg(feature = "bincode")]
-impl bincode::Decode for ExtendedEd25519PrivKey {
-    fn decode<D: bincode::de::Decoder>(
+impl<C> bincode::Decode<C> for ExtendedEd25519PrivKey {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         Ok(ExtendedEd25519PrivKey {
@@ -555,8 +555,8 @@ impl bincode::Encode for ExtendedEd25519PubKey {
 }
 
 #[cfg(feature = "bincode")]
-impl bincode::Decode for ExtendedEd25519PubKey {
-    fn decode<D: bincode::de::Decoder>(
+impl<C> bincode::Decode<C> for ExtendedEd25519PubKey {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let network = Network::decode(decoder)?;
@@ -580,20 +580,20 @@ impl bincode::Decode for ExtendedEd25519PubKey {
 }
 
 #[cfg(feature = "bincode")]
-impl<'de> bincode::BorrowDecode<'de> for ExtendedEd25519PrivKey {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+impl<'de, C> bincode::BorrowDecode<'de, C> for ExtendedEd25519PrivKey {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
-        <Self as bincode::Decode>::decode(decoder)
+        <Self as bincode::Decode<C>>::decode(decoder)
     }
 }
 
 #[cfg(feature = "bincode")]
-impl<'de> bincode::BorrowDecode<'de> for ExtendedEd25519PubKey {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+impl<'de, C> bincode::BorrowDecode<'de, C> for ExtendedEd25519PubKey {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
-        <Self as bincode::Decode>::decode(decoder)
+        <Self as bincode::Decode<C>>::decode(decoder)
     }
 }
 

--- a/key-wallet/src/mnemonic.rs
+++ b/key-wallet/src/mnemonic.rs
@@ -70,8 +70,8 @@ impl bincode::Encode for Mnemonic {
 }
 
 #[cfg(feature = "bincode")]
-impl bincode::Decode for Mnemonic {
-    fn decode<D: bincode::de::Decoder>(
+impl<C> bincode::Decode<C> for Mnemonic {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> core::result::Result<Self, bincode::error::DecodeError> {
         let phrase: String = bincode::Decode::decode(decoder)?;
@@ -86,8 +86,8 @@ impl bincode::Decode for Mnemonic {
 }
 
 #[cfg(feature = "bincode")]
-impl<'de> bincode::BorrowDecode<'de> for Mnemonic {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+impl<'de, C> bincode::BorrowDecode<'de, C> for Mnemonic {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> core::result::Result<Self, bincode::error::DecodeError> {
         let phrase: String = bincode::BorrowDecode::borrow_decode(decoder)?;

--- a/key-wallet/src/wallet/root_extended_keys.rs
+++ b/key-wallet/src/wallet/root_extended_keys.rs
@@ -170,8 +170,8 @@ impl Encode for RootExtendedPrivKey {
 }
 
 #[cfg(feature = "bincode")]
-impl Decode for RootExtendedPrivKey {
-    fn decode<D: bincode::de::Decoder>(
+impl<C> Decode<C> for RootExtendedPrivKey {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         // Decode the private key bytes
@@ -192,13 +192,13 @@ impl Decode for RootExtendedPrivKey {
 }
 
 #[cfg(feature = "bincode")]
-impl<'de> BorrowDecode<'de> for RootExtendedPrivKey {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+impl<'de, C> BorrowDecode<'de, C> for RootExtendedPrivKey {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         // For borrowed decode, we still need to copy the data since secp256k1::SecretKey
         // doesn't support borrowing from the decoder
-        Self::decode(decoder)
+        <Self as Decode<C>>::decode(decoder)
     }
 }
 
@@ -306,8 +306,8 @@ impl Encode for RootExtendedPubKey {
 }
 
 #[cfg(feature = "bincode")]
-impl Decode for RootExtendedPubKey {
-    fn decode<D: bincode::de::Decoder>(
+impl<C> Decode<C> for RootExtendedPubKey {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         // Decode the public key bytes
@@ -327,13 +327,13 @@ impl Decode for RootExtendedPubKey {
 }
 
 #[cfg(feature = "bincode")]
-impl<'de> BorrowDecode<'de> for RootExtendedPubKey {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+impl<'de, C> BorrowDecode<'de, C> for RootExtendedPubKey {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         // For borrowed decode, we still need to copy the data since secp256k1::PublicKey
         // doesn't support borrowing from the decoder
-        Self::decode(decoder)
+        <Self as Decode<C>>::decode(decoder)
     }
 }
 

--- a/rpc-json/Cargo.toml
+++ b/rpc-json/Cargo.toml
@@ -28,4 +28,4 @@ hex = { version="0.4", features=["serde"]}
 key-wallet = { path = "../key-wallet", features=["serde"] }
 dashcore = { path = "../dash", features=["std", "secp-recovery", "rand-std", "signer", "serde"], default-features = false }
 
-bincode = { version = "=2.0.0-rc.3", features = ["serde"] }
+bincode = { version = "2.0.1", features = ["serde"] }


### PR DESCRIPTION
We need to replace abandoned `bincode` crate with some fork of it. In this PR, we update our code base to work with bincode v2.0.1. 

In future, we will replace bincode with one of its forks, but for now we will stick to original bincode until there is a stable candidate for replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated bincode serialization library to stable 2.0.1 across the workspace.

* **New Features**
  * Decoding interfaces generalized to support contextualized decoding across wallet, address, hash and key types (improves flexibility for serialized data handling).

* **Documentation**
  * Serialization docs updated to reflect bincode 2.0 compatibility and expanded serialized wallet contents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->