### PR TITLE
remove SPVClient::config_update method

### DIFF
--- a/dash-spv-ffi/FFI_API.md
+++ b/dash-spv-ffi/FFI_API.md
@@ -4,7 +4,7 @@ This document provides a comprehensive reference for all FFI (Foreign Function I
 
 **Auto-generated**: This documentation is automatically generated from the source code. Do not edit manually.
 
-**Total Functions**: 67
+**Total Functions**: 66
 
 ## Table of Contents
 
@@ -34,11 +34,10 @@ Functions: 4
 
 ### Configuration
 
-Functions: 25
+Functions: 24
 
 | Function | Description | Module |
 |----------|-------------|--------|
-| `dash_spv_ffi_client_update_config` | Update the running client's configuration | client |
 | `dash_spv_ffi_config_add_peer` | Adds a peer address to the configuration  Accepts socket addresses with or... | config |
 | `dash_spv_ffi_config_destroy` | Destroys an FFIClientConfig and frees its memory  # Safety - `config` must... | config |
 | `dash_spv_ffi_config_get_data_dir` | Gets the data directory path from the configuration  # Safety - `config`... | config |
@@ -227,22 +226,6 @@ Stop the SPV client.  # Safety - `client` must be a valid, non-null pointer to a
 ---
 
 ### Configuration - Detailed
-
-#### `dash_spv_ffi_client_update_config`
-
-```c
-dash_spv_ffi_client_update_config(client: *mut FFIDashSpvClient, config: *const FFIClientConfig,) -> i32
-```
-
-**Description:**
-Update the running client's configuration.  # Safety - `client` must be a valid pointer to an `FFIDashSpvClient`. - `config` must be a valid pointer to an `FFIClientConfig`. - The network in `config` must match the client's network; changing networks at runtime is not supported.
-
-**Safety:**
-- `client` must be a valid pointer to an `FFIDashSpvClient`. - `config` must be a valid pointer to an `FFIClientConfig`. - The network in `config` must match the client's network; changing networks at runtime is not supported.
-
-**Module:** `client`
-
----
 
 #### `dash_spv_ffi_config_add_peer`
 

--- a/dash-spv-ffi/include/dash_spv_ffi.h
+++ b/dash-spv-ffi/include/dash_spv_ffi.h
@@ -294,19 +294,6 @@ struct FFIArray dash_spv_ffi_checkpoints_between_heights(FFINetwork network,
  int32_t dash_spv_ffi_client_drain_events(struct FFIDashSpvClient *client) ;
 
 /**
- * Update the running client's configuration.
- *
- * # Safety
- * - `client` must be a valid pointer to an `FFIDashSpvClient`.
- * - `config` must be a valid pointer to an `FFIClientConfig`.
- * - The network in `config` must match the client's network; changing networks at runtime is not supported.
- */
-
-int32_t dash_spv_ffi_client_update_config(struct FFIDashSpvClient *client,
-                                          const struct FFIClientConfig *config)
-;
-
-/**
  * Start the SPV client.
  *
  * # Safety

--- a/dash-spv/src/client/core.rs
+++ b/dash-spv/src/client/core.rs
@@ -264,24 +264,6 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         Ok(())
     }
 
-    // ============ Configuration ============
-
-    /// Update the client configuration.
-    pub async fn update_config(&mut self, new_config: ClientConfig) -> Result<()> {
-        // Validate new configuration
-        new_config.validate().map_err(SpvError::Config)?;
-
-        // Ensure network hasn't changed
-        if new_config.network != self.config.network {
-            return Err(SpvError::Config("Cannot change network on running client".to_string()));
-        }
-
-        // Update configuration
-        self.config = new_config;
-
-        Ok(())
-    }
-
     // ============ Terminal UI ============
 
     /// Enable terminal UI for status display.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed runtime configuration update capability. Client configuration can no longer be modified after initialization. All configuration settings must be specified during client setup. Existing applications relying on dynamic configuration changes will require code adjustments to establish all settings before client startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->