### PR TITLE
fix: maintenance loop stops connecting at 1 peer

### DIFF
--- a/dash-spv/src/network/constants.rs
+++ b/dash-spv/src/network/constants.rs
@@ -3,13 +3,7 @@
 use std::time::Duration;
 
 // Connection limits
-pub const MIN_PEERS: usize = 1;
 pub const TARGET_PEERS: usize = 3;
-pub const MAX_PEERS: usize = 3;
-
-// Compile-time check to ensure proper peer count relationships
-const _: () = assert!(MIN_PEERS <= TARGET_PEERS, "MIN_PEERS must be <= TARGET_PEERS");
-const _: () = assert!(TARGET_PEERS <= MAX_PEERS, "TARGET_PEERS must be <= MAX_PEERS");
 
 // Timeouts
 pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -790,7 +790,7 @@ impl PeerNetworkManager {
                     }
                 } else {
                     // Normal mode: try to maintain minimum peer count with discovery
-                    if count < MIN_PEERS {
+                    if count < TARGET_PEERS {
                         // Try known addresses first, sorted by reputation
                         let known = this.addrv2_handler.get_known_addresses().await;
                         let needed = TARGET_PEERS.saturating_sub(count);
@@ -851,7 +851,7 @@ impl PeerNetworkManager {
                     }
                     _ = dns_interval.tick(), if !this.exclusive_mode => {
                         let count = this.pool.peer_count().await;
-                        if count >= MIN_PEERS {
+                        if count >= TARGET_PEERS {
                             continue;
                         }
                         let dns_peers = tokio::select! {

--- a/dash-spv/src/network/pool.rs
+++ b/dash-spv/src/network/pool.rs
@@ -1,7 +1,7 @@
 //! Peer pool for managing multiple peer connections
 
 use crate::error::{NetworkError, SpvError as Error};
-use crate::network::constants::{MAX_PEERS, MIN_PEERS};
+use crate::network::constants::TARGET_PEERS;
 use crate::network::peer::Peer;
 use dashcore::prelude::CoreBlockHeight;
 use std::collections::{HashMap, HashSet};
@@ -41,10 +41,10 @@ impl PeerPool {
         connecting.remove(&addr);
 
         // Check if we're at capacity
-        if peers.len() >= MAX_PEERS {
+        if peers.len() >= TARGET_PEERS {
             return Err(Error::Network(NetworkError::ConnectionFailed(format!(
                 "Maximum peers ({}) reached",
-                MAX_PEERS
+                TARGET_PEERS
             ))));
         }
 
@@ -151,12 +151,12 @@ impl PeerPool {
 
     /// Check if we need more peers
     pub async fn needs_more_peers(&self) -> bool {
-        self.peer_count().await < MIN_PEERS
+        self.peer_count().await < TARGET_PEERS
     }
 
     /// Check if we can accept more peers
     pub async fn can_accept_peers(&self) -> bool {
-        self.peer_count().await < MAX_PEERS
+        self.peer_count().await < TARGET_PEERS
     }
 
     /// Clean up disconnected peers

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -28,7 +28,7 @@ mod pool_tests {
         // Test needs_more_peers logic
         assert!(pool.needs_more_peers().await);
 
-        // Can accept up to MAX_PEERS
+        // Can accept up to TARGET_PEERS
         assert!(pool.can_accept_peers().await);
 
         // Test peer count

--- a/dash-spv/tests/peer_test.rs
+++ b/dash-spv/tests/peer_test.rs
@@ -156,36 +156,6 @@ async fn test_peer_disconnection() {
     }
 }
 
-#[tokio::test]
-async fn test_max_peer_limit() {
-    use dash_spv::network::constants::MAX_PEERS;
-
-    let _ = env_logger::builder().is_test(true).try_init();
-
-    let mut config = create_test_config(Network::Testnet);
-
-    // Add at least one peer to avoid "No peers specified" error
-    config.peers = vec!["127.0.0.1:19999".parse().unwrap()];
-
-    // Create network manager
-    let network_manager = PeerNetworkManager::new(&config).await.unwrap();
-
-    // Create storage manager
-    let storage_manager =
-        DiskStorageManager::new(&config).await.expect("Failed to create tmp storage");
-
-    // Create wallet manager
-    let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
-
-    let _client =
-        DashSpvClient::new(config, network_manager, storage_manager, wallet).await.unwrap();
-
-    // The client should never connect to more than MAX_PEERS
-    // This is enforced in the PeerPool
-    println!("Maximum peer limit is set to: {}", MAX_PEERS);
-    assert_eq!(MAX_PEERS, 3, "Default max peers should be 12");
-}
-
 #[cfg(test)]
 mod unit_tests {
     use super::*;


### PR DESCRIPTION
With `MIN_PEERS=1` used as a "should we connect more peers" check, we ended up not trying to connect more peers in the maintenance loop which leads to getting stuck with 1 peer only after initial peers are gone.

Remove `MIN_PEERS` and `MAX_PEERS` and use `TARGET_PEERS` as the only peer count constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated multiple peer-count thresholds into a single unified threshold (TARGET_PEERS), simplifying peer connection logic and changing when the system adds peers or triggers discovery.

* **Behavioral change**
  * DNS discovery and auto-adding peers now wait until the unified TARGET_PEERS threshold is reached, raising the effective minimum connected peer target.

* **Tests**
  * Updated and removed network tests to match the simplified peer management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->