### PR TITLE
refactor(key-wallet): drop FeeLevel

### DIFF
--- a/key-wallet-ffi/src/transaction.rs
+++ b/key-wallet-ffi/src/transaction.rs
@@ -114,7 +114,6 @@ pub unsafe extern "C" fn wallet_build_and_sign_transaction(
 
     unsafe {
         use key_wallet::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
-        use key_wallet::wallet::managed_wallet_info::fee::FeeLevel;
         use key_wallet::wallet::managed_wallet_info::transaction_builder::TransactionBuilder;
 
         let manager_ref = &*manager;
@@ -246,7 +245,7 @@ pub unsafe extern "C" fn wallet_build_and_sign_transaction(
 
             tx_builder = tx_builder
                 .set_change_address(change_address)
-                .set_fee_level(FeeLevel::Custom(FeeRate::new(fee_per_kb)));
+                .set_fee_rate(FeeRate::new(fee_per_kb));
 
             // Get available UTXOs (collect owned UTXOs, not references)
             let utxos: Vec<key_wallet::Utxo> = managed_account.utxos.values().cloned().collect();

--- a/key-wallet-manager/src/wallet_manager/transaction_building.rs
+++ b/key-wallet-manager/src/wallet_manager/transaction_building.rs
@@ -2,7 +2,7 @@
 
 use super::{WalletError, WalletId, WalletManager};
 use dashcore::Transaction;
-use key_wallet::wallet::managed_wallet_info::fee::FeeLevel;
+use key_wallet::wallet::managed_wallet_info::fee::FeeRate;
 use key_wallet::wallet::managed_wallet_info::transaction_building::{
     AccountTypePreference, TransactionError,
 };
@@ -21,7 +21,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         account_index: u32,
         account_type_pref: Option<AccountTypePreference>,
         recipients: Vec<(Address, u64)>,
-        fee_level: FeeLevel,
+        fee_rate: FeeRate,
         current_block_height: u32,
     ) -> Result<Transaction, WalletError> {
         // Get the wallet
@@ -38,7 +38,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
                 account_index,
                 account_type_pref,
                 recipients,
-                fee_level,
+                fee_rate,
                 current_block_height,
             )
             .map_err(|e| match e {

--- a/key-wallet/src/wallet/managed_wallet_info/fee.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/fee.rs
@@ -92,32 +92,6 @@ impl FeeRate {
     }
 }
 
-/// Fee estimation levels
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum FeeLevel {
-    /// Economy - slower confirmation
-    Economy,
-    /// Normal - standard confirmation
-    Normal,
-    /// Priority - faster confirmation
-    Priority,
-    /// Custom fee rate
-    Custom(FeeRate),
-}
-
-impl FeeLevel {
-    /// Get the fee rate for this level
-    pub fn fee_rate(&self) -> FeeRate {
-        match self {
-            Self::Economy => FeeRate::economy(),
-            Self::Normal => FeeRate::normal(),
-            Self::Priority => FeeRate::priority(),
-            Self::Custom(rate) => *rate,
-        }
-    }
-}
-
 /// Calculate the size of a transaction
 pub fn estimate_tx_size(num_inputs: usize, num_outputs: usize, has_change: bool) -> usize {
     // Base size: version (2) + type (2) + locktime (4) + varint counts
@@ -169,16 +143,6 @@ mod tests {
         let rate = FeeRate::from_sat_per_byte(5);
         assert_eq!(rate.as_sat_per_kb(), 5000);
         assert_eq!(rate.calculate_fee(1000), 5000);
-    }
-
-    #[test]
-    fn test_fee_levels() {
-        assert_eq!(FeeLevel::Economy.fee_rate().as_sat_per_kb(), 500);
-        assert_eq!(FeeLevel::Normal.fee_rate().as_sat_per_kb(), 1000);
-        assert_eq!(FeeLevel::Priority.fee_rate().as_sat_per_kb(), 2000);
-
-        let custom = FeeLevel::Custom(FeeRate::new(3000));
-        assert_eq!(custom.fee_rate().as_sat_per_kb(), 3000);
     }
 
     #[test]

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -27,7 +27,7 @@ use secp256k1::{Message, Secp256k1, SecretKey};
 use std::net::SocketAddr;
 
 use crate::wallet::managed_wallet_info::coin_selection::{CoinSelector, SelectionStrategy};
-use crate::wallet::managed_wallet_info::fee::FeeLevel;
+use crate::wallet::managed_wallet_info::fee::FeeRate;
 use crate::Utxo;
 
 /// Calculate varint size for a given number
@@ -52,8 +52,8 @@ pub struct TransactionBuilder {
     outputs: Vec<TxOut>,
     /// Change address
     change_address: Option<Address>,
-    /// Fee rate or level
-    fee_level: FeeLevel,
+    /// Fee rate (satoshis per kilobyte)
+    fee_rate: FeeRate,
     /// Lock time
     lock_time: u32,
     /// Transaction version
@@ -75,7 +75,7 @@ impl TransactionBuilder {
             inputs: Vec::new(),
             outputs: Vec::new(),
             change_address: None,
-            fee_level: FeeLevel::Normal,
+            fee_rate: FeeRate::normal(),
             lock_time: 0,
             version: 2, // Default to version 2 for Dash
             special_payload: None,
@@ -120,7 +120,7 @@ impl TransactionBuilder {
         let base_size = self.calculate_base_size();
         let input_size = 148; // Size per P2PKH input
 
-        let fee_rate = self.fee_level.fee_rate();
+        let fee_rate = self.fee_rate;
 
         // Use the CoinSelector with the proper size context
         let selector = CoinSelector::new(strategy);
@@ -193,9 +193,9 @@ impl TransactionBuilder {
         self
     }
 
-    /// Set the fee level
-    pub fn set_fee_level(mut self, level: FeeLevel) -> Self {
-        self.fee_level = level;
+    /// Set the fee rate
+    pub fn set_fee_rate(mut self, fee_rate: FeeRate) -> Self {
+        self.fee_rate = fee_rate;
         self
     }
 
@@ -336,7 +336,7 @@ impl TransactionBuilder {
 
     /// Calculates the transaction fee for the current number of outputs and inputs
     pub fn calculate_fee(&self) -> u64 {
-        let fee_rate = self.fee_level.fee_rate();
+        let fee_rate = self.fee_rate;
         let estimated_size = self.estimate_transaction_size(self.inputs.len(), self.outputs.len());
         fee_rate.calculate_fee(estimated_size)
     }
@@ -348,7 +348,7 @@ impl TransactionBuilder {
     /// Basically we are calculating the fee with that extra change output before
     /// adding it
     pub fn calculate_fee_with_extra_output(&self) -> u64 {
-        let fee_rate = self.fee_level.fee_rate();
+        let fee_rate = self.fee_rate;
         let estimated_size =
             self.estimate_transaction_size(self.inputs.len(), self.outputs.len() + 1);
         fee_rate.calculate_fee(estimated_size)
@@ -932,7 +932,7 @@ mod tests {
         let change_address = Address::dummy(Network::Testnet, 0);
 
         let builder = TransactionBuilder::new()
-            .set_fee_level(FeeLevel::Normal)
+            .set_fee_rate(FeeRate::normal())
             .set_change_address(change_address.clone())
             .add_output(&recipient_address, 150000)
             .unwrap()
@@ -966,7 +966,7 @@ mod tests {
         let change_address = Address::dummy(Network::Testnet, 0);
 
         let tx = TransactionBuilder::new()
-            .set_fee_level(FeeLevel::Normal) // 1 duff per byte
+            .set_fee_rate(FeeRate::normal()) // 1 duff per byte
             .set_change_address(change_address.clone())
             .add_inputs(utxos.into_iter().map(|u| (u, None)).collect())
             .add_output(&recipient_address, 500000)
@@ -993,7 +993,7 @@ mod tests {
         let change_address = Address::dummy(Network::Testnet, 0);
 
         let tx = TransactionBuilder::new()
-            .set_fee_level(FeeLevel::Normal)
+            .set_fee_rate(FeeRate::normal())
             .set_change_address(change_address.clone())
             .add_inputs(utxos.into_iter().map(|u| (u, None)).collect())
             .add_output(&recipient_address, 150000)
@@ -1088,7 +1088,7 @@ mod tests {
         let change_address = Address::dummy(Network::Testnet, 0);
 
         let tx = TransactionBuilder::new()
-            .set_fee_level(FeeLevel::Normal)
+            .set_fee_rate(FeeRate::normal())
             .set_change_address(change_address)
             .add_input(utxo, None)
             // Add outputs in non-sorted order
@@ -1158,7 +1158,7 @@ mod tests {
         let change = Address::dummy(Network::Testnet, 0);
 
         let tx = TransactionBuilder::new()
-            .set_fee_level(FeeLevel::Normal)
+            .set_fee_rate(FeeRate::normal())
             .set_change_address(change)
             // Add inputs in non-sorted order
             .add_input(utxo1.clone(), None)
@@ -1224,7 +1224,7 @@ mod tests {
         };
 
         let result = TransactionBuilder::new()
-            .set_fee_level(FeeLevel::Normal)
+            .set_fee_rate(FeeRate::normal())
             .set_change_address(change_address)
             .set_special_payload(TransactionPayload::AssetLockPayloadType(asset_lock_payload))
             .add_output(&recipient_address, 50000)

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_building.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_building.rs
@@ -1,9 +1,9 @@
 //! Transaction building functionality for managed wallets
 
 use super::coin_selection::{SelectionError, SelectionStrategy};
-use super::fee::FeeLevel;
 use super::transaction_builder::{BuilderError, TransactionBuilder};
 use super::ManagedWalletInfo;
+use crate::wallet::managed_wallet_info::fee::FeeRate;
 use crate::{Address, Network, Wallet};
 use alloc::vec::Vec;
 use dashcore::Transaction;
@@ -46,7 +46,7 @@ impl ManagedWalletInfo {
         account_index: u32,
         account_type_pref: Option<AccountTypePreference>,
         recipients: Vec<(Address, u64)>,
-        fee_level: FeeLevel,
+        fee_rate: FeeRate,
         current_block_height: u32,
     ) -> Result<Transaction, TransactionError> {
         // Validate network consistency
@@ -131,7 +131,7 @@ impl ManagedWalletInfo {
 
         // Use TransactionBuilder to create the transaction
         let mut builder = TransactionBuilder::new()
-            .set_fee_level(fee_level)
+            .set_fee_rate(fee_rate)
             .set_change_address(change_address.clone());
 
         // Add outputs for recipients first
@@ -203,7 +203,7 @@ mod tests {
             .unwrap();
 
         let mut builder = TransactionBuilder::new()
-            .set_fee_level(FeeLevel::Normal)
+            .set_fee_rate(FeeRate::normal())
             .set_change_address(change_address.clone());
 
         // Add output
@@ -307,7 +307,7 @@ mod tests {
             .unwrap();
 
         let mut builder = TransactionBuilder::new()
-            .set_fee_level(FeeLevel::Normal)
+            .set_fee_rate(FeeRate::normal())
             .set_change_address(change_address.clone())
             .add_output(&recipient_address, 150000)
             .unwrap()
@@ -342,7 +342,7 @@ mod tests {
             .unwrap();
 
         let mut builder = TransactionBuilder::new()
-            .set_fee_level(FeeLevel::Normal) // 1 duff per byte
+            .set_fee_rate(FeeRate::normal()) // 1 duff per byte
             .set_change_address(change_address.clone())
             .add_output(&recipient_address, 500000)
             .unwrap()
@@ -376,7 +376,7 @@ mod tests {
             .unwrap();
 
         let result = TransactionBuilder::new()
-            .set_fee_level(FeeLevel::Normal)
+            .set_fee_rate(FeeRate::normal())
             .set_change_address(change_address.clone())
             .add_output(&recipient_address, 1000000) // More than available
             .unwrap()
@@ -400,7 +400,7 @@ mod tests {
             .unwrap();
 
         let mut builder = TransactionBuilder::new()
-            .set_fee_level(FeeLevel::Normal)
+            .set_fee_rate(FeeRate::normal())
             .set_change_address(change_address.clone())
             .add_output(&recipient_address, 150000)
             .unwrap()

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -6,7 +6,7 @@ use super::managed_account_operations::ManagedAccountOperations;
 use crate::account::ManagedAccountTrait;
 use crate::managed_account::managed_account_collection::ManagedAccountCollection;
 use crate::transaction_checking::WalletTransactionChecker;
-use crate::wallet::managed_wallet_info::fee::FeeLevel;
+use crate::wallet::managed_wallet_info::fee::FeeRate;
 use crate::wallet::managed_wallet_info::transaction_building::{
     AccountTypePreference, TransactionError,
 };
@@ -96,7 +96,7 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
         account_index: u32,
         account_type_pref: Option<AccountTypePreference>,
         recipients: Vec<(Address, u64)>,
-        fee_level: FeeLevel,
+        fee_rate: FeeRate,
         current_block_height: u32,
     ) -> Result<Transaction, TransactionError>;
 
@@ -245,7 +245,7 @@ impl WalletInfoInterface for ManagedWalletInfo {
         account_index: u32,
         account_type_pref: Option<AccountTypePreference>,
         recipients: Vec<(Address, u64)>,
-        fee_level: FeeLevel,
+        fee_rate: FeeRate,
         current_block_height: u32,
     ) -> Result<Transaction, TransactionError> {
         self.create_unsigned_payment_transaction_internal(
@@ -254,7 +254,7 @@ impl WalletInfoInterface for ManagedWalletInfo {
             account_index,
             account_type_pref,
             recipients,
-            fee_level,
+            fee_rate,
             current_block_height,
         )
     }


### PR DESCRIPTION
This PR drops FeeLEvel, the struct was just a wrapper around FeeRate that, at the same time, is a wrapper around u64 to represent duffs per kb, unnecessary layer imo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Replaced the predefined fee level system with direct fee rate configuration for transaction building, providing more granular control over transaction fees.
* Updated transaction builder APIs and method signatures across wallet operations to use the new fee rate model for consistency and simplification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->