### PR TITLE
chore: improve ASAN stack trace and symbolization

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -37,9 +37,8 @@ jobs:
       - name: Run tests with ASAN
         env:
           RUST_BACKTRACE: 1
-          RUSTFLAGS: "-Zsanitizer=address -Cdebuginfo=2"
-          ASAN_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer
-          ASAN_OPTIONS: "symbolize=1"
+          RUSTFLAGS: "-Zsanitizer=address -Cdebuginfo=2 -Cforce-frame-pointers=yes"
+          ASAN_OPTIONS: "symbolize=1:allow_addr2line=1"
           LSAN_OPTIONS: "fast_unwind_on_malloc=0"
         run: |
           # FFI crates (C interop)


### PR DESCRIPTION
Use `allow_addr2line=1` so ASAN falls back to the pre-installed `addr2line` for symbolization. This avoids LLVM version mismatch issues between the system `llvm-symbolizer` and nightly Rust's LLVM, and works regardless of which LLVM version nightly uses. Also enable `force-frame-pointers` for more complete stack traces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal test workflow configuration for memory-safety tooling and runtime symbolization flags.

**Note:** This release contains no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->