### PR TITLE
refactor(dash-spv): PeerInfo safely removed

### DIFF
--- a/dash-spv-ffi/src/types.rs
+++ b/dash-spv-ffi/src/types.rs
@@ -1,6 +1,6 @@
 use dash_spv::client::config::MempoolStrategy;
 use dash_spv::types::{DetailedSyncProgress, MempoolRemovalReason, SyncStage};
-use dash_spv::{ChainState, PeerInfo, SpvStats, SyncProgress};
+use dash_spv::{ChainState, SpvStats, SyncProgress};
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_void};
 
@@ -231,39 +231,6 @@ impl From<SpvStats> for FFISpvStats {
             bytes_received: stats.bytes_received,
             bytes_sent: stats.bytes_sent,
             uptime: stats.uptime.as_secs(),
-        }
-    }
-}
-
-#[repr(C)]
-pub struct FFIPeerInfo {
-    pub address: FFIString,
-    pub connected: u64,
-    pub last_seen: u64,
-    pub version: u32,
-    pub services: u64,
-    pub user_agent: FFIString,
-    pub best_height: u32,
-}
-
-impl From<PeerInfo> for FFIPeerInfo {
-    fn from(info: PeerInfo) -> Self {
-        FFIPeerInfo {
-            address: FFIString::new(&info.address.to_string()),
-            connected: if info.connected {
-                1
-            } else {
-                0
-            },
-            last_seen: info
-                .last_seen
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or(std::time::Duration::from_secs(0))
-                .as_secs(),
-            version: info.version.unwrap_or(0),
-            services: info.services.unwrap_or(0),
-            user_agent: FFIString::new(info.user_agent.as_deref().unwrap_or("")),
-            best_height: info.best_height.unwrap_or(0),
         }
     }
 }

--- a/dash-spv-ffi/tests/unit/test_type_conversions.rs
+++ b/dash-spv-ffi/tests/unit/test_type_conversions.rs
@@ -227,38 +227,6 @@ mod tests {
     }
 
     #[test]
-    fn test_peer_info_all_none() {
-        let info = dash_spv::PeerInfo {
-            address: "127.0.0.1:9999".parse().unwrap(),
-            connected: false,
-            last_seen: std::time::SystemTime::now(),
-            version: None,
-            services: None,
-            user_agent: None,
-            best_height: None,
-            wants_dsq_messages: None,
-            has_sent_headers2: false,
-        };
-
-        let ffi_info = FFIPeerInfo::from(info);
-        assert_eq!(ffi_info.connected, 0);
-        assert_eq!(ffi_info.version, 0);
-        assert_eq!(ffi_info.services, 0);
-        assert_eq!(ffi_info.best_height, 0);
-
-        unsafe {
-            let addr_str = FFIString::from_ptr(ffi_info.address.ptr).unwrap();
-            assert_eq!(addr_str, "127.0.0.1:9999");
-
-            let agent_str = FFIString::from_ptr(ffi_info.user_agent.ptr).unwrap();
-            assert_eq!(agent_str, "");
-
-            dash_spv_ffi_string_destroy(ffi_info.address);
-            dash_spv_ffi_string_destroy(ffi_info.user_agent);
-        }
-    }
-
-    #[test]
     fn test_concurrent_ffi_string_creation() {
         use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;

--- a/dash-spv/src/client/queries.rs
+++ b/dash-spv/src/client/queries.rs
@@ -27,11 +27,6 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         self.network.peer_count()
     }
 
-    /// Get information about connected peers.
-    pub fn peer_info(&self) -> Vec<crate::types::PeerInfo> {
-        self.network.peer_info()
-    }
-
     /// Get the number of connected peers (async version).
     pub async fn get_peer_count(&self) -> usize {
         self.network.peer_count()

--- a/dash-spv/src/lib.rs
+++ b/dash-spv/src/lib.rs
@@ -79,7 +79,7 @@ pub use error::{
 };
 pub use logging::{init_console_logging, init_logging, LogFileConfig, LoggingConfig, LoggingGuard};
 pub use tracing::level_filters::LevelFilter;
-pub use types::{ChainState, FilterMatch, PeerInfo, SpvStats, SyncProgress, ValidationMode};
+pub use types::{ChainState, FilterMatch, SpvStats, SyncProgress, ValidationMode};
 
 // Re-export commonly used dashcore types
 pub use dashcore::{Address, BlockHash, Network, OutPoint, QuorumHash, ScriptBuf};

--- a/dash-spv/src/network/handshake.rs
+++ b/dash-spv/src/network/handshake.rs
@@ -239,7 +239,7 @@ impl HandshakeManager {
 
     /// Send version message.
     async fn send_version(&mut self, connection: &mut Peer) -> NetworkResult<()> {
-        let version_message = self.build_version_message(connection.peer_info().address)?;
+        let version_message = self.build_version_message(connection.address())?;
         connection.send_message(NetworkMessage::Version(version_message)).await?;
         tracing::debug!("Sent version message");
         Ok(())

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -47,9 +47,6 @@ pub trait NetworkManager: Send + Sync + 'static {
     /// Get the number of connected peers.
     fn peer_count(&self) -> usize;
 
-    /// Get peer information.
-    fn peer_info(&self) -> Vec<crate::types::PeerInfo>;
-
     /// Get the best block height reported by connected peers.
     async fn get_peer_best_height(&self) -> NetworkResult<Option<u32>>;
 

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -13,7 +13,7 @@ mod peer_tests {
         let peer = Peer::new(addr, timeout, Network::Dash);
 
         assert!(!peer.is_connected());
-        assert_eq!(peer.peer_info().address, addr);
+        assert_eq!(peer.address(), addr);
     }
 }
 

--- a/dash-spv/src/test_utils/network.rs
+++ b/dash-spv/src/test_utils/network.rs
@@ -10,7 +10,6 @@ use dashcore_hashes::Hash;
 
 use crate::error::{NetworkError, NetworkResult};
 use crate::network::NetworkManager;
-use crate::types::PeerInfo;
 
 /// Mock network manager for testing
 pub struct MockNetworkManager {
@@ -142,24 +141,6 @@ impl NetworkManager for MockNetworkManager {
             1
         } else {
             0
-        }
-    }
-
-    fn peer_info(&self) -> Vec<PeerInfo> {
-        if self.connected {
-            vec![PeerInfo {
-                address: "127.0.0.1:9999".parse().unwrap(),
-                connected: true,
-                last_seen: std::time::SystemTime::now(),
-                version: Some(70015),
-                services: Some(1),
-                user_agent: Some("/MockPeer:1.0.0/".to_string()),
-                best_height: Some(self.headers_chain.len() as u32),
-                wants_dsq_messages: None,
-                has_sent_headers2: false,
-            }]
-        } else {
-            vec![]
         }
     }
 

--- a/dash-spv/src/types.rs
+++ b/dash-spv/src/types.rs
@@ -402,55 +402,6 @@ pub enum ValidationMode {
     None,
 }
 
-/// Peer information.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PeerInfo {
-    /// Peer address.
-    pub address: std::net::SocketAddr,
-
-    /// Connection state.
-    pub connected: bool,
-
-    /// Last seen time.
-    pub last_seen: SystemTime,
-
-    /// Peer version.
-    pub version: Option<u32>,
-
-    /// Peer services.
-    pub services: Option<u64>,
-
-    /// User agent.
-    pub user_agent: Option<String>,
-
-    /// Best height reported by peer.
-    pub best_height: Option<u32>,
-
-    /// Whether this peer wants to receive DSQ (CoinJoin queue) messages.
-    pub wants_dsq_messages: Option<bool>,
-
-    /// Whether this peer has actually sent us Headers2 messages (not just supports it).
-    pub has_sent_headers2: bool,
-}
-
-impl PeerInfo {
-    /// Check if peer supports compact filters (BIP 157/158).
-    pub fn supports_compact_filters(&self) -> bool {
-        use dashcore::network::constants::ServiceFlags;
-
-        self.services
-            .map(|s| ServiceFlags::from(s).has(ServiceFlags::COMPACT_FILTERS))
-            .unwrap_or(false)
-    }
-
-    /// Check if peer supports headers2 compression (DIP-0025).
-    pub fn supports_headers2(&self) -> bool {
-        use dashcore::network::constants::{ServiceFlags, NODE_HEADERS_COMPRESSED};
-
-        self.services.map(|s| ServiceFlags::from(s).has(NODE_HEADERS_COMPRESSED)).unwrap_or(false)
-    }
-}
-
 /// Filter match result.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FilterMatch {

--- a/dash-spv/tests/edge_case_filter_sync_test.rs
+++ b/dash-spv/tests/edge_case_filter_sync_test.rs
@@ -83,10 +83,6 @@ impl NetworkManager for MockNetworkManager {
         1
     }
 
-    fn peer_info(&self) -> Vec<dash_spv::types::PeerInfo> {
-        Vec::new()
-    }
-
     async fn get_peer_best_height(&self) -> dash_spv::error::NetworkResult<Option<u32>> {
         Ok(Some(100))
     }

--- a/dash-spv/tests/filter_header_verification_test.rs
+++ b/dash-spv/tests/filter_header_verification_test.rs
@@ -14,7 +14,6 @@ use dash_spv::{
     network::NetworkManager,
     storage::{BlockHeaderStorage, DiskStorageManager, FilterHeaderStorage},
     sync::legacy::filters::FilterSyncManager,
-    types::PeerInfo,
 };
 use dashcore::{
     block::{Header as BlockHeader, Version},
@@ -73,10 +72,6 @@ impl NetworkManager for MockNetworkManager {
 
     fn peer_count(&self) -> usize {
         1
-    }
-
-    fn peer_info(&self) -> Vec<PeerInfo> {
-        vec![]
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/dash-spv/tests/handshake_test.rs
+++ b/dash-spv/tests/handshake_test.rs
@@ -29,10 +29,9 @@ async fn test_handshake_with_mainnet_peer() {
                 "Peer should be connected after successful handshake"
             );
 
-            // Get peer info
-            let peer_info = connection.peer_info();
-            assert_eq!(peer_info.address, peer_addr, "Peer address should match");
-            assert!(peer_info.connected, "Peer should be marked as connected");
+            // Check peer info
+            assert_eq!(connection.address(), peer_addr, "Peer address should match");
+            assert!(connection.is_connected(), "Peer should be marked as connected");
 
             // Clean disconnect
             connection.disconnect().await.expect("Failed to disconnect");
@@ -81,7 +80,6 @@ async fn test_network_manager_creation() {
 
     assert!(!network.is_connected(), "Should start disconnected");
     assert_eq!(network.peer_count(), 0, "Should start with no peers");
-    assert!(network.peer_info().is_empty(), "Should start with empty peer info");
 }
 
 #[tokio::test]

--- a/dash-spv/tests/peer_test.rs
+++ b/dash-spv/tests/peer_test.rs
@@ -57,15 +57,6 @@ async fn test_peer_connection() {
     let peer_count = client.peer_count();
     assert!(peer_count > 0, "Should have connected to at least one peer");
 
-    // Get peer info
-    let peer_info = client.peer_info();
-    assert_eq!(peer_info.len(), peer_count);
-
-    println!("Connected to {} peers:", peer_count);
-    for info in peer_info {
-        println!("  - {} (version: {:?})", info.address, info.version);
-    }
-
     // Stop the client
     client.stop().await.unwrap();
 }


### PR DESCRIPTION
For some reason we where using this big struct to access Peer data, this PR drops the struct and adds a couple of methods to Peer replacing the PeerInfo methods no longer available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed peer information query API from public interfaces
  * Added granular peer capability accessor methods for headers2 support, compact filter compatibility, best height lookup, and service flag checks
  * Updated internal logic to use new capability accessors instead of querying full peer information structures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->