### PR TITLE
chore: add `RUST_BACKTRACE=1` to CI test runs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         group: ${{ fromJson(inputs.groups) }}
+    env:
+      RUST_BACKTRACE: 1
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Run tests with ASAN
         env:
+          RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=address -Cdebuginfo=2"
           ASAN_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer
           ASAN_OPTIONS: "symbolize=1"
@@ -60,6 +61,7 @@ jobs:
 
       - name: Run tests with TSAN
         env:
+          RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=thread -Cdebuginfo=2"
           TSAN_OPTIONS: "second_deadlock_stack=1"
         run: |


### PR DESCRIPTION
Set `RUST_BACKTRACE=1` in CI workflows so test failures print full backtraces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build and testing infrastructure configuration to improve diagnostic capabilities during automated testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->