### PR TITLE
fix: distinguish between new and existing transactions in wallet

### DIFF
--- a/dash-spv/src/sync/legacy/message_handlers.rs
+++ b/dash-spv/src/sync/legacy/message_handlers.rs
@@ -681,14 +681,17 @@ impl<S: StorageManager, N: NetworkManager, W: WalletInterface> SyncManager<S, N,
 
         drop(wallet);
 
-        if !result.relevant_txids.is_empty() {
+        let total_relevant = result.relevant_tx_count();
+        if total_relevant > 0 {
             tracing::info!(
-                "💰 Found {} relevant transactions in block {} at height {}",
-                result.relevant_txids.len(),
+                "Found {} relevant transactions ({} new, {} existing) in block {} at height {}",
+                total_relevant,
+                result.new_txids.len(),
+                result.existing_txids.len(),
                 block_hash,
                 block_height
             );
-            for txid in &result.relevant_txids {
+            for txid in result.relevant_txids() {
                 tracing::debug!("  - Transaction: {}", txid);
             }
         }

--- a/key-wallet-manager/src/test_utils/wallet.rs
+++ b/key-wallet-manager/src/test_utils/wallet.rs
@@ -45,9 +45,9 @@ impl WalletInterface for MockWallet {
         let mut processed = self.processed_blocks.lock().await;
         processed.push((block.block_hash(), height));
 
-        // Return txids of all transactions in block as "relevant"
         BlockProcessingResult {
-            relevant_txids: block.txdata.iter().map(|tx| tx.txid()).collect(),
+            new_txids: block.txdata.iter().map(|tx| tx.txid()).collect(),
+            existing_txids: Vec::new(),
             new_addresses: Vec::new(),
         }
     }

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -12,10 +12,24 @@ use dashcore::{Address, Block, Transaction, Txid};
 /// Result of processing a block through the wallet
 #[derive(Debug, Default, Clone)]
 pub struct BlockProcessingResult {
-    /// Transaction IDs that were relevant to the wallet
-    pub relevant_txids: Vec<Txid>,
+    /// Transaction IDs that were newly discovered
+    pub new_txids: Vec<Txid>,
+    /// Transaction IDs that were already in wallet history
+    pub existing_txids: Vec<Txid>,
     /// New addresses generated during gap limit maintenance
     pub new_addresses: Vec<Address>,
+}
+
+impl BlockProcessingResult {
+    /// Returns all relevant transaction IDs (new and existing)
+    pub fn relevant_txids(&self) -> impl Iterator<Item = &Txid> {
+        self.new_txids.iter().chain(self.existing_txids.iter())
+    }
+
+    /// Returns the count of all relevant transactions (new and existing)
+    pub fn relevant_tx_count(&self) -> usize {
+        self.new_txids.len() + self.existing_txids.len()
+    }
 }
 
 /// Trait for wallet implementations to receive SPV events

--- a/key-wallet-manager/src/wallet_manager/mod.rs
+++ b/key-wallet-manager/src/wallet_manager/mod.rs
@@ -54,6 +54,8 @@ pub struct AddressGenerationResult {
 pub struct CheckTransactionsResult {
     /// Wallets that found the transaction relevant
     pub affected_wallets: Vec<WalletId>,
+    /// Set to false if the transaction was already stored and is being re-processed (e.g., during rescan)
+    pub is_new_transaction: bool,
     /// New addresses generated during gap limit maintenance
     pub new_addresses: Vec<Address>,
 }
@@ -485,6 +487,10 @@ impl<T: WalletInfoInterface> WalletManager<T> {
                 // If the transaction is relevant
                 if check_result.is_relevant {
                     result.affected_wallets.push(wallet_id);
+                    // If any wallet reports this as new, mark result as new
+                    if check_result.is_new_transaction {
+                        result.is_new_transaction = true;
+                    }
                     // Note: balance update is already handled in check_transaction
                 }
 

--- a/key-wallet-manager/src/wallet_manager/process_block.rs
+++ b/key-wallet-manager/src/wallet_manager/process_block.rs
@@ -33,7 +33,11 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             let check_result = self.check_transaction_in_all_wallets(tx, context, true).await;
 
             if !check_result.affected_wallets.is_empty() {
-                result.relevant_txids.push(tx.txid());
+                if check_result.is_new_transaction {
+                    result.new_txids.push(tx.txid());
+                } else {
+                    result.existing_txids.push(tx.txid());
+                }
             }
 
             result.new_addresses.extend(check_result.new_addresses);

--- a/key-wallet/src/managed_account/managed_account_collection.rs
+++ b/key-wallet/src/managed_account/managed_account_collection.rs
@@ -12,6 +12,7 @@ use crate::gap_limit::{
 use crate::managed_account::address_pool::{AddressPool, AddressPoolType};
 use crate::managed_account::managed_account_type::ManagedAccountType;
 use crate::managed_account::ManagedAccount;
+use crate::transaction_checking::account_checker::AccountTypeMatch;
 use crate::{Account, AccountCollection};
 use crate::{KeySource, Network};
 use alloc::collections::BTreeMap;
@@ -674,6 +675,100 @@ impl ManagedAccountCollection {
         }
 
         None
+    }
+
+    /// Get an account reference by AccountTypeMatch
+    pub fn get_by_account_type_match(
+        &self,
+        account_type_match: &AccountTypeMatch,
+    ) -> Option<&ManagedAccount> {
+        match account_type_match {
+            AccountTypeMatch::StandardBIP44 {
+                account_index,
+                ..
+            } => self.standard_bip44_accounts.get(account_index),
+            AccountTypeMatch::StandardBIP32 {
+                account_index,
+                ..
+            } => self.standard_bip32_accounts.get(account_index),
+            AccountTypeMatch::CoinJoin {
+                account_index,
+                ..
+            } => self.coinjoin_accounts.get(account_index),
+            AccountTypeMatch::IdentityRegistration {
+                ..
+            } => self.identity_registration.as_ref(),
+            AccountTypeMatch::IdentityTopUp {
+                account_index,
+                ..
+            } => self.identity_topup.get(account_index),
+            AccountTypeMatch::IdentityTopUpNotBound {
+                ..
+            } => self.identity_topup_not_bound.as_ref(),
+            AccountTypeMatch::IdentityInvitation {
+                ..
+            } => self.identity_invitation.as_ref(),
+            AccountTypeMatch::ProviderVotingKeys {
+                ..
+            } => self.provider_voting_keys.as_ref(),
+            AccountTypeMatch::ProviderOwnerKeys {
+                ..
+            } => self.provider_owner_keys.as_ref(),
+            AccountTypeMatch::ProviderOperatorKeys {
+                ..
+            } => self.provider_operator_keys.as_ref(),
+            AccountTypeMatch::ProviderPlatformKeys {
+                ..
+            } => self.provider_platform_keys.as_ref(),
+            AccountTypeMatch::DashpayReceivingFunds {
+                account_index,
+                involved_addresses,
+            } => {
+                // Match by index and addresses since multiple accounts can share the same index
+                self.dashpay_receival_accounts.values().find(|account| {
+                    match &account.account_type {
+                        ManagedAccountType::DashpayReceivingFunds {
+                            index,
+                            addresses,
+                            ..
+                        } => {
+                            *index == *account_index
+                                && involved_addresses
+                                    .iter()
+                                    .any(|addr| addresses.contains_address(&addr.address))
+                        }
+                        _ => false,
+                    }
+                })
+            }
+            AccountTypeMatch::DashpayExternalAccount {
+                account_index,
+                involved_addresses,
+            } => {
+                // Match by index and addresses since multiple accounts can share the same index
+                self.dashpay_external_accounts.values().find(|account| {
+                    match &account.account_type {
+                        ManagedAccountType::DashpayExternalAccount {
+                            index,
+                            addresses,
+                            ..
+                        } => {
+                            *index == *account_index
+                                && involved_addresses
+                                    .iter()
+                                    .any(|addr| addresses.contains_address(&addr.address))
+                        }
+                        _ => false,
+                    }
+                })
+            }
+            AccountTypeMatch::PlatformPayment {
+                ..
+            } => {
+                // Platform Payment addresses are not used in Core chain transactions (DIP-17)
+                None
+            }
+        }
     }
 
     /// Remove an account from the collection

--- a/key-wallet/src/transaction_checking/account_checker.rs
+++ b/key-wallet/src/transaction_checking/account_checker.rs
@@ -30,6 +30,8 @@ pub enum AddressClassification {
 pub struct TransactionCheckResult {
     /// Whether the transaction belongs to any account
     pub is_relevant: bool,
+    /// Set to false if the transaction was already stored and is being re-processed (e.g., during rescan)
+    pub is_new_transaction: bool,
     /// Accounts that the transaction affects
     pub affected_accounts: Vec<AccountMatch>,
     /// Total value received by our accounts
@@ -282,6 +284,7 @@ impl ManagedAccountCollection {
     ) -> TransactionCheckResult {
         let mut result = TransactionCheckResult {
             is_relevant: false,
+            is_new_transaction: true,
             affected_accounts: Vec::new(),
             total_received: 0,
             total_sent: 0,

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -76,6 +76,20 @@ impl WalletTransactionChecker for ManagedWalletInfo {
 
         // Update state if requested and transaction is relevant
         if update_state && result.is_relevant {
+            // Check if this transaction already exists in any affected account.
+            // If so, mark it as not new.
+            let txid = tx.txid();
+            for account_match in &result.affected_accounts {
+                if let Some(account) =
+                    self.accounts.get_by_account_type_match(&account_match.account_type_match)
+                {
+                    if account.transactions.contains_key(&txid) {
+                        result.is_new_transaction = false;
+                        break;
+                    }
+                }
+            }
+
             for account_match in &result.affected_accounts {
                 // Find and update the specific account
                 use super::account_checker::AccountTypeMatch;
@@ -285,8 +299,10 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                 }
             }
 
-            // Update wallet metadata
-            self.metadata.total_transactions += 1;
+            // Update wallet metadata only for new transactions
+            if result.is_new_transaction {
+                self.metadata.total_transactions += 1;
+            }
 
             // Log the detected transaction
             let wallet_net: i64 = (result.total_received as i64) - (result.total_sent as i64);
@@ -829,5 +845,84 @@ mod tests {
         assert_eq!(stored_tx.height, None, "Mempool transaction should have no height");
         assert_eq!(stored_tx.block_hash, None, "Mempool transaction should have no block hash");
         assert_eq!(stored_tx.timestamp, 0, "Mempool transaction should have timestamp 0");
+    }
+
+    /// Test that rescanning a block marks transactions as existing
+    #[tokio::test]
+    async fn test_transaction_rescan_marks_as_existing() {
+        let network = Network::Testnet;
+        let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
+            .expect("Should create wallet");
+
+        let mut managed_wallet =
+            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
+
+        // Get a wallet address
+        let account =
+            wallet.accounts.standard_bip44_accounts.get(&0).expect("Should have BIP44 account");
+        let xpub = account.account_xpub;
+
+        let address = managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("Should have managed account")
+            .next_receive_address(Some(&xpub), true)
+            .expect("Should get address");
+
+        let tx = create_transaction_to_address(&address, 100_000);
+
+        let context = TransactionContext::InBlock {
+            height: 100,
+            block_hash: Some(BlockHash::from_slice(&[1u8; 32]).expect("Should create block hash")),
+            timestamp: Some(1234567890),
+        };
+
+        // First processing - should be marked as new
+        let result1 = managed_wallet.check_transaction(&tx, context, &mut wallet, true).await;
+
+        assert!(result1.is_relevant, "Transaction should be relevant");
+        assert!(
+            result1.is_new_transaction,
+            "First time seeing transaction should be marked as new"
+        );
+        assert_eq!(result1.total_received, 100_000);
+
+        // Verify transaction is stored
+        let managed_account =
+            managed_wallet.first_bip44_managed_account().expect("Should have managed account");
+        assert!(
+            managed_account.transactions.contains_key(&tx.txid()),
+            "Transaction should be stored"
+        );
+        let tx_count_before = managed_account.transactions.len();
+        let total_tx_count_before = managed_wallet.metadata.total_transactions;
+        assert_eq!(
+            total_tx_count_before, 1,
+            "total_transactions should be 1 after first processing"
+        );
+
+        // Second processing (simulating rescan) - should be marked as existing
+        let result2 = managed_wallet.check_transaction(&tx, context, &mut wallet, true).await;
+
+        assert!(result2.is_relevant, "Transaction should still be relevant on rescan");
+        assert!(
+            !result2.is_new_transaction,
+            "Re-processing transaction should be marked as existing, not new"
+        );
+        assert_eq!(result2.total_received, 100_000);
+
+        // Verify transaction count hasn't changed (no duplicates)
+        let managed_account =
+            managed_wallet.first_bip44_managed_account().expect("Should have managed account");
+        assert_eq!(
+            managed_account.transactions.len(),
+            tx_count_before,
+            "Transaction count should not increase on rescan"
+        );
+
+        // Verify total_transactions metadata hasn't changed on rescan
+        assert_eq!(
+            managed_wallet.metadata.total_transactions, total_tx_count_before,
+            "total_transactions should not increase on rescan"
+        );
     }
 }


### PR DESCRIPTION
`BlockProcessingResult` now distinguishes between new and existing transactions. When blocks are rescanned (e.g., after gap limit maintenance discovers new addresses), transactions that already exist in the wallet are categorized as existing rather than new.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced transaction processing to distinguish new transactions from previously-seen ones during rescans.
  * Added account retrieval by type matching capability.

* **Bug Fixes**
  * Wallet transaction history no longer grows incorrectly during rescans.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->