### PR TITLE
fix: consolidate duplicate `FFISyncProgress` destroy functions

### DIFF
--- a/dash-spv-ffi/FFI_API.md
+++ b/dash-spv-ffi/FFI_API.md
@@ -4,7 +4,7 @@ This document provides a comprehensive reference for all FFI (Foreign Function I
 
 **Auto-generated**: This documentation is automatically generated from the source code. Do not edit manually.
 
-**Total Functions**: 49
+**Total Functions**: 48
 
 ## Table of Contents
 
@@ -56,7 +56,7 @@ Functions: 16
 
 ### Synchronization
 
-Functions: 6
+Functions: 5
 
 | Function | Description | Module |
 |----------|-------------|--------|
@@ -64,8 +64,7 @@ Functions: 6
 | `dash_spv_ffi_client_get_manager_sync_progress` | Get the current manager-based sync progress | client |
 | `dash_spv_ffi_client_get_sync_progress` | Get the current sync progress snapshot | client |
 | `dash_spv_ffi_client_set_sync_event_callbacks` | Set sync event callbacks for push-based event notifications | client |
-| `dash_spv_ffi_manager_sync_progress_destroy` | Destroy an `FFISyncProgress` object and all its nested pointers | types |
-| `dash_spv_ffi_sync_progress_destroy` | Destroy a `FFISyncProgress` object returned by this crate | client |
+| `dash_spv_ffi_sync_progress_destroy` | Destroy an `FFISyncProgress` object and all its nested pointers | types |
 
 ### Wallet Operations
 
@@ -465,7 +464,7 @@ dash_spv_ffi_client_get_manager_sync_progress(client: *mut FFIDashSpvClient,) ->
 ```
 
 **Description:**
-Get the current manager-based sync progress.  Returns the new parallel sync system's progress with per-manager details. Use `dash_spv_ffi_manager_sync_progress_destroy` to free the returned struct.  # Safety - `client` must be a valid, non-null pointer.
+Get the current manager-based sync progress.  Returns the new parallel sync system's progress with per-manager details. Use `dash_spv_ffi_sync_progress_destroy` to free the returned struct.  # Safety - `client` must be a valid, non-null pointer.
 
 **Safety:**
 - `client` must be a valid, non-null pointer.
@@ -506,10 +505,10 @@ Set sync event callbacks for push-based event notifications.  The monitoring tas
 
 ---
 
-#### `dash_spv_ffi_manager_sync_progress_destroy`
+#### `dash_spv_ffi_sync_progress_destroy`
 
 ```c
-dash_spv_ffi_manager_sync_progress_destroy(progress: *mut FFISyncProgress,) -> ()
+dash_spv_ffi_sync_progress_destroy(progress: *mut FFISyncProgress) -> ()
 ```
 
 **Description:**
@@ -519,22 +518,6 @@ Destroy an `FFISyncProgress` object and all its nested pointers.  # Safety - `pr
 - `progress` must be a pointer returned from this crate, or null.
 
 **Module:** `types`
-
----
-
-#### `dash_spv_ffi_sync_progress_destroy`
-
-```c
-dash_spv_ffi_sync_progress_destroy(progress: *mut FFISyncProgress) -> ()
-```
-
-**Description:**
-Destroy a `FFISyncProgress` object returned by this crate.  # Safety - `progress` must be a pointer returned from this crate, or null.
-
-**Safety:**
-- `progress` must be a pointer returned from this crate, or null.
-
-**Module:** `client`
 
 ---
 

--- a/dash-spv-ffi/include/dash_spv_ffi.h
+++ b/dash-spv-ffi/include/dash_spv_ffi.h
@@ -518,7 +518,7 @@ int32_t dash_spv_ffi_client_update_config(struct FFIDashSpvClient *client,
  * Get the current manager-based sync progress.
  *
  * Returns the new parallel sync system's progress with per-manager details.
- * Use `dash_spv_ffi_manager_sync_progress_destroy` to free the returned struct.
+ * Use `dash_spv_ffi_sync_progress_destroy` to free the returned struct.
  *
  * # Safety
  * - `client` must be a valid, non-null pointer.
@@ -557,14 +557,6 @@ int32_t dash_spv_ffi_client_broadcast_transaction(struct FFIDashSpvClient *clien
  * - `client` must be either null or a pointer obtained from `dash_spv_ffi_client_new`.
  */
  void dash_spv_ffi_client_destroy(struct FFIDashSpvClient *client) ;
-
-/**
- * Destroy a `FFISyncProgress` object returned by this crate.
- *
- * # Safety
- * - `progress` must be a pointer returned from this crate, or null.
- */
- void dash_spv_ffi_sync_progress_destroy(struct FFISyncProgress *progress) ;
 
 /**
  * Get the wallet manager from the SPV client
@@ -951,7 +943,7 @@ struct FFIResult ffi_dash_spv_get_platform_activation_height(struct FFIDashSpvCl
  * # Safety
  * - `progress` must be a pointer returned from this crate, or null.
  */
- void dash_spv_ffi_manager_sync_progress_destroy(struct FFISyncProgress *progress) ;
+ void dash_spv_ffi_sync_progress_destroy(struct FFISyncProgress *progress) ;
 
 /**
  * Initialize logging for the SPV library.

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -6,7 +6,7 @@
 //! - `FFINetworkEventCallbacks` - Network manager events
 //! - `FFIWalletEventCallbacks` - Wallet manager events
 
-use crate::{dash_spv_ffi_manager_sync_progress_destroy, FFISyncProgress};
+use crate::{dash_spv_ffi_sync_progress_destroy, FFISyncProgress};
 use dashcore::hashes::Hash;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
@@ -93,7 +93,7 @@ impl FFIProgressCallback {
 
             // Clean up the progress and all its nested pointers
             unsafe {
-                dash_spv_ffi_manager_sync_progress_destroy(ptr);
+                dash_spv_ffi_sync_progress_destroy(ptr);
             }
         }
     }

--- a/dash-spv-ffi/src/client.rs
+++ b/dash-spv-ffi/src/client.rs
@@ -425,7 +425,7 @@ pub unsafe extern "C" fn dash_spv_ffi_client_get_sync_progress(
 /// Get the current manager-based sync progress.
 ///
 /// Returns the new parallel sync system's progress with per-manager details.
-/// Use `dash_spv_ffi_manager_sync_progress_destroy` to free the returned struct.
+/// Use `dash_spv_ffi_sync_progress_destroy` to free the returned struct.
 ///
 /// # Safety
 /// - `client` must be a valid, non-null pointer.
@@ -532,17 +532,6 @@ pub unsafe extern "C" fn dash_spv_ffi_client_destroy(client: *mut FFIDashSpvClie
         client.cancel_active_tasks();
 
         tracing::info!("✅ FFI client destroyed and all tasks cleaned up");
-    }
-}
-
-/// Destroy a `FFISyncProgress` object returned by this crate.
-///
-/// # Safety
-/// - `progress` must be a pointer returned from this crate, or null.
-#[no_mangle]
-pub unsafe extern "C" fn dash_spv_ffi_sync_progress_destroy(progress: *mut FFISyncProgress) {
-    if !progress.is_null() {
-        let _ = Box::from_raw(progress);
     }
 }
 

--- a/dash-spv-ffi/src/types.rs
+++ b/dash-spv-ffi/src/types.rs
@@ -493,9 +493,7 @@ pub unsafe extern "C" fn dash_spv_ffi_instantsend_progress_destroy(
 /// # Safety
 /// - `progress` must be a pointer returned from this crate, or null.
 #[no_mangle]
-pub unsafe extern "C" fn dash_spv_ffi_manager_sync_progress_destroy(
-    progress: *mut FFISyncProgress,
-) {
+pub unsafe extern "C" fn dash_spv_ffi_sync_progress_destroy(progress: *mut FFISyncProgress) {
     if !progress.is_null() {
         let p = Box::from_raw(progress);
 

--- a/dash-spv-ffi/tests/test_types.rs
+++ b/dash-spv-ffi/tests/test_types.rs
@@ -195,7 +195,7 @@ mod tests {
 
         // Cleanup all allocated memory
         unsafe {
-            dash_spv_ffi_manager_sync_progress_destroy(Box::into_raw(Box::new(ffi_progress)));
+            dash_spv_ffi_sync_progress_destroy(Box::into_raw(Box::new(ffi_progress)));
         }
     }
 }


### PR DESCRIPTION
`dash_spv_ffi_sync_progress_destroy` didn't cleanup the nested progress pointers which leads to leaks on cleanup. This PR merges `dash_spv_ffi_sync_progress_destroy` into `dash_spv_ffi_manager_sync_progress_destroy`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the synchronization progress cleanup function for consistent public API naming.
  * Consolidated duplicate manager-specific cleanup into the single, renamed public cleanup function, slightly reducing the documented API surface.

* **Documentation**
  * Updated API docs and examples to reference the renamed cleanup function for correct usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->