### PR TITLE
feat: introduce `BlockHeaderStorage.get_tip` helper

### DIFF
--- a/dash-spv/src/client/core.rs
+++ b/dash-spv/src/client/core.rs
@@ -184,11 +184,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
     /// Returns the current chain tip hash if available.
     pub async fn tip_hash(&self) -> Option<dashcore::BlockHash> {
         let storage = self.storage.lock().await;
-
-        let tip_height = storage.get_tip_height().await?;
-        let header = storage.get_header(tip_height).await.ok()??;
-
-        Some(header.block_hash())
+        storage.get_tip().await.map(|tip| *tip.hash())
     }
 
     /// Returns the current chain tip height (absolute), accounting for checkpoint base.

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use tokio::sync::RwLock;
 
 use crate::error::StorageResult;
-use crate::storage::blocks::PersistentBlockHeaderStorage;
+use crate::storage::blocks::{BlockHeaderTip, PersistentBlockHeaderStorage};
 use crate::storage::chainstate::PersistentChainStateStorage;
 use crate::storage::filters::{PersistentFilterHeaderStorage, PersistentFilterStorage};
 use crate::storage::lockfile::LockFile;
@@ -271,6 +271,10 @@ impl blocks::BlockHeaderStorage for DiskStorageManager {
 
     async fn get_tip_height(&self) -> Option<u32> {
         self.block_headers.read().await.get_tip_height().await
+    }
+
+    async fn get_tip(&self) -> Option<BlockHeaderTip> {
+        self.block_headers.read().await.get_tip().await
     }
 
     async fn get_start_height(&self) -> Option<u32> {


### PR DESCRIPTION
Introduces `get_tip() -> Option<HashesBlockHeader>` in `BlockHeaderStorage`. This consolidates two-step pattern of `get_tip_height()` followed by `get_header(tip_height)` into a single `get_tip()` call. I didn't adjust any of the other places (except for one) where it's currently possible to be used since they are in the "old" sync code and this PR here is more like a preparation to be used by the sync rewrite.

#### Based on: 
- #347 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized block tip hash retrieval by eliminating intermediate lookups, reducing computational overhead and improving query responsiveness
  * Enhanced block storage interface with streamlined access to current block header tip information
  * Simplified internal control flow while maintaining complete backward compatibility with existing APIs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->