### PR TITLE
feat: add synced height to the wallet interface

### DIFF
--- a/dash-spv/src/sync/legacy/message_handlers.rs
+++ b/dash-spv/src/sync/legacy/message_handlers.rs
@@ -513,6 +513,8 @@ impl<S: StorageManager, N: NetworkManager, W: WalletInterface> SyncManager<S, N,
             .await
             .map_err(|e| SyncError::Storage(format!("Failed to store filter: {}", e)))?;
 
+        self.wallet.write().await.update_synced_height(height);
+
         let key = FilterMatchKey::new(height, cfilter.block_hash);
         let input = HashMap::from([(key, BlockFilter::new(&cfilter.filter))]);
         let addresses = self.wallet.read().await.monitored_addresses();

--- a/dash-spv/src/sync/legacy/post_sync.rs
+++ b/dash-spv/src/sync/legacy/post_sync.rs
@@ -451,6 +451,8 @@ impl<S: StorageManager, N: NetworkManager, W: WalletInterface> SyncManager<S, N,
             .await
             .map_err(|e| SyncError::Storage(format!("Failed to store filter: {}", e)))?;
 
+        self.wallet.write().await.update_synced_height(height);
+
         // TODO: Check filter against wallet instead of watch items
         // This will be integrated with wallet's check_compact_filter method
         tracing::debug!("Filter checking disabled until wallet integration is complete");

--- a/key-wallet-ffi/src/wallet_manager.rs
+++ b/key-wallet-ffi/src/wallet_manager.rs
@@ -831,7 +831,7 @@ pub unsafe extern "C" fn wallet_manager_current_height(
     // Get current height from network state if it exists
     let height = manager_ref.runtime.block_on(async {
         let manager_guard = manager_ref.manager.read().await;
-        manager_guard.current_height()
+        manager_guard.synced_height()
     });
 
     FFIError::set_success(error);

--- a/key-wallet-ffi/src/wallet_manager_tests.rs
+++ b/key-wallet-ffi/src/wallet_manager_tests.rs
@@ -5,6 +5,7 @@
 mod tests {
     use crate::error::{FFIError, FFIErrorCode};
     use crate::{wallet, wallet_manager, FFINetwork};
+    use key_wallet_manager::wallet_interface::WalletInterface;
     use std::ffi::{CStr, CString};
     use std::ptr;
     use std::slice;
@@ -441,7 +442,7 @@ mod tests {
     }
 
     #[test]
-    fn test_wallet_manager_current_height() {
+    fn test_wallet_manager_synced_height() {
         let mut error = FFIError::success();
         let error = &mut error as *mut FFIError;
 
@@ -458,7 +459,7 @@ mod tests {
             let manager_ref = &*manager;
             manager_ref.runtime.block_on(async {
                 let mut manager_guard = manager_ref.manager.write().await;
-                manager_guard.update_height(new_height);
+                manager_guard.update_synced_height(new_height);
             });
         }
 

--- a/key-wallet-manager/examples/wallet_creation.rs
+++ b/key-wallet-manager/examples/wallet_creation.rs
@@ -10,6 +10,7 @@ use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::wallet::managed_wallet_info::transaction_building::AccountTypePreference;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet::{AccountType, Network};
+use key_wallet_manager::wallet_interface::WalletInterface;
 use key_wallet_manager::wallet_manager::WalletManager;
 
 fn main() {
@@ -141,11 +142,11 @@ fn main() {
     // Example 7: Block height tracking
     println!("\n7. Block height tracking...");
 
-    println!("   Current height (Testnet): {}", manager.current_height());
+    println!("   Current height (Testnet): {:?}", manager.synced_height());
 
     // Update height
-    manager.update_height(850_000);
-    println!("   Updated height to: {}", manager.current_height());
+    manager.update_synced_height(850_000);
+    println!("   Updated height to: {:?}", manager.synced_height());
 
     println!("\n=== Summary ===");
     println!("Total wallets created: {}", manager.wallet_count());

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -69,6 +69,12 @@ pub trait WalletInterface: Send + Sync + 'static {
         0
     }
 
+    /// Return the last fully processed height of the wallet.
+    fn synced_height(&self) -> CoreBlockHeight;
+
+    /// Update the wallet's synced height. This also triggers balance updates.
+    fn update_synced_height(&mut self, height: CoreBlockHeight);
+
     /// Provide a human-readable description of the wallet implementation.
     ///
     /// Implementations are encouraged to include high-level state such as the

--- a/key-wallet-manager/tests/integration_test.rs
+++ b/key-wallet-manager/tests/integration_test.rs
@@ -8,6 +8,7 @@ use key_wallet::wallet::managed_wallet_info::transaction_building::AccountTypePr
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet::{mnemonic::Language, Mnemonic, Network};
+use key_wallet_manager::wallet_interface::WalletInterface;
 use key_wallet_manager::wallet_manager::{WalletError, WalletManager};
 
 #[test]
@@ -16,7 +17,7 @@ fn test_wallet_manager_creation() {
     let manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
     // WalletManager::new returns Self, not Result
-    assert_eq!(manager.current_height(), 0);
+    assert_eq!(manager.synced_height(), 0);
     assert_eq!(manager.wallet_count(), 0); // No wallets created yet
 }
 
@@ -157,11 +158,11 @@ fn test_block_height_tracking() {
     let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
 
     // Initial state
-    assert_eq!(manager.current_height(), 0);
+    assert_eq!(manager.synced_height(), 0);
 
     // Set height before adding wallets
-    manager.update_height(1000);
-    assert_eq!(manager.current_height(), 1000);
+    manager.update_synced_height(1000);
+    assert_eq!(manager.synced_height(), 1000);
 
     let mnemonic1 = Mnemonic::generate(12, Language::English).unwrap();
     let wallet_id1 = manager
@@ -191,8 +192,8 @@ fn test_block_height_tracking() {
     }
 
     // Update height - should propagate to all wallets
-    manager.update_height(12345);
-    assert_eq!(manager.current_height(), 12345);
+    manager.update_synced_height(12345);
+    assert_eq!(manager.synced_height(), 12345);
 
     // Verify all wallets got updated
     let wallet_info1 = manager.get_wallet_info(&wallet_id1).unwrap();
@@ -201,8 +202,8 @@ fn test_block_height_tracking() {
     assert_eq!(wallet_info2.synced_height(), 12345);
 
     // Update again - verify subsequent updates work
-    manager.update_height(20000);
-    assert_eq!(manager.current_height(), 20000);
+    manager.update_synced_height(20000);
+    assert_eq!(manager.synced_height(), 20000);
 
     for wallet_info in manager.get_all_wallet_infos().values() {
         assert_eq!(wallet_info.synced_height(), 20000);
@@ -222,7 +223,7 @@ fn test_block_height_tracking() {
     assert_eq!(wallet_info2.synced_height(), 25000);
 
     // Manager update_height still syncs all wallets
-    manager.update_height(40000);
+    manager.update_synced_height(40000);
     let wallet_info1 = manager.get_wallet_info(&wallet_id1).unwrap();
     let wallet_info2 = manager.get_wallet_info(&wallet_id2).unwrap();
     assert_eq!(wallet_info1.synced_height(), 40000);

--- a/key-wallet-manager/tests/spv_integration_tests.rs
+++ b/key-wallet-manager/tests/spv_integration_tests.rs
@@ -69,7 +69,7 @@ async fn test_block_processing_result_empty() {
 }
 
 fn assert_wallet_heights(manager: &WalletManager<ManagedWalletInfo>, expected_height: u32) {
-    assert_eq!(manager.current_height(), expected_height, "height should be {}", expected_height);
+    assert_eq!(manager.synced_height(), expected_height, "height should be {}", expected_height);
     for wallet_info in manager.get_all_wallet_infos().values() {
         assert_eq!(
             wallet_info.synced_height(),

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -61,9 +61,6 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Update last synced timestamp
     fn update_last_synced(&mut self, timestamp: u64);
 
-    /// Get the synced height
-    fn synced_height(&self) -> CoreBlockHeight;
-
     /// Get all monitored addresses
     fn monitored_addresses(&self) -> Vec<DashAddress>;
 
@@ -102,6 +99,9 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
         fee_level: FeeLevel,
         current_block_height: u32,
     ) -> Result<Transaction, TransactionError>;
+
+    /// Return the last fully processed height of the wallet.
+    fn synced_height(&self) -> CoreBlockHeight;
 
     /// Update chain state and process any matured transactions
     /// This should be called when the chain tip advances to a new height


### PR DESCRIPTION
Add the height management to the interface to make it more accessible and rename it in the same go to `synced_height` since it's more to the point. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated wallet synchronization height tracking to use synced height for better state management consistency.

* **Tests**
  * Updated integration and unit tests to reflect synchronized height tracking changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->