### PR TITLE
feat: include module names in the log output

### DIFF
--- a/dash-spv/src/logging.rs
+++ b/dash-spv/src/logging.rs
@@ -128,7 +128,7 @@ pub fn init_logging(config: LoggingConfig) -> LoggingResult<LoggingGuard> {
 
     // Set up console layer if requested
     let console_layer =
-        config.console.then(|| fmt::layer().with_target(false).with_thread_ids(false));
+        config.console.then(|| fmt::layer().with_target(true).with_thread_ids(false));
 
     // Combine layers and initialize
     tracing_subscriber::registry()


### PR DESCRIPTION
Enable module path (target) in log output to allow filtering by module.

before:
```bash
2026-01-29T01:30:02.487715+0100 INFO  Starting sync...
2026-01-29T01:30:02.487715+0100 DEBUG Processing block 12345
```
now:
```bash
2026-01-29T01:30:02.487715+0100 INFO  dash_spv::sync::manager Starting sync...
2026-01-29T01:30:02.487715+0100 DEBUG dash_spv::storage::block_storage Processing block 12345
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Console logs now display target names alongside messages, providing improved visibility of logging context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->