### PR TITLE
refactor: move `get_peer_best_height` into `PeerPool`

### DIFF
--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -219,13 +219,8 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
                         storage.get_tip_height().await.unwrap_or(0)
                     };
                     let current_height = current_tip_height;
-                    let peer_best = self
-                        .network
-                        .get_peer_best_height()
-                        .await
-                        .ok()
-                        .flatten()
-                        .unwrap_or(current_height);
+                    let peer_best =
+                        self.network.get_peer_best_height().await.unwrap_or(current_height);
 
                     // Calculate headers downloaded this second
                     if current_tip_height > last_height {
@@ -298,13 +293,8 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
 
                 {
                     // Build and emit a fresh DetailedSyncProgress snapshot reflecting current filter progress
-                    let peer_best = self
-                        .network
-                        .get_peer_best_height()
-                        .await
-                        .ok()
-                        .flatten()
-                        .unwrap_or(abs_header_height);
+                    let peer_best =
+                        self.network.get_peer_best_height().await.unwrap_or(abs_header_height);
 
                     let phase_snapshot = self.sync_manager.current_phase().clone();
                     let status_display = self.create_status_display().await;

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -17,6 +17,7 @@ mod tests;
 use crate::error::NetworkResult;
 use async_trait::async_trait;
 use dashcore::network::message::NetworkMessage;
+use dashcore::prelude::CoreBlockHeight;
 use dashcore::BlockHash;
 pub use handshake::{HandshakeManager, HandshakeState};
 pub use manager::PeerNetworkManager;
@@ -51,7 +52,7 @@ pub trait NetworkManager: Send + Sync + 'static {
     fn peer_count(&self) -> usize;
 
     /// Get the best block height reported by connected peers.
-    async fn get_peer_best_height(&self) -> NetworkResult<Option<u32>>;
+    async fn get_peer_best_height(&self) -> Option<CoreBlockHeight>;
 
     /// Check if any connected peer supports a specific service.
     async fn has_peer_with_service(

--- a/dash-spv/src/network/peer.rs
+++ b/dash-spv/src/network/peer.rs
@@ -125,6 +125,10 @@ impl Peer {
         })
     }
 
+    pub fn version(&self) -> Option<u32> {
+        self.version
+    }
+
     pub fn best_height(&self) -> Option<u32> {
         self.best_height
     }

--- a/dash-spv/src/test_utils/network.rs
+++ b/dash-spv/src/test_utils/network.rs
@@ -1,6 +1,7 @@
 use crate::error::{NetworkError, NetworkResult};
 use crate::network::{Message, MessageDispatcher, MessageType, NetworkManager};
 use async_trait::async_trait;
+use dashcore::prelude::CoreBlockHeight;
 use dashcore::{
     block::Header as BlockHeader, network::constants::ServiceFlags,
     network::message::NetworkMessage, network::message_blockdata::GetHeadersMessage, BlockHash,
@@ -19,6 +20,7 @@ pub struct MockNetworkManager {
     connected: bool,
     connected_peer: SocketAddr,
     headers_chain: Vec<BlockHeader>,
+    peer_best_height: Option<u32>,
     message_dispatcher: MessageDispatcher,
     sent_messages: Vec<NetworkMessage>,
 }
@@ -30,6 +32,7 @@ impl MockNetworkManager {
             connected: true,
             connected_peer: SocketAddr::new(std::net::Ipv4Addr::LOCALHOST.into(), 9999),
             headers_chain: Vec::new(),
+            peer_best_height: None,
             message_dispatcher: MessageDispatcher::default(),
             sent_messages: Vec::new(),
         }
@@ -152,8 +155,8 @@ impl NetworkManager for MockNetworkManager {
         }
     }
 
-    async fn get_peer_best_height(&self) -> NetworkResult<Option<u32>> {
-        Ok(Some(self.headers_chain.len() as u32))
+    async fn get_peer_best_height(&self) -> Option<CoreBlockHeight> {
+        self.peer_best_height
     }
 
     async fn has_peer_with_service(&self, _service_flags: ServiceFlags) -> bool {


### PR DESCRIPTION
Move the logic into `PeerPool`, just makes more sense imo. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified peer best-height handling and moved aggregation responsibility to the pool.

* **New Features**
  * Added a method to compute the maximum height across connected peers.
  * Exposed a public accessor for peer version information.

* **Tests**
  * Updated mock network manager to align with the new peer-height retrieval behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->