### PR TITLE
refactor(dash-spv): Building storage from config

### DIFF
--- a/dash-spv-ffi/src/client.rs
+++ b/dash-spv-ffi/src/client.rs
@@ -147,35 +147,12 @@ pub unsafe extern "C" fn dash_spv_ffi_client_new(
         }
     };
 
-    let mut client_config = config.clone_inner();
-
-    let storage_path = client_config.storage_path.clone().unwrap_or_else(|| {
-        // Create a unique temporary directory if none was provided
-        static PATH_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-        let mut path = std::env::temp_dir();
-        path.push("dash-spv");
-        path.push(
-            format!(
-                "{:?}-{}-{}",
-                client_config.network,
-                std::process::id(),
-                PATH_COUNTER.fetch_add(1, Ordering::Relaxed)
-            )
-            .to_lowercase(),
-        );
-        tracing::warn!(
-            "dash-spv FFI config missing storage path, falling back to temp dir {:?}",
-            path
-        );
-        path
-    });
-    client_config.storage_path = Some(storage_path.clone());
+    let client_config = config.clone_inner();
 
     let client_result = runtime.block_on(async move {
         // Construct concrete implementations for generics
         let network = dash_spv::network::PeerNetworkManager::new(&client_config).await;
-        let storage = DiskStorageManager::new(storage_path.clone()).await;
+        let storage = DiskStorageManager::new(&client_config).await;
         let wallet = key_wallet_manager::wallet_manager::WalletManager::<
             key_wallet::wallet::managed_wallet_info::ManagedWalletInfo,
         >::new(client_config.network);

--- a/dash-spv-ffi/src/config.rs
+++ b/dash-spv-ffi/src/config.rs
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn dash_spv_ffi_config_set_data_dir(
     let config = unsafe { &mut *((*config).inner as *mut ClientConfig) };
     match CStr::from_ptr(path).to_str() {
         Ok(path_str) => {
-            config.storage_path = Some(path_str.into());
+            config.storage_path = path_str.into();
             FFIErrorCode::Success as i32
         }
         Err(e) => {
@@ -331,13 +331,7 @@ pub unsafe extern "C" fn dash_spv_ffi_config_get_data_dir(
     }
 
     let config = unsafe { &*((*config).inner as *const ClientConfig) };
-    match &config.storage_path {
-        Some(dir) => FFIString::new(&dir.to_string_lossy()),
-        None => FFIString {
-            ptr: std::ptr::null_mut(),
-            length: 0,
-        },
-    }
+    FFIString::new(&config.storage_path.to_string_lossy())
 }
 
 /// Destroys an FFIClientConfig and frees its memory

--- a/dash-spv-ffi/tests/test_wallet_manager.rs
+++ b/dash-spv-ffi/tests/test_wallet_manager.rs
@@ -11,7 +11,8 @@ mod tests {
         FFIError, FFINetwork, FFIWalletManager,
     };
     use key_wallet_manager::wallet_manager::WalletManager;
-    use std::ffi::CStr;
+    use std::ffi::{CStr, CString};
+    use tempfile::TempDir;
 
     #[test]
     fn test_get_wallet_manager() {
@@ -19,6 +20,12 @@ mod tests {
             // Create a config
             let config = dash_spv_ffi_config_testnet();
             assert!(!config.is_null());
+
+            let temp_dir = TempDir::new().unwrap();
+            dash_spv_ffi_config_set_data_dir(
+                config,
+                CString::new(temp_dir.path().to_str().unwrap()).unwrap().as_ptr(),
+            );
 
             // Create a client
             let client = dash_spv_ffi_client_new(config);
@@ -50,6 +57,12 @@ mod tests {
         unsafe {
             let config = dash_spv_ffi_config_testnet();
             assert!(!config.is_null());
+
+            let temp_dir = TempDir::new().unwrap();
+            dash_spv_ffi_config_set_data_dir(
+                config,
+                CString::new(temp_dir.path().to_str().unwrap()).unwrap().as_ptr(),
+            );
 
             let client = dash_spv_ffi_client_new(config);
             assert!(!client.is_null());

--- a/dash-spv/examples/filter_sync.rs
+++ b/dash-spv/examples/filter_sync.rs
@@ -22,13 +22,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // Create configuration with filter support
-    let config = ClientConfig::mainnet().without_masternodes(); // Skip masternode sync for this example
+    let config = ClientConfig::mainnet()
+        .with_storage_path("./.tmp/filter-sync-example-storage")
+        .without_masternodes(); // Skip masternode sync for this example
 
     // Create network manager
     let network_manager = PeerNetworkManager::new(&config).await?;
 
     // Create storage manager
-    let storage_manager = DiskStorageManager::new("./.tmp/filter-sync-example-storage").await?;
+    let storage_manager = DiskStorageManager::new(&config).await?;
 
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));

--- a/dash-spv/examples/simple_sync.rs
+++ b/dash-spv/examples/simple_sync.rs
@@ -17,6 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a simple configuration
     let config = ClientConfig::mainnet()
+        .with_storage_path("./.tmp/simple-sync-example-storage")
         .without_filters() // Skip filter sync for this example
         .without_masternodes(); // Skip masternode sync for this example
 
@@ -24,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let network_manager = PeerNetworkManager::new(&config).await?;
 
     // Create storage manager
-    let storage_manager = DiskStorageManager::new("./.tmp/simple-sync-example-storage").await?;
+    let storage_manager = DiskStorageManager::new(&config).await?;
 
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));

--- a/dash-spv/examples/spv_with_wallet.rs
+++ b/dash-spv/examples/spv_with_wallet.rs
@@ -17,16 +17,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _logging_guard = dash_spv::init_console_logging(LevelFilter::INFO)?;
 
     // Create SPV client configuration
-    let mut config = ClientConfig::testnet();
-    config.storage_path = Some("/tmp/dash-spv-example".into());
-    config.validation_mode = dash_spv::types::ValidationMode::Full;
-    config.enable_filters = true;
+    let config = ClientConfig::testnet()
+        .with_storage_path("./.tmp/spv-with-wallet-example-storage")
+        .with_validation_mode(dash_spv::ValidationMode::Full);
 
     // Create network manager
     let network_manager = PeerNetworkManager::new(&config).await?;
 
     // Create storage manager - use disk storage for persistence
-    let storage_manager = DiskStorageManager::new("./.tmp/spv-with-wallet-example-storage").await?;
+    let storage_manager = DiskStorageManager::new(&config).await?;
 
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));

--- a/dash-spv/src/client/config.rs
+++ b/dash-spv/src/client/config.rs
@@ -34,8 +34,8 @@ pub struct ClientConfig {
     /// If no peers are configured, no outbound connections will be made.
     pub restrict_to_configured_peers: bool,
 
-    /// Optional path for persistent storage.
-    pub storage_path: Option<PathBuf>,
+    /// Path for persistent storage. Defaults to ./dash-spv-storage
+    pub storage_path: PathBuf,
 
     /// Validation mode.
     pub validation_mode: ValidationMode,
@@ -80,7 +80,7 @@ impl Default for ClientConfig {
             network: Network::Dash,
             peers: vec![],
             restrict_to_configured_peers: false,
-            storage_path: None,
+            storage_path: PathBuf::from("./dash-spv-storage"),
             validation_mode: ValidationMode::Full,
             enable_filters: true,
             enable_masternodes: true,
@@ -136,8 +136,8 @@ impl ClientConfig {
     }
 
     /// Set storage path.
-    pub fn with_storage_path(mut self, path: PathBuf) -> Self {
-        self.storage_path = Some(path);
+    pub fn with_storage_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.storage_path = path.into();
         self
     }
 
@@ -205,6 +205,13 @@ impl ClientConfig {
                 "max_mempool_transactions must be > 0 when mempool tracking is enabled".to_string()
             );
         }
+
+        std::fs::create_dir_all(&self.storage_path).map_err(|e| {
+            format!(
+                "A valid storage path must be provided to the ClientConfig {:?}: {e}",
+                self.storage_path
+            )
+        })?;
 
         Ok(())
     }

--- a/dash-spv/src/client/config_test.rs
+++ b/dash-spv/src/client/config_test.rs
@@ -55,7 +55,7 @@ mod tests {
             .with_mempool_persistence(true)
             .with_start_height(100000);
 
-        assert_eq!(config.storage_path, Some(path));
+        assert_eq!(config.storage_path, path);
         assert_eq!(config.validation_mode, ValidationMode::Basic);
 
         // Mempool settings
@@ -86,12 +86,6 @@ mod tests {
 
         assert!(!config.enable_filters);
         assert!(!config.enable_masternodes);
-    }
-
-    #[test]
-    fn test_validation_valid_config() {
-        let config = ClientConfig::default();
-        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/dash-spv/src/client/mod.rs
+++ b/dash-spv/src/client/mod.rs
@@ -64,12 +64,14 @@ mod message_handler_test;
 #[cfg(test)]
 mod tests {
     use super::{ClientConfig, DashSpvClient};
+    use crate::client::config::MempoolStrategy;
     use crate::storage::DiskStorageManager;
     use crate::{test_utils::MockNetworkManager, types::UnconfirmedTransaction};
-    use dashcore::{Address, Amount, Network, Transaction, TxOut};
+    use dashcore::{Address, Amount, Transaction, TxOut};
     use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
     use key_wallet_manager::wallet_manager::WalletManager;
     use std::sync::Arc;
+    use tempfile::TempDir;
     use tokio::sync::RwLock;
 
     // Tests for get_mempool_balance function
@@ -80,13 +82,11 @@ mod tests {
 
     #[tokio::test]
     async fn client_exposes_shared_wallet_manager() {
-        let config = ClientConfig {
-            network: Network::Dash,
-            enable_filters: false,
-            enable_masternodes: false,
-            enable_mempool_tracking: false,
-            ..Default::default()
-        };
+        let config = ClientConfig::mainnet()
+            .without_filters()
+            .without_masternodes()
+            .with_mempool_tracking(MempoolStrategy::FetchAll)
+            .with_storage_path(TempDir::new().unwrap().path());
 
         let network_manager = MockNetworkManager::new();
         let storage =
@@ -108,17 +108,14 @@ mod tests {
         // This test validates the get_mempool_balance logic by directly testing
         // the balance calculation code using a mocked mempool state.
 
-        let config = ClientConfig {
-            network: Network::Testnet,
-            enable_filters: false,
-            enable_masternodes: false,
-            enable_mempool_tracking: true,
-            ..Default::default()
-        };
+        let config = ClientConfig::testnet()
+            .without_filters()
+            .without_masternodes()
+            .with_mempool_tracking(MempoolStrategy::FetchAll)
+            .with_storage_path(TempDir::new().unwrap().path());
 
         let network_manager = MockNetworkManager::new();
-        let storage =
-            DiskStorageManager::with_temp_dir().await.expect("Failed to create tmp storage");
+        let storage = DiskStorageManager::new(&config).await.expect("Failed to create tmp storage");
         let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
         let test_address = Address::dummy(config.network, 0);

--- a/dash-spv/src/lib.rs
+++ b/dash-spv/src/lib.rs
@@ -26,11 +26,11 @@
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Create configuration for mainnet
 //!     let config = ClientConfig::mainnet()
-//!         .with_storage_path("/path/to/data".into());
+//!         .with_storage_path("./.tmp/example-storage");
 //!
 //!     // Create the required components
 //!     let network = PeerNetworkManager::new(&config).await?;
-//!     let storage = DiskStorageManager::new("./.tmp/example-storage").await?;
+//!     let storage = DiskStorageManager::new(&config).await?;
 //!     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 //!
 //!     // Create and start the client

--- a/dash-spv/src/main.rs
+++ b/dash-spv/src/main.rs
@@ -320,13 +320,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    let path = if let Some(path) = &config.storage_path {
-        path.clone()
-    } else {
-        "./.tmp/main-exec-storage".into()
-    };
-
-    let storage_manager = match dash_spv::storage::DiskStorageManager::new(path.clone()).await {
+    let storage_manager = match dash_spv::storage::DiskStorageManager::new(&config).await {
         Ok(sm) => sm,
         Err(e) => {
             eprintln!("Failed to create disk storage manager: {}", e);

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -76,7 +76,7 @@ impl PeerNetworkManager {
     /// Create a new peer network manager
     pub async fn new(config: &ClientConfig) -> Result<Self, Error> {
         let discovery = DnsDiscovery::new().await?;
-        let data_dir = config.storage_path.clone().unwrap_or_else(|| PathBuf::from("."));
+        let data_dir = config.storage_path.clone();
 
         let peer_store = PersistentPeerStorage::open(data_dir.clone()).await?;
 

--- a/dash-spv/tests/block_download_test.rs
+++ b/dash-spv/tests/block_download_test.rs
@@ -17,6 +17,7 @@ fn create_test_config() -> ClientConfig {
     ClientConfig::testnet()
         .without_masternodes()
         .with_validation_mode(dash_spv::types::ValidationMode::None)
+        .with_storage_path(TempDir::new().unwrap().path())
 }
 
 #[tokio::test]
@@ -139,9 +140,7 @@ async fn test_sync_manager_integration() {}
 #[tokio::test]
 async fn test_filter_match_and_download_workflow() {
     let config = create_test_config();
-    let _storage = DiskStorageManager::new(TempDir::new().unwrap().path().to_path_buf())
-        .await
-        .expect("Failed to create tmp storage");
+    let _storage = DiskStorageManager::new(&config).await.expect("Failed to create tmp storage");
     let received_heights = Arc::new(Mutex::new(HashSet::new()));
     let mut filter_sync: FilterSyncManager<DiskStorageManager, MockNetworkManager> =
         FilterSyncManager::new(&config, received_heights);

--- a/dash-spv/tests/chainlock_simple_test.rs
+++ b/dash-spv/tests/chainlock_simple_test.rs
@@ -27,7 +27,6 @@ async fn test_chainlock_validation_flow() {
 
     // Create temp directory for storage
     let temp_dir = TempDir::new().unwrap();
-    let storage_path = temp_dir.path().to_path_buf();
 
     // Create client config with masternodes enabled
     let network = Network::Dash;
@@ -37,7 +36,7 @@ async fn test_chainlock_validation_flow() {
         enable_filters: false,
         enable_masternodes,
         validation_mode: ValidationMode::Basic,
-        storage_path: Some(storage_path),
+        storage_path: temp_dir.path().to_path_buf(),
         peers: vec!["127.0.0.1:9999".parse().unwrap()], // Dummy peer to satisfy config
         ..Default::default()
     };
@@ -46,8 +45,7 @@ async fn test_chainlock_validation_flow() {
     let network_manager = PeerNetworkManager::new(&config).await.unwrap();
 
     // Create storage manager
-    let storage_manager =
-        DiskStorageManager::new(config.storage_path.clone().unwrap()).await.unwrap();
+    let storage_manager = DiskStorageManager::new(&config).await.unwrap();
 
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
@@ -78,7 +76,6 @@ async fn test_chainlock_manager_initialization() {
 
     // Create temp directory for storage
     let temp_dir = TempDir::new().unwrap();
-    let storage_path = temp_dir.path().to_path_buf();
 
     // Create client config
     let config = ClientConfig {
@@ -86,7 +83,7 @@ async fn test_chainlock_manager_initialization() {
         enable_filters: false,
         enable_masternodes: false,
         validation_mode: ValidationMode::Basic,
-        storage_path: Some(storage_path),
+        storage_path: temp_dir.path().to_path_buf(),
         peers: vec!["127.0.0.1:9999".parse().unwrap()], // Dummy peer to satisfy config
         ..Default::default()
     };
@@ -95,8 +92,7 @@ async fn test_chainlock_manager_initialization() {
     let network_manager = PeerNetworkManager::new(&config).await.unwrap();
 
     // Create storage manager
-    let storage_manager =
-        DiskStorageManager::new(config.storage_path.clone().unwrap()).await.unwrap();
+    let storage_manager = DiskStorageManager::new(&config).await.unwrap();
 
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));

--- a/dash-spv/tests/edge_case_filter_sync_test.rs
+++ b/dash-spv/tests/edge_case_filter_sync_test.rs
@@ -103,14 +103,12 @@ impl NetworkManager for MockNetworkManager {
 
 #[tokio::test]
 async fn test_filter_sync_at_tip_edge_case() {
-    let config = ClientConfig::new(Network::Dash);
-    let received_heights = Arc::new(Mutex::new(HashSet::new()));
-    let mut filter_sync: FilterSyncManager<DiskStorageManager, MockNetworkManager> =
-        FilterSyncManager::new(&config, received_heights);
+    let config = ClientConfig::new(Network::Dash).with_storage_path(TempDir::new().unwrap().path());
 
-    let mut storage = DiskStorageManager::new(TempDir::new().unwrap().path().to_path_buf())
-        .await
-        .expect("Failed to create tmp storage");
+    let received_heights = Arc::new(Mutex::new(HashSet::new()));
+    let mut filter_sync = FilterSyncManager::new(&config, received_heights);
+
+    let mut storage = DiskStorageManager::new(&config).await.expect("Failed to create tmp storage");
     let mut network = MockNetworkManager::new();
 
     // Set up storage with headers and filter headers at the same height (tip)
@@ -147,14 +145,12 @@ async fn test_filter_sync_at_tip_edge_case() {
 
 #[tokio::test]
 async fn test_no_invalid_getcfheaders_at_tip() {
-    let config = ClientConfig::new(Network::Dash);
-    let received_heights = Arc::new(Mutex::new(HashSet::new()));
-    let mut filter_sync: FilterSyncManager<DiskStorageManager, MockNetworkManager> =
-        FilterSyncManager::new(&config, received_heights);
+    let config = ClientConfig::new(Network::Dash).with_storage_path(TempDir::new().unwrap().path());
 
-    let mut storage = DiskStorageManager::new(TempDir::new().unwrap().path().to_path_buf())
-        .await
-        .expect("Failed to create tmp storage");
+    let received_heights = Arc::new(Mutex::new(HashSet::new()));
+    let mut filter_sync = FilterSyncManager::new(&config, received_heights);
+
+    let mut storage = DiskStorageManager::new(&config).await.expect("Failed to create tmp storage");
     let mut network = MockNetworkManager::new();
 
     // Create a scenario where we're one block behind

--- a/dash-spv/tests/filter_header_verification_test.rs
+++ b/dash-spv/tests/filter_header_verification_test.rs
@@ -169,9 +169,9 @@ async fn test_filter_header_verification_failure_reproduction() {
     println!("=== Testing Filter Header Chain Verification Failure ===");
 
     // Create storage and sync manager
-    let mut storage = DiskStorageManager::new(TempDir::new().unwrap().path().to_path_buf())
-        .await
-        .expect("Failed to create tmp storage");
+    let config = ClientConfig::new(Network::Dash).with_storage_path(TempDir::new().unwrap().path());
+
+    let mut storage = DiskStorageManager::new(&config).await.expect("Failed to create tmp storage");
     let mut network = MockNetworkManager::new();
 
     let config = ClientConfig::new(Network::Dash);
@@ -333,9 +333,9 @@ async fn test_overlapping_batches_from_different_peers() {
     // The system should handle this gracefully, but currently it crashes.
     // This test will FAIL until we implement the fix.
 
-    let mut storage = DiskStorageManager::new(TempDir::new().unwrap().path().to_path_buf())
-        .await
-        .expect("Failed to create tmp storage");
+    let config = ClientConfig::new(Network::Dash).with_storage_path(TempDir::new().unwrap().path());
+
+    let mut storage = DiskStorageManager::new(&config).await.expect("Failed to create tmp storage");
     let mut network = MockNetworkManager::new();
 
     let config = ClientConfig::new(Network::Dash);
@@ -509,12 +509,11 @@ async fn test_filter_header_verification_overlapping_batches() {
     // This test simulates what happens when we receive overlapping filter header batches
     // due to recovery/retry mechanisms or multiple peers
 
-    let mut storage = DiskStorageManager::new(TempDir::new().unwrap().path().to_path_buf())
-        .await
-        .expect("Failed to create tmp storage");
+    let config = ClientConfig::new(Network::Dash).with_storage_path(TempDir::new().unwrap().path());
+
+    let mut storage = DiskStorageManager::new(&config).await.expect("Failed to create tmp storage");
     let mut network = MockNetworkManager::new();
 
-    let config = ClientConfig::new(Network::Dash);
     let received_heights = Arc::new(Mutex::new(HashSet::new()));
     let mut filter_sync: FilterSyncManager<DiskStorageManager, MockNetworkManager> =
         FilterSyncManager::new(&config, received_heights);
@@ -607,12 +606,11 @@ async fn test_filter_header_verification_race_condition_simulation() {
     // This test simulates the race condition that might occur when multiple
     // filter header requests are in flight simultaneously
 
-    let mut storage = DiskStorageManager::new(TempDir::new().unwrap().path().to_path_buf())
-        .await
-        .expect("Failed to create tmp storage");
+    let config = ClientConfig::new(Network::Dash).with_storage_path(TempDir::new().unwrap().path());
+
+    let mut storage = DiskStorageManager::new(&config).await.expect("Failed to create tmp storage");
     let mut network = MockNetworkManager::new();
 
-    let config = ClientConfig::new(Network::Dash);
     let received_heights = Arc::new(Mutex::new(HashSet::new()));
     let mut filter_sync: FilterSyncManager<DiskStorageManager, MockNetworkManager> =
         FilterSyncManager::new(&config, received_heights);

--- a/dash-spv/tests/header_sync_test.rs
+++ b/dash-spv/tests/header_sync_test.rs
@@ -32,10 +32,7 @@ async fn test_header_sync_with_client_integration() {
         PeerNetworkManager::new(&config).await.expect("Failed to create network manager");
 
     // Create storage manager
-    let storage_manager =
-        DiskStorageManager::new(TempDir::new().expect("Failed to create tmp dir").path())
-            .await
-            .expect("Failed to create tmp storage");
+    let storage_manager = DiskStorageManager::new(&config).await.expect("Failed to create storage");
 
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
@@ -91,8 +88,8 @@ fn create_test_header_chain_from(start: usize, count: usize) -> Vec<BlockHeader>
 #[tokio::test]
 async fn test_prepare_sync(sync_base_height: u32, header_count: usize) {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
-    let mut storage =
-        DiskStorageManager::new(temp_dir.path()).await.expect("Failed to create storage");
+    let config = ClientConfig::regtest().with_storage_path(temp_dir.path());
+    let mut storage = DiskStorageManager::new(&config).await.expect("Failed to create storage");
 
     let headers = create_test_header_chain(header_count);
     let expected_tip_hash = headers.last().unwrap().block_hash();

--- a/dash-spv/tests/peer_test.rs
+++ b/dash-spv/tests/peer_test.rs
@@ -15,9 +15,11 @@ use dashcore::Network;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet_manager::wallet_manager::WalletManager;
 /// Create a test configuration with the given network
-fn create_test_config(network: Network, data_dir: Option<TempDir>) -> ClientConfig {
+fn create_test_config(network: Network) -> ClientConfig {
     let mut config = ClientConfig::new(network);
-    config.storage_path = data_dir.map(|d| d.path().to_path_buf());
+
+    config.storage_path = TempDir::new().unwrap().path().to_path_buf();
+
     config.validation_mode = ValidationMode::Basic;
     config.enable_filters = false;
     config.enable_masternodes = false;
@@ -31,15 +33,13 @@ fn create_test_config(network: Network, data_dir: Option<TempDir>) -> ClientConf
 async fn test_peer_connection() {
     let _ = env_logger::builder().is_test(true).try_init();
 
-    let temp_dir = TempDir::new().unwrap();
-    let temp_path = temp_dir.path().to_path_buf();
-    let config = create_test_config(Network::Testnet, Some(temp_dir));
+    let config = create_test_config(Network::Testnet);
 
     // Create network manager
     let network_manager = PeerNetworkManager::new(&config).await.unwrap();
 
     // Create storage manager
-    let storage_manager = DiskStorageManager::new(temp_path).await.unwrap();
+    let storage_manager = DiskStorageManager::new(&config).await.unwrap();
 
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
@@ -66,24 +66,23 @@ async fn test_peer_connection() {
 async fn test_peer_persistence() {
     let _ = env_logger::builder().is_test(true).try_init();
 
-    let temp_dir = TempDir::new().unwrap();
-    let temp_path = temp_dir.path().to_path_buf();
+    let config = create_test_config(Network::Testnet);
 
     // First run: connect and save peers
     {
-        let config = create_test_config(Network::Testnet, Some(temp_dir));
-
         // Create network manager
         let network_manager = PeerNetworkManager::new(&config).await.unwrap();
 
         // Create storage manager
-        let storage_manager = DiskStorageManager::new(temp_path.clone()).await.unwrap();
+        let storage_manager = DiskStorageManager::new(&config).await.unwrap();
 
         // Create wallet manager
         let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
         let mut client =
-            DashSpvClient::new(config, network_manager, storage_manager, wallet).await.unwrap();
+            DashSpvClient::new(config.clone(), network_manager, storage_manager, wallet)
+                .await
+                .unwrap();
 
         client.start().await.unwrap();
         time::sleep(Duration::from_secs(5)).await;
@@ -96,14 +95,11 @@ async fn test_peer_persistence() {
 
     // Second run: should load saved peers
     {
-        let mut config = create_test_config(Network::Testnet, None);
-        config.storage_path = Some(temp_path.clone());
-
         // Create network manager
         let network_manager = PeerNetworkManager::new(&config).await.unwrap();
 
         // Create storage manager - reuse same path
-        let storage_manager = DiskStorageManager::new(temp_path).await.unwrap();
+        let storage_manager = DiskStorageManager::new(&config).await.unwrap();
 
         // Create wallet manager
         let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
@@ -132,9 +128,7 @@ async fn test_peer_persistence() {
 async fn test_peer_disconnection() {
     let _ = env_logger::builder().is_test(true).try_init();
 
-    let temp_dir = TempDir::new().unwrap();
-    let temp_path = temp_dir.path().to_path_buf();
-    let mut config = create_test_config(Network::Regtest, Some(temp_dir));
+    let mut config = create_test_config(Network::Regtest);
 
     // Add manual test peers (would need actual regtest nodes running)
     config.peers = vec!["127.0.0.1:19899".parse().unwrap(), "127.0.0.1:19898".parse().unwrap()];
@@ -143,7 +137,7 @@ async fn test_peer_disconnection() {
     let network_manager = PeerNetworkManager::new(&config).await.unwrap();
 
     // Create storage manager
-    let storage_manager = DiskStorageManager::new(temp_path).await.unwrap();
+    let storage_manager = DiskStorageManager::new(&config).await.unwrap();
 
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
@@ -168,8 +162,7 @@ async fn test_max_peer_limit() {
 
     let _ = env_logger::builder().is_test(true).try_init();
 
-    let temp_dir = TempDir::new().unwrap();
-    let mut config = create_test_config(Network::Testnet, Some(temp_dir));
+    let mut config = create_test_config(Network::Testnet);
 
     // Add at least one peer to avoid "No peers specified" error
     config.peers = vec!["127.0.0.1:19999".parse().unwrap()];
@@ -179,9 +172,7 @@ async fn test_max_peer_limit() {
 
     // Create storage manager
     let storage_manager =
-        DiskStorageManager::new(TempDir::new().expect("Failed to create tmp dir").path())
-            .await
-            .expect("Failed to create tmp storage");
+        DiskStorageManager::new(&config).await.expect("Failed to create tmp storage");
 
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));

--- a/dash-spv/tests/wallet_integration_test.rs
+++ b/dash-spv/tests/wallet_integration_test.rs
@@ -15,20 +15,16 @@ use key_wallet_manager::wallet_manager::WalletManager;
 /// Create a test SPV client with memory storage for integration testing.
 async fn create_test_client(
 ) -> DashSpvClient<WalletManager<ManagedWalletInfo>, PeerNetworkManager, DiskStorageManager> {
-    let temp_dir = tempfile::TempDir::new().expect("Failed to create temporary directory");
     let config = ClientConfig::testnet()
         .without_filters()
-        .without_masternodes()
-        .with_storage_path(temp_dir.path().to_path_buf());
+        .with_storage_path(TempDir::new().unwrap().path())
+        .without_masternodes();
 
     // Create network manager
     let network_manager = PeerNetworkManager::new(&config).await.unwrap();
 
     // Create storage manager
-    let storage_manager =
-        DiskStorageManager::new(TempDir::new().expect("Failed to create tmp dir").path())
-            .await
-            .expect("Failed to create tmp storage");
+    let storage_manager = DiskStorageManager::new(&config).await.expect("Failed to create storage");
 
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));


### PR DESCRIPTION
 - storage_path field in Config has a default value and is no longer an Option, avoiding a lot of match statements
 - DiskStorageManager is built from the Config to ensure the storage_path field usage by removing  the constructor that allowed us to use a path. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Storage is now configured centrally via the client configuration builder; initialization uses the config rather than ad-hoc paths.
  * Storage path is a required field with a sensible default and is created automatically during validation.
  * Fluent builder methods (e.g., with_storage_path) simplify configuration chaining.

* **Tests**
  * Tests updated to use config-driven storage setup, aligning test initialization with the new configuration flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->