### PR TITLE
chore: remove mempool tracking config mutation method

### DIFF
--- a/dash-spv-ffi/FFI_API.md
+++ b/dash-spv-ffi/FFI_API.md
@@ -4,7 +4,7 @@ This document provides a comprehensive reference for all FFI (Foreign Function I
 
 **Auto-generated**: This documentation is automatically generated from the source code. Do not edit manually.
 
-**Total Functions**: 67
+**Total Functions**: 66
 
 ## Table of Contents
 
@@ -13,7 +13,6 @@ This document provides a comprehensive reference for all FFI (Foreign Function I
 - [Synchronization](#synchronization)
 - [Address Monitoring](#address-monitoring)
 - [Transaction Management](#transaction-management)
-- [Mempool Operations](#mempool-operations)
 - [Platform Integration](#platform-integration)
 - [Event Callbacks](#event-callbacks)
 - [Error Handling](#error-handling)
@@ -94,14 +93,6 @@ Functions: 3
 | `dash_spv_ffi_client_broadcast_transaction` | Broadcasts a transaction to the Dash network via connected peers | broadcast |
 | `dash_spv_ffi_unconfirmed_transaction_destroy` | Destroys an FFIUnconfirmedTransaction and all its associated resources  #... | types |
 | `dash_spv_ffi_unconfirmed_transaction_destroy_raw_tx` | Destroys the raw transaction bytes allocated for an FFIUnconfirmedTransaction... | types |
-
-### Mempool Operations
-
-Functions: 1
-
-| Function | Description | Module |
-|----------|-------------|--------|
-| `dash_spv_ffi_client_enable_mempool_tracking` | Enable mempool tracking with a given strategy | client |
 
 ### Platform Integration
 
@@ -773,24 +764,6 @@ Destroys the raw transaction bytes allocated for an FFIUnconfirmedTransaction  #
 - `raw_tx` must be a valid pointer to memory allocated by the caller - `raw_tx_len` must be the correct length of the allocated memory - The pointer must not be used after this function is called - This function should only be called once per allocation
 
 **Module:** `types`
-
----
-
-### Mempool Operations - Detailed
-
-#### `dash_spv_ffi_client_enable_mempool_tracking`
-
-```c
-dash_spv_ffi_client_enable_mempool_tracking(client: *mut FFIDashSpvClient, strategy: FFIMempoolStrategy,) -> i32
-```
-
-**Description:**
-Enable mempool tracking with a given strategy.  # Safety - `client` must be a valid, non-null pointer.
-
-**Safety:**
-- `client` must be a valid, non-null pointer.
-
-**Module:** `client`
 
 ---
 

--- a/dash-spv-ffi/include/dash_spv_ffi.h
+++ b/dash-spv-ffi/include/dash_spv_ffi.h
@@ -29,16 +29,16 @@ typedef enum FFISyncStage {
   Failed = 9,
 } FFISyncStage;
 
-typedef enum FFIMempoolStrategy {
-  FetchAll = 0,
-  BloomFilter = 1,
-} FFIMempoolStrategy;
-
 typedef enum DashSpvValidationMode {
   None = 0,
   Basic = 1,
   Full = 2,
 } DashSpvValidationMode;
+
+typedef enum FFIMempoolStrategy {
+  FetchAll = 0,
+  BloomFilter = 1,
+} FFIMempoolStrategy;
 
 typedef struct FFIDashSpvClient FFIDashSpvClient;
 
@@ -480,17 +480,6 @@ int32_t dash_spv_ffi_client_set_event_callbacks(struct FFIDashSpvClient *client,
 
 int32_t dash_spv_ffi_client_rescan_blockchain(struct FFIDashSpvClient *client,
                                               uint32_t _from_height)
-;
-
-/**
- * Enable mempool tracking with a given strategy.
- *
- * # Safety
- * - `client` must be a valid, non-null pointer.
- */
-
-int32_t dash_spv_ffi_client_enable_mempool_tracking(struct FFIDashSpvClient *client,
-                                                    enum FFIMempoolStrategy strategy)
 ;
 
 /**

--- a/dash-spv/src/client/mempool.rs
+++ b/dash-spv/src/client/mempool.rs
@@ -15,33 +15,9 @@ use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use key_wallet_manager::wallet_interface::WalletInterface;
 
-use super::{config, DashSpvClient};
+use super::DashSpvClient;
 
 impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
-    /// Enable mempool tracking with the specified strategy.
-    pub async fn enable_mempool_tracking(
-        &mut self,
-        strategy: config::MempoolStrategy,
-    ) -> Result<()> {
-        // Update config
-        self.config.enable_mempool_tracking = true;
-        self.config.mempool_strategy = strategy;
-
-        // Initialize mempool filter if not already done
-        if self.mempool_filter.is_none() {
-            // TODO: Get monitored addresses from wallet
-            self.mempool_filter = Some(Arc::new(MempoolFilter::new(
-                self.config.mempool_strategy,
-                self.config.max_mempool_transactions,
-                self.mempool_state.clone(),
-                HashSet::new(), // Will be populated from wallet's monitored addresses
-                self.config.network,
-            )));
-        }
-
-        Ok(())
-    }
-
     /// Get mempool balance for an address.
     pub async fn get_mempool_balance(
         &self,

--- a/dash-spv/src/client/mod.rs
+++ b/dash-spv/src/client/mod.rs
@@ -123,15 +123,9 @@ mod tests {
 
         let test_address = Address::dummy(config.network, 0);
 
-        let mut client = DashSpvClient::new(config, network_manager, storage, wallet)
+        let client = DashSpvClient::new(config, network_manager, storage, wallet)
             .await
             .expect("client construction must succeed");
-
-        // Enable mempool tracking to initialize mempool_filter
-        client
-            .enable_mempool_tracking(crate::client::config::MempoolStrategy::BloomFilter)
-            .await
-            .expect("enable mempool tracking must succeed");
 
         // Create a transaction that sends 10 Dash to the test address
         let tx = Transaction {


### PR DESCRIPTION
Part of the config builder update. Since the config is gonna become immutable once is built to ensure is valid while it is alive this method must be removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed mempool tracking functionality from the API.

* **Documentation**
  * Updated API documentation to reflect removal of mempool operations. Total available functions reduced from 67 to 66.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->