### PR TITLE
chore: error cleanup

### DIFF
--- a/dash-spv-ffi/src/error.rs
+++ b/dash-spv-ffi/src/error.rs
@@ -16,11 +16,8 @@ pub enum FFIErrorCode {
     StorageError = 4,
     ValidationError = 5,
     SyncError = 6,
-    WalletError = 7,
-    ConfigError = 8,
-    RuntimeError = 9,
-    NotImplemented = 10,
-    Unknown = 99,
+    ConfigError = 7,
+    RuntimeError = 8,
 }
 
 pub fn set_last_error(err: &str) {
@@ -50,15 +47,9 @@ impl From<SpvError> for FFIErrorCode {
             SpvError::ChannelFailure(_, _) => FFIErrorCode::RuntimeError,
             SpvError::Network(_) => FFIErrorCode::NetworkError,
             SpvError::Storage(_) => FFIErrorCode::StorageError,
-            SpvError::Validation(_) => FFIErrorCode::ValidationError,
             SpvError::Sync(_) => FFIErrorCode::SyncError,
-            SpvError::Io(_) => FFIErrorCode::RuntimeError,
             SpvError::Config(_) => FFIErrorCode::ConfigError,
-            SpvError::Parse(_) => FFIErrorCode::ValidationError,
-            SpvError::Logging(_) => FFIErrorCode::RuntimeError,
-            SpvError::Wallet(_) => FFIErrorCode::WalletError,
             SpvError::QuorumLookupError(_) => FFIErrorCode::ValidationError,
-            SpvError::General(_) => FFIErrorCode::Unknown,
         }
     }
 }

--- a/dash-spv-ffi/tests/test_error.rs
+++ b/dash-spv-ffi/tests/test_error.rs
@@ -25,22 +25,6 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_error_codes() {
-        assert_eq!(FFIErrorCode::Success as i32, 0);
-        assert_eq!(FFIErrorCode::NullPointer as i32, 1);
-        assert_eq!(FFIErrorCode::InvalidArgument as i32, 2);
-        assert_eq!(FFIErrorCode::NetworkError as i32, 3);
-        assert_eq!(FFIErrorCode::StorageError as i32, 4);
-        assert_eq!(FFIErrorCode::ValidationError as i32, 5);
-        assert_eq!(FFIErrorCode::SyncError as i32, 6);
-        assert_eq!(FFIErrorCode::WalletError as i32, 7);
-        assert_eq!(FFIErrorCode::ConfigError as i32, 8);
-        assert_eq!(FFIErrorCode::RuntimeError as i32, 9);
-        assert_eq!(FFIErrorCode::Unknown as i32, 99);
-    }
-
-    #[test]
-    #[serial]
     fn test_handle_error() {
         let ok_result: Result<i32, String> = Ok(42);
         let handled = handle_error(ok_result);

--- a/dash-spv-ffi/tests/unit/test_error_handling.rs
+++ b/dash-spv-ffi/tests/unit/test_error_handling.rs
@@ -79,28 +79,17 @@ mod tests {
         assert_eq!(FFIErrorCode::StorageError as i32, 4);
         assert_eq!(FFIErrorCode::ValidationError as i32, 5);
         assert_eq!(FFIErrorCode::SyncError as i32, 6);
-        assert_eq!(FFIErrorCode::WalletError as i32, 7);
-        assert_eq!(FFIErrorCode::ConfigError as i32, 8);
-        assert_eq!(FFIErrorCode::RuntimeError as i32, 9);
-        assert_eq!(FFIErrorCode::Unknown as i32, 99);
+        assert_eq!(FFIErrorCode::ConfigError as i32, 7);
+        assert_eq!(FFIErrorCode::RuntimeError as i32, 8);
 
         // Test conversions from SpvError
-        use dash_spv::{NetworkError, SpvError, StorageError, SyncError, ValidationError};
+        use dash_spv::{NetworkError, SpvError, StorageError};
 
         let net_err = SpvError::Network(NetworkError::ConnectionFailed("test".to_string()));
         assert_eq!(FFIErrorCode::from(net_err) as i32, FFIErrorCode::NetworkError as i32);
 
         let storage_err = SpvError::Storage(StorageError::NotFound("test".to_string()));
         assert_eq!(FFIErrorCode::from(storage_err) as i32, FFIErrorCode::StorageError as i32);
-
-        let val_err = SpvError::Validation(ValidationError::InvalidProofOfWork);
-        assert_eq!(FFIErrorCode::from(val_err) as i32, FFIErrorCode::ValidationError as i32);
-
-        let sync_err = SpvError::Sync(SyncError::Timeout("Test timeout".to_string()));
-        assert_eq!(FFIErrorCode::from(sync_err) as i32, FFIErrorCode::SyncError as i32);
-
-        let io_err = SpvError::Io(std::io::Error::other("test"));
-        assert_eq!(FFIErrorCode::from(io_err) as i32, FFIErrorCode::RuntimeError as i32);
 
         let config_err = SpvError::Config("test".to_string());
         assert_eq!(FFIErrorCode::from(config_err) as i32, FFIErrorCode::ConfigError as i32);

--- a/dash-spv/src/error.rs
+++ b/dash-spv/src/error.rs
@@ -17,55 +17,21 @@ pub enum SpvError {
     #[error("Storage error: {0}")]
     Storage(#[from] StorageError),
 
-    #[error("Validation error: {0}")]
-    Validation(#[from] ValidationError),
-
     #[error("Sync error: {0}")]
     Sync(#[from] SyncError),
 
     #[error("Configuration error: {0}")]
     Config(String),
 
-    #[error("IO error: {0}")]
-    Io(#[from] io::Error),
-
-    #[error("General error: {0}")]
-    General(String),
-
-    #[error("Parse error: {0}")]
-    Parse(#[from] ParseError),
-
-    #[error("Logging error: {0}")]
-    Logging(#[from] LoggingError),
-
-    #[error("Wallet error: {0}")]
-    Wallet(#[from] WalletError),
-
     #[error("Quorum lookup error: {0}")]
     QuorumLookupError(String),
-}
-
-/// Parse-related errors.
-#[derive(Debug, Error)]
-pub enum ParseError {
-    #[error("Invalid network address: {0}")]
-    InvalidAddress(String),
-
-    #[error("Invalid network name: {0}")]
-    InvalidNetwork(String),
-
-    #[error("Missing required argument: {0}")]
-    MissingArgument(String),
-
-    #[error("Invalid argument value for {0}: {1}")]
-    InvalidArgument(String, String),
 }
 
 /// Logging-related errors.
 #[derive(Debug, Error)]
 pub enum LoggingError {
     #[error("Failed to create log directory: {0}")]
-    DirectoryCreation(#[from] std::io::Error),
+    DirectoryCreation(#[from] io::Error),
 
     #[error("Subscriber initialization failed: {0}")]
     SubscriberInit(String),
@@ -79,9 +45,6 @@ pub enum LoggingError {
 pub enum NetworkError {
     #[error("Connection failed: {0}")]
     ConnectionFailed(String),
-
-    #[error("Handshake failed: {0}")]
-    HandshakeFailed(String),
 
     #[error("Protocol error: {0}")]
     ProtocolError(String),
@@ -98,14 +61,8 @@ pub enum NetworkError {
     #[error("Message serialization error: {0}")]
     Serialization(#[from] dashcore::consensus::encode::Error),
 
-    #[error("IO error: {0}")]
-    Io(#[from] io::Error),
-
     #[error("Address parse error: {0}")]
     AddressParse(String),
-
-    #[error("System time error: {0}")]
-    SystemTime(String),
 }
 
 /// Storage-related errors.
@@ -129,30 +86,8 @@ pub enum StorageError {
     #[error("Serialization error: {0}")]
     Serialization(String),
 
-    #[error("Inconsistent state: {0}")]
-    InconsistentState(String),
-
-    #[error("Lock poisoned: {0}")]
-    LockPoisoned(String),
-
     #[error("Data directory locked: {0}")]
     DirectoryLocked(String),
-}
-
-impl Clone for StorageError {
-    fn clone(&self) -> Self {
-        match self {
-            StorageError::Corruption(s) => StorageError::Corruption(s.clone()),
-            StorageError::NotFound(s) => StorageError::NotFound(s.clone()),
-            StorageError::WriteFailed(s) => StorageError::WriteFailed(s.clone()),
-            StorageError::ReadFailed(s) => StorageError::ReadFailed(s.clone()),
-            StorageError::Io(err) => StorageError::Io(io::Error::new(err.kind(), err.to_string())),
-            StorageError::Serialization(s) => StorageError::Serialization(s.clone()),
-            StorageError::InconsistentState(s) => StorageError::InconsistentState(s.clone()),
-            StorageError::LockPoisoned(s) => StorageError::LockPoisoned(s.clone()),
-            StorageError::DirectoryLocked(s) => StorageError::DirectoryLocked(s.clone()),
-        }
-    }
 }
 
 /// Validation-related errors.
@@ -164,9 +99,6 @@ pub enum ValidationError {
     #[error("Invalid header chain: {0}")]
     InvalidHeaderChain(String),
 
-    #[error("Invalid ChainLock: {0}")]
-    InvalidChainLock(String),
-
     #[error("Invalid InstantLock: {0}")]
     InvalidInstantLock(String),
 
@@ -175,15 +107,6 @@ pub enum ValidationError {
 
     #[error("Invalid filter header chain: {0}")]
     InvalidFilterHeaderChain(String),
-
-    #[error("Consensus error: {0}")]
-    Consensus(String),
-
-    #[error("Masternode verification failed: {0}")]
-    MasternodeVerification(String),
-
-    #[error("Storage error: {0}")]
-    StorageError(#[from] StorageError),
 }
 
 /// Synchronization-related errors.
@@ -193,11 +116,6 @@ pub enum SyncError {
     #[error("{0} already started")]
     SyncInProgress(ManagerIdentifier),
 
-    /// Deprecated: Use specific error variants instead
-    #[deprecated(note = "Use Network, Storage, Validation, or Timeout variants instead")]
-    #[error("Sync failed: {0}")]
-    SyncFailed(String),
-
     /// Indicates an invalid state in the sync process (e.g., unexpected phase transitions)
     /// Use this for sync state machine errors, not validation errors
     #[error("Invalid sync state: {0}")]
@@ -206,11 +124,6 @@ pub enum SyncError {
     /// Indicates a missing dependency required for sync (e.g., missing previous block)
     #[error("Missing dependency: {0}")]
     MissingDependency(String),
-
-    // Explicit error category variants
-    /// Timeout errors during sync operations (e.g., peer response timeout)
-    #[error("Timeout error: {0}")]
-    Timeout(String),
 
     /// Network-related errors (e.g., connection failures, protocol errors)
     #[error("Network error: {0}")]
@@ -225,10 +138,6 @@ pub enum SyncError {
     #[error("Storage error: {0}")]
     Storage(String),
 
-    /// Headers2 decompression failed - can trigger fallback to regular headers
-    #[error("Headers2 decompression failed: {0}")]
-    Headers2DecompressionFailed(String),
-
     /// Masternode sync failed (QRInfo or MnListDiff processing error)
     #[error("Masternode sync failed: {0}")]
     MasternodeSyncFailed(String),
@@ -236,27 +145,6 @@ pub enum SyncError {
     /// Operation requires the client to be fully synced
     #[error("Client is not synced")]
     NotSynced,
-}
-
-impl SyncError {
-    /// Returns a static string representing the error category based on the variant
-    pub fn category(&self) -> &'static str {
-        match self {
-            SyncError::SyncInProgress(_) | SyncError::InvalidState(_) | SyncError::NotSynced => {
-                "state"
-            }
-            SyncError::Timeout(_) => "timeout",
-            SyncError::Validation(_) => "validation",
-            SyncError::MissingDependency(_) => "dependency",
-            SyncError::Network(_) => "network",
-            SyncError::Storage(_) => "storage",
-            SyncError::Headers2DecompressionFailed(_) => "headers2",
-            SyncError::MasternodeSyncFailed(_) => "masternode",
-            // Deprecated variant - should not be used
-            #[allow(deprecated)]
-            SyncError::SyncFailed(_) => "unknown",
-        }
-    }
 }
 
 /// Type alias for Result with SpvError.
@@ -277,40 +165,6 @@ pub type SyncResult<T> = std::result::Result<T, SyncError>;
 /// Type alias for logging operation results.
 pub type LoggingResult<T> = std::result::Result<T, LoggingError>;
 
-/// Wallet-related errors.
-#[derive(Debug, Error)]
-pub enum WalletError {
-    #[error("Balance calculation overflow")]
-    BalanceOverflow,
-
-    #[error("Unsupported address type: {0}")]
-    UnsupportedAddressType(String),
-
-    #[error("UTXO not found: {0}")]
-    UtxoNotFound(dashcore::OutPoint),
-
-    #[error("Invalid script pubkey")]
-    InvalidScriptPubkey,
-
-    #[error("Wallet not initialized")]
-    NotInitialized,
-
-    #[error("Transaction validation failed: {0}")]
-    TransactionValidation(String),
-
-    #[error("Invalid transaction output at index {0}")]
-    InvalidOutput(usize),
-
-    #[error("Address error: {0}")]
-    AddressError(String),
-
-    #[error("Script error: {0}")]
-    ScriptError(String),
-}
-
-/// Type alias for wallet operation results.
-pub type WalletResult<T> = std::result::Result<T, WalletError>;
-
 impl From<NetworkError> for SyncError {
     fn from(err: NetworkError) -> Self {
         SyncError::Network(err.to_string())
@@ -326,41 +180,5 @@ impl From<StorageError> for SyncError {
 impl From<ValidationError> for SyncError {
     fn from(err: ValidationError) -> Self {
         SyncError::Validation(err.to_string())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_sync_error_category() {
-        // Test explicit variant categories
-        assert_eq!(SyncError::Timeout("test".to_string()).category(), "timeout");
-        assert_eq!(SyncError::Network("test".to_string()).category(), "network");
-        assert_eq!(SyncError::Validation("test".to_string()).category(), "validation");
-        assert_eq!(SyncError::Storage("test".to_string()).category(), "storage");
-
-        // Test existing variant categories
-        assert_eq!(SyncError::SyncInProgress(ManagerIdentifier::BlockHeader).category(), "state");
-        assert_eq!(SyncError::InvalidState("test".to_string()).category(), "state");
-        assert_eq!(SyncError::MissingDependency("test".to_string()).category(), "dependency");
-        assert_eq!(SyncError::NotSynced.category(), "state");
-
-        // Test deprecated SyncFailed always returns "unknown"
-        #[allow(deprecated)]
-        {
-            assert_eq!(
-                SyncError::SyncFailed("connection timeout".to_string()).category(),
-                "unknown"
-            );
-            assert_eq!(SyncError::SyncFailed("network error".to_string()).category(), "unknown");
-            assert_eq!(
-                SyncError::SyncFailed("validation failed".to_string()).category(),
-                "unknown"
-            );
-            assert_eq!(SyncError::SyncFailed("disk full".to_string()).category(), "unknown");
-            assert_eq!(SyncError::SyncFailed("something else".to_string()).category(), "unknown");
-        }
     }
 }

--- a/dash-spv/src/main.rs
+++ b/dash-spv/src/main.rs
@@ -172,9 +172,7 @@ async fn main() {
             match spv_error {
                 dash_spv::SpvError::Network(_) => 1,
                 dash_spv::SpvError::Storage(_) => 2,
-                dash_spv::SpvError::Validation(_) => 3,
-                dash_spv::SpvError::Config(_) => 4,
-                dash_spv::SpvError::Parse(_) => 5,
+                dash_spv::SpvError::Config(_) => 3,
                 _ => 255,
             }
         } else {

--- a/dash-spv/tests/error_types_test.rs
+++ b/dash-spv/tests/error_types_test.rs
@@ -6,25 +6,10 @@
 //! - Error category classification
 //! - Nested error handling
 
-use dashcore::{OutPoint, Txid};
-use dashcore_hashes::Hash;
 use std::io;
 
 use dash_spv::error::*;
 use dash_spv::sync::ManagerIdentifier;
-
-#[test]
-fn test_network_error_from_io_error() {
-    let io_err = io::Error::new(io::ErrorKind::ConnectionRefused, "Connection refused");
-    let net_err: NetworkError = io_err.into();
-
-    match net_err {
-        NetworkError::Io(_) => {
-            assert!(net_err.to_string().contains("Connection refused"));
-        }
-        _ => panic!("Expected NetworkError::Io variant"),
-    }
-}
 
 #[test]
 fn test_storage_error_from_io_error() {
@@ -67,19 +52,6 @@ fn test_spv_error_from_storage_error() {
 }
 
 #[test]
-fn test_spv_error_from_validation_error() {
-    let val_err = ValidationError::InvalidProofOfWork;
-    let spv_err: SpvError = val_err.into();
-
-    match spv_err {
-        SpvError::Validation(ValidationError::InvalidProofOfWork) => {
-            assert_eq!(spv_err.to_string(), "Validation error: Invalid proof of work");
-        }
-        _ => panic!("Expected SpvError::Validation variant"),
-    }
-}
-
-#[test]
 fn test_spv_error_from_sync_error() {
     let sync_err = SyncError::SyncInProgress(ManagerIdentifier::BlockHeader);
     let spv_err: SpvError = sync_err.into();
@@ -93,41 +65,11 @@ fn test_spv_error_from_sync_error() {
 }
 
 #[test]
-fn test_spv_error_from_io_error() {
-    let io_err = io::Error::new(io::ErrorKind::UnexpectedEof, "Unexpected end of file");
-    let spv_err: SpvError = io_err.into();
-
-    match spv_err {
-        SpvError::Io(_) => {
-            assert!(spv_err.to_string().contains("Unexpected end of file"));
-        }
-        _ => panic!("Expected SpvError::Io variant"),
-    }
-}
-
-#[test]
-fn test_validation_error_from_storage_error() {
-    let storage_err = StorageError::NotFound("Block header at height 12345".to_string());
-    let val_err: ValidationError = storage_err.into();
-
-    match val_err {
-        ValidationError::StorageError(StorageError::NotFound(msg)) => {
-            assert_eq!(msg, "Block header at height 12345");
-        }
-        _ => panic!("Expected ValidationError::StorageError variant"),
-    }
-}
-
-#[test]
 fn test_network_error_variants() {
     let errors = vec![
         (
             NetworkError::ConnectionFailed("127.0.0.1:9999 refused connection".to_string()),
             "Connection failed: 127.0.0.1:9999 refused connection",
-        ),
-        (
-            NetworkError::HandshakeFailed("Version mismatch".to_string()),
-            "Handshake failed: Version mismatch",
         ),
         (
             NetworkError::ProtocolError("Invalid message format".to_string()),
@@ -139,10 +81,6 @@ fn test_network_error_variants() {
         (
             NetworkError::AddressParse("Invalid IP address".to_string()),
             "Address parse error: Invalid IP address",
-        ),
-        (
-            NetworkError::SystemTime("Clock drift detected".to_string()),
-            "System time error: Clock drift detected",
         ),
     ];
 
@@ -174,14 +112,6 @@ fn test_storage_error_variants() {
             StorageError::Serialization("Invalid encoding".to_string()),
             "Serialization error: Invalid encoding",
         ),
-        (
-            StorageError::InconsistentState("Height mismatch".to_string()),
-            "Inconsistent state: Height mismatch",
-        ),
-        (
-            StorageError::LockPoisoned("Mutex poisoned by panic".to_string()),
-            "Lock poisoned: Mutex poisoned by panic",
-        ),
     ];
 
     for (error, expected_msg) in errors {
@@ -198,24 +128,12 @@ fn test_validation_error_variants() {
             "Invalid header chain: Height 5000: timestamp regression",
         ),
         (
-            ValidationError::InvalidChainLock("Signature verification failed".to_string()),
-            "Invalid ChainLock: Signature verification failed",
-        ),
-        (
             ValidationError::InvalidInstantLock("Quorum not found".to_string()),
             "Invalid InstantLock: Quorum not found",
         ),
         (
             ValidationError::InvalidFilterHeaderChain("Hash mismatch at height 3000".to_string()),
             "Invalid filter header chain: Hash mismatch at height 3000",
-        ),
-        (
-            ValidationError::Consensus("Block size exceeds limit".to_string()),
-            "Consensus error: Block size exceeds limit",
-        ),
-        (
-            ValidationError::MasternodeVerification("Invalid ProRegTx".to_string()),
-            "Masternode verification failed: Invalid ProRegTx",
         ),
     ];
 
@@ -227,127 +145,25 @@ fn test_validation_error_variants() {
 #[test]
 fn test_sync_error_variants_and_categories() {
     let test_cases = vec![
-        (
-            SyncError::SyncInProgress(ManagerIdentifier::BlockHeader),
-            "state",
-            "BlockHeader already started",
-        ),
+        (SyncError::SyncInProgress(ManagerIdentifier::BlockHeader), "BlockHeader already started"),
         (
             SyncError::InvalidState("Unexpected phase transition".to_string()),
-            "state",
             "Invalid sync state: Unexpected phase transition",
         ),
         (
             SyncError::MissingDependency("Previous block not found".to_string()),
-            "dependency",
             "Missing dependency: Previous block not found",
         ),
-        (
-            SyncError::Timeout("Peer response timeout".to_string()),
-            "timeout",
-            "Timeout error: Peer response timeout",
-        ),
-        (
-            SyncError::Network("Connection lost".to_string()),
-            "network",
-            "Network error: Connection lost",
-        ),
+        (SyncError::Network("Connection lost".to_string()), "Network error: Connection lost"),
         (
             SyncError::Validation("Invalid block header".to_string()),
-            "validation",
             "Validation error: Invalid block header",
         ),
-        (
-            SyncError::Storage("Database locked".to_string()),
-            "storage",
-            "Storage error: Database locked",
-        ),
-        (
-            SyncError::Headers2DecompressionFailed("Invalid zstd stream".to_string()),
-            "headers2",
-            "Headers2 decompression failed: Invalid zstd stream",
-        ),
     ];
 
-    for (error, expected_category, expected_msg) in test_cases {
-        assert_eq!(error.category(), expected_category);
+    for (error, expected_msg) in test_cases {
         assert_eq!(error.to_string(), expected_msg);
     }
-}
-
-#[test]
-fn test_wallet_error_variants() {
-    let outpoint = OutPoint {
-        txid: Txid::from_byte_array([0xAB; 32]),
-        vout: 5,
-    };
-
-    let errors = vec![
-        (WalletError::BalanceOverflow, "Balance calculation overflow"),
-        (
-            WalletError::UnsupportedAddressType("P2WSH".to_string()),
-            "Unsupported address type: P2WSH",
-        ),
-        (WalletError::InvalidScriptPubkey, "Invalid script pubkey"),
-        (WalletError::NotInitialized, "Wallet not initialized"),
-        (
-            WalletError::TransactionValidation("Invalid signature".to_string()),
-            "Transaction validation failed: Invalid signature",
-        ),
-        (WalletError::InvalidOutput(3), "Invalid transaction output at index 3"),
-        (
-            WalletError::AddressError("Invalid network byte".to_string()),
-            "Address error: Invalid network byte",
-        ),
-        (
-            WalletError::ScriptError("Script execution failed".to_string()),
-            "Script error: Script execution failed",
-        ),
-    ];
-
-    for (error, expected_msg) in errors {
-        assert_eq!(error.to_string(), expected_msg);
-    }
-
-    // Special case for UTXO not found (contains hex)
-    let utxo_error = WalletError::UtxoNotFound(outpoint);
-    assert!(utxo_error.to_string().contains("UTXO not found"));
-    assert!(utxo_error.to_string().contains("abab")); // Partial hex from txid
-}
-
-#[test]
-fn test_parse_error_variants() {
-    let errors = vec![
-        (ParseError::InvalidAddress("xyz123".to_string()), "Invalid network address: xyz123"),
-        (ParseError::InvalidNetwork("mainnet2".to_string()), "Invalid network name: mainnet2"),
-        (
-            ParseError::MissingArgument("--storage-path".to_string()),
-            "Missing required argument: --storage-path",
-        ),
-        (
-            ParseError::InvalidArgument("port".to_string(), "abc".to_string()),
-            "Invalid argument value for port: abc",
-        ),
-    ];
-
-    for (error, expected_msg) in errors {
-        assert_eq!(error.to_string(), expected_msg);
-    }
-}
-
-#[test]
-fn test_error_context_preservation() {
-    // Create a chain of errors to test context preservation
-    let io_err = io::Error::other("Disk failure");
-    let storage_err: StorageError = io_err.into();
-    let val_err: ValidationError = storage_err.into();
-    let spv_err: SpvError = val_err.into();
-
-    // The final error should still contain the original context
-    let error_string = spv_err.to_string();
-    assert!(error_string.contains("Validation error"));
-    assert!(error_string.contains("Storage error"));
-    assert!(error_string.contains("Disk failure"));
 }
 
 #[test]
@@ -369,15 +185,10 @@ fn test_result_type_aliases() {
         Err(SyncError::SyncInProgress(ManagerIdentifier::BlockHeader))
     }
 
-    fn wallet_operation() -> WalletResult<u64> {
-        Err(WalletError::BalanceOverflow)
-    }
-
     assert!(network_operation().is_err());
     assert!(storage_operation().is_err());
     assert!(validation_operation().is_err());
     assert!(sync_operation().is_err());
-    assert!(wallet_operation().is_err());
 }
 
 #[test]
@@ -396,12 +207,6 @@ fn test_error_display_formatting() {
             "Block 523412: Previous block hash mismatch. Expected: 0x1234..., Got: 0x5678..."
                 .to_string(),
         )),
-        Box::new(SyncError::Timeout(
-            "No response from peer after 60 seconds during header download".to_string(),
-        )),
-        Box::new(WalletError::TransactionValidation(
-            "Transaction abc123... has invalid signature in input 0".to_string(),
-        )),
     ];
 
     for error in errors {
@@ -413,16 +218,6 @@ fn test_error_display_formatting() {
         let debug_formatted = format!("{:?}", error);
         assert!(debug_formatted.len() > formatted.len()); // Debug format should be more verbose
     }
-}
-
-#[test]
-fn test_sync_error_deprecated_variant() {
-    // Test that deprecated SyncFailed variant still works but is marked deprecated
-    #[allow(deprecated)]
-    let error = SyncError::SyncFailed("This should not be used".to_string());
-
-    assert_eq!(error.category(), "unknown");
-    assert!(error.to_string().contains("This should not be used"));
 }
 
 #[test]


### PR DESCRIPTION
- Removed unused error variants

Extra: Some tests for the errors are really weird, I want to drop a bunch of them xd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Simplified and consolidated error taxonomy; removed deprecated error variants and streamlined error conversions.
  * Updated numeric error-code assignments for consistency.
  * Adjusted CLI exit-code mapping for certain error classes.

* **Tests**
  * Updated and consolidated error-related tests; removed obsolete tests.

* **Chores**
  * Enforced a lint forbidding standard sync types in favor of async-friendly alternatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->