### PR TITLE
refactor: simplify `FiltersManager.start_download`

### DIFF
--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -100,6 +100,15 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         }
     }
 
+    /// Returns true if there is no in-flight processing state.
+    fn is_idle(&self) -> bool {
+        self.active_batches.is_empty()
+            && self.blocks_remaining.is_empty()
+            && self.filters_matched.is_empty()
+            && self.pending_batches.is_empty()
+            && self.filter_pipeline.is_idle()
+    }
+
     /// Clear all in-flight processing state. Called on peer disconnect when
     /// in-flight filter batches and block tracking become invalid.
     pub(super) fn clear_in_flight_state(&mut self) {
@@ -133,11 +142,13 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         Ok(filters)
     }
 
-    /// Start or resume filter download.
+    /// Initialize the filter download state and begin downloading from the current position.
     pub(super) async fn start_download(
         &mut self,
         requests: &RequestSender,
     ) -> SyncResult<Vec<SyncEvent>> {
+        debug_assert!(self.is_idle(), "manager should have no in-flight state on start");
+
         self.set_state(SyncState::Syncing);
         // Use filter_committed_height for restart recovery instead of
         // synced_height, which advances per-block and may exceed committed scan progress.
@@ -185,59 +196,26 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             scan_start
         };
 
-        // Initialize storage tracking
-        // If we have pending batches from a previous run, continue from their boundaries
-        // instead of recalculating from storage (which might not reflect in-flight batches)
-        if !self.pending_batches.is_empty() {
-            let first_pending = self.pending_batches.first().unwrap().start_height();
-            tracing::info!(
-                "Resuming with {} pending batches, next_batch_to_store staying at {} (first pending: {})",
-                self.pending_batches.len(),
-                self.next_batch_to_store,
-                first_pending
-            );
-            // Don't reset next_batch_to_store - keep the existing value
-        } else {
-            tracing::info!(
-                "Initializing next_batch_to_store to {} (stored_filters_tip={}, scan_start={})",
-                download_start,
-                stored_filters_tip,
-                scan_start
-            );
-            self.next_batch_to_store = download_start;
-        }
-
+        self.next_batch_to_store = download_start;
         self.processing_height = scan_start;
 
-        // Initialize download pipeline for all remaining filters
-        if download_start <= self.progress.filter_header_tip_height() {
-            // Only reinitialize if pipeline is empty - avoid losing in-flight batches
-            if self.filter_pipeline.active_count() == 0 && self.pending_batches.is_empty() {
-                self.filter_pipeline.init(download_start, self.progress.filter_header_tip_height());
-                tracing::info!(
-                    "Starting filter download from {} to {} (batch-based processing)",
-                    download_start,
-                    self.progress.filter_header_tip_height()
-                );
-            } else {
-                // Extend target without resetting state - batches still in flight
-                self.filter_pipeline.extend_target(self.progress.filter_header_tip_height());
-                tracing::info!(
-                    "Resuming filter download to {} (active batches: {}, pending: {})",
-                    self.progress.filter_header_tip_height(),
-                    self.filter_pipeline.active_count(),
-                    self.pending_batches.len()
-                );
-            }
+        tracing::info!(
+            "Starting filter download (scan_start={}, download_start={}, stored_filters_tip={}, target={})",
+            scan_start,
+            download_start,
+            stored_filters_tip,
+            self.progress.filter_header_tip_height()
+        );
 
+        // Initialize download pipeline for remaining filters
+        if download_start <= self.progress.filter_header_tip_height() {
+            self.filter_pipeline.init(download_start, self.progress.filter_header_tip_height());
             let header_storage = self.header_storage.read().await;
             self.filter_pipeline.send_pending(requests, &*header_storage).await?;
             drop(header_storage);
         } else {
-            // No new filters to download - initialize pipeline to a "complete" state
-            // so it doesn't try to download from its default start height
+            // No new filters to download, scanning stored filters only
             self.filter_pipeline.init(download_start, download_start.saturating_sub(1));
-            tracing::info!("Rescan mode: no new filters to download, scanning stored filters only");
         }
 
         // Initialize the first processing batch
@@ -924,6 +902,47 @@ mod tests {
         // Verify batch association
         assert_eq!(manager.blocks_remaining.get(&hash1), Some(&(100, 0)));
         assert_eq!(manager.blocks_remaining.get(&hash2), Some(&(5100, 5000)));
+    }
+
+    #[tokio::test]
+    async fn test_is_idle() {
+        let mut manager = create_test_manager().await;
+        let hash = dashcore::block::Header::dummy(0).block_hash();
+
+        // Fresh manager is idle
+        assert!(manager.is_idle());
+
+        // Test each involved field separately
+        manager.active_batches.insert(0, FiltersBatch::new(0, 999, HashMap::new()));
+        assert!(!manager.is_idle());
+        manager.active_batches.clear();
+
+        manager.blocks_remaining.insert(hash, (0, 0));
+        assert!(!manager.is_idle());
+        manager.blocks_remaining.clear();
+
+        manager.filters_matched.insert(hash);
+        assert!(!manager.is_idle());
+        manager.filters_matched.clear();
+
+        manager.pending_batches.insert(FiltersBatch::new(0, 999, HashMap::new()));
+        assert!(!manager.is_idle());
+        manager.pending_batches.clear();
+
+        manager.filter_pipeline.init(0, 999);
+        assert!(!manager.is_idle());
+        manager.filter_pipeline = FiltersPipeline::new();
+
+        // Populate all fields, then clear_in_flight_state restores idleness
+        manager.active_batches.insert(0, FiltersBatch::new(0, 999, HashMap::new()));
+        manager.blocks_remaining.insert(hash, (0, 0));
+        manager.filters_matched.insert(hash);
+        manager.pending_batches.insert(FiltersBatch::new(1000, 1999, HashMap::new()));
+        manager.filter_pipeline.init(2000, 2999);
+        assert!(!manager.is_idle());
+
+        manager.clear_in_flight_state();
+        assert!(manager.is_idle());
     }
 
     #[tokio::test]

--- a/dash-spv/src/sync/filters/pipeline.rs
+++ b/dash-spv/src/sync/filters/pipeline.rs
@@ -80,9 +80,9 @@ impl FiltersPipeline {
         }
     }
 
-    /// Get the number of active batches.
-    pub(super) fn active_count(&self) -> usize {
-        self.coordinator.active_count()
+    /// Returns true if the pipeline has no in-flight or pending work.
+    pub(super) fn is_idle(&self) -> bool {
+        self.coordinator.active_count() == 0 && self.coordinator.pending_count() == 0
     }
 
     /// Take completed batches with their buffered filter data for processing.
@@ -315,7 +315,7 @@ mod tests {
     fn test_pipeline_new() {
         let pipeline = FiltersPipeline::new();
 
-        assert_eq!(pipeline.active_count(), 0);
+        assert_eq!(pipeline.coordinator.active_count(), 0);
         assert!(pipeline.batch_trackers.is_empty());
         assert!(pipeline.completed_batches.is_empty());
         assert_eq!(pipeline.target_height, 0);
@@ -324,11 +324,23 @@ mod tests {
     }
 
     #[test]
+    fn test_is_idle() {
+        let mut pipeline = FiltersPipeline::new();
+        assert!(pipeline.is_idle());
+
+        pipeline.init(0, 999);
+        assert!(!pipeline.is_idle());
+    }
+
+    #[test]
     fn test_pipeline_default_trait() {
         let default_pipeline = FiltersPipeline::default();
         let new_pipeline = FiltersPipeline::new();
 
-        assert_eq!(default_pipeline.active_count(), new_pipeline.active_count());
+        assert_eq!(
+            default_pipeline.coordinator.active_count(),
+            new_pipeline.coordinator.active_count()
+        );
         assert_eq!(default_pipeline.target_height, new_pipeline.target_height);
     }
 
@@ -360,7 +372,7 @@ mod tests {
 
         assert!(pipeline.batch_trackers.is_empty());
         assert!(pipeline.completed_batches.is_empty());
-        assert_eq!(pipeline.active_count(), 0);
+        assert_eq!(pipeline.coordinator.active_count(), 0);
         assert_eq!(pipeline.filters_received, 0);
         // 1 batch queued for heights 200-300
         assert_eq!(pipeline.coordinator.pending_count(), 1);
@@ -609,7 +621,7 @@ mod tests {
         assert_eq!(timed_out, vec![0]);
         // Batch should be re-queued in coordinator's pending queue
         assert_eq!(pipeline.coordinator.pending_count(), 1);
-        assert_eq!(pipeline.active_count(), 0);
+        assert_eq!(pipeline.coordinator.active_count(), 0);
     }
 
     #[test]
@@ -660,7 +672,7 @@ mod tests {
         pipeline.batch_trackers.insert(2000, BatchTracker::new(2999));
         pipeline.coordinator.mark_sent(&[0, 1000, 2000]);
 
-        assert_eq!(pipeline.active_count(), 3);
+        assert_eq!(pipeline.coordinator.active_count(), 3);
         assert_eq!(pipeline.coordinator.pending_count(), 0);
 
         // Wait for timeout
@@ -672,7 +684,7 @@ mod tests {
 
         // All 3 batches should be in the pending queue, not duplicated
         assert_eq!(pipeline.coordinator.pending_count(), 3);
-        assert_eq!(pipeline.active_count(), 0);
+        assert_eq!(pipeline.coordinator.active_count(), 0);
 
         // Take pending items - should get exactly 3, not more
         let pending = pipeline.coordinator.take_pending(10);
@@ -701,7 +713,7 @@ mod tests {
         let count = pipeline.send_pending(&sender, &storage).await.unwrap();
 
         assert_eq!(count, 1);
-        assert_eq!(pipeline.active_count(), 1);
+        assert_eq!(pipeline.coordinator.active_count(), 1);
         assert!(pipeline.batch_trackers.contains_key(&0));
         // No more pending since the single batch was sent
         assert_eq!(pipeline.coordinator.pending_count(), 0);
@@ -735,7 +747,7 @@ mod tests {
         // Should respect MAX_CONCURRENT_FILTER_BATCHES (20)
         // 25 batches needed, but only 20 can be in-flight at once
         assert_eq!(count, MAX_CONCURRENT_FILTER_BATCHES);
-        assert_eq!(pipeline.active_count(), MAX_CONCURRENT_FILTER_BATCHES);
+        assert_eq!(pipeline.coordinator.active_count(), MAX_CONCURRENT_FILTER_BATCHES);
         assert_eq!(pipeline.batch_trackers.len(), MAX_CONCURRENT_FILTER_BATCHES);
         // 5 batches still pending
         assert_eq!(pipeline.coordinator.pending_count(), 5);
@@ -783,7 +795,7 @@ mod tests {
 
         // Should send all 3 batches: 0-999, 1000-1999, 2000-2500
         assert_eq!(count, 3);
-        assert_eq!(pipeline.active_count(), 3);
+        assert_eq!(pipeline.coordinator.active_count(), 3);
         assert_eq!(pipeline.coordinator.pending_count(), 0);
     }
 
@@ -827,7 +839,7 @@ mod tests {
         // Send request
         let sent = pipeline.send_pending(&sender, &storage).await.unwrap();
         assert_eq!(sent, 1);
-        assert_eq!(pipeline.active_count(), 1);
+        assert_eq!(pipeline.coordinator.active_count(), 1);
 
         // Receive all filters
         for h in 0..=99 {
@@ -836,7 +848,7 @@ mod tests {
         }
 
         // Batch should be complete
-        assert_eq!(pipeline.active_count(), 0);
+        assert_eq!(pipeline.coordinator.active_count(), 0);
         assert_eq!(pipeline.completed_batches.len(), 1);
         assert_eq!(pipeline.filters_received, 100);
         assert_eq!(pipeline.highest_received, 99);
@@ -861,7 +873,7 @@ mod tests {
 
         // Send initial request
         pipeline.send_pending(&sender, &storage).await.unwrap();
-        assert_eq!(pipeline.active_count(), 1);
+        assert_eq!(pipeline.coordinator.active_count(), 1);
         assert_eq!(pipeline.coordinator.pending_count(), 0);
 
         // Wait for timeout
@@ -871,14 +883,14 @@ mod tests {
         let timed_out = pipeline.handle_timeouts();
         assert_eq!(timed_out.len(), 1);
         assert_eq!(pipeline.coordinator.pending_count(), 1);
-        assert_eq!(pipeline.active_count(), 0);
+        assert_eq!(pipeline.coordinator.active_count(), 0);
 
         // Tracker should still exist for late arrivals
         assert!(pipeline.batch_trackers.contains_key(&0));
 
         // Can retry by sending again
         pipeline.send_pending(&sender, &storage).await.unwrap();
-        assert_eq!(pipeline.active_count(), 1);
+        assert_eq!(pipeline.coordinator.active_count(), 1);
 
         // Existing tracker is reused (not replaced)
         assert!(pipeline.batch_trackers.contains_key(&0));


### PR DESCRIPTION
- remove `init`/`extend_target` blocks in `start_download()` and just always call `init()` since there shouldn't be any inflight state when `start_download` is called.
- add `is_idle()` helper to `FiltersManager` and `FiltersPipeline` to verify this via `debug_assert`
- remove `FiltersPipeline::active_count()` since its dead code after removing the relevant log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified download initialization to remove conditional branches and make startup behavior consistent.
  * Consolidated idle-state checks into a single detection mechanism for clearer synchronization flow.
  * Eliminated complex batch-preservation and conditional pipeline reinitialization logic.

* **Bug Fixes**
  * More reliable startup/resume behavior and fewer synchronization edge cases due to improved idle detection and initialization.

* **Tests**
  * Added tests validating idle detection and state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->