### PR TITLE
fix: correct initial percentage to only average active managers

### DIFF
--- a/dash-spv/src/sync/progress.rs
+++ b/dash-spv/src/sync/progress.rs
@@ -100,12 +100,21 @@ impl SyncProgress {
     }
 
     /// Get overall completion percentage (0.0 to 1.0).
+    ///
+    /// Only managers that are active contribute to the average.
     pub fn percentage(&self) -> f64 {
-        let percentages = [
-            self.headers.as_ref().map(|h| h.percentage()).unwrap_or(1.0),
-            self.filter_headers.as_ref().map(|f| f.percentage()).unwrap_or(1.0),
-            self.filters.as_ref().map(|f| f.percentage()).unwrap_or(1.0),
-        ];
+        let percentages: Vec<f64> = [
+            self.headers.as_ref().map(|h| h.percentage()),
+            self.filter_headers.as_ref().map(|f| f.percentage()),
+            self.filters.as_ref().map(|f| f.percentage()),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+
+        if percentages.is_empty() {
+            return 0.0;
+        }
         percentages.iter().sum::<f64>() / percentages.len() as f64
     }
 

--- a/dash-spv/src/sync/sync_coordinator.rs
+++ b/dash-spv/src/sync/sync_coordinator.rs
@@ -381,7 +381,7 @@ fn update_progress_from_manager(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sync::{BlockHeadersProgress, FiltersProgress, SyncState};
+    use crate::sync::{BlockHeadersProgress, FilterHeadersProgress, FiltersProgress, SyncState};
 
     #[test]
     fn test_sync_progress_default() {
@@ -397,12 +397,12 @@ mod tests {
     #[test]
     fn test_sync_percentage_empty() {
         let progress = SyncProgress::default();
-        // Both headers and filters are None, so percentage defaults to 1.0
-        assert_eq!(progress.percentage(), 1.0);
+        // All fields are None, no active phases, so percentage is 0.0
+        assert_eq!(progress.percentage(), 0.0);
     }
 
     #[test]
-    fn test_sync_percentage() {
+    fn test_sync_percentage_headers_only() {
         let mut progress = SyncProgress::default();
 
         // Create headers progress at 50%
@@ -413,6 +413,30 @@ mod tests {
         headers_progress.add_processed(500);
         progress.update_headers(headers_progress);
 
+        // Only headers is active, so percentage = 0.5
+        assert_eq!(progress.percentage(), 0.5);
+    }
+
+    #[test]
+    fn test_sync_percentage_mixed() {
+        let mut progress = SyncProgress::default();
+
+        // Create headers progress at 75%
+        let mut headers_progress = BlockHeadersProgress::default();
+        headers_progress.set_state(SyncState::Syncing);
+        headers_progress.update_tip_height(750);
+        headers_progress.update_target_height(1000);
+        headers_progress.add_processed(750);
+        progress.update_headers(headers_progress);
+
+        // Create filter headers progress at 50%
+        let mut filter_headers_progress = FilterHeadersProgress::default();
+        filter_headers_progress.set_state(SyncState::Syncing);
+        filter_headers_progress.update_current_height(500);
+        filter_headers_progress.update_target_height(1000);
+        filter_headers_progress.add_processed(500);
+        progress.update_filter_headers(filter_headers_progress);
+
         // Create filters progress at 25%
         let mut filters_progress = FiltersProgress::default();
         filters_progress.set_state(SyncState::Syncing);
@@ -421,7 +445,7 @@ mod tests {
         filters_progress.add_downloaded(250);
         progress.update_filters(filters_progress);
 
-        // (0.5 + 1.0 + 0.25) / 3 = ~0.583 (filter_headers defaults to 1.0)
-        assert!((progress.percentage() - 0.583).abs() < 0.01);
+        // Headers 75%, filter headers 50%, filters 25%: (0.75 + 0.5 + 0.25) / 3 = 0.5
+        assert_eq!(progress.percentage(), 0.5);
     }
 }


### PR DESCRIPTION
At the moment `None` managers use `unwrap_or(0.0)` which dragged down the percentage when only some managers are active like when filters are disabled, only block headers are active. With this PR only phases that have actually started contribute to the average.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Enhanced sync progress tracking by refining how synchronization phases are aggregated, ensuring progress percentages now accurately reflect only active phases for more precise progress reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->