### PR TITLE
chore(dash-spv): unified all mock networks into one

### DIFF
--- a/dash-spv/src/test_utils/network.rs
+++ b/dash-spv/src/test_utils/network.rs
@@ -20,6 +20,7 @@ pub struct MockNetworkManager {
     connected_peer: SocketAddr,
     headers_chain: Vec<BlockHeader>,
     message_dispatcher: MessageDispatcher,
+    sent_messages: Vec<NetworkMessage>,
 }
 
 impl MockNetworkManager {
@@ -30,6 +31,7 @@ impl MockNetworkManager {
             connected_peer: SocketAddr::new(std::net::Ipv4Addr::LOCALHOST.into(), 9999),
             headers_chain: Vec::new(),
             message_dispatcher: MessageDispatcher::default(),
+            sent_messages: Vec::new(),
         }
     }
 
@@ -87,6 +89,10 @@ impl MockNetworkManager {
             Vec::new()
         }
     }
+
+    pub fn sent_messages(&self) -> &Vec<NetworkMessage> {
+        &self.sent_messages
+    }
 }
 
 impl Default for MockNetworkManager {
@@ -128,6 +134,8 @@ impl NetworkManager for MockNetworkManager {
                 self.message_dispatcher.dispatch(&message);
             }
         }
+
+        self.sent_messages.push(message);
 
         Ok(())
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tracking of outbound network messages in the shared test network mock with a new sent_messages accessor.
  * Replaced duplicated in-file mocks with a consolidated shared MockNetworkManager across tests.
  * Updated tests to use the synchronous message inspection API instead of async message retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->