### PR TITLE
chore: drop unused "peer sent headers2" tracking

### DIFF
--- a/dash-spv/src/client/message_handler.rs
+++ b/dash-spv/src/client/message_handler.rs
@@ -64,11 +64,6 @@ impl<'a, S: StorageManager, N: NetworkManager, W: WalletInterface> MessageHandle
                     headers2.headers.len()
                 );
 
-                // Track that this peer has sent us Headers2
-                if let Err(e) = self.network.mark_peer_sent_headers2().await {
-                    tracing::error!("Failed to mark peer sent headers2: {}", e);
-                }
-
                 // Move to sync manager without cloning
                 return self
                     .sync_manager

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -56,11 +56,6 @@ pub trait NetworkManager: Send + Sync + 'static {
         service_flags: dashcore::network::constants::ServiceFlags,
     ) -> bool;
 
-    /// Check if any connected peer supports headers2 compression.
-    async fn has_headers2_peer(&self) -> bool {
-        self.has_peer_with_service(dashcore::network::constants::NODE_HEADERS_COMPRESSED).await
-    }
-
     /// Get the peer ID of the last peer that sent us a message.
     /// Returns PeerId(0) if no message has been received yet.
     async fn get_last_message_peer_id(&self) -> crate::types::PeerId {
@@ -71,16 +66,6 @@ pub trait NetworkManager: Send + Sync + 'static {
     /// Default implementation returns None; implementations with peer tracking can override.
     async fn get_last_message_peer_addr(&self) -> Option<std::net::SocketAddr> {
         None
-    }
-
-    /// Mark that the current peer has sent us Headers2 messages.
-    async fn mark_peer_sent_headers2(&mut self) -> NetworkResult<()> {
-        Ok(()) // Default implementation
-    }
-
-    /// Check if the current peer has sent us Headers2 messages.
-    async fn peer_has_sent_headers2(&self) -> bool {
-        false // Default implementation
     }
 
     /// Request QRInfo from the network.


### PR DESCRIPTION
It's not used and we also just don't need it imo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified peer message handling by removing internal tracking mechanisms and associated methods, streamlining the network architecture without affecting external functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->