### PR TITLE
fix: masternode list around height

### DIFF
--- a/dash-spv-ffi/src/platform_integration.rs
+++ b/dash-spv-ffi/src/platform_integration.rs
@@ -125,7 +125,6 @@ pub unsafe extern "C" fn ffi_dash_spv_get_quorum_public_key(
                 core_chain_locked_height
             ),
         );
-    };
 
     let list_height = ml.known_height;
     match ml.quorums.get(&llmq_type) {

--- a/dash-spv-ffi/src/platform_integration.rs
+++ b/dash-spv-ffi/src/platform_integration.rs
@@ -117,14 +117,18 @@ pub unsafe extern "C" fn ffi_dash_spv_get_quorum_public_key(
 
     let engine_guard = engine.blocking_read();
     let (before, _after) = engine_guard.masternode_lists_around_height(core_chain_locked_height);
-    let Some(ml) = before else {
-        return FFIResult::error(
-            FFIErrorCode::ValidationError,
-            &format!(
-                "No masternode list found at or before height {}",
-                core_chain_locked_height
-            ),
-        );
+    let ml = match before {
+        Some(ml) => ml,
+        None => {
+            return FFIResult::error(
+                FFIErrorCode::ValidationError,
+                &format!(
+                    "No masternode list found at or before height {}",
+                    core_chain_locked_height
+                ),
+            );
+        }
+    };
 
     let list_height = ml.known_height;
     match ml.quorums.get(&llmq_type) {

--- a/dash-spv-ffi/src/platform_integration.rs
+++ b/dash-spv-ffi/src/platform_integration.rs
@@ -115,58 +115,53 @@ pub unsafe extern "C" fn ffi_dash_spv_get_quorum_public_key(
         }
     };
 
-    // Lock the engine for reading
     let engine_guard = engine.blocking_read();
+    let (before, _after) = engine_guard.masternode_lists_around_height(core_chain_locked_height);
+    let Some(ml) = before else {
+        return FFIResult::error(
+            FFIErrorCode::ValidationError,
+            &format!(
+                "No masternode list found at or before height {}",
+                core_chain_locked_height
+            ),
+        );
+    };
 
-    // Use the global quorum status index for efficient lookup
-    match engine_guard
-        .quorum_statuses
-        .get(&llmq_type)
-        .and_then(|type_map| type_map.get(&quorum_hash))
-    {
-        Some((heights, public_key, _status)) => {
-            // Check if the requested height is one of the heights where this quorum exists
-            if !heights.contains(&core_chain_locked_height) {
-                // Quorum exists but not at requested height - provide helpful info
-                let height_list: Vec<u32> = heights.iter().copied().collect();
-                return FFIResult::error(
-                    FFIErrorCode::ValidationError,
-                    &format!(
-                        "Quorum type {} with hash {:x} exists but not at height {}. Available at heights: {:?}",
-                        quorum_type, quorum_hash, core_chain_locked_height, height_list
-                    ),
+    let list_height = ml.known_height;
+    match ml.quorums.get(&llmq_type) {
+        Some(quorums) => match quorums.get(&quorum_hash) {
+            Some(quorum) => {
+                let pubkey_bytes: &[u8; 48] = quorum.quorum_entry.quorum_public_key.as_ref();
+                std::ptr::copy_nonoverlapping(
+                    pubkey_bytes.as_ptr(),
+                    out_pubkey,
+                    QUORUM_PUBKEY_SIZE,
                 );
+
+                FFIResult {
+                    error_code: 0,
+                    error_message: ptr::null(),
+                }
             }
-
-            // Get the public key's canonical 48-byte representation safely
-            let pubkey_bytes: &[u8; 48] = public_key.as_ref();
-            std::ptr::copy_nonoverlapping(pubkey_bytes.as_ptr(), out_pubkey, QUORUM_PUBKEY_SIZE);
-
-            // Return success
-            FFIResult {
-                error_code: 0,
-                error_message: ptr::null(),
-            }
-        }
-        None => {
-            // Quorum not found in global index - provide diagnostic info
-            let total_lists = engine_guard.masternode_lists.len();
-            let (min_height, max_height) = if total_lists > 0 {
-                let min = engine_guard.masternode_lists.keys().min().copied().unwrap_or(0);
-                let max = engine_guard.masternode_lists.keys().max().copied().unwrap_or(0);
-                (min, max)
-            } else {
-                (0, 0)
-            };
-
-            FFIResult::error(
+            None => FFIResult::error(
                 FFIErrorCode::ValidationError,
                 &format!(
-                    "Quorum not found: type={}, hash={:x}. Core SDK has {} masternode lists ranging from height {} to {}. The quorum may not exist or the Core SDK may still be syncing.",
-                    quorum_type, quorum_hash, total_lists, min_height, max_height
+                    "Quorum not found: type {} at list height {} (requested {}) with hash {:x} (masternode list exists with {} quorums of this type)",
+                    quorum_type,
+                    list_height,
+                    core_chain_locked_height,
+                    quorum_hash,
+                    quorums.len()
                 ),
-            )
-        }
+            ),
+        },
+        None => FFIResult::error(
+            FFIErrorCode::ValidationError,
+            &format!(
+                "No quorums of type {} found at list height {} (requested {})",
+                quorum_type, list_height, core_chain_locked_height
+            ),
+        ),
     }
 }
 

--- a/dash-spv/src/client/queries.rs
+++ b/dash-spv/src/client/queries.rs
@@ -69,7 +69,6 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         let masternode_engine = self.masternode_list_engine()?;
         let masternode_engine_guard = masternode_engine.read().await;
         let (before, _after) = masternode_engine_guard.masternode_lists_around_height(height);
-
         if let Some(ml) = before {
             let list_height = ml.known_height;
             match ml.quorums.get(&quorum_type) {

--- a/dash-spv/src/client/queries.rs
+++ b/dash-spv/src/client/queries.rs
@@ -68,49 +68,58 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
     ) -> Result<QualifiedQuorumEntry> {
         let masternode_engine = self.masternode_list_engine()?;
         let masternode_engine_guard = masternode_engine.read().await;
-        // First check if we have the masternode list at this height
-        match masternode_engine_guard.masternode_lists.get(&height) {
-            Some(ml) => {
-                // We have the masternode list, now look for the quorum
-                match ml.quorums.get(&quorum_type) {
-                    Some(quorums) => match quorums.get(&quorum_hash) {
-                        Some(quorum) => {
-                            tracing::debug!(
-                                "Found quorum type {} at height {} with hash {}",
-                                quorum_type,
-                                height,
-                                hex::encode(quorum_hash)
-                            );
-                            Ok(quorum.clone())
-                        }
-                        None => {
-                            let message = format!("Quorum not found: type {} at height {} with hash {} (masternode list exists with {} quorums of this type)",
-                                                quorum_type,
-                                                height,
-                                                hex::encode(quorum_hash),
-                                                quorums.len());
-                            tracing::warn!(message);
-                            Err(SpvError::QuorumLookupError(message))
-                        }
-                    },
-                    None => {
-                        tracing::warn!(
-                            "No quorums of type {} found at height {} (masternode list exists)",
+        let (before, _after) = masternode_engine_guard.masternode_lists_around_height(height);
+
+        if let Some(ml) = before {
+            let list_height = ml.known_height;
+            match ml.quorums.get(&quorum_type) {
+                Some(quorums) => match quorums.get(&quorum_hash) {
+                    Some(quorum) => {
+                        tracing::debug!(
+                            "Found quorum type {} at list height {} (requested {}) with hash {}",
                             quorum_type,
-                            height
+                            list_height,
+                            height,
+                            hex::encode(quorum_hash)
                         );
-                        Err(SpvError::QuorumLookupError(format!(
-                            "No quorums of type {} found at height {}",
-                            quorum_type, height
-                        )))
+                        return Ok(quorum.clone());
                     }
+                    None => {
+                        let message = format!(
+                            "Quorum not found: type {} at list height {} (requested {}) with hash {} (masternode list exists with {} quorums of this type)",
+                            quorum_type,
+                            list_height,
+                            height,
+                            hex::encode(quorum_hash),
+                            quorums.len()
+                        );
+                        tracing::warn!(message);
+                        return Err(SpvError::QuorumLookupError(message));
+                    }
+                },
+                None => {
+                    tracing::warn!(
+                        "No quorums of type {} found at list height {} (requested {}) (masternode list exists)",
+                        quorum_type,
+                        list_height,
+                        height
+                    );
+                    return Err(SpvError::QuorumLookupError(format!(
+                        "No quorums of type {} found at list height {} (requested {})",
+                        quorum_type, list_height, height
+                    )));
                 }
             }
-            None => Err(SpvError::QuorumLookupError(format!(
-                "No masternode list found at height {}",
-                height
-            ))),
         }
+
+        tracing::warn!(
+            "No masternode list found at or before height {} - cannot retrieve quorum",
+            height
+        );
+        Err(SpvError::QuorumLookupError(format!(
+            "No masternode list found at or before height {}",
+            height
+        )))
     }
 
     // ============ Balance Queries ============


### PR DESCRIPTION
## Summary
Align quorum lookup semantics to use the masternode list at or before the requested height.
Apply the same rule in both Rust API (dash-spv) and FFI (dash-spv-ffi) so platform integration behaves consistently.

## Why
Masternode lists are stored at diff heights (sparse), so exact-height lookup will likely fail after sync. For “active at height” logic, the list at or before the requested height is authoritative, and must be used. It was not previously.

## What changed

queries.rs: get_quorum_at_height now uses the nearest list at or below height only (no fallback to newer list).
platform_integration.rs: ffi_dash_spv_get_quorum_public_key uses the same “at or before” rule.

## Behavioral notes

If there is no masternode list at/before the requested height, return a clear error.
If the list exists but the quorum is missing, return a quorum-not-found error tied to that list height.

This should not be a breaking change, makes usage more flexible.

## Testing

cargo fmt
cargo check

I intend to test this in DET soon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quorum lookup now uses nearby masternode lists instead of a stale global index, improving accuracy.
  * Added clearer early-error handling when required list or quorum data is missing.
  * Error messages are more contextual (list height, requested height, quorum counts) to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->