### PR TITLE
fix: add missing transaction types in serialization

### DIFF
--- a/dash/src/blockdata/transaction/mod.rs
+++ b/dash/src/blockdata/transaction/mod.rs
@@ -554,8 +554,18 @@ impl Encodable for Transaction {
                 break;
             }
         }
-        // Forcing have_witness to false for AssetUnlock, as currently Core doesn't support BIP141 SegWit.
+        // Forcing have_witness to false for special transaction types that legitimately have no inputs.
+        // Dash Core doesn't support BIP141 SegWit.
         if self.tx_type() == TransactionType::AssetUnlock {
+            have_witness = false;
+        }
+        if self.tx_type() == TransactionType::QuorumCommitment {
+            have_witness = false;
+        }
+        if self.tx_type() == TransactionType::MnhfSignal {
+            have_witness = false;
+        }
+        if self.tx_type() == TransactionType::Coinbase {
             have_witness = false;
         }
         if !have_witness {
@@ -594,7 +604,8 @@ impl Decodable for Transaction {
         let input = Vec::<TxIn>::consensus_decode_from_finite_reader(r)?;
         // segwit
         let mut segwit = input.is_empty();
-        // Forcing segwit to false for AssetUnlock, as currently Core doesn't support BIP141 SegWit.
+        // Forcing segwit to false for special transaction types that legitimately have no inputs.
+        // Dash Core doesn't support BIP141 SegWit.
         if special_transaction_type == TransactionType::AssetUnlock {
             segwit = false;
         }
@@ -602,6 +613,9 @@ impl Decodable for Transaction {
             segwit = false;
         }
         if special_transaction_type == TransactionType::MnhfSignal {
+            segwit = false;
+        }
+        if special_transaction_type == TransactionType::Coinbase {
             segwit = false;
         }
         if segwit {


### PR DESCRIPTION
The block serialization needed by the sync rewrite which uses #397 fails for special transactions/coinbase because we don't have segwit support. This is intermediate fix. Im have a PR to fully drop support for it (#400) but its not quite ready and i want to look a bit more into it first once the sync stuff is done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of special transaction types (AssetUnlock, QuorumCommitment, MnhfSignal, Coinbase) to ensure correct serialization and deserialization during transaction processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->