### PR TITLE
feat: dispatch progress callback on registration

### DIFF
--- a/dash-spv-ffi/src/client.rs
+++ b/dash-spv-ffi/src/client.rs
@@ -695,7 +695,12 @@ pub unsafe extern "C" fn dash_spv_ffi_client_set_progress_callback(
     null_check!(client);
 
     let client = &(*client);
-    *client.progress_callback.lock().unwrap() = Some(callback);
+    let progress = client.runtime.block_on(async { client.inner.progress().await });
+    let mut cb_guard = client.progress_callback.lock().unwrap();
+    *cb_guard = Some(callback);
+    if let Some(ref cb) = *cb_guard {
+        cb.dispatch(&progress);
+    }
 
     FFIErrorCode::Success as i32
 }

--- a/dash-spv-ffi/tests/test_client.rs
+++ b/dash-spv-ffi/tests/test_client.rs
@@ -4,7 +4,23 @@ mod tests {
     use key_wallet_ffi::FFINetwork;
     use serial_test::serial;
     use std::ffi::CString;
+    use std::os::raw::c_void;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    struct ProgressCallbackData {
+        state: Mutex<Option<FFISyncState>>,
+        is_synced: Mutex<Option<bool>>,
+    }
+
+    impl ProgressCallbackData {
+        fn new() -> Self {
+            Self {
+                state: Mutex::new(None),
+                is_synced: Mutex::new(None),
+            }
+        }
+    }
 
     fn create_test_config() -> (*mut FFIClientConfig, TempDir) {
         let temp_dir = TempDir::new().unwrap();
@@ -69,6 +85,50 @@ mod tests {
 
             let progress = dash_spv_ffi_client_get_sync_progress(std::ptr::null_mut());
             assert!(progress.is_null());
+        }
+    }
+
+    extern "C" fn test_progress_callback(progress: *const FFISyncProgress, user_data: *mut c_void) {
+        assert!(!progress.is_null());
+        let data = unsafe { &*(user_data as *const ProgressCallbackData) };
+        let p = unsafe { &*progress };
+
+        *data.state.lock().unwrap() = Some(p.state);
+        *data.is_synced.lock().unwrap() = Some(p.is_synced);
+    }
+
+    #[test]
+    #[serial]
+    fn test_set_progress_callback_emits_progress() {
+        unsafe {
+            let (config, _temp_dir) = create_test_config();
+            let client = dash_spv_ffi_client_new(config);
+            assert!(!client.is_null());
+
+            let callback_data = Box::new(ProgressCallbackData::new());
+            let data_ptr = &*callback_data as *const ProgressCallbackData as *mut c_void;
+
+            let progress_callback = FFIProgressCallback {
+                on_progress: Some(test_progress_callback),
+                user_data: data_ptr,
+            };
+
+            let result = dash_spv_ffi_client_set_progress_callback(client, progress_callback);
+            assert_eq!(result, FFIErrorCode::Success as i32);
+
+            // Verify callback was invoked with expected initial values
+            assert_eq!(
+                callback_data.state.lock().unwrap().unwrap(),
+                FFISyncState::WaitingForConnections,
+                "initial state should be WaitingForConnections"
+            );
+            assert!(
+                !callback_data.is_synced.lock().unwrap().unwrap(),
+                "initial is_synced should be false"
+            );
+
+            dash_spv_ffi_client_destroy(client);
+            dash_spv_ffi_config_destroy(config);
         }
     }
 }


### PR DESCRIPTION
Send the current sync progress to a newly registered callback immediately on registration, so callers don't have to wait for the next progress update to get the current state.

Based on:
- #472 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Progress callbacks now synchronously retrieve and immediately dispatch the current progress state when registered, ensuring callbacks are invoked with up-to-date status information upon registration.

* **Tests**
  * Added comprehensive test coverage for progress callback registration and initial state emission verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->