### PR TITLE
fix: handle broadcast RecvError::Lagged gracefully in maintenance loop

### DIFF
--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -883,8 +883,11 @@ impl PeerNetworkManager {
                                 dns_interval.reset();
                                 this.maintenance_tick().await;
                             }
-                            Err(error) => {
-                                tracing::error!("Network event error: {}", error);
+                            Err(broadcast::error::RecvError::Lagged(n)) => {
+                                log::warn!("Network event receiver lagged by {} messages", n);
+                            }
+                            Err(broadcast::error::RecvError::Closed) => {
+                                log::error!("Network event channel closed");
                                 break;
                             }
                         }


### PR DESCRIPTION
Addresses review feedback from CodeRabbit on #433:

**1. Consistent logging macros**
Replaced `tracing::error!` with `log::error!` to match the rest of `manager.rs` which uses the `log` crate throughout.

**2. Handle `RecvError::Lagged` vs `RecvError::Closed` separately**
Previously, any `broadcast::RecvError` was treated as fatal (broke the loop). Now:
- `RecvError::Lagged(n)`: Log a warning with the count and continue. Lagged just means we missed some broadcast events — not fatal.
- `RecvError::Closed`: Log an error and break. The channel is gone, maintenance loop should stop.

---
🤖 *This was generated by an automated review bot.*
Don't want automated PRs or comments on your code? You can opt out by replying here or messaging @PastaPastaPasta on Slack — we'll make sure the bot skips your PRs/repos going forward.