### PR TITLE
refactor: cleanup storage usage in `DashSpvClient` constructor

### DIFF
--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -60,7 +60,6 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
             W,
         > = Managers::default();
 
-        let header_storage = storage.header_storage_ref().expect("Headers storage must exist");
         let checkpoints = match config.network {
             dashcore::Network::Dash => mainnet_checkpoints(),
             dashcore::Network::Testnet => testnet_checkpoints(),
@@ -68,31 +67,19 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         };
         let checkpoint_manager = Arc::new(CheckpointManager::new(checkpoints));
         managers.block_headers =
-            Some(BlockHeadersManager::new(header_storage.clone(), checkpoint_manager));
+            Some(BlockHeadersManager::new(storage.block_headers(), checkpoint_manager));
 
         if config.enable_filters {
-            let filter_headers_storage = storage
-                .filter_header_storage_ref()
-                .expect("Filters headers storage must exist if filters are enabled");
-            let filters_storage = storage
-                .filter_storage_ref()
-                .expect("Filters storage must exist if filters are enabled");
-            let blocks_storage = storage
-                .block_storage_ref()
-                .expect("Blocks storage must exist if filters are enabled");
-
-            managers.filter_headers = Some(FilterHeadersManager::new(
-                header_storage.clone(),
-                filter_headers_storage.clone(),
-            ));
+            managers.filter_headers =
+                Some(FilterHeadersManager::new(storage.block_headers(), storage.filter_headers()));
             managers.filters = Some(FiltersManager::new(
                 wallet.clone(),
-                header_storage.clone(),
-                filter_headers_storage,
-                filters_storage,
+                storage.block_headers(),
+                storage.filter_headers(),
+                storage.filters(),
             ));
             managers.blocks =
-                Some(BlocksManager::new(wallet.clone(), header_storage.clone(), blocks_storage));
+                Some(BlocksManager::new(wallet.clone(), storage.block_headers(), storage.blocks()));
         }
 
         // Build masternode manager if enabled
@@ -101,12 +88,14 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
                 .clone()
                 .expect("Masternode list engine must exist if masternodes are enabled");
             managers.masternode = Some(MasternodesManager::new(
-                header_storage.clone(),
+                storage.block_headers(),
                 masternode_list_engine.clone(),
                 config.network,
             ));
-            managers.chainlock =
-                Some(ChainLockManager::new(header_storage.clone(), masternode_list_engine.clone()));
+            managers.chainlock = Some(ChainLockManager::new(
+                storage.block_headers(),
+                masternode_list_engine.clone(),
+            ));
             managers.instantsend = Some(InstantSendManager::new(masternode_list_engine.clone()));
         }
 

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -72,25 +72,17 @@ pub trait StorageManager:
     /// Stops all background tasks and persists the data.
     async fn shutdown(&mut self);
 
-    /// Get shared reference to header storage for parallel access.
-    fn header_storage_ref(&self) -> Option<Arc<RwLock<PersistentBlockHeaderStorage>>> {
-        None
-    }
+    /// Returns shared access to the block headers storage.
+    fn block_headers(&self) -> Arc<RwLock<PersistentBlockHeaderStorage>>;
 
-    /// Get shared reference to filter header storage for parallel access.
-    fn filter_header_storage_ref(&self) -> Option<Arc<RwLock<PersistentFilterHeaderStorage>>> {
-        None
-    }
+    /// Returns shared access to the filter headers storage.
+    fn filter_headers(&self) -> Arc<RwLock<PersistentFilterHeaderStorage>>;
 
-    /// Get shared reference to filter storage for parallel access.
-    fn filter_storage_ref(&self) -> Option<Arc<RwLock<PersistentFilterStorage>>> {
-        None
-    }
+    /// Returns shared access to the filters storage.
+    fn filters(&self) -> Arc<RwLock<PersistentFilterStorage>>;
 
-    /// Get shared reference to block storage for parallel access.
-    fn block_storage_ref(&self) -> Option<Arc<RwLock<PersistentBlockStorage>>> {
-        None
-    }
+    /// Returns shared access to the block storage.
+    fn blocks(&self) -> Arc<RwLock<PersistentBlockStorage>>;
 }
 
 /// Disk-based storage manager with segmented files and async background saving.
@@ -203,41 +195,6 @@ impl DiskStorageManager {
         }
     }
 
-    /// Get a reference to the block headers storage.
-    pub fn header_storage(&self) -> Arc<RwLock<PersistentBlockHeaderStorage>> {
-        Arc::clone(&self.block_headers)
-    }
-
-    /// Get a reference to the filter headers storage.
-    pub fn filter_header_storage(&self) -> Arc<RwLock<PersistentFilterHeaderStorage>> {
-        Arc::clone(&self.filter_headers)
-    }
-
-    /// Get a reference to the filters storage.
-    pub fn filter_storage(&self) -> Arc<RwLock<PersistentFilterStorage>> {
-        Arc::clone(&self.filters)
-    }
-
-    /// Get a reference to the block storage.
-    pub fn block_storage(&self) -> Arc<RwLock<PersistentBlockStorage>> {
-        Arc::clone(&self.blocks)
-    }
-
-    /// Get a reference to the transaction storage.
-    pub fn transaction_storage(&self) -> Arc<RwLock<PersistentTransactionStorage>> {
-        Arc::clone(&self.transactions)
-    }
-
-    /// Get a reference to the metadata storage.
-    pub fn metadata_storage(&self) -> Arc<RwLock<PersistentMetadataStorage>> {
-        Arc::clone(&self.metadata)
-    }
-
-    /// Get a reference to the masternode state storage.
-    pub fn masternode_storage(&self) -> Arc<RwLock<PersistentMasternodeStateStorage>> {
-        Arc::clone(&self.masternodestate)
-    }
-
     async fn persist(&self) {
         let storage_path = &self.storage_path;
 
@@ -302,20 +259,20 @@ impl StorageManager for DiskStorageManager {
         self.persist().await;
     }
 
-    fn header_storage_ref(&self) -> Option<Arc<RwLock<PersistentBlockHeaderStorage>>> {
-        Some(Arc::clone(&self.block_headers))
+    fn block_headers(&self) -> Arc<RwLock<PersistentBlockHeaderStorage>> {
+        Arc::clone(&self.block_headers)
     }
 
-    fn filter_header_storage_ref(&self) -> Option<Arc<RwLock<PersistentFilterHeaderStorage>>> {
-        Some(Arc::clone(&self.filter_headers))
+    fn filter_headers(&self) -> Arc<RwLock<PersistentFilterHeaderStorage>> {
+        Arc::clone(&self.filter_headers)
     }
 
-    fn filter_storage_ref(&self) -> Option<Arc<RwLock<PersistentFilterStorage>>> {
-        Some(Arc::clone(&self.filters))
+    fn filters(&self) -> Arc<RwLock<PersistentFilterStorage>> {
+        Arc::clone(&self.filters)
     }
 
-    fn block_storage_ref(&self) -> Option<Arc<RwLock<PersistentBlockStorage>>> {
-        Some(Arc::clone(&self.blocks))
+    fn blocks(&self) -> Arc<RwLock<PersistentBlockStorage>> {
+        Arc::clone(&self.blocks)
     }
 }
 

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -217,7 +217,7 @@ mod tests {
     use super::*;
     use crate::chain::checkpoints::testnet_checkpoints;
     use crate::network::MessageType;
-    use crate::storage::{DiskStorageManager, PersistentBlockHeaderStorage};
+    use crate::storage::{DiskStorageManager, PersistentBlockHeaderStorage, StorageManager};
     use crate::sync::{ManagerIdentifier, SyncManagerProgress};
 
     type TestBlockHeadersManager = BlockHeadersManager<PersistentBlockHeaderStorage>;
@@ -229,7 +229,7 @@ mod tests {
     async fn create_test_manager() -> TestBlockHeadersManager {
         let storage = DiskStorageManager::with_temp_dir().await.unwrap();
         let checkpoint_manager = create_test_checkpoint_manager();
-        BlockHeadersManager::new(storage.header_storage(), checkpoint_manager)
+        BlockHeadersManager::new(storage.block_headers(), checkpoint_manager)
     }
 
     #[tokio::test]

--- a/dash-spv/src/sync/blocks/manager.rs
+++ b/dash-spv/src/sync/blocks/manager.rs
@@ -155,7 +155,7 @@ mod tests {
     use super::*;
     use crate::network::{MessageType, NetworkManager};
     use crate::storage::{
-        DiskStorageManager, PersistentBlockHeaderStorage, PersistentBlockStorage,
+        DiskStorageManager, PersistentBlockHeaderStorage, PersistentBlockStorage, StorageManager,
     };
     use crate::sync::{ManagerIdentifier, SyncEvent, SyncManagerProgress};
     use crate::test_utils::MockNetworkManager;
@@ -170,7 +170,7 @@ mod tests {
     async fn create_test_manager() -> TestBlocksManager {
         let storage = DiskStorageManager::with_temp_dir().await.unwrap();
         let wallet = Arc::new(RwLock::new(MockWallet::new()));
-        BlocksManager::new(wallet, storage.header_storage(), storage.block_storage())
+        BlocksManager::new(wallet, storage.block_headers(), storage.blocks())
     }
 
     #[tokio::test]

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -191,7 +191,7 @@ impl<H: BlockHeaderStorage> std::fmt::Debug for ChainLockManager<H> {
 mod tests {
     use super::*;
     use crate::network::MessageType;
-    use crate::storage::{DiskStorageManager, PersistentBlockHeaderStorage};
+    use crate::storage::{DiskStorageManager, PersistentBlockHeaderStorage, StorageManager};
     use crate::sync::{ManagerIdentifier, SyncManager, SyncManagerProgress, SyncState};
     use crate::Network;
     use dashcore::bls_sig_utils::BLSSignature;
@@ -204,7 +204,7 @@ mod tests {
         let storage = DiskStorageManager::with_temp_dir().await.unwrap();
         let engine =
             Arc::new(RwLock::new(MasternodeListEngine::default_for_network(Network::Testnet)));
-        ChainLockManager::new(storage.header_storage(), engine)
+        ChainLockManager::new(storage.block_headers(), engine)
     }
 
     fn create_test_chainlock(height: u32) -> ChainLock {

--- a/dash-spv/src/sync/filter_headers/manager.rs
+++ b/dash-spv/src/sync/filter_headers/manager.rs
@@ -230,6 +230,7 @@ mod tests {
     use crate::network::MessageType;
     use crate::storage::{
         DiskStorageManager, PersistentBlockHeaderStorage, PersistentFilterHeaderStorage,
+        StorageManager,
     };
     use crate::sync::{ManagerIdentifier, SyncManagerProgress};
 
@@ -239,7 +240,7 @@ mod tests {
 
     async fn create_test_manager() -> TestFilterHeadersManager {
         let storage = DiskStorageManager::with_temp_dir().await.unwrap();
-        FilterHeadersManager::new(storage.header_storage(), storage.filter_header_storage())
+        FilterHeadersManager::new(storage.block_headers(), storage.filter_headers())
     }
 
     #[tokio::test]

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -765,7 +765,7 @@ mod tests {
     use crate::network::MessageType;
     use crate::storage::{
         DiskStorageManager, PersistentBlockHeaderStorage, PersistentFilterHeaderStorage,
-        PersistentFilterStorage,
+        PersistentFilterStorage, StorageManager,
     };
     use crate::sync::{ManagerIdentifier, SyncManagerProgress};
     use key_wallet_manager::test_utils::MockWallet;
@@ -783,9 +783,9 @@ mod tests {
         let wallet = Arc::new(RwLock::new(MockWallet::new()));
         FiltersManager::new(
             wallet,
-            storage.header_storage(),
-            storage.filter_header_storage(),
-            storage.filter_storage(),
+            storage.block_headers(),
+            storage.filter_headers(),
+            storage.filters(),
         )
     }
 

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -213,7 +213,7 @@ impl<H: BlockHeaderStorage> std::fmt::Debug for MasternodesManager<H> {
 mod tests {
     use super::*;
     use crate::network::MessageType;
-    use crate::storage::{DiskStorageManager, PersistentBlockHeaderStorage};
+    use crate::storage::{DiskStorageManager, PersistentBlockHeaderStorage, StorageManager};
     use crate::sync::sync_manager::SyncManager;
     use crate::sync::{ManagerIdentifier, SyncManagerProgress};
 
@@ -224,7 +224,7 @@ mod tests {
         let engine = Arc::new(RwLock::new(MasternodeListEngine::default_for_network(
             dashcore::Network::Testnet,
         )));
-        MasternodesManager::new(storage.header_storage(), engine, dashcore::Network::Testnet)
+        MasternodesManager::new(storage.block_headers(), engine, dashcore::Network::Testnet)
     }
 
     #[tokio::test]


### PR DESCRIPTION
Don't return optionals, it's not really needed. And remove duplicated getters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal storage access patterns for enhanced consistency and maintainability across the application's data layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->