### PR TITLE
chore: drop incomplete dsq preference updates

### DIFF
--- a/dash-spv/src/client/message_handler.rs
+++ b/dash-spv/src/client/message_handler.rs
@@ -293,10 +293,6 @@ impl<'a, S: StorageManager, N: NetworkManager, W: WalletInterface> MessageHandle
             }
             NetworkMessage::SendDsq(wants_dsq) => {
                 tracing::info!("Received SendDsq message - peer wants DSQ messages: {}", wants_dsq);
-                // Store peer's DSQ preference
-                if let Err(e) = self.network.update_peer_dsq_preference(*wants_dsq).await {
-                    tracing::error!("Failed to update peer DSQ preference: {}", e);
-                }
 
                 // Send our own SendDsq(false) in response - we're an SPV client and don't want DSQ messages
                 tracing::info!("Sending SendDsq(false) to indicate we don't want DSQ messages");

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -1409,25 +1409,6 @@ impl NetworkManager for PeerNetworkManager {
         self.get_last_message_peer_id().await
     }
 
-    async fn update_peer_dsq_preference(&mut self, wants_dsq: bool) -> NetworkResult<()> {
-        // Get the last peer that sent us a message
-        let peer_id = self.get_last_message_peer_id().await;
-
-        if peer_id.0 == 0 {
-            return Err(NetworkError::ConnectionFailed("No peer to update".to_string()));
-        }
-
-        // Find the peer's address from the last message data
-        let last_msg_peer = self.last_message_peer.lock().await;
-        if let Some(addr) = &*last_msg_peer {
-            // For now, just log it as we don't have a mutable peer manager
-            // In a real implementation, we'd store this preference
-            tracing::info!("Updated peer {} DSQ preference to: {}", addr, wants_dsq);
-        }
-
-        Ok(())
-    }
-
     async fn mark_peer_sent_headers2(&mut self) -> NetworkResult<()> {
         // Get the last peer that sent us a message
         let last_msg_peer = self.last_message_peer.lock().await;

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -76,9 +76,6 @@ pub trait NetworkManager: Send + Sync + 'static {
         None
     }
 
-    /// Update the DSQ (CoinJoin queue) message preference for the current peer.
-    async fn update_peer_dsq_preference(&mut self, wants_dsq: bool) -> NetworkResult<()>;
-
     /// Mark that the current peer has sent us Headers2 messages.
     async fn mark_peer_sent_headers2(&mut self) -> NetworkResult<()> {
         Ok(()) // Default implementation

--- a/dash-spv/src/test_utils/network.rs
+++ b/dash-spv/src/test_utils/network.rs
@@ -179,9 +179,4 @@ impl NetworkManager for MockNetworkManager {
             crate::types::PeerId(0)
         }
     }
-
-    async fn update_peer_dsq_preference(&mut self, _wants_dsq: bool) -> NetworkResult<()> {
-        // Mock implementation - do nothing
-        Ok(())
-    }
 }

--- a/dash-spv/tests/edge_case_filter_sync_test.rs
+++ b/dash-spv/tests/edge_case_filter_sync_test.rs
@@ -101,10 +101,6 @@ impl NetworkManager for MockNetworkManager {
     async fn get_last_message_peer_id(&self) -> dash_spv::types::PeerId {
         dash_spv::types::PeerId(1)
     }
-
-    async fn update_peer_dsq_preference(&mut self, _wants_dsq: bool) -> NetworkResult<()> {
-        Ok(())
-    }
 }
 
 #[tokio::test]

--- a/dash-spv/tests/filter_header_verification_test.rs
+++ b/dash-spv/tests/filter_header_verification_test.rs
@@ -10,7 +10,7 @@
 
 use dash_spv::{
     client::ClientConfig,
-    error::{NetworkError, NetworkResult, SyncError},
+    error::{NetworkError, SyncError},
     network::NetworkManager,
     storage::{BlockHeaderStorage, DiskStorageManager, FilterHeaderStorage},
     sync::filters::FilterSyncManager,
@@ -96,10 +96,6 @@ impl NetworkManager for MockNetworkManager {
 
     async fn get_last_message_peer_id(&self) -> dash_spv::types::PeerId {
         dash_spv::types::PeerId(1)
-    }
-
-    async fn update_peer_dsq_preference(&mut self, _wants_dsq: bool) -> NetworkResult<()> {
-        Ok(())
     }
 }
 


### PR DESCRIPTION
We probably anyway don't want to relay dsq message but easy enough to bring it back if we want to follow through with an actual implementation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed peer DSQ preference update functionality from the network layer. The system no longer attempts to update or negotiate DSQ preferences with peers, eliminating associated logging and preference update pathways. DSQ message handling now uses a simplified approach. Test utilities and mock implementations have been updated accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->