### PR TITLE
feat(wallet): add PlatformPayment account specifications and creation logic

### DIFF
--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -80,7 +80,13 @@ typedef enum {
      Provider platform P2P keys (DIP-3, ED25519) - Path: m/9'/5'/3'/4'/\[key_index\]
      */
     PROVIDER_PLATFORM_KEYS = 10,
+    /*
+     DashPay incoming funds account using 256-bit derivation
+     */
     DASHPAY_RECEIVING_FUNDS = 11,
+    /*
+     DashPay external (watch-only) account using 256-bit derivation
+     */
     DASHPAY_EXTERNAL_ACCOUNT = 12,
     /*
      Platform Payment address (DIP-17) - Path: m/9'/5'/17'/account'/key_class'/index

--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -722,6 +722,23 @@ typedef struct {
 } FFIUTXO;
 
 /*
+ FFI specification for a PlatformPayment account to create
+
+ PlatformPayment accounts (DIP-17) use the derivation path:
+ `m/9'/coin_type'/17'/account'/key_class'/index`
+ */
+typedef struct {
+    /*
+     Account index (hardened) - the account' level in the derivation path
+     */
+    uint32_t account;
+    /*
+     Key class (hardened) - defaults to 0', 1' is reserved for change-like segregation
+     */
+    uint32_t key_class;
+} FFIPlatformPaymentAccountSpec;
+
+/*
  FFI structure for wallet account creation options
  This single struct represents all possible account creation configurations
  */
@@ -750,6 +767,11 @@ typedef struct {
      */
     const uint32_t *topup_indices;
     size_t topup_count;
+    /*
+     Array of PlatformPayment account specs to create
+     */
+    const FFIPlatformPaymentAccountSpec *platform_payment_specs;
+    size_t platform_payment_count;
     /*
      For SpecificAccounts: Additional special account types to create
      (e.g., IdentityRegistration, ProviderKeys, etc.)

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -184,7 +184,9 @@ pub enum FFIAccountType {
     ProviderOperatorKeys = 9,
     /// Provider platform P2P keys (DIP-3, ED25519) - Path: m/9'/5'/3'/4'/\[key_index\]
     ProviderPlatformKeys = 10,
+    /// DashPay incoming funds account using 256-bit derivation
     DashpayReceivingFunds = 11,
+    /// DashPay external (watch-only) account using 256-bit derivation
     DashpayExternalAccount = 12,
     /// Platform Payment address (DIP-17) - Path: m/9'/5'/17'/account'/key_class'/index
     PlatformPayment = 13,

--- a/key-wallet-ffi/src/wallet_manager_serialization_tests.rs
+++ b/key-wallet-ffi/src/wallet_manager_serialization_tests.rs
@@ -389,6 +389,8 @@ mod tests {
             coinjoin_count: 0,
             topup_indices: ptr::null(),
             topup_count: 0,
+            platform_payment_specs: ptr::null(),
+            platform_payment_count: 0,
             special_account_types: ptr::null(),
             special_account_types_count: 0,
         };

--- a/key-wallet-ffi/tests/test_account_collection.rs
+++ b/key-wallet-ffi/tests/test_account_collection.rs
@@ -27,6 +27,8 @@ fn test_account_collection_comprehensive() {
             coinjoin_count: 2,
             topup_indices: [0, 1, 2].as_ptr(),
             topup_count: 3,
+            platform_payment_specs: ptr::null(),
+            platform_payment_count: 0,
             special_account_types: ptr::null(),
             special_account_types_count: 0,
         };

--- a/key-wallet-manager/tests/integration_test.rs
+++ b/key-wallet-manager/tests/integration_test.rs
@@ -59,10 +59,10 @@ fn test_account_management() {
     );
     assert!(result.is_ok());
 
-    // Get accounts from wallet - Default creates 8 accounts, plus the one we added
+    // Get accounts from wallet - Default creates 9 accounts (including PlatformPayment), plus the one we added
     let accounts = manager.get_accounts(&wallet_id);
     assert!(accounts.is_ok());
-    assert_eq!(accounts.unwrap().len(), 9); // 8 from Default + 1 we added
+    assert_eq!(accounts.unwrap().len(), 10); // 9 from Default + 1 we added
 }
 
 #[test]

--- a/key-wallet/src/tests/integration_tests.rs
+++ b/key-wallet/src/tests/integration_tests.rs
@@ -129,6 +129,7 @@ fn test_wallet_with_all_account_types() {
             [0].into(),
             [0, 1].into(),
             [0, 1].into(),
+            std::collections::BTreeSet::new(), // PlatformPayment accounts
         ),
     )
     .unwrap();

--- a/key-wallet/src/wallet/helper.rs
+++ b/key-wallet/src/wallet/helper.rs
@@ -167,6 +167,15 @@ impl Wallet {
 
                 // Create all special purpose accounts
                 self.create_special_purpose_accounts()?;
+
+                // Create default PlatformPayment account (account=0, key_class=0)
+                self.add_account(
+                    AccountType::PlatformPayment {
+                        account: 0,
+                        key_class: 0,
+                    },
+                    None,
+                )?;
             }
 
             WalletAccountCreationOptions::AllAccounts(
@@ -174,6 +183,7 @@ impl Wallet {
                 bip32_indices,
                 coinjoin_indices,
                 top_up_accounts,
+                platform_payment_specs,
             ) => {
                 // Create specified BIP44 accounts
                 for index in bip44_indices {
@@ -186,7 +196,7 @@ impl Wallet {
                     )?;
                 }
 
-                // Create specified BIP44 accounts
+                // Create specified BIP32 accounts
                 for index in bip32_indices {
                     self.add_account(
                         AccountType::Standard {
@@ -207,11 +217,22 @@ impl Wallet {
                     )?;
                 }
 
-                // Create specified CoinJoin accounts
+                // Create specified IdentityTopUp accounts
                 for registration_index in top_up_accounts {
                     self.add_account(
                         AccountType::IdentityTopUp {
                             registration_index,
+                        },
+                        None,
+                    )?;
+                }
+
+                // Create specified PlatformPayment accounts
+                for spec in platform_payment_specs {
+                    self.add_account(
+                        AccountType::PlatformPayment {
+                            account: spec.account,
+                            key_class: spec.key_class,
                         },
                         None,
                     )?;
@@ -239,6 +260,7 @@ impl Wallet {
                 bip32_indices,
                 coinjoin_indices,
                 topup_indices,
+                platform_payment_specs,
                 special_accounts,
             ) => {
                 // Create specified BIP44 accounts
@@ -278,6 +300,17 @@ impl Wallet {
                     self.add_account(
                         AccountType::IdentityTopUp {
                             registration_index,
+                        },
+                        None,
+                    )?;
+                }
+
+                // Create specified PlatformPayment accounts
+                for spec in platform_payment_specs {
+                    self.add_account(
+                        AccountType::PlatformPayment {
+                            account: spec.account,
+                            key_class: spec.key_class,
                         },
                         None,
                     )?;
@@ -340,6 +373,15 @@ impl Wallet {
 
                 // Create all special purpose accounts
                 self.create_special_purpose_accounts_with_passphrase(passphrase)?;
+
+                // Create default PlatformPayment account (account=0, key_class=0)
+                self.add_account_with_passphrase(
+                    AccountType::PlatformPayment {
+                        account: 0,
+                        key_class: 0,
+                    },
+                    passphrase,
+                )?;
             }
 
             WalletAccountCreationOptions::AllAccounts(
@@ -347,6 +389,7 @@ impl Wallet {
                 bip32_indices,
                 coinjoin_indices,
                 top_up_accounts,
+                platform_payment_specs,
             ) => {
                 // Create specified BIP44 accounts
                 for index in bip44_indices {
@@ -380,11 +423,22 @@ impl Wallet {
                     )?;
                 }
 
-                // Create specified CoinJoin accounts
+                // Create specified IdentityTopUp accounts
                 for registration_index in top_up_accounts {
                     self.add_account_with_passphrase(
                         AccountType::IdentityTopUp {
                             registration_index,
+                        },
+                        passphrase,
+                    )?;
+                }
+
+                // Create specified PlatformPayment accounts
+                for spec in platform_payment_specs {
+                    self.add_account_with_passphrase(
+                        AccountType::PlatformPayment {
+                            account: spec.account,
+                            key_class: spec.key_class,
                         },
                         passphrase,
                     )?;
@@ -412,6 +466,7 @@ impl Wallet {
                 bip32_indices,
                 coinjoin_indices,
                 topup_indices,
+                platform_payment_specs,
                 special_accounts,
             ) => {
                 // Create specified BIP44 accounts
@@ -451,6 +506,17 @@ impl Wallet {
                     self.add_account_with_passphrase(
                         AccountType::IdentityTopUp {
                             registration_index,
+                        },
+                        passphrase,
+                    )?;
+                }
+
+                // Create specified PlatformPayment accounts
+                for spec in platform_payment_specs {
+                    self.add_account_with_passphrase(
+                        AccountType::PlatformPayment {
+                            account: spec.account,
+                            key_class: spec.key_class,
                         },
                         passphrase,
                     )?;

--- a/key-wallet/src/wallet/initialization.rs
+++ b/key-wallet/src/wallet/initialization.rs
@@ -30,21 +30,12 @@ pub type WalletAccountCreationTopUpAccounts = BTreeSet<u32>;
 ///
 /// PlatformPayment accounts (DIP-17) use the derivation path:
 /// `m/9'/coin_type'/17'/account'/key_class'/index`
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PlatformPaymentAccountSpec {
     /// Account index (hardened) - the account' level in the derivation path
     pub account: u32,
     /// Key class (hardened) - defaults to 0', 1' is reserved for change-like segregation
     pub key_class: u32,
-}
-
-impl Default for PlatformPaymentAccountSpec {
-    fn default() -> Self {
-        Self {
-            account: 0,
-            key_class: 0,
-        }
-    }
 }
 
 /// Set of PlatformPayment account specs to create

--- a/key-wallet/src/wallet/initialization.rs
+++ b/key-wallet/src/wallet/initialization.rs
@@ -26,6 +26,30 @@ pub type WalletAccountCreationCoinjoinAccounts = BTreeSet<u32>;
 /// Set of identity top-up account registration indices to create
 pub type WalletAccountCreationTopUpAccounts = BTreeSet<u32>;
 
+/// Specification for a PlatformPayment account to create
+///
+/// PlatformPayment accounts (DIP-17) use the derivation path:
+/// `m/9'/coin_type'/17'/account'/key_class'/index`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PlatformPaymentAccountSpec {
+    /// Account index (hardened) - the account' level in the derivation path
+    pub account: u32,
+    /// Key class (hardened) - defaults to 0', 1' is reserved for change-like segregation
+    pub key_class: u32,
+}
+
+impl Default for PlatformPaymentAccountSpec {
+    fn default() -> Self {
+        Self {
+            account: 0,
+            key_class: 0,
+        }
+    }
+}
+
+/// Set of PlatformPayment account specs to create
+pub type WalletAccountCreationPlatformPaymentAccounts = BTreeSet<PlatformPaymentAccountSpec>;
+
 /// Options for specifying which accounts to create when initializing a wallet
 #[derive(Debug, Clone, Default)]
 pub enum WalletAccountCreationOptions {
@@ -42,11 +66,13 @@ pub enum WalletAccountCreationOptions {
     /// * Second parameter: Set of BIP32 account indices to create
     /// * Third parameter: Set of CoinJoin account indices to create
     /// * Fourth parameter: Set of identity top-up registration indices to create
+    /// * Fifth parameter: Set of PlatformPayment account specs to create
     AllAccounts(
         WalletAccountCreationBIP44Accounts,
         WalletAccountCreationBIP32Accounts,
         WalletAccountCreationCoinjoinAccounts,
         WalletAccountCreationTopUpAccounts,
+        WalletAccountCreationPlatformPaymentAccounts,
     ),
 
     /// Create only BIP44 accounts (no CoinJoin or special accounts), with optional
@@ -63,12 +89,14 @@ pub enum WalletAccountCreationOptions {
     /// * Second: Set of BIP32 account indices
     /// * Third: Set of CoinJoin account indices
     /// * Fourth: Set of identity top-up registration indices
-    /// * Fifth: Additional special account type to create (e.g., IdentityRegistration)
+    /// * Fifth: Set of PlatformPayment account specs to create
+    /// * Sixth: Additional special account types to create (e.g., IdentityRegistration)
     SpecificAccounts(
         WalletAccountCreationBIP44Accounts,
         WalletAccountCreationBIP32Accounts,
         WalletAccountCreationCoinjoinAccounts,
         WalletAccountCreationTopUpAccounts,
+        WalletAccountCreationPlatformPaymentAccounts,
         Option<Vec<AccountType>>,
     ),
 


### PR DESCRIPTION
Wallets didn't have Platform payment accounts by default. This is the first of 2 PRs to address the situation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Platform Payment accounts during wallet setup: multiple platform-payment specs can be provided and a default platform-payment account is created.
  * Added two new DashPay account types (receiving and external) alongside existing account types.

* **Tests**
  * Updated tests and expectations to reflect the new platform-payment account being included by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->