### PR TITLE
fix: announce tip to new peers when synced

### DIFF
--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -97,6 +97,20 @@ impl RequestSender {
         )))
     }
 
+    pub fn request_block_headers_from_peer(
+        &self,
+        start_hash: BlockHash,
+        address: SocketAddr,
+    ) -> NetworkResult<()> {
+        self.send_message_to_peer(
+            NetworkMessage::GetHeaders(GetHeadersMessage::new(
+                vec![start_hash],
+                BlockHash::all_zeros(),
+            )),
+            address,
+        )
+    }
+
     pub fn request_filter_headers(
         &self,
         start_height: u32,

--- a/dash-spv/src/sync/block_headers/manager.rs
+++ b/dash-spv/src/sync/block_headers/manager.rs
@@ -6,7 +6,8 @@
 //! Uses HeadersPipeline for parallel downloads across checkpoint-defined segments
 //! during initial sync. The same pipeline is reused for post-sync updates.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -41,6 +42,9 @@ pub struct BlockHeadersManager<H: BlockHeaderStorage, M: MetadataStorage> {
     pub(super) pipeline: HeadersPipeline,
     /// Pending block announcements waiting for headers message (post-sync).
     pub(super) pending_announcements: HashMap<BlockHash, Instant>,
+    /// Peers we've sent a GetHeaders to after sync, so Dash Core knows our tip
+    /// and can send us header announcements instead of inv.
+    pub(super) announced_peers: HashSet<SocketAddr>,
 }
 
 impl<H: BlockHeaderStorage, M: MetadataStorage> std::fmt::Debug for BlockHeadersManager<H, M> {
@@ -83,6 +87,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
             metadata_storage,
             pipeline: HeadersPipeline::new(checkpoint_manager),
             pending_announcements: HashMap::new(),
+            announced_peers: HashSet::new(),
         })
     }
 
@@ -207,17 +212,19 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
             }
         }
 
-        self.progress.bump_last_activity();
+        if matched.is_some() {
+            self.progress.bump_last_activity();
+        }
         Ok(events)
     }
 
     /// Handle inventory announcements for new blocks.
     ///
-    /// During initial sync, Dash Core sends inv (not headers2) because it doesn't
-    /// think we have the parent block. We track these announcements so we can
-    /// request headers after sync completes.
+    /// During initial sync, Dash Core sends inv (not header announcements) because
+    /// it doesn't think we have the parent block. We track these announcements so
+    /// we can request headers after sync completes.
     ///
-    /// When synced, we expect unsolicited headers2 announcements. The tick handler
+    /// When synced, we expect unsolicited header announcements. The tick handler
     /// uses a timeout to send fallback GetHeaders if headers don't arrive.
     pub(super) async fn handle_inventory(
         &mut self,
@@ -251,11 +258,11 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> BlockHeadersManager<H, M> {
 mod tests {
     use super::*;
     use crate::chain::checkpoints::testnet_checkpoints;
-    use crate::network::{MessageType, NetworkRequest, RequestSender};
+    use crate::network::{MessageType, NetworkEvent, NetworkRequest, RequestSender};
     use crate::storage::{
         DiskStorageManager, PersistentBlockHeaderStorage, PersistentMetadataStorage, StorageManager,
     };
-    use crate::sync::{ManagerIdentifier, SyncManagerProgress};
+    use crate::sync::{ManagerIdentifier, SyncManager, SyncManagerProgress};
     use tokio::sync::mpsc::unbounded_channel;
 
     type TestBlockHeadersManager =
@@ -274,6 +281,15 @@ mod tests {
         BlockHeadersManager::new(storage.block_headers(), storage.metadata(), checkpoint_manager)
             .await
             .expect("Failed to create BlockHeadersManager")
+    }
+
+    /// Create a manager in synced state with an initialized pipeline.
+    async fn create_synced_manager() -> TestBlockHeadersManager {
+        let mut manager = create_test_manager().await;
+        let tip = manager.tip().await.unwrap();
+        manager.pipeline.init(tip.height(), *tip.hash(), tip.height());
+        manager.progress.set_state(SyncState::Synced);
+        manager
     }
 
     #[tokio::test]
@@ -346,6 +362,92 @@ mod tests {
         assert!(rx.try_recv().is_err());
 
         // Tip segment marked complete again for the next unsolicited header
+        assert!(manager.pipeline.is_tip_complete());
+    }
+
+    #[tokio::test]
+    async fn test_peer_tip_announcement_lifecycle() {
+        let mut manager = create_synced_manager().await;
+        let (requests, mut rx) = create_test_request_sender();
+
+        let addr: SocketAddr = "1.2.3.4:9999".parse().unwrap();
+        let connect = NetworkEvent::PeerConnected {
+            address: addr,
+        };
+
+        // Connect sends a peer-targeted GetHeaders
+        let events = manager.handle_network_event(&connect, &requests).await.unwrap();
+        assert!(events.is_empty());
+        assert!(manager.announced_peers.contains(&addr));
+        match rx.try_recv().unwrap() {
+            NetworkRequest::SendMessageToPeer(_, target_addr) => {
+                assert_eq!(target_addr, addr);
+            }
+            other => panic!("Expected SendMessageToPeer, got {:?}", other),
+        }
+
+        // Same peer again sends nothing (already announced)
+        manager.handle_network_event(&connect, &requests).await.unwrap();
+        assert!(rx.try_recv().is_err());
+
+        // Disconnect removes from announced set
+        let disconnect = NetworkEvent::PeerDisconnected {
+            address: addr,
+        };
+        manager.handle_network_event(&disconnect, &requests).await.unwrap();
+        assert!(!manager.announced_peers.contains(&addr));
+
+        // Reconnect sends GetHeaders again
+        manager.handle_network_event(&connect, &requests).await.unwrap();
+        assert!(manager.announced_peers.contains(&addr));
+        assert!(rx.try_recv().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_peer_tip_announcement_guards() {
+        // Not synced: peer connect does nothing
+        let mut manager = create_test_manager().await;
+        let (requests, mut rx) = create_test_request_sender();
+        let addr: SocketAddr = "1.2.3.4:9999".parse().unwrap();
+        let connect = NetworkEvent::PeerConnected {
+            address: addr,
+        };
+
+        manager.handle_network_event(&connect, &requests).await.unwrap();
+        assert!(!manager.announced_peers.contains(&addr));
+        assert!(rx.try_recv().is_err());
+
+        // Active catch-up: peer connect skipped while pipeline has pending request
+        let mut manager = create_synced_manager().await;
+        manager.pipeline.reset_tip_segment();
+        manager.pipeline.send_pending(&requests).unwrap();
+        rx.try_recv().unwrap(); // drain the pipeline GetHeaders
+
+        manager.handle_network_event(&connect, &requests).await.unwrap();
+        assert!(!manager.announced_peers.contains(&addr));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_empty_headers_after_tip_announcement_is_harmless() {
+        let mut manager = create_synced_manager().await;
+        manager.pipeline.mark_tip_complete();
+        let (requests, mut rx) = create_test_request_sender();
+
+        // Announce tip to a new peer
+        let addr: SocketAddr = "1.2.3.4:9999".parse().unwrap();
+        let connect = NetworkEvent::PeerConnected {
+            address: addr,
+        };
+        manager.handle_network_event(&connect, &requests).await.unwrap();
+        rx.try_recv().unwrap(); // drain the GetHeaders request
+
+        // Peer responds with empty headers (same height as us)
+        let events = manager.handle_headers_pipeline(&[], &requests).await.unwrap();
+
+        // No events emitted, no requests sent, tip segment stays complete
+        assert!(events.is_empty());
+        assert!(rx.try_recv().is_err());
         assert!(manager.pipeline.is_tip_complete());
     }
 }

--- a/dash-spv/src/sync/block_headers/sync_manager.rs
+++ b/dash-spv/src/sync/block_headers/sync_manager.rs
@@ -41,6 +41,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for BlockHeadersMana
         let checkpoint_manager = self.pipeline.checkpoint_manager().clone();
         self.pipeline = HeadersPipeline::new(checkpoint_manager);
         self.pending_announcements.clear();
+        self.announced_peers.clear();
     }
 
     async fn start_sync(&mut self, requests: &RequestSender) -> SyncResult<Vec<SyncEvent>> {
@@ -151,37 +152,61 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for BlockHeadersMana
         event: &NetworkEvent,
         requests: &RequestSender,
     ) -> SyncResult<Vec<SyncEvent>> {
-        if let NetworkEvent::PeersUpdated {
-            connected_count,
-            best_height,
-            ..
-        } = event
-        {
-            if let Some(best_height) = best_height {
-                self.progress.update_target_height(*best_height);
-                let mut metadata_storage = self.metadata_storage.write().await;
-                metadata_storage.store_last_target_height(*best_height).await?;
-            }
-            if *connected_count == 0 {
-                self.stop_sync();
-            } else if *connected_count > 0 {
-                if self.state() == SyncState::WaitingForConnections {
-                    return self.start_sync(requests).await;
+        match event {
+            NetworkEvent::PeerConnected {
+                address,
+            } => {
+                // When synced, send GetHeaders to new peers so Dash Core learns our tip
+                // and sends header announcements instead of inv. Skip when the
+                // pipeline has an active catch-up request to avoid the empty
+                // response prematurely completing the tip segment.
+                if self.state() == SyncState::Synced
+                    && self.pipeline.is_initialized()
+                    && !self.announced_peers.contains(address)
+                    && !self.pipeline.tip_segment_has_pending_request()
+                {
+                    let tip = self.tip().await?;
+                    tracing::info!("Announcing tip {} to new peer {}", tip.height(), address);
+                    requests.request_block_headers_from_peer(*tip.hash(), *address)?;
+                    self.announced_peers.insert(*address);
                 }
-                // When already synced but behind peer height, request missing headers
-                if self.state() == SyncState::Synced {
-                    if let Some(best_height) = best_height {
-                        if *best_height > self.progress.tip_height()
-                            && !self.pipeline.tip_segment_has_pending_request()
-                        {
-                            tracing::info!(
-                                "Peer height {} > our height {}, requesting headers to catch up",
-                                best_height,
-                                self.progress.tip_height()
-                            );
-                            // Reset tip segment and send requests via pipeline
-                            self.pipeline.reset_tip_segment();
-                            self.pipeline.send_pending(requests)?;
+            }
+            NetworkEvent::PeerDisconnected {
+                address,
+            } => {
+                self.announced_peers.remove(address);
+            }
+            NetworkEvent::PeersUpdated {
+                connected_count,
+                best_height,
+                ..
+            } => {
+                if let Some(best_height) = best_height {
+                    self.progress.update_target_height(*best_height);
+                    let mut metadata_storage = self.metadata_storage.write().await;
+                    metadata_storage.store_last_target_height(*best_height).await?;
+                }
+                if *connected_count == 0 {
+                    self.stop_sync();
+                } else if *connected_count > 0 {
+                    if self.state() == SyncState::WaitingForConnections {
+                        return self.start_sync(requests).await;
+                    }
+                    // When already synced but behind peer height, request missing headers
+                    if self.state() == SyncState::Synced {
+                        if let Some(best_height) = best_height {
+                            if *best_height > self.progress.tip_height()
+                                && !self.pipeline.tip_segment_has_pending_request()
+                            {
+                                tracing::info!(
+                                    "Peer height {} > our height {}, requesting headers to catch up",
+                                    best_height,
+                                    self.progress.tip_height()
+                                );
+                                // Reset tip segment and send requests via pipeline
+                                self.pipeline.reset_tip_segment();
+                                self.pipeline.send_pending(requests)?;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
When already synced, send a `GetHeaders` with our tip locator to each
newly connected peer. Without this, Dash Core never learns our best-known
header and falls back to inv announcements instead of pushing unsolicited
header messages.

Based on: 
- #486 
- #489 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Enhanced peer connection handling for block header synchronization, enabling more efficient tracking of header announcements across peer reconnections.

* **Bug Fixes**
  * Prevents duplicate header requests from being sent to peers that have already received announcements after reconnection.

* **Performance**
  * Improved synchronization efficiency by optimizing how the system manages peer-to-peer header announcements in synced state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->