### PR TITLE
refactor: drop headers2 stats

### DIFF
--- a/dash-spv/src/sync/headers/manager.rs
+++ b/dash-spv/src/sync/headers/manager.rs
@@ -454,14 +454,6 @@ impl<S: StorageManager, N: NetworkManager> HeaderSyncManager<S, N> {
             }
         };
 
-        // Log compression statistics
-        let stats = self.headers2_state.get_stats();
-        tracing::info!(
-            "📊 Headers2 compression stats: {:.1}% bandwidth saved, {:.1}% compression ratio",
-            stats.bandwidth_savings,
-            stats.compression_ratio * 100.0
-        );
-
         let headers_count = headers.len();
 
         // Process decompressed headers through the normal flow

--- a/dash-spv/src/sync/headers2/mod.rs
+++ b/dash-spv/src/sync/headers2/mod.rs
@@ -2,4 +2,4 @@
 
 mod manager;
 
-pub use manager::{Headers2StateManager, Headers2Stats, ProcessError};
+pub use manager::{Headers2StateManager, ProcessError};

--- a/dash-spv/src/sync/mod.rs
+++ b/dash-spv/src/sync/mod.rs
@@ -44,7 +44,7 @@ pub mod transitions;
 // Re-exports
 pub use filters::FilterSyncManager;
 pub use headers::{HeaderSyncManager, ReorgConfig};
-pub use headers2::{Headers2StateManager, Headers2Stats, ProcessError};
+pub use headers2::{Headers2StateManager, ProcessError};
 pub use manager::SyncManager;
 pub use masternodes::MasternodeSyncManager;
 pub use phases::{PhaseTransition, SyncPhase};


### PR DESCRIPTION
I just don't think they are very useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed compression statistics tracking and related logging from header synchronization; public-facing statistics accessors and types were removed.
  * Adjusted public exports: statistics-related types were removed and transition management functionality was newly exposed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->