### PR TITLE
chore: fix codecov uploads

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,7 +9,6 @@ coverage:
         target: auto
         threshold: 2%
 
-
 comment:
   layout: "diff, flags, files"
   behavior: default
@@ -21,30 +20,28 @@ flag_management:
     carryforward: true
 
 flags:
-  dashcore:
-    paths: [dash/src/]
-  dashcore_hashes:
-    paths: [hashes/src/]
-  dashcore-private:
-    paths: [internals/src/]
-  dash-network:
-    paths: [dash-network/src/]
-  dash-spv:
-    paths: [dash-spv/src/]
-  key-wallet:
-    paths: [key-wallet/src/]
-  key-wallet-manager:
-    paths: [key-wallet-manager/src/]
-  dash-network-ffi:
-    paths: [dash-network-ffi/src/]
-  dash-spv-ffi:
-    paths: [dash-spv-ffi/src/]
-  key-wallet-ffi:
-    paths: [key-wallet-ffi/src/]
-  dashcore-rpc:
-    paths: [rpc-client/src/]
-  dashcore-rpc-json:
-    paths: [rpc-json/src/]
+  core:
+    paths:
+      - dash/src/
+      - hashes/src/
+      - internals/src/
+      - dash-network/src/
+  spv:
+    paths:
+      - dash-spv/src/
+  wallet:
+    paths:
+      - key-wallet/src/
+      - key-wallet-manager/src/
+  ffi:
+    paths:
+      - dash-network-ffi/src/
+      - dash-spv-ffi/src/
+      - key-wallet-ffi/src/
+  rpc:
+    paths:
+      - rpc-client/src/
+      - rpc-json/src/
 
 ignore:
   - "**/tests/**"

--- a/.github/ci-groups.yml
+++ b/.github/ci-groups.yml
@@ -27,6 +27,10 @@ groups:
   tools:
     - dash-fuzz
 
+# Groups excluded from coverage collection
+no_coverage:
+  - tools
+
 # Crates intentionally not tested (with reason)
 excluded:
   - integration_test  # Requires live Dash node

--- a/.github/scripts/ci_config.py
+++ b/.github/scripts/ci_config.py
@@ -174,9 +174,10 @@ def run_group_tests(args):
     crates = groups[args.group] or []
     failed = []
     coverage = getattr(args, "coverage", False)
+    no_coverage = config.get("no_coverage", []) or []
 
-    if coverage:
-        github_output("crate_flags", ",".join(crates))
+    if coverage and args.group not in no_coverage:
+        github_output("crate_flags", args.group)
 
     for crate in crates:
         # Skip dash-fuzz on Windows
@@ -186,7 +187,7 @@ def run_group_tests(args):
 
         github_group_start(f"Testing {crate}")
 
-        if coverage:
+        if coverage and args.group not in no_coverage:
             cmd = ["cargo", "llvm-cov", "--no-report", "-p", crate, "--all-features"]
         else:
             cmd = ["cargo", "test", "-p", crate, "--all-features"]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,11 +49,11 @@ jobs:
           ${{ inputs.coverage && '--coverage' || '' }}
 
       - name: Generate coverage report
-        if: inputs.coverage
+        if: inputs.coverage && steps.tests.outputs.crate_flags
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        if: inputs.coverage
+        if: inputs.coverage && steps.tests.outputs.crate_flags
         uses: codecov/codecov-action@v5
         with:
           files: lcov.info

--- a/README.md
+++ b/README.md
@@ -22,20 +22,13 @@
 <details>
 <summary>Per-crate coverage</summary>
 
-| Crate | Coverage |
-|-------|----------|
-| dashcore | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dashcore)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dashcore) |
-| dashcore_hashes | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dashcore_hashes)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dashcore_hashes) |
-| dashcore-private | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dashcore-private)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dashcore-private) |
-| dash-network | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dash-network)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dash-network) |
-| dash-spv | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dash-spv)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dash-spv) |
-| key-wallet | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=key-wallet)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=key-wallet) |
-| key-wallet-manager | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=key-wallet-manager)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=key-wallet-manager) |
-| dash-network-ffi | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dash-network-ffi)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dash-network-ffi) |
-| dash-spv-ffi | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dash-spv-ffi)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dash-spv-ffi) |
-| key-wallet-ffi | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=key-wallet-ffi)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=key-wallet-ffi) |
-| dashcore-rpc | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dashcore-rpc)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dashcore-rpc) |
-| dashcore-rpc-json | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=dashcore-rpc-json)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=dashcore-rpc-json) |
+| Group | Crates | Coverage |
+|-------|--------|----------|
+| core | dashcore, dashcore_hashes, dashcore-private, dash-network | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=core)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=core) |
+| spv | dash-spv | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=spv)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=spv) |
+| wallet | key-wallet, key-wallet-manager | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=wallet)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=wallet) |
+| ffi | dash-network-ffi, dash-spv-ffi, key-wallet-ffi | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=ffi)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=ffi) |
+| rpc | dashcore-rpc, dashcore-rpc-json | [![codecov](https://codecov.io/gh/dashpay/rust-dashcore/graph/badge.svg?flag=rpc)](https://codecov.io/gh/dashpay/rust-dashcore?flags[0]=rpc) |
 
 </details>
 


### PR DESCRIPTION
Codecov requires one flag per upload. Switch from per-crate flags to group-based flags matching CI matrix groups (core, spv, wallet, ffi, rpc). Exclude the tools group from coverage since fuzz targets produce unusable reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized coverage collection into logical component groups (core, spv, wallet, ffi, rpc) for clearer reporting.
  * Excluded tools from coverage collection to focus metrics on primary components.
  * Updated coverage documentation to reflect the new grouping structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->