### PR TITLE
fix: ensure `PeerDisconnected` is emitted on write-path disconnects

### DIFF
--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -656,8 +656,6 @@ impl PeerNetworkManager {
                                     }
                                 }
 
-                                // For other errors, wait a bit then break
-                                tokio::time::sleep(Duration::from_secs(1)).await;
                                 break;
                             }
                         }

--- a/dash-spv/src/network/peer.rs
+++ b/dash-spv/src/network/peer.rs
@@ -368,11 +368,9 @@ impl Peer {
 
     /// Receive a message from the peer.
     pub async fn receive_message(&mut self) -> NetworkResult<Option<Message>> {
-        // First check if we have a state
-        let state_arc = self
-            .state
-            .as_ref()
-            .ok_or_else(|| NetworkError::ConnectionFailed("Not connected".to_string()))?;
+        // If the state was cleared e.g. by a write-path broken pipe, treat as disconnected
+        // so the reader loop handles it identically to a read-path EOF.
+        let state_arc = self.state.as_ref().ok_or(NetworkError::PeerDisconnected)?;
 
         // Lock the state for the entire read operation
         // This ensures no concurrent access to the socket


### PR DESCRIPTION
This fixes flaky failures in some of the integration tests coming soon. When a peer disconnects and the write path (broken pipe) detects it before the read path (EOF), the `PeerDisconnected` event could be lost entirely. `receive_message()` returned
  `ConnectionFailed` instead of `PeerDisconnected`, causing the reader loop to hit the catch-all error handler which slept 1 second before cleanup. During that sleep, the maintenance
  loop could silently remove the peer from the pool, preventing the event from ever being emitted.

  - Return `PeerDisconnected` from `receive_message()` when connection state is already cleared
  - Remove unnecessary 1-second sleep in the reader loop error handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network error handling and responsiveness by removing unnecessary delays and refining error classification in disconnect scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->