### PR TITLE
chore: add `__pycache__/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,8 @@ cobertura.xml
 *.tmp
 .tmp/
 
+# Python
+__pycache__/
+
 # Build scripts artifacts
 *.log


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated .gitignore to exclude Python bytecode directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->