### PR TITLE
fix: avoid extra `GetHeaders` after post-sync header processing

### DIFF
--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -127,6 +127,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
         }
 
         let was_syncing = self.state() == SyncState::Syncing;
+        let tip_was_complete = self.pipeline.is_tip_complete();
 
         // Route headers to the pipeline, validates checkpoint match.
         let matched = self.pipeline.receive_headers(headers)?;
@@ -138,10 +139,13 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
             );
         }
 
-        // Send more requests if capacity available
-        let sent = self.pipeline.send_pending(requests)?;
-        if sent > 0 {
-            tracing::debug!("Pipeline sent {} more requests", sent);
+        // Send more requests during initial sync or active post-sync catch-up.
+        // Skip for unsolicited headers.
+        if was_syncing || !tip_was_complete {
+            let sent = self.pipeline.send_pending(requests)?;
+            if sent > 0 {
+                tracing::debug!("Pipeline sent {} more requests", sent);
+            }
         }
 
         // Process ready-to-store segments
@@ -174,6 +178,12 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
                     tip_height: new_tip.height(),
                 });
             }
+        }
+
+        // After storing unsolicited post-sync headers, mark the tip complete so the next header goes through
+        // the clean reset path. Don't mark complete during active catch-up.
+        if !was_syncing && tip_was_complete && !events.is_empty() {
+            self.pipeline.mark_tip_complete();
         }
 
         if was_syncing && self.pipeline.is_complete() {
@@ -241,11 +251,12 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
 mod tests {
     use super::*;
     use crate::chain::checkpoints::testnet_checkpoints;
-    use crate::network::MessageType;
+    use crate::network::{MessageType, NetworkRequest, RequestSender};
     use crate::storage::{
         DiskStorageManager, PersistentBlockHeaderStorage, PersistentMetadataStorage, StorageManager,
     };
     use crate::sync::{ManagerIdentifier, SyncManagerProgress};
+    use tokio::sync::mpsc::unbounded_channel;
 
     type TestBlockHeadersManager =
         BlockHeadersManager<PersistentBlockHeaderStorage, PersistentMetadataStorage>;
@@ -297,5 +308,44 @@ mod tests {
         let manager = create_test_manager().await;
         assert!(!manager.pipeline.is_initialized());
         assert_eq!(manager.pipeline.segment_count(), 0);
+    }
+
+    fn create_test_request_sender(
+    ) -> (RequestSender, tokio::sync::mpsc::UnboundedReceiver<NetworkRequest>) {
+        let (tx, rx) = unbounded_channel();
+        (RequestSender::new(tx), rx)
+    }
+
+    #[tokio::test]
+    async fn test_unsolicited_post_sync_header_does_not_trigger_get_headers() {
+        let mut manager = create_test_manager().await;
+        let tip = manager.tip().await.unwrap();
+        let tip_hash = *tip.hash();
+
+        // Simulate completed sync: pipeline initialized with tip segment marked complete
+        manager.pipeline.init(0, tip_hash, 0);
+        manager.pipeline.mark_tip_complete();
+        manager.progress.set_state(SyncState::Synced);
+
+        let (sender, mut rx) = create_test_request_sender();
+
+        let header = Header::dummy_chain(1, tip_hash).remove(0);
+
+        let events = manager.handle_headers_pipeline(&[header], &sender).await.unwrap();
+
+        // Header should have been stored
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            SyncEvent::BlockHeadersStored {
+                tip_height: 1
+            }
+        ));
+
+        // No GetHeaders request should have been sent
+        assert!(rx.try_recv().is_err());
+
+        // Tip segment marked complete again for the next unsolicited header
+        assert!(manager.pipeline.is_tip_complete());
     }
 }

--- a/dash-spv/src/sync/block_headers/pipeline.rs
+++ b/dash-spv/src/sync/block_headers/pipeline.rs
@@ -192,6 +192,14 @@ impl HeadersPipeline {
             }
         }
 
+        // Check if these are duplicate headers from another peer. The first
+        // header's hash matches a segment's current tip, meaning we already have it.
+        let first_hash = headers[0].block_hash();
+        if self.segments.iter().any(|s| s.current_tip_hash == first_hash) {
+            tracing::debug!("Ignoring duplicate header {} from another peer", first_hash);
+            return Ok(None);
+        }
+
         tracing::warn!(
             "Received {} headers with prev_hash {} but no segment matched",
             headers.len(),
@@ -268,6 +276,26 @@ impl HeadersPipeline {
     /// Check if pipeline is initialized.
     pub fn is_initialized(&self) -> bool {
         self.initialized
+    }
+
+    /// Check if the tip segment is currently marked complete.
+    pub(super) fn is_tip_complete(&self) -> bool {
+        self.segments.iter().any(|s| s.target_height.is_none() && s.complete)
+    }
+
+    /// Mark the tip segment as complete.
+    pub(super) fn mark_tip_complete(&mut self) {
+        for segment in &mut self.segments {
+            if segment.target_height.is_none() && !segment.complete {
+                segment.complete = true;
+                tracing::debug!(
+                    "Tip segment {} marked complete at height {}",
+                    segment.segment_id,
+                    segment.current_height
+                );
+                break;
+            }
+        }
     }
 
     /// Reset the tip segment for continued syncing after initial sync completes.
@@ -474,5 +502,59 @@ mod tests {
         assert!(pipeline.segments[0].buffered_headers.is_empty());
         // Segment 1 should have the header
         assert_eq!(pipeline.segments[1].buffered_headers.len(), 1);
+    }
+
+    #[test]
+    fn test_duplicate_headers_from_another_peer_are_ignored() {
+        let tip_hash = BlockHash::dummy(50);
+
+        let mut tip_seg = SegmentState::new(0, 1000, tip_hash, None, None);
+        tip_seg.current_height = 1001;
+        // Simulate that we already received a header and advanced the tip
+        let mut first_header = Header::dummy(1);
+        first_header.prev_blockhash = tip_hash;
+        let new_tip_hash = first_header.block_hash();
+        tip_seg.current_tip_hash = new_tip_hash;
+
+        let cm = create_test_checkpoint_manager(true);
+        let mut pipeline = HeadersPipeline::new(cm);
+        pipeline.initialized = true;
+        pipeline.segments = vec![tip_seg];
+
+        // Another peer sends the same header (prev_blockhash is old tip, first
+        // header hash matches the segment's current tip)
+        let matched = pipeline.receive_headers(&[first_header]).unwrap();
+        assert_eq!(matched, None, "Duplicate headers should be silently ignored");
+        assert!(pipeline.segments[0].buffered_headers.is_empty());
+    }
+
+    #[test]
+    fn test_tip_complete_lifecycle() {
+        let cm = create_test_checkpoint_manager(true);
+        let mut pipeline = HeadersPipeline::new(cm);
+        pipeline.initialized = true;
+
+        // No tip segment → not complete
+        let checkpoint_seg = SegmentState::new(0, 0, BlockHash::dummy(0), Some(100), None);
+        pipeline.segments = vec![checkpoint_seg];
+        assert!(!pipeline.is_tip_complete());
+
+        // Add a complete tip segment
+        let mut tip_seg = SegmentState::new(1, 500, BlockHash::dummy(77), None, None);
+        tip_seg.complete = true;
+        pipeline.segments.push(tip_seg);
+        assert!(pipeline.is_tip_complete());
+
+        // mark_tip_complete is a no-op when already complete
+        pipeline.mark_tip_complete();
+        assert!(pipeline.is_tip_complete());
+
+        // Simulate receive_headers resetting the tip segment
+        pipeline.segments[1].complete = false;
+        assert!(!pipeline.is_tip_complete());
+
+        // mark_tip_complete restores the state after storing headers
+        pipeline.mark_tip_complete();
+        assert!(pipeline.is_tip_complete());
     }
 }

--- a/dash/src/test_utils/block.rs
+++ b/dash/src/test_utils/block.rs
@@ -40,6 +40,27 @@ impl Header {
     pub fn dummy_batch(height_range: Range<u32>) -> Vec<Self> {
         height_range.map(Self::dummy).collect()
     }
+
+    /// Create a chain of headers where each header's `prev_blockhash` is the
+    /// actual `block_hash()` of the previous one. Uses an easy PoW target so
+    /// headers pass validation.
+    pub fn dummy_chain(count: usize, prev_blockhash: BlockHash) -> Vec<Self> {
+        let mut headers = Vec::with_capacity(count);
+        let mut prev = prev_blockhash;
+        for i in 0..count {
+            let header = Header {
+                version: Version::ONE,
+                prev_blockhash: prev,
+                merkle_root: TxMerkleNode::from_byte_array([0u8; 32]),
+                time: i as u32,
+                bits: CompactTarget::from_consensus(0x2100ffff),
+                nonce: i as u32,
+            };
+            prev = header.block_hash();
+            headers.push(header);
+        }
+        headers
+    }
 }
 
 impl BlockFilter {


### PR DESCRIPTION
When synced, `handle_headers_pipeline` always calls `send_pending()` after receiving each new block header, triggering a follow-up `GetHeaders` that always returned empty. This causes lot of unnecessary round-trips and leaves the tip segment in a pending state that rejected the next actual header as "unrequested headers".

Use `tip_was_complete` to distinguish unsolicited headers from active catch-up responses. Only skip `send_pending()` and mark the tip complete for the unsolicited case, so multi-batch catch-up still works correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a test helper to generate chained headers for easier end-to-end header tests.

* **Bug Fixes**
  * Stop sending extra header requests after initial sync when the tip is already complete.
  * Ignore duplicate unsolicited headers that match the current tip to avoid redundant processing.
  * Improve tip-complete state management for cleaner handling of subsequent headers.

* **Tests**
  * Added unit tests validating duplicate-header ignoring and tip-complete lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->