### PR TITLE
feat: validate received headers were actually requested

### DIFF
--- a/dash-spv/src/sync/block_headers/pipeline.rs
+++ b/dash-spv/src/sync/block_headers/pipeline.rs
@@ -175,6 +175,8 @@ impl HeadersPipeline {
                 if segment.complete && segment.target_height.is_none() {
                     segment.complete = false;
                     self.next_to_store = idx;
+                    // Mark as in-flight so the coordinator accepts these unsolicited headers
+                    segment.coordinator.mark_sent(&[prev_hash]);
                     tracing::debug!(
                         "Tip segment {} receiving post-sync headers, reset for continued processing",
                         segment.segment_id
@@ -399,6 +401,35 @@ mod tests {
 
         let ready = pipeline.take_ready_to_store();
         assert!(ready.is_empty());
+    }
+
+    #[test]
+    fn test_completed_tip_segment_accepts_unsolicited_post_sync_headers() {
+        // After initial sync completes, peers may push new block headers without
+        // us requesting them. The completed tip segment should accept these
+        // unsolicited headers by marking them as in-flight before processing.
+        let tip_hash = BlockHash::dummy(99);
+
+        let mut tip_seg = SegmentState::new(0, 1000, tip_hash, None, None);
+        tip_seg.complete = true;
+        tip_seg.current_height = 1000;
+        tip_seg.current_tip_hash = tip_hash;
+
+        let cm = create_test_checkpoint_manager(true);
+        let mut pipeline = HeadersPipeline::new(cm);
+        pipeline.initialized = true;
+        pipeline.segments = vec![tip_seg];
+
+        // Simulate an unsolicited header arriving from a peer (no in-flight request)
+        let mut header = Header::dummy(1);
+        header.prev_blockhash = tip_hash;
+
+        let matched = pipeline.receive_headers(&[header]).unwrap();
+        assert_eq!(matched, Some(0), "Tip segment should accept unsolicited post-sync headers");
+
+        assert!(!pipeline.segments[0].complete, "Tip segment should be reset to non-complete");
+        assert_eq!(pipeline.segments[0].buffered_headers.len(), 1);
+        assert_eq!(pipeline.segments[0].current_height, 1001);
     }
 
     #[test]

--- a/dash-spv/src/sync/block_headers/segment_state.rs
+++ b/dash-spv/src/sync/block_headers/segment_state.rs
@@ -100,9 +100,24 @@ impl SegmentState {
             return Ok(0);
         }
 
-        // Mark the request as received
+        // Reject headers on a segment that already reached its checkpoint
+        if self.complete {
+            return Err(SyncError::InvalidState(format!(
+                "Segment {}: received {} headers on completed segment (height {})",
+                self.segment_id,
+                headers.len(),
+                self.current_height
+            )));
+        }
+
+        // Mark the request as received, reject if we never requested this hash
         let prev_hash = headers[0].prev_blockhash;
-        self.coordinator.receive(&prev_hash);
+        if !self.coordinator.receive(&prev_hash) {
+            return Err(SyncError::InvalidState(format!(
+                "Segment {}: received unrequested headers (prev_hash {})",
+                self.segment_id, prev_hash
+            )));
+        }
 
         // Process headers
         let mut processed = 0;
@@ -307,5 +322,49 @@ mod tests {
         // Segment should be complete with the header buffered
         assert!(segment.complete);
         assert_eq!(segment.buffered_headers.len(), 1);
+    }
+
+    #[test]
+    fn test_unrequested_headers_returns_error() {
+        let start_hash = BlockHash::dummy(0);
+        let mut segment = SegmentState::new(0, 0, start_hash, None, None);
+
+        let mut header = Header::dummy(1);
+        header.prev_blockhash = start_hash;
+
+        let result = segment.receive_headers(&[header]);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SyncError::InvalidState(msg) => {
+                assert!(msg.contains("unrequested headers"));
+            }
+            other => panic!("Expected SyncError::InvalidState, got {:?}", other),
+        }
+        assert!(segment.buffered_headers.is_empty());
+    }
+
+    #[test]
+    fn test_completed_segment_rejects_new_headers() {
+        let start_hash = BlockHash::dummy(0);
+        let mut segment = SegmentState::new(0, 0, start_hash, Some(100), None);
+
+        // Mark segment as complete (simulating checkpoint reached)
+        segment.complete = true;
+        segment.current_height = 100;
+
+        // Create a header that would match
+        let mut header = Header::dummy(1);
+        header.prev_blockhash = start_hash;
+
+        // Completed segment should return an invalid state error
+        let result = segment.receive_headers(&[header]);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SyncError::InvalidState(msg) => {
+                assert!(msg.contains("completed segment"));
+            }
+            other => panic!("Expected SyncError::InvalidState, got {:?}", other),
+        }
+        assert!(segment.buffered_headers.is_empty());
     }
 }


### PR DESCRIPTION
Reject headers in `SegmentState::receive_headers` if the coordinator
does not recognize the `prev_hash` as an in-flight request. Returns an `InvalidState` error instead of silently processing unexpected responses.

Also adjust the post-sync processing to allow for unrequested headers since we don't request post-sync headers, they get announced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened header validation: rejects unrequested headers and headers for already-completed segments, preventing them from being buffered.

* **Behavior Changes**
  * Tip segments can be reset to accept unsolicited post-sync headers: such headers are marked in-flight, completion is cleared, and they are buffered for storage in order.

* **Tests**
  * Added tests covering unrequested headers rejection and completed-segment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->