### PR TITLE
fix: clear up failed connection attempts

### DIFF
--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -295,6 +295,7 @@ impl PeerNetworkManager {
                         }
                         Err(e) => {
                             log::warn!("Handshake failed with {}: {}", addr, e);
+                            pool.remove_peer(&addr).await;
                             // Update reputation for handshake failure
                             reputation_manager
                                 .update_reputation(
@@ -310,6 +311,7 @@ impl PeerNetworkManager {
                 }
                 Err(e) => {
                     log::debug!("Failed to connect to {}: {}", addr, e);
+                    pool.remove_peer(&addr).await;
                     // Minor reputation penalty for connection failure
                     reputation_manager
                         .update_reputation(

--- a/dash-spv/src/network/pool.rs
+++ b/dash-spv/src/network/pool.rs
@@ -61,8 +61,9 @@ impl PeerPool {
         Ok(())
     }
 
-    /// Remove a peer from the pool
+    /// Remove a peer from the pool and clear connecting state
     pub async fn remove_peer(&self, addr: &SocketAddr) -> Option<Arc<RwLock<Peer>>> {
+        self.connecting.write().await.remove(addr);
         let removed = self.peers.write().await.remove(addr);
         if removed.is_some() {
             log::info!("Removed peer {}", addr);


### PR DESCRIPTION
Not clearing them up restricts from repeated connection attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed peer connections by ensuring problematic peers are immediately removed from the active pool, reducing unnecessary reconnection attempts and enhancing network stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->