### PR TITLE
chore: add codecov coverage tracking

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,56 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+    patch:
+      default:
+        target: auto
+        threshold: 2%
+
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: true
+  show_carryforward_flags: true
+
+flag_management:
+  default_rules:
+    carryforward: true
+
+flags:
+  dashcore:
+    paths: [dash/src/]
+  dashcore_hashes:
+    paths: [hashes/src/]
+  dashcore-private:
+    paths: [internals/src/]
+  dash-network:
+    paths: [dash-network/src/]
+  dash-spv:
+    paths: [dash-spv/src/]
+  key-wallet:
+    paths: [key-wallet/src/]
+  key-wallet-manager:
+    paths: [key-wallet-manager/src/]
+  dash-network-ffi:
+    paths: [dash-network-ffi/src/]
+  dash-spv-ffi:
+    paths: [dash-spv-ffi/src/]
+  key-wallet-ffi:
+    paths: [key-wallet-ffi/src/]
+  dashcore-rpc:
+    paths: [rpc-client/src/]
+  dashcore-rpc-json:
+    paths: [rpc-json/src/]
+
+ignore:
+  - "**/tests/**"
+  - "**/tests.rs"
+  - "**/test_utils/**"
+  - "**/test_utils.rs"
+  - "**/examples/**"
+  - "fuzz/**"
+  - "contrib/**"

--- a/.github/scripts/ci_config.py
+++ b/.github/scripts/ci_config.py
@@ -173,6 +173,10 @@ def run_group_tests(args):
 
     crates = groups[args.group] or []
     failed = []
+    coverage = getattr(args, "coverage", False)
+
+    if coverage:
+        github_output("crate_flags", ",".join(crates))
 
     for crate in crates:
         # Skip dash-fuzz on Windows
@@ -182,7 +186,10 @@ def run_group_tests(args):
 
         github_group_start(f"Testing {crate}")
 
-        cmd = ["cargo", "test", "-p", crate, "--all-features"]
+        if coverage:
+            cmd = ["cargo", "llvm-cov", "--no-report", "-p", crate, "--all-features"]
+        else:
+            cmd = ["cargo", "test", "-p", crate, "--all-features"]
         result = subprocess.run(cmd)
 
         github_group_end()
@@ -225,6 +232,11 @@ def main():
     run_group_parser = subparsers.add_parser("run-group", help="Run tests for a group")
     run_group_parser.add_argument("group", help="Group name")
     run_group_parser.add_argument("--os", default="ubuntu-latest", help="OS name")
+    run_group_parser.add_argument(
+        "--coverage",
+        action="store_true",
+        help="Use cargo-llvm-cov for coverage collection",
+    )
 
     args = parser.parse_args()
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,10 @@ on:
       groups:
         required: true
         type: string
+      coverage:
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -26,9 +30,33 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: ${{ inputs.coverage && 'llvm-tools' || '' }}
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "test-${{ inputs.os }}-${{ matrix.group }}"
+
+      - name: Install cargo-llvm-cov
+        if: inputs.coverage
+        uses: taiki-e/install-action@cargo-llvm-cov
+
       - run: pip install pyyaml
       - name: Run tests
-        run: python .github/scripts/ci_config.py run-group ${{ matrix.group }} --os ${{ inputs.os }}
+        id: tests
+        run: >
+          python .github/scripts/ci_config.py run-group ${{ matrix.group }}
+          --os ${{ inputs.os }}
+          ${{ inputs.coverage && '--coverage' || '' }}
+
+      - name: Generate coverage report
+        if: inputs.coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        if: inputs.coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          flags: ${{ steps.tests.outputs.crate_flags }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,6 +64,8 @@ jobs:
     with:
       os: ubuntu-latest
       groups: ${{ needs.verify-execution.outputs.groups }}
+      coverage: true
+    secrets: inherit
 
   test-ubuntu-arm:
     name: Ubuntu ARM

--- a/README.md
+++ b/README.md
@@ -11,11 +11,33 @@
     <a href="https://crates.io/crates/dash"><img alt="Crate Info" src="https://img.shields.io/crates/v/dash.svg"/></a>
     <a href="https://github.com/dashevo/rust-dashcore/blob/master/LICENSE"><img alt="MIT or Apache-2.0 Licensed" src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg"/></a>
     <a href="https://github.com/dashevo/rust-dashcore/actions?query=workflow%3AContinuous%20integration"><img alt="CI Status" src="https://github.com/dashevo/rust-dashcore/workflows/Continuous%20integration/badge.svg"></a>
+    <a href="https://codecov.io/gh/dashpay/rust-dashcore/branch/master"><img alt="Coverage (master)" src="https://codecov.io/gh/dashpay/rust-dashcore/branch/master/graph/badge.svg"/></a>
+    <a href="https://codecov.io/gh/dashpay/rust-dashcore/branch/v0.42-dev"><img alt="Coverage (develop)" src="https://codecov.io/gh/dashpay/rust-dashcore/branch/v0.42-dev/graph/badge.svg"/></a>
     <a href="https://docs.rs"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-rust--dashcore-green"/></a>
     <a href="#minimum-supported-rust-version-msrv"><img alt="Rustc Version 1.89+" src="https://img.shields.io/badge/rustc-1.89%2B-lightgrey.svg"/></a>
     <img alt="Lines of code" src="https://img.shields.io/tokei/lines/github/dashevo/rust-dashcore">
   </p>
 </div>
+
+<details>
+<summary>Per-crate coverage</summary>
+
+| Crate | Coverage |
+|-------|----------|
+| dashcore | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dashcore)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dashcore) |
+| dashcore_hashes | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dashcore_hashes)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dashcore_hashes) |
+| dashcore-private | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dashcore-private)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dashcore-private) |
+| dash-network | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dash-network)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dash-network) |
+| dash-spv | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dash-spv)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dash-spv) |
+| key-wallet | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=key-wallet)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=key-wallet) |
+| key-wallet-manager | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=key-wallet-manager)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=key-wallet-manager) |
+| dash-network-ffi | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dash-network-ffi)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dash-network-ffi) |
+| dash-spv-ffi | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dash-spv-ffi)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dash-spv-ffi) |
+| key-wallet-ffi | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=key-wallet-ffi)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=key-wallet-ffi) |
+| dashcore-rpc | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dashcore-rpc)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dashcore-rpc) |
+| dashcore-rpc-json | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dashcore-rpc-json)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dashcore-rpc-json) |
+
+</details>
 
 For contributors: see CONTRIBUTING.md and AGENTS.md for branch policy and commands.
 


### PR DESCRIPTION
Inspired by #492 but integrated into the existing workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added per-branch and per-crate coverage badges and a collapsible per-crate coverage section in the README for easier visibility.

* **Chores**
  * Added Codecov configuration and ignore patterns.
  * Introduced an optional CI coverage mode with conditional install/steps, report generation, and upload.
  * Added a CLI flag to enable coverage-driven test runs and enabled coverage for the Ubuntu test job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->