### PR TITLE
fix: prevent invalid header response routing

### DIFF
--- a/dash-spv/src/sync/block_headers/pipeline.rs
+++ b/dash-spv/src/sync/block_headers/pipeline.rs
@@ -164,6 +164,12 @@ impl HeadersPipeline {
         // Find the segment that matches
         for (idx, segment) in self.segments.iter_mut().enumerate() {
             if segment.matches(&prev_hash) {
+                // Skip completed non-tip segments. After a segment reaches its checkpoint,
+                // its current_tip_hash equals the next segment's start_hash, so it would
+                // incorrectly steal the next segment's responses.
+                if segment.complete && segment.target_height.is_some() {
+                    continue;
+                }
                 // If tip segment was completed but receives new headers (post-sync),
                 // reset it so take_ready_to_store() can process the new headers
                 if segment.complete && segment.target_height.is_none() {
@@ -294,6 +300,7 @@ mod tests {
     use tokio::sync::mpsc::unbounded_channel;
 
     use crate::network::{NetworkRequest, RequestSender};
+    use crate::sync::block_headers::segment_state::SegmentState;
 
     fn create_test_checkpoint_manager(is_testnet: bool) -> Arc<CheckpointManager> {
         let checkpoints = if is_testnet {
@@ -392,5 +399,44 @@ mod tests {
 
         let ready = pipeline.take_ready_to_store();
         assert!(ready.is_empty());
+    }
+
+    #[test]
+    fn test_completed_segment_does_not_steal_next_segment_headers() {
+        // Create two segments which share the checkpoint hash boundary.
+        // - Segment 0: height 0 -> target 100
+        // - Segment 1: height 100 -> target 200
+        let shared_hash = BlockHash::dummy(42);
+
+        let mut segment_0 =
+            SegmentState::new(0, 0, BlockHash::dummy(0), Some(100), Some(shared_hash));
+        // Mark segment 0 as complete at the checkpoint — its current_tip_hash is the shared hash
+        segment_0.complete = true;
+        segment_0.current_height = 100;
+        segment_0.current_tip_hash = shared_hash;
+
+        let segment_1 = SegmentState::new(1, 100, shared_hash, Some(200), None);
+
+        // Build a pipeline with these two segments
+        let checkpoint_manager = create_test_checkpoint_manager(true);
+        let mut pipeline = HeadersPipeline::new(checkpoint_manager);
+        pipeline.initialized = true;
+        pipeline.segments = vec![segment_0, segment_1];
+
+        // Create a header whose prev_blockhash is the shared hash
+        let mut header = Header::dummy(1);
+        header.prev_blockhash = shared_hash;
+
+        // Mark segment 1 request as in-flight so receive works
+        pipeline.segments[1].coordinator.mark_sent(&[shared_hash]);
+
+        // Route headers should go to segment 1, not the completed segment 0
+        let matched = pipeline.receive_headers(&[header]).unwrap();
+        assert_eq!(matched, Some(1), "Headers should route to segment 1, not completed segment 0");
+
+        // Segment 0 should still have no extra buffered headers
+        assert!(pipeline.segments[0].buffered_headers.is_empty());
+        // Segment 1 should have the header
+        assert_eq!(pipeline.segments[1].buffered_headers.len(), 1);
     }
 }

--- a/dash-spv/src/sync/block_headers/segment_state.rs
+++ b/dash-spv/src/sync/block_headers/segment_state.rs
@@ -20,7 +20,7 @@ pub(super) struct SegmentState {
     /// Target hash (next checkpoint hash for validation).
     target_hash: Option<BlockHash>,
     /// Current tip hash for GetHeaders locator.
-    current_tip_hash: BlockHash,
+    pub(super) current_tip_hash: BlockHash,
     /// Current height reached in this segment.
     pub(super) current_height: u32,
     /// Download coordinator for tracking in-flight requests.


### PR DESCRIPTION
After a `Segment` reaches its checkpoint, its `current_tip_hash` equals the next segment's `start_hash`. Since segments are iterated in order, the completed segment matches first and consumes responses meant for the next segment, buffering headers past its target height. This advanced the storage tip beyond the next segment's start, causing a validation failure and the header sync getting stuck.

Skip completed non-tip segments when routing incoming headers, and reject headers in `receive_headers()` if the segment is already complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced block header synchronization to prevent routing headers to already-completed segments, improving sync efficiency and preventing unnecessary buffering.
  * Improved tip segment recovery when headers are received in post-sync scenarios.

* **Tests**
  * Added validation for correct header routing behavior to active segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->