### PR TITLE
refactor: remove `SyncState::Initializing` variant

### DIFF
--- a/dash-spv-ffi/include/dash_spv_ffi.h
+++ b/dash-spv-ffi/include/dash_spv_ffi.h
@@ -20,12 +20,11 @@ namespace dash_spv_ffi {
  * SyncState exposed by the FFI as FFISyncState.
  */
 typedef enum FFISyncState {
-  Initializing = 0,
+  WaitForEvents = 0,
   WaitingForConnections = 1,
-  WaitForEvents = 2,
-  Syncing = 3,
-  Synced = 4,
-  Error = 5,
+  Syncing = 2,
+  Synced = 3,
+  Error = 4,
 } FFISyncState;
 
 /**

--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -201,9 +201,8 @@ extern "C" fn on_progress_update(progress: *const FFISyncProgress, _user_data: *
     let p = unsafe { &*progress };
 
     let state_str = match p.state {
-        FFISyncState::Initializing => "Initializing",
-        FFISyncState::WaitingForConnections => "WaitingForConnections",
         FFISyncState::WaitForEvents => "WaitForEvents",
+        FFISyncState::WaitingForConnections => "WaitingForConnections",
         FFISyncState::Syncing => "Syncing",
         FFISyncState::Synced => "Synced",
         FFISyncState::Error => "Error",

--- a/dash-spv-ffi/src/types.rs
+++ b/dash-spv-ffi/src/types.rs
@@ -51,18 +51,16 @@ impl FFIString {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum FFISyncState {
     #[default]
-    Initializing = 0,
+    WaitForEvents = 0,
     WaitingForConnections = 1,
-    WaitForEvents = 2,
-    Syncing = 3,
-    Synced = 4,
-    Error = 5,
+    Syncing = 2,
+    Synced = 3,
+    Error = 4,
 }
 
 impl From<SyncState> for FFISyncState {
     fn from(state: SyncState) -> Self {
         match state {
-            SyncState::Initializing => FFISyncState::Initializing,
             SyncState::WaitingForConnections => FFISyncState::WaitingForConnections,
             SyncState::WaitForEvents => FFISyncState::WaitForEvents,
             SyncState::Syncing => FFISyncState::Syncing,

--- a/dash-spv-ffi/tests/test_types.rs
+++ b/dash-spv-ffi/tests/test_types.rs
@@ -101,7 +101,7 @@ mod tests {
         progress.update_chainlocks(chainlocks);
 
         let mut instantsend = InstantSendProgress::default();
-        instantsend.set_state(SyncState::Initializing);
+        instantsend.set_state(SyncState::WaitForEvents);
         instantsend.update_pending(700);
         instantsend.add_valid(200);
         instantsend.add_invalid(15);
@@ -187,7 +187,7 @@ mod tests {
         assert!(!ffi_progress.instantsend.is_null());
         unsafe {
             let instantsend = &*ffi_progress.instantsend;
-            assert_eq!(instantsend.state, FFISyncState::Initializing);
+            assert_eq!(instantsend.state, FFISyncState::WaitForEvents);
             assert_eq!(instantsend.pending, 700);
             assert_eq!(instantsend.valid, 200);
             assert_eq!(instantsend.invalid, 15);

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -236,7 +236,7 @@ mod tests {
     async fn test_block_headers_manager_new() {
         let manager = create_test_manager().await;
         assert_eq!(manager.identifier(), ManagerIdentifier::BlockHeader);
-        assert_eq!(manager.state(), SyncState::Initializing);
+        assert_eq!(manager.state(), SyncState::WaitForEvents);
         assert_eq!(manager.wanted_message_types(), vec![MessageType::Headers, MessageType::Inv]);
     }
 
@@ -249,7 +249,7 @@ mod tests {
 
         let progress = manager.progress();
         if let SyncManagerProgress::BlockHeaders(progress) = progress {
-            assert_eq!(progress.state(), SyncState::Initializing);
+            assert_eq!(progress.state(), SyncState::WaitForEvents);
             assert_eq!(progress.tip_height(), 100);
             assert_eq!(progress.target_height(), 200);
             assert_eq!(progress.processed(), 50);

--- a/dash-spv/src/sync/blocks/manager.rs
+++ b/dash-spv/src/sync/blocks/manager.rs
@@ -177,7 +177,7 @@ mod tests {
     async fn test_blocks_manager_new() {
         let manager = create_test_manager().await;
         assert_eq!(manager.identifier(), ManagerIdentifier::Block);
-        assert_eq!(manager.state(), SyncState::Initializing);
+        assert_eq!(manager.state(), SyncState::WaitForEvents);
         assert_eq!(manager.wanted_message_types(), vec![MessageType::Block]);
     }
 

--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -280,7 +280,7 @@ mod tests {
     async fn test_chainlock_manager_new() {
         let manager = create_test_manager().await;
         assert_eq!(manager.identifier(), ManagerIdentifier::ChainLock);
-        assert_eq!(manager.state(), SyncState::Initializing);
+        assert_eq!(manager.state(), SyncState::WaitForEvents);
         assert_eq!(manager.wanted_message_types(), vec![MessageType::CLSig, MessageType::Inv]);
     }
 

--- a/dash-spv/src/sync/filter_headers/manager.rs
+++ b/dash-spv/src/sync/filter_headers/manager.rs
@@ -250,7 +250,7 @@ mod tests {
     async fn test_filter_headers_manager_new() {
         let manager = create_test_manager().await;
         assert_eq!(manager.identifier(), ManagerIdentifier::FilterHeader);
-        assert_eq!(manager.state(), SyncState::Initializing);
+        assert_eq!(manager.state(), SyncState::WaitForEvents);
         assert_eq!(manager.wanted_message_types(), vec![MessageType::CFHeaders]);
     }
 
@@ -265,7 +265,7 @@ mod tests {
         let manager_ref: &TestSyncManager = &manager;
         let progress = manager_ref.progress();
         if let SyncManagerProgress::FilterHeaders(progress) = progress {
-            assert_eq!(progress.state(), SyncState::Initializing);
+            assert_eq!(progress.state(), SyncState::WaitForEvents);
             assert_eq!(progress.current_height(), 500);
             assert_eq!(progress.target_height(), 2000);
             assert_eq!(progress.block_header_tip_height(), 1000);

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -797,7 +797,7 @@ mod tests {
     async fn test_filters_manager_new() {
         let manager = create_test_manager().await;
         assert_eq!(manager.identifier(), ManagerIdentifier::Filter);
-        assert_eq!(manager.state(), SyncState::Initializing);
+        assert_eq!(manager.state(), SyncState::WaitForEvents);
         assert_eq!(manager.wanted_message_types(), vec![MessageType::CFilter]);
     }
 
@@ -984,7 +984,7 @@ mod tests {
     #[tokio::test]
     async fn test_start_download_waits_when_filter_headers_insufficient() {
         let mut manager = create_test_manager().await;
-        assert_eq!(manager.state(), SyncState::Initializing);
+        assert_eq!(manager.state(), SyncState::WaitForEvents);
 
         // Wallet committed to height 100, so scan_start will be 101
         manager.wallet.write().await.update_synced_height(100);
@@ -1004,7 +1004,7 @@ mod tests {
     #[tokio::test]
     async fn test_start_download_transitions_to_syncing_when_filters_available() {
         let mut manager = create_test_manager().await;
-        assert_eq!(manager.state(), SyncState::Initializing);
+        assert_eq!(manager.state(), SyncState::WaitForEvents);
 
         // Store headers so send_pending can resolve stop hashes
         let headers = dashcore::block::Header::dummy_batch(0..101);

--- a/dash-spv/src/sync/instantsend/manager.rs
+++ b/dash-spv/src/sync/instantsend/manager.rs
@@ -312,7 +312,7 @@ mod tests {
     async fn test_instantsend_manager_new() {
         let manager = create_test_manager();
         assert_eq!(manager.identifier(), ManagerIdentifier::InstantSend);
-        assert_eq!(manager.state(), SyncState::Initializing);
+        assert_eq!(manager.state(), SyncState::WaitForEvents);
         assert_eq!(manager.wanted_message_types(), vec![MessageType::ISLock, MessageType::Inv]);
     }
 

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -231,7 +231,7 @@ mod tests {
     async fn test_masternode_manager_new() {
         let manager = create_test_manager().await;
         assert_eq!(manager.identifier(), ManagerIdentifier::Masternode);
-        assert_eq!(manager.state(), SyncState::Initializing);
+        assert_eq!(manager.state(), SyncState::WaitForEvents);
         assert_eq!(
             manager.wanted_message_types(),
             vec![MessageType::MnListDiff, MessageType::QRInfo]

--- a/dash-spv/src/sync/progress.rs
+++ b/dash-spv/src/sync/progress.rs
@@ -10,9 +10,8 @@ use std::fmt;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SyncState {
     #[default]
-    Initializing,
-    WaitingForConnections,
     WaitForEvents,
+    WaitingForConnections,
     Syncing,
     Synced,
     Error,
@@ -41,7 +40,7 @@ impl SyncProgress {
     /// Get the overall sync state.
     ///
     /// Returns the most progressed state among all managers,
-    /// or Initializing if no managers have started.
+    /// or WaitForEvents if no managers have started.
     pub fn state(&self) -> SyncState {
         let states: Vec<SyncState> = [
             self.headers.as_ref().map(|h| h.state()),
@@ -55,19 +54,16 @@ impl SyncProgress {
         .collect();
 
         if states.is_empty() {
-            return SyncState::Initializing;
+            return SyncState::WaitForEvents;
         }
 
         // Return the "most progressed" state
-        // Priority: Error > Syncing > WaitForEvents > WaitingForConnections > Synced > Initializing
+        // Priority: Error > Syncing > WaitingForConnections > Synced > WaitForEvents
         if states.contains(&SyncState::Error) {
             return SyncState::Error;
         }
         if states.contains(&SyncState::Syncing) {
             return SyncState::Syncing;
-        }
-        if states.contains(&SyncState::WaitForEvents) {
-            return SyncState::WaitForEvents;
         }
         if states.contains(&SyncState::WaitingForConnections) {
             return SyncState::WaitingForConnections;
@@ -75,7 +71,7 @@ impl SyncProgress {
         if states.iter().all(|s| *s == SyncState::Synced) {
             return SyncState::Synced;
         }
-        SyncState::Initializing
+        SyncState::WaitForEvents
     }
 
     /// Check if all managers are idle (sync complete).

--- a/dash-spv/src/sync/sync_coordinator.rs
+++ b/dash-spv/src/sync/sync_coordinator.rs
@@ -386,7 +386,7 @@ mod tests {
     #[test]
     fn test_sync_progress_default() {
         let progress = SyncProgress::default();
-        assert_eq!(progress.state(), SyncState::Initializing);
+        assert_eq!(progress.state(), SyncState::WaitForEvents);
         assert!(!progress.is_synced());
         // Fields are None by default - getters return errors
         assert!(progress.headers().is_err());

--- a/dash-spv/src/sync/sync_manager.rs
+++ b/dash-spv/src/sync/sync_manager.rs
@@ -404,7 +404,7 @@ mod tests {
 
         let manager = MockManager {
             identifier: ManagerIdentifier::BlockHeader,
-            state: SyncState::Initializing,
+            state: SyncState::WaitForEvents,
             message_count: message_count.clone(),
             event_count: event_count.clone(),
             tick_count: tick_count.clone(),


### PR DESCRIPTION
The `Initializing` state was only used as a default before `initialize()` was called. Replace it with `WaitForEvents` as the default state to simplify the state machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reordered and simplified synchronization state ordering; replaced the previous initial state with a new "wait for events" state and updated status labels used in progress reporting.

* **Tests**
  * Updated test expectations across the suite to align with the revised synchronization state names and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->