### PR TITLE
feat: introduce `PersistentBlockStorage`

### DIFF
--- a/dash-spv/src/storage/blocks.rs
+++ b/dash-spv/src/storage/blocks.rs
@@ -1,0 +1,162 @@
+//! Block storage for persisting full blocks that contain wallet-relevant transactions.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use crate::error::StorageResult;
+use crate::storage::segments::{Persistable, SegmentCache};
+use crate::storage::PersistentStorage;
+use crate::types::HashedBlock;
+use async_trait::async_trait;
+use dashcore::prelude::CoreBlockHeight;
+use tokio::sync::RwLock;
+
+/// Trait for block storage operations.
+#[async_trait]
+pub trait BlockStorage: Send + Sync + 'static {
+    /// Store a block at a specific height.
+    async fn store_block(
+        &mut self,
+        height: CoreBlockHeight,
+        block: HashedBlock,
+    ) -> StorageResult<()>;
+
+    /// Load a single block by height.
+    async fn load_block(&self, height: CoreBlockHeight) -> StorageResult<Option<HashedBlock>>;
+}
+
+/// Persistent storage for full blocks using segmented files.
+pub struct PersistentBlockStorage {
+    /// Block storage segments.
+    blocks: RwLock<SegmentCache<HashedBlock>>,
+    /// Set of available block heights used for fast lookups and to bypass sentinel loading and gap
+    /// detection asserts (in debug builds) in the underlying segment implementation.
+    available_heights: HashSet<CoreBlockHeight>,
+}
+
+impl PersistentBlockStorage {
+    const FOLDER_NAME: &str = "blocks";
+}
+
+#[async_trait]
+impl PersistentStorage for PersistentBlockStorage {
+    async fn open(storage_path: impl Into<PathBuf> + Send) -> StorageResult<Self> {
+        let storage_path = storage_path.into();
+        let blocks_folder = storage_path.join(Self::FOLDER_NAME);
+
+        tracing::debug!("Opening PersistentBlockStorage from {:?}", blocks_folder);
+
+        let mut blocks: SegmentCache<HashedBlock> =
+            SegmentCache::load_or_new(&blocks_folder).await?;
+
+        let mut available_heights = HashSet::new();
+
+        if let (Some(start), Some(end)) = (blocks.start_height(), blocks.tip_height()) {
+            let hashed_blocks = blocks.get_items(start..end + 1).await?;
+            let sentinel = HashedBlock::sentinel();
+            for (i, hashed_block) in hashed_blocks.iter().enumerate() {
+                if hashed_block != &sentinel {
+                    available_heights.insert(start + i as CoreBlockHeight);
+                }
+            }
+        }
+
+        Ok(Self {
+            blocks: RwLock::new(blocks),
+            available_heights,
+        })
+    }
+
+    async fn persist(&mut self, storage_path: impl Into<PathBuf> + Send) -> StorageResult<()> {
+        let blocks_folder = storage_path.into().join(Self::FOLDER_NAME);
+        tokio::fs::create_dir_all(&blocks_folder).await?;
+        self.blocks.write().await.persist(&blocks_folder).await;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl BlockStorage for PersistentBlockStorage {
+    async fn store_block(&mut self, height: u32, hashed_block: HashedBlock) -> StorageResult<()> {
+        self.available_heights.insert(height);
+        self.blocks.write().await.store_items_at_height(&[hashed_block], height).await
+    }
+
+    async fn load_block(&self, height: u32) -> StorageResult<Option<HashedBlock>> {
+        // This early return avoids unnecessary disk lookups and bypasses sentinel loading and gap
+        // detection asserts (in debug builds) in the underlying segment implementation.
+        if !self.available_heights.contains(&height) {
+            return Ok(None);
+        }
+        Ok(self.blocks.write().await.get_items(height..height + 1).await?.first().cloned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_store_and_load_block() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut storage = PersistentBlockStorage::open(temp_dir.path()).await.unwrap();
+
+        let hashed_block = HashedBlock::dummy(100, vec![]);
+        storage.store_block(100, hashed_block.clone()).await.unwrap();
+
+        let loaded = storage.load_block(100).await.unwrap();
+        assert_eq!(loaded, Some(hashed_block));
+    }
+
+    #[tokio::test]
+    async fn test_persistence_across_reopen() {
+        let temp_dir = TempDir::new().unwrap();
+        let hashed_block = HashedBlock::dummy(100, vec![]);
+
+        {
+            let mut storage = PersistentBlockStorage::open(temp_dir.path()).await.unwrap();
+            storage.store_block(100, hashed_block.clone()).await.unwrap();
+            storage.persist(temp_dir.path()).await.unwrap();
+        }
+
+        {
+            let storage = PersistentBlockStorage::open(temp_dir.path()).await.unwrap();
+            let loaded = storage.load_block(100).await.unwrap();
+            assert_eq!(loaded, Some(hashed_block));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_nonexistent_block() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = PersistentBlockStorage::open(temp_dir.path()).await.unwrap();
+
+        let loaded = storage.load_block(999).await.unwrap();
+        assert!(loaded.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_returns_none_for_gaps() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut storage = PersistentBlockStorage::open(temp_dir.path()).await.unwrap();
+
+        // Store blocks at non-contiguous height
+        let hashed_block_1 = HashedBlock::dummy(100, vec![]);
+        let hashed_block_2 = HashedBlock::dummy(200, vec![]);
+
+        storage.store_block(100, hashed_block_1.clone()).await.unwrap();
+        storage.store_block(200, hashed_block_2.clone()).await.unwrap();
+
+        // Stored blocks should load correctly
+        assert_eq!(storage.load_block(100).await.unwrap(), Some(hashed_block_1));
+        assert_eq!(storage.load_block(200).await.unwrap(), Some(hashed_block_2));
+
+        // Height in between (gap) should return None, not a sentinel
+        assert_eq!(storage.load_block(150).await.unwrap(), None);
+
+        // Heights outside range should also return None
+        assert_eq!(storage.load_block(50).await.unwrap(), None);
+        assert_eq!(storage.load_block(250).await.unwrap(), None);
+    }
+}

--- a/dash-spv/src/storage/segments.rs
+++ b/dash-spv/src/storage/segments.rs
@@ -13,12 +13,15 @@ use dashcore::{
     block::{Header as BlockHeader, Version},
     consensus::{encode, Decodable, Encodable},
     hash_types::FilterHeader,
-    BlockHash, CompactTarget,
+    Block, BlockHash, CompactTarget,
 };
 use dashcore_hashes::Hash;
 
 use crate::{
-    error::StorageResult, storage::io::atomic_write, types::HashedBlockHeader, StorageError,
+    error::StorageResult,
+    storage::io::atomic_write,
+    types::{HashedBlock, HashedBlockHeader},
+    StorageError,
 };
 
 pub trait Persistable: Sized + Encodable + Decodable + PartialEq + Clone {
@@ -56,6 +59,16 @@ impl Persistable for HashedBlockHeader {
 impl Persistable for FilterHeader {
     fn sentinel() -> Self {
         FilterHeader::from_byte_array([0u8; 32])
+    }
+}
+
+impl Persistable for HashedBlock {
+    fn sentinel() -> Self {
+        let block = Block {
+            header: *HashedBlockHeader::sentinel().header(),
+            txdata: Vec::new(),
+        };
+        Self::from(block)
     }
 }
 

--- a/dash-spv/src/sync/legacy/message_handlers.rs
+++ b/dash-spv/src/sync/legacy/message_handlers.rs
@@ -12,6 +12,7 @@ use super::phases::SyncPhase;
 use crate::error::{SyncError, SyncResult};
 use crate::network::{Message, NetworkManager};
 use crate::storage::StorageManager;
+use crate::types::HashedBlock;
 use key_wallet_manager::wallet_interface::WalletInterface;
 use key_wallet_manager::wallet_manager::{check_compact_filters_for_addresses, FilterMatchKey};
 
@@ -646,6 +647,11 @@ impl<S: StorageManager, N: NetworkManager, W: WalletInterface> SyncManager<S, N,
             .unwrap_or(0);
 
         let result = wallet.process_block(block, block_height).await;
+
+        storage
+            .store_block(block_height, HashedBlock::from(block))
+            .await
+            .map_err(|e| SyncError::Storage(e.to_string()))?;
 
         drop(wallet);
 

--- a/dash-spv/src/test_utils/mod.rs
+++ b/dash-spv/src/test_utils/mod.rs
@@ -3,5 +3,6 @@ mod chain_work;
 mod checkpoint;
 mod filter;
 mod network;
+mod types;
 
 pub use network::{test_socket_address, MockNetworkManager};

--- a/dash-spv/src/test_utils/types.rs
+++ b/dash-spv/src/test_utils/types.rs
@@ -1,0 +1,9 @@
+use crate::types::HashedBlock;
+use dashcore::prelude::CoreBlockHeight;
+use dashcore::{Block, Transaction};
+
+impl HashedBlock {
+    pub fn dummy(height: CoreBlockHeight, transactions: Vec<Transaction>) -> Self {
+        Self::from(Block::dummy(height, transactions))
+    }
+}

--- a/dash-spv/src/types.rs
+++ b/dash-spv/src/types.rs
@@ -21,7 +21,7 @@ use dashcore::{
     hash_types::FilterHeader,
     network::constants::NetworkExt,
     sml::masternode_list_engine::MasternodeListEngine,
-    Amount, BlockHash, Network, Transaction, Txid,
+    Amount, Block, BlockHash, Network, Transaction, Txid,
 };
 use serde::{Deserialize, Serialize};
 
@@ -105,6 +105,71 @@ impl Decodable for HashedBlockHeader {
         Ok(Self {
             header: BlockHeader::consensus_decode(reader)?,
             hash: BlockHash::consensus_decode(reader)?,
+        })
+    }
+}
+
+/// A block with its cached hash to avoid expensive X11 recomputation.
+#[derive(Debug, Clone)]
+pub struct HashedBlock {
+    hash: BlockHash,
+    block: Block,
+}
+
+impl HashedBlock {
+    /// Get a reference to the cached block hash.
+    pub fn hash(&self) -> &BlockHash {
+        &self.hash
+    }
+
+    /// Get a reference to the block.
+    pub fn block(&self) -> &Block {
+        &self.block
+    }
+}
+
+impl From<Block> for HashedBlock {
+    fn from(block: Block) -> Self {
+        Self {
+            hash: block.block_hash(),
+            block,
+        }
+    }
+}
+
+impl From<&Block> for HashedBlock {
+    fn from(block: &Block) -> Self {
+        Self {
+            hash: block.block_hash(),
+            block: block.clone(),
+        }
+    }
+}
+
+impl PartialEq for HashedBlock {
+    fn eq(&self, other: &Self) -> bool {
+        self.block == other.block
+    }
+}
+
+impl Encodable for HashedBlock {
+    #[inline]
+    fn consensus_encode<W: std::io::Write + ?Sized>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize, std::io::Error> {
+        Ok(self.hash().consensus_encode(writer)? + self.block().consensus_encode(writer)?)
+    }
+}
+
+impl Decodable for HashedBlock {
+    #[inline]
+    fn consensus_decode<R: std::io::Read + ?Sized>(
+        reader: &mut R,
+    ) -> Result<Self, dashcore::consensus::encode::Error> {
+        Ok(Self {
+            hash: BlockHash::consensus_decode(reader)?,
+            block: Block::consensus_decode(reader)?,
         })
     }
 }


### PR DESCRIPTION
This is to allow storing blocks during sync to avoid the need of re-fetching for potential rescan. At the moment we don't have persistens wallets in the CLI and storing the blocks also helps there to make restarts ~15s on my machine compared to ~50s without cached blocks.

 I was thinking about maybe making storing blocks optional by config although i think some "clear sync cache" command for the spv client would be better since usually there are not many blocks stored anyway unless its super heavy used wallets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent block storage to cache full blockchain blocks across restarts and integrated it into disk storage management.
  * Blocks are now stored automatically during block processing, introducing an observable storage error path.

* **Tests**
  * Added unit tests covering store/load, persistence across restarts, nonexistent blocks, and gap handling.

* **Chores**
  * Added test utilities to simplify constructing block instances for tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->