### PR TITLE
chore: drop unused `_TestCallbackData`

### DIFF
--- a/dash-spv-ffi/tests/test_client.rs
+++ b/dash-spv-ffi/tests/test_client.rs
@@ -4,14 +4,7 @@ mod tests {
     use key_wallet_ffi::FFINetwork;
     use serial_test::serial;
     use std::ffi::CString;
-    use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
-
-    struct _TestCallbackData {
-        progress_called: Arc<Mutex<bool>>,
-        completion_called: Arc<Mutex<bool>>,
-        last_progress: Arc<Mutex<f64>>,
-    }
 
     fn create_test_config() -> (*mut FFIClientConfig, TempDir) {
         let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed unused test scaffolding and related imports to simplify test code and reduce unnecessary synchronization plumbing. This cleans up dead code and makes tests easier to read and maintain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->