### PR TITLE
refactor: remove duplicate `get_peer_count` method

### DIFF
--- a/dash-spv/src/client/queries.rs
+++ b/dash-spv/src/client/queries.rs
@@ -27,11 +27,6 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         self.network.lock().await.peer_count()
     }
 
-    /// Get the number of connected peers (async version).
-    pub async fn get_peer_count(&self) -> usize {
-        self.network.lock().await.peer_count()
-    }
-
     /// Disconnect a specific peer.
     pub async fn disconnect_peer(&self, addr: &std::net::SocketAddr, reason: &str) -> Result<()> {
         // Cast network manager to PeerNetworkManager to access disconnect_peer


### PR DESCRIPTION
Identical to `peer_count()` and unused by any caller.

Based on:
- #453 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed a redundant method for retrieving peer count. Use the primary method instead to access the number of connected peers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->