### PR TITLE
refactor: introduce `ProgressPercentage` trait

### DIFF
--- a/dash-spv-ffi/include/dash_spv_ffi.h
+++ b/dash-spv-ffi/include/dash_spv_ffi.h
@@ -59,7 +59,7 @@ typedef struct FFIClientConfig {
  */
 typedef struct FFIBlockHeadersProgress {
   enum FFISyncState state;
-  uint32_t current_height;
+  uint32_t tip_height;
   uint32_t target_height;
   uint32_t processed;
   uint32_t buffered;

--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -213,7 +213,7 @@ extern "C" fn on_progress_update(progress: *const FFISyncProgress, _user_data: *
 
     if !p.headers.is_null() {
         let h = unsafe { &*p.headers };
-        print!("headers:{}/{} ", h.current_height + h.buffered, h.target_height);
+        print!("headers:{}/{} ", h.tip_height + h.buffered, h.target_height);
     }
     if !p.filter_headers.is_null() {
         let fh = unsafe { &*p.filter_headers };

--- a/dash-spv-ffi/src/types.rs
+++ b/dash-spv-ffi/src/types.rs
@@ -1,7 +1,8 @@
 use dash_spv::client::config::MempoolStrategy;
 use dash_spv::sync::{
     BlockHeadersProgress, BlocksProgress, ChainLockProgress, FilterHeadersProgress,
-    FiltersProgress, InstantSendProgress, MasternodesProgress, SyncProgress, SyncState,
+    FiltersProgress, InstantSendProgress, MasternodesProgress, ProgressPercentage, SyncProgress,
+    SyncState,
 };
 use dash_spv::types::MempoolRemovalReason;
 use std::ffi::{CStr, CString};
@@ -76,7 +77,7 @@ impl From<SyncState> for FFISyncState {
 #[derive(Debug, Clone, Default)]
 pub struct FFIBlockHeadersProgress {
     pub state: FFISyncState,
-    pub current_height: u32,
+    pub tip_height: u32,
     pub target_height: u32,
     pub processed: u32,
     pub buffered: u32,
@@ -88,7 +89,7 @@ impl From<&BlockHeadersProgress> for FFIBlockHeadersProgress {
     fn from(progress: &BlockHeadersProgress) -> Self {
         FFIBlockHeadersProgress {
             state: progress.state().into(),
-            current_height: progress.current_height(),
+            tip_height: progress.tip_height(),
             target_height: progress.target_height(),
             processed: progress.processed(),
             buffered: progress.buffered(),

--- a/dash-spv-ffi/tests/test_types.rs
+++ b/dash-spv-ffi/tests/test_types.rs
@@ -49,7 +49,7 @@ mod tests {
 
         let mut headers = BlockHeadersProgress::default();
         headers.set_state(SyncState::Syncing);
-        headers.update_current_height(100);
+        headers.update_tip_height(100);
         headers.update_target_height(200);
         headers.add_processed(20);
         headers.update_buffered(5);
@@ -116,7 +116,7 @@ mod tests {
         unsafe {
             let headers = &*ffi_progress.headers;
             assert_eq!(headers.state, FFISyncState::Syncing);
-            assert_eq!(headers.current_height, 100);
+            assert_eq!(headers.tip_height, 100);
             assert_eq!(headers.target_height, 200);
             assert_eq!(headers.processed, 20);
             assert_eq!(headers.buffered, 5);

--- a/dash-spv-ffi/tests/unit/test_client_lifecycle.rs
+++ b/dash-spv-ffi/tests/unit/test_client_lifecycle.rs
@@ -198,7 +198,7 @@ mod tests {
 
             // Basic consistency checks
             assert!(
-                headers.current_height <= filter_headers.target_height
+                headers.tip_height <= filter_headers.target_height
                     || filter_headers.current_height == 0
             );
             // headers_downloaded is u64, always >= 0

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -15,7 +15,7 @@ use crate::error::{SyncError, SyncResult};
 use crate::network::RequestSender;
 use crate::storage::{BlockHeaderStorage, BlockHeaderTip};
 use crate::sync::block_headers::HeadersPipeline;
-use crate::sync::{BlockHeadersProgress, SyncEvent, SyncManager, SyncState};
+use crate::sync::{BlockHeadersProgress, ProgressPercentage, SyncEvent, SyncManager, SyncState};
 use crate::types::HashedBlockHeader;
 use crate::validation::{BlockHeaderValidator, Validator};
 use dashcore::block::Header;
@@ -83,7 +83,7 @@ impl<H: BlockHeaderStorage> BlockHeadersManager<H> {
         let tip = self.tip().await?;
 
         // Update state
-        self.progress.update_current_height(tip.height());
+        self.progress.update_tip_height(tip.height());
         self.progress.add_processed(headers.len() as u32);
 
         Ok(tip)
@@ -243,14 +243,14 @@ mod tests {
     #[tokio::test]
     async fn test_headers_manager_progress() {
         let mut manager = create_test_manager().await;
-        manager.progress.update_current_height(100);
+        manager.progress.update_tip_height(100);
         manager.progress.update_target_height(200);
         manager.progress.add_processed(50);
 
         let progress = manager.progress();
         if let SyncManagerProgress::BlockHeaders(progress) = progress {
             assert_eq!(progress.state(), SyncState::Initializing);
-            assert_eq!(progress.current_height(), 100);
+            assert_eq!(progress.tip_height(), 100);
             assert_eq!(progress.target_height(), 200);
             assert_eq!(progress.processed(), 50);
             assert!(progress.last_activity().elapsed().as_secs() < 1);

--- a/dash-spv/src/sync/block_headers/progress.rs
+++ b/dash-spv/src/sync/block_headers/progress.rs
@@ -1,3 +1,4 @@
+use crate::sync::progress::ProgressPercentage;
 use crate::sync::SyncState;
 use std::fmt;
 use std::time::Instant;
@@ -8,7 +9,7 @@ pub struct BlockHeadersProgress {
     /// Current sync state.
     state: SyncState,
     /// The tip height of the block-header storage.
-    current_height: u32,
+    tip_height: u32,
     /// Equals to current_height (blockchain tip) when synced and to the best height of connected peers during initial sync.
     target_height: u32,
     /// Number of block-headers processed (stored) in the current sync session.
@@ -23,7 +24,7 @@ impl Default for BlockHeadersProgress {
     fn default() -> Self {
         Self {
             state: SyncState::default(),
-            current_height: 0,
+            tip_height: 0,
             target_height: 0,
             processed: 0,
             buffered: 0,
@@ -33,34 +34,17 @@ impl Default for BlockHeadersProgress {
 }
 
 impl BlockHeadersProgress {
-    /// Get completion percentage (0.0 to 1.0).
-    /// Includes buffered headers for more accurate progress during parallel sync.
-    pub fn percentage(&self) -> f64 {
-        if self.target_height == 0 {
-            return 1.0;
-        }
-        // Include buffered headers in progress calculation
-        (self.effective_height() as f64 / self.target_height as f64).min(1.0)
-    }
     /// Get the current sync state.
     pub fn state(&self) -> SyncState {
         self.state
     }
     /// Get the current height (last successfully processed height).
-    pub fn current_height(&self) -> u32 {
-        self.current_height
-    }
-    /// Get the target height (the best height of the connected peers)
-    pub fn target_height(&self) -> u32 {
-        self.target_height
+    pub fn tip_height(&self) -> u32 {
+        self.tip_height
     }
     /// Number of block-headers processed (stored) in the current sync session.
     pub fn processed(&self) -> u32 {
         self.processed
-    }
-    /// Get the effective height (current_height + buffered).
-    pub fn effective_height(&self) -> u32 {
-        self.current_height + self.buffered
     }
     /// The last time a block-header was stored to disk or the last manager state change.
     pub fn last_activity(&self) -> Instant {
@@ -71,9 +55,9 @@ impl BlockHeadersProgress {
         self.state = state;
         self.bump_last_activity();
     }
-    /// Update the current height (last successfully processed height).
-    pub fn update_current_height(&mut self, height: u32) {
-        self.current_height = height;
+    /// Update the tip height (last successfully processed height).
+    pub fn update_tip_height(&mut self, height: u32) {
+        self.tip_height = height;
         self.bump_last_activity();
     }
     /// Update the target height (the best height of the connected peers).
@@ -110,12 +94,23 @@ impl fmt::Display for BlockHeadersProgress {
             f,
             "{:?} {}/{} ({:.1}%) processed: {}, buffered: {}, last_activity: {}s",
             self.state,
-            self.effective_height(),
+            self.current_height(),
             self.target_height,
             pct,
             self.processed,
             self.buffered,
             self.last_activity.elapsed().as_secs()
         )
+    }
+}
+
+impl ProgressPercentage for BlockHeadersProgress {
+    fn target_height(&self) -> u32 {
+        self.target_height
+    }
+    fn current_height(&self) -> u32 {
+        // Use the effective height here for the progress to show more realistic values since
+        // we download headers in parallel and the tip height is only updated when sequential segments complete.
+        self.tip_height + self.buffered
     }
 }

--- a/dash-spv/src/sync/block_headers/sync_manager.rs
+++ b/dash-spv/src/sync/block_headers/sync_manager.rs
@@ -2,7 +2,8 @@ use crate::error::SyncResult;
 use crate::network::{Message, MessageType, NetworkEvent, RequestSender};
 use crate::storage::BlockHeaderStorage;
 use crate::sync::{
-    BlockHeadersManager, ManagerIdentifier, SyncEvent, SyncManager, SyncManagerProgress, SyncState,
+    BlockHeadersManager, ManagerIdentifier, ProgressPercentage, SyncEvent, SyncManager,
+    SyncManagerProgress, SyncState,
 };
 use crate::SyncError;
 use async_trait::async_trait;
@@ -45,7 +46,7 @@ impl<H: BlockHeaderStorage> SyncManager for BlockHeadersManager<H> {
             .ok_or_else(|| SyncError::MissingDependency("No tip in storage".to_string()))?;
 
         self.progress.set_state(SyncState::WaitingForConnections);
-        self.progress.update_current_height(tip.height());
+        self.progress.update_tip_height(tip.height());
         self.progress.update_target_height(tip.height());
 
         tracing::info!("BlockHeadersManager initialized at height {}", tip.height());
@@ -182,13 +183,13 @@ impl<H: BlockHeaderStorage> SyncManager for BlockHeadersManager<H> {
                 // When already synced but behind peer height, request missing headers
                 if self.state() == SyncState::Synced {
                     if let Some(best_height) = best_height {
-                        if *best_height > self.progress.current_height()
+                        if *best_height > self.progress.tip_height()
                             && !self.pipeline.tip_segment_has_pending_request()
                         {
                             tracing::info!(
                                 "Peer height {} > our height {}, requesting headers to catch up",
                                 best_height,
-                                self.progress.current_height()
+                                self.progress.tip_height()
                             );
                             // Reset tip segment and send requests via pipeline
                             self.pipeline.reset_tip_segment();

--- a/dash-spv/src/sync/filter_headers/manager.rs
+++ b/dash-spv/src/sync/filter_headers/manager.rs
@@ -13,6 +13,7 @@ use crate::error::SyncResult;
 use crate::network::RequestSender;
 use crate::storage::{BlockHeaderStorage, FilterHeaderStorage};
 use crate::sync::filter_headers::util::compute_filter_headers;
+use crate::sync::progress::ProgressPercentage;
 use crate::sync::{FilterHeadersProgress, SyncEvent, SyncManager, SyncState};
 
 /// Filter headers manager for downloading compact block filter headers.

--- a/dash-spv/src/sync/filter_headers/progress.rs
+++ b/dash-spv/src/sync/filter_headers/progress.rs
@@ -1,7 +1,7 @@
+use crate::sync::progress::ProgressPercentage;
+use crate::sync::SyncState;
 use std::fmt;
 use std::time::Instant;
-
-use crate::sync::SyncState;
 
 /// Progress for filter-header synchronization.
 #[derive(Debug, Clone, PartialEq)]
@@ -34,30 +34,10 @@ impl Default for FilterHeadersProgress {
 }
 
 impl FilterHeadersProgress {
-    /// Get completion percentage (0.0 to 1.0).
-    /// Uses target_height (peer's best height) for accurate progress display.
-    pub fn percentage(&self) -> f64 {
-        if self.target_height == 0 {
-            return 1.0;
-        }
-        (self.current_height as f64 / self.target_height as f64).min(1.0)
-    }
-
     /// Get the current sync state.
     pub fn state(&self) -> SyncState {
         self.state
     }
-
-    /// Get the current height (last successfully processed filter-header height).
-    pub fn current_height(&self) -> u32 {
-        self.current_height
-    }
-
-    /// Get the target height (peer's best height, for progress display).
-    pub fn target_height(&self) -> u32 {
-        self.target_height
-    }
-
     /// Get the block-header tip height (the download limit for filter headers).
     pub fn block_header_tip_height(&self) -> u32 {
         self.block_header_tip_height
@@ -125,5 +105,14 @@ impl fmt::Display for FilterHeadersProgress {
             self.processed,
             self.last_activity.elapsed().as_secs()
         )
+    }
+}
+
+impl ProgressPercentage for FilterHeadersProgress {
+    fn target_height(&self) -> u32 {
+        self.target_height
+    }
+    fn current_height(&self) -> u32 {
+        self.current_height
     }
 }

--- a/dash-spv/src/sync/filter_headers/sync_manager.rs
+++ b/dash-spv/src/sync/filter_headers/sync_manager.rs
@@ -1,6 +1,7 @@
 use crate::error::SyncResult;
 use crate::network::{Message, MessageType, RequestSender};
 use crate::storage::{BlockHeaderStorage, FilterHeaderStorage};
+use crate::sync::progress::ProgressPercentage;
 use crate::sync::{
     FilterHeadersManager, ManagerIdentifier, SyncEvent, SyncManager, SyncManagerProgress, SyncState,
 };

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -19,6 +19,7 @@ use crate::sync::filters::util::get_prev_filter_header;
 use crate::sync::{FiltersProgress, SyncEvent, SyncManager, SyncState};
 use crate::validation::{FilterValidationInput, FilterValidator, Validator};
 
+use crate::sync::progress::ProgressPercentage;
 use dashcore::hash_types::FilterHeader;
 use key_wallet_manager::wallet_interface::WalletInterface;
 use key_wallet_manager::wallet_manager::{check_compact_filters_for_addresses, FilterMatchKey};

--- a/dash-spv/src/sync/filters/progress.rs
+++ b/dash-spv/src/sync/filters/progress.rs
@@ -1,3 +1,4 @@
+use crate::sync::progress::ProgressPercentage;
 use crate::sync::SyncState;
 use std::fmt;
 use std::time::Instant;
@@ -40,28 +41,9 @@ impl Default for FiltersProgress {
 }
 
 impl FiltersProgress {
-    /// Get completion percentage (0.0 to 1.0).
-    /// Uses target_height (peer's best height) for accurate progress display.
-    pub fn percentage(&self) -> f64 {
-        if self.target_height == 0 {
-            return 1.0;
-        }
-        (self.current_height as f64 / self.target_height as f64).min(1.0)
-    }
-
     /// Get the current sync state.
     pub fn state(&self) -> SyncState {
         self.state
-    }
-
-    /// Get the current height (last successfully processed height).
-    pub fn current_height(&self) -> u32 {
-        self.current_height
-    }
-
-    /// Get the target height (peer's best height, for progress display).
-    pub fn target_height(&self) -> u32 {
-        self.target_height
     }
 
     /// Get the filter header tip height (the download limit for filters).
@@ -155,5 +137,14 @@ impl fmt::Display for FiltersProgress {
             self.matched,
             self.last_activity.elapsed().as_secs(),
         )
+    }
+}
+
+impl ProgressPercentage for FiltersProgress {
+    fn target_height(&self) -> u32 {
+        self.target_height
+    }
+    fn current_height(&self) -> u32 {
+        self.current_height
     }
 }

--- a/dash-spv/src/sync/filters/sync_manager.rs
+++ b/dash-spv/src/sync/filters/sync_manager.rs
@@ -1,6 +1,7 @@
 use crate::error::{SyncError, SyncResult};
 use crate::network::{Message, MessageType, RequestSender};
 use crate::storage::{BlockHeaderStorage, FilterHeaderStorage, FilterStorage};
+use crate::sync::progress::ProgressPercentage;
 use crate::sync::{
     FiltersManager, ManagerIdentifier, SyncEvent, SyncManager, SyncManagerProgress, SyncState,
 };

--- a/dash-spv/src/sync/mod.rs
+++ b/dash-spv/src/sync/mod.rs
@@ -24,6 +24,6 @@ pub use masternodes::{MasternodesManager, MasternodesProgress};
 
 pub use events::SyncEvent;
 pub use identifier::ManagerIdentifier;
-pub use progress::{SyncProgress, SyncState};
+pub use progress::{ProgressPercentage, SyncProgress, SyncState};
 pub use sync_coordinator::{Managers, SyncCoordinator};
 pub use sync_manager::{SyncManager, SyncManagerProgress, SyncManagerTaskContext};

--- a/dash-spv/src/sync/progress.rs
+++ b/dash-spv/src/sync/progress.rs
@@ -3,6 +3,7 @@ use crate::sync::{
     BlockHeadersProgress, BlocksProgress, ChainLockProgress, FilterHeadersProgress,
     FiltersProgress, InstantSendProgress, MasternodesProgress,
 };
+use dashcore::prelude::CoreBlockHeight;
 use std::fmt;
 
 /// Overall state of the parallel sync system.
@@ -230,5 +231,21 @@ impl fmt::Display for SyncProgress {
             writeln!(f, "  InstantSend:    {}", i)?;
         }
         Ok(())
+    }
+}
+
+/// A trait that provides methods for calculating progress as a percentage from a current height
+/// towards a target height.
+pub trait ProgressPercentage {
+    /// Get the target height used for calculating progress.
+    fn target_height(&self) -> CoreBlockHeight;
+    /// Get the current height used for calculating progress.
+    fn current_height(&self) -> CoreBlockHeight;
+    /// Get completion percentage (0.0 to 1.0).
+    fn percentage(&self) -> f64 {
+        if self.target_height() == 0 {
+            return 0.0;
+        }
+        (self.current_height() as f64 / self.target_height() as f64).min(1.0)
     }
 }

--- a/dash-spv/src/sync/sync_coordinator.rs
+++ b/dash-spv/src/sync/sync_coordinator.rs
@@ -17,6 +17,7 @@ use crate::network::NetworkManager;
 use crate::storage::{
     BlockHeaderStorage, BlockStorage, FilterHeaderStorage, FilterStorage, MetadataStorage,
 };
+use crate::sync::progress::ProgressPercentage;
 use crate::sync::{
     BlockHeadersManager, BlocksManager, ChainLockManager, FilterHeadersManager, FiltersManager,
     InstantSendManager, ManagerIdentifier, MasternodesManager, SyncEvent, SyncManager,
@@ -407,7 +408,7 @@ mod tests {
         // Create headers progress at 50%
         let mut headers_progress = BlockHeadersProgress::default();
         headers_progress.set_state(SyncState::Syncing);
-        headers_progress.update_current_height(500);
+        headers_progress.update_tip_height(500);
         headers_progress.update_target_height(1000);
         headers_progress.add_processed(500);
         progress.update_headers(headers_progress);


### PR DESCRIPTION
- add the `ProgressPercentage` trait
- implement the trait for all progress structs where its relevant
- adjust the default value (target_height == 0) for percentage from 1.0 to 0.0 because its more reasonable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized progress reporting across sync components and updated displays/logs to reference "tip height" instead of "current height".
* **Public API**
  * Progress reporting now exposes a unified progress interface and the FFI/CLI progress output uses tip_height for header progress reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->