### PR TITLE
feat: add `--mnemonic-file`, `--data-dir` and logfiles to ffi-cli

### DIFF
--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -8,7 +8,8 @@ use std::time::Duration;
 use clap::{Arg, ArgAction, Command, ValueEnum};
 
 use dash_spv_ffi::*;
-use key_wallet_ffi::FFINetwork;
+use key_wallet_ffi::wallet_manager::wallet_manager_add_wallet_from_mnemonic;
+use key_wallet_ffi::{FFIError, FFINetwork};
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
 enum NetworkOpt {
@@ -104,11 +105,6 @@ fn main() {
     };
 
     unsafe {
-        // Initialize tracing/logging via FFI so `tracing::info!` emits output
-        let level = matches.get_one::<String>("log-level").map(String::as_str).unwrap_or("info");
-        let level_c = CString::new(level).unwrap();
-        let _ = dash_spv_ffi_init_logging(level_c.as_ptr(), true, std::ptr::null(), 0);
-
         // Build config
         let cfg = dash_spv_ffi_config_new(network);
         if cfg.is_null() {
@@ -118,6 +114,31 @@ fn main() {
             );
             std::process::exit(1);
         }
+
+        // Determine and set data directory
+        let data_dir = matches
+            .get_one::<String>("data-dir")
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| ".tmp/ffi-cli".to_string());
+
+        let storage_dir_c = CString::new(data_dir.as_str()).unwrap();
+        let rc = dash_spv_ffi_config_set_data_dir(cfg, storage_dir_c.as_ptr());
+        if rc != FFIErrorCode::Success as i32 {
+            eprintln!(
+                "Failed to set data dir: {}",
+                ffi_string_to_rust(dash_spv_ffi_get_last_error())
+            );
+            std::process::exit(1);
+        }
+        println!("Storage directory: {}", data_dir);
+
+        // Initialize tracing/logging via FFI with file logging to data_dir/logs
+        let level = matches.get_one::<String>("log-level").map(String::as_str).unwrap_or("info");
+        let level_c = CString::new(level).unwrap();
+        let log_dir = format!("{}/logs", data_dir);
+        let log_dir_c = CString::new(log_dir.as_str()).unwrap();
+        let _ = dash_spv_ffi_init_logging(level_c.as_ptr(), false, log_dir_c.as_ptr(), 5);
+        println!("Log directory: {}", log_dir);
 
         if let Some(height) = matches.get_one::<u32>("start-height") {
             let _ = dash_spv_ffi_config_set_start_from_height(cfg, *height);
@@ -141,6 +162,17 @@ fn main() {
             }
         }
 
+        // Read mnemonic file if provided
+        let mnemonic_phrase = matches.get_one::<String>("mnemonic-file").map(|path| {
+            std::fs::read_to_string(path)
+                .unwrap_or_else(|e| {
+                    eprintln!("Failed to read mnemonic file '{}': {}", path, e);
+                    std::process::exit(1);
+                })
+                .trim()
+                .to_string()
+        });
+
         // Create client
         let client = dash_spv_ffi_client_new(cfg);
         if client.is_null() {
@@ -149,6 +181,35 @@ fn main() {
                 ffi_string_to_rust(dash_spv_ffi_get_last_error())
             );
             std::process::exit(1);
+        }
+
+        // Add wallet from mnemonic if provided
+        if let Some(ref mnemonic) = mnemonic_phrase {
+            let wallet_manager = dash_spv_ffi_client_get_wallet_manager(client);
+            if wallet_manager.is_null() {
+                eprintln!(
+                    "Failed to get wallet manager: {}",
+                    ffi_string_to_rust(dash_spv_ffi_get_last_error())
+                );
+                std::process::exit(1);
+            }
+
+            let mnemonic_c = CString::new(mnemonic.as_str()).unwrap();
+            let mut error = FFIError::success();
+            let success = wallet_manager_add_wallet_from_mnemonic(
+                wallet_manager as *mut _,
+                mnemonic_c.as_ptr(),
+                ptr::null(), // no passphrase
+                &mut error,
+            );
+
+            if !success {
+                eprintln!("Failed to add wallet from mnemonic: {:?}", error);
+                std::process::exit(1);
+            }
+
+            println!("Wallet created from mnemonic");
+            dash_spv_ffi_wallet_manager_free(wallet_manager);
         }
 
         // Set minimal event callbacks


### PR DESCRIPTION
For better usability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating wallets from mnemonic files via command line.
  * Introduced configurable data directory for storing wallet and log data (defaults to .tmp/ffi-cli).
  * Logging now writes to the data directory instead of console output, with informational messages for storage and log locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->