### PR TITLE
refactor: rename `Dash` network entries to `Mainnet`

### DIFF
--- a/dash-spv-ffi/FFI_API.md
+++ b/dash-spv-ffi/FFI_API.md
@@ -241,10 +241,10 @@ dash_spv_ffi_config_get_network(config: *const FFIClientConfig,) -> FFINetwork
 ```
 
 **Description:**
-Gets the network type from the configuration  # Safety - `config` must be a valid pointer to an FFIClientConfig or null - If null, returns FFINetwork::Dash as default
+Gets the network type from the configuration  # Safety - `config` must be a valid pointer to an FFIClientConfig or null - If null, returns FFINetwork::Mainnet as default
 
 **Safety:**
-- `config` must be a valid pointer to an FFIClientConfig or null - If null, returns FFINetwork::Dash as default
+- `config` must be a valid pointer to an FFIClientConfig or null - If null, returns FFINetwork::Mainnet as default
 
 **Module:** `config`
 
@@ -921,7 +921,7 @@ Release a wallet manager obtained from `dash_spv_ffi_client_get_wallet_manager`.
 
 ### Enumerations
 
-- `FFINetwork` - Network type (Dash, Testnet, Regtest, Devnet)
+- `FFINetwork` - Network type (Mainnet, Testnet, Regtest, Devnet)
 - `FFIValidationMode` - Validation mode (None, Basic, Full)
 - `FFIMempoolStrategy` - Mempool strategy (FetchAll, BloomFilter, Selective)
 

--- a/dash-spv-ffi/dash_spv_ffi.h
+++ b/dash-spv-ffi/dash_spv_ffi.h
@@ -686,7 +686,7 @@ int32_t dash_spv_ffi_config_set_masternode_sync_enabled(struct FFIClientConfig *
  *
  * # Safety
  * - `config` must be a valid pointer to an FFIClientConfig or null
- * - If null, returns FFINetwork::Dash as default
+ * - If null, returns FFINetwork::Mainnet as default
  */
  FFINetwork dash_spv_ffi_config_get_network(const struct FFIClientConfig *config) ;
 

--- a/dash-spv-ffi/include/dash_spv_ffi.h
+++ b/dash-spv-ffi/include/dash_spv_ffi.h
@@ -795,7 +795,7 @@ int32_t dash_spv_ffi_config_set_masternode_sync_enabled(struct FFIClientConfig *
  *
  * # Safety
  * - `config` must be a valid pointer to an FFIClientConfig or null
- * - If null, returns FFINetwork::Dash as default
+ * - If null, returns FFINetwork::Mainnet as default
  */
  FFINetwork dash_spv_ffi_config_get_network(const struct FFIClientConfig *config) ;
 

--- a/dash-spv-ffi/scripts/generate_ffi_docs.py
+++ b/dash-spv-ffi/scripts/generate_ffi_docs.py
@@ -276,7 +276,7 @@ def generate_markdown(functions: List[FFIFunction]) -> str:
 
     md.append("### Enumerations")
     md.append("")
-    md.append("- `FFINetwork` - Network type (Dash, Testnet, Regtest, Devnet)")
+    md.append("- `FFINetwork` - Network type (Mainnet, Testnet, Regtest, Devnet)")
     md.append("- `FFIValidationMode` - Validation mode (None, Basic, Full)")
     md.append("- `FFIMempoolStrategy` - Mempool strategy (FetchAll, BloomFilter, Selective)")
     md.append("")

--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -289,10 +289,10 @@ fn main() {
 
     // Map network
     let network = match matches.get_one::<String>("network").map(|s| s.as_str()) {
-        Some("mainnet") => FFINetwork::Dash,
+        Some("mainnet") => FFINetwork::Mainnet,
         Some("testnet") => FFINetwork::Testnet,
         Some("regtest") => FFINetwork::Regtest,
-        _ => FFINetwork::Dash,
+        _ => FFINetwork::Mainnet,
     };
 
     unsafe {

--- a/dash-spv-ffi/src/config.rs
+++ b/dash-spv-ffi/src/config.rs
@@ -114,7 +114,7 @@ pub unsafe extern "C" fn dash_spv_ffi_config_add_peer(
 
     let cfg = unsafe { &mut *((*config).inner as *mut ClientConfig) };
     let default_port = match cfg.network {
-        dashcore::Network::Dash => 9999,
+        dashcore::Network::Mainnet => 9999,
         dashcore::Network::Testnet => 19999,
         dashcore::Network::Regtest => 19899,
         dashcore::Network::Devnet => 29999,
@@ -232,13 +232,13 @@ pub unsafe extern "C" fn dash_spv_ffi_config_set_masternode_sync_enabled(
 ///
 /// # Safety
 /// - `config` must be a valid pointer to an FFIClientConfig or null
-/// - If null, returns FFINetwork::Dash as default
+/// - If null, returns FFINetwork::Mainnet as default
 #[no_mangle]
 pub unsafe extern "C" fn dash_spv_ffi_config_get_network(
     config: *const FFIClientConfig,
 ) -> FFINetwork {
     if config.is_null() {
-        return FFINetwork::Dash;
+        return FFINetwork::Mainnet;
     }
 
     let config = unsafe { &*((*config).inner as *const ClientConfig) };

--- a/dash-spv-ffi/src/platform_integration.rs
+++ b/dash-spv-ffi/src/platform_integration.rs
@@ -183,10 +183,10 @@ pub unsafe extern "C" fn ffi_dash_spv_get_platform_activation_height(
 
     // Platform activation heights per network
     let height = match network {
-        dashcore::Network::Dash => 1_888_888, // Mainnet (placeholder - needs verification)
+        dashcore::Network::Mainnet => 1_888_888, // Mainnet (placeholder - needs verification)
         dashcore::Network::Testnet => 1_289_520, // Testnet confirmed height
-        dashcore::Network::Devnet => 1,       // Devnet starts immediately
-        _ => 0,                               // Unknown network
+        dashcore::Network::Devnet => 1,          // Devnet starts immediately
+        _ => 0,                                  // Unknown network
     };
 
     // Set the output value

--- a/dash-spv-ffi/tests/test_config.rs
+++ b/dash-spv-ffi/tests/test_config.rs
@@ -27,7 +27,7 @@ mod tests {
             assert!(!config.is_null());
 
             let network = dash_spv_ffi_config_get_network(config);
-            assert_eq!(network as i32, FFINetwork::Dash as i32);
+            assert_eq!(network as i32, FFINetwork::Mainnet as i32);
 
             dash_spv_ffi_config_destroy(config);
         }

--- a/dash-spv-ffi/tests/test_types.rs
+++ b/dash-spv-ffi/tests/test_types.rs
@@ -32,12 +32,12 @@ mod tests {
 
     #[test]
     fn test_ffi_network_conversion() {
-        assert_eq!(dashcore::Network::Dash, FFINetwork::Dash.into());
+        assert_eq!(dashcore::Network::Mainnet, FFINetwork::Mainnet.into());
         assert_eq!(dashcore::Network::Testnet, FFINetwork::Testnet.into());
         assert_eq!(dashcore::Network::Regtest, FFINetwork::Regtest.into());
         assert_eq!(dashcore::Network::Devnet, FFINetwork::Devnet.into());
 
-        assert_eq!(FFINetwork::Dash, dashcore::Network::Dash.into());
+        assert_eq!(FFINetwork::Mainnet, dashcore::Network::Mainnet.into());
         assert_eq!(FFINetwork::Testnet, dashcore::Network::Testnet.into());
         assert_eq!(FFINetwork::Regtest, dashcore::Network::Regtest.into());
         assert_eq!(FFINetwork::Devnet, dashcore::Network::Devnet.into());

--- a/dash-spv-ffi/tests/test_utils.rs
+++ b/dash-spv-ffi/tests/test_utils.rs
@@ -42,10 +42,10 @@ mod tests {
     #[test]
     fn test_network_names() {
         unsafe {
-            let name = ffi_network_get_name(FFINetwork::Dash);
+            let name = ffi_network_get_name(FFINetwork::Mainnet);
             assert!(!name.is_null());
             let name_str = CStr::from_ptr(name).to_str().unwrap();
-            assert_eq!(name_str, "dash");
+            assert_eq!(name_str, "mainnet");
 
             let name = ffi_network_get_name(FFINetwork::Testnet);
             assert!(!name.is_null());

--- a/dash-spv-ffi/tests/unit/test_configuration.rs
+++ b/dash-spv-ffi/tests/unit/test_configuration.rs
@@ -11,7 +11,7 @@ mod tests {
         unsafe {
             // Test creating config with each valid network
             let networks =
-                [FFINetwork::Dash, FFINetwork::Testnet, FFINetwork::Regtest, FFINetwork::Devnet];
+                [FFINetwork::Mainnet, FFINetwork::Testnet, FFINetwork::Regtest, FFINetwork::Devnet];
             for net in networks {
                 let config = dash_spv_ffi_config_new(net);
                 assert!(!config.is_null());
@@ -218,7 +218,7 @@ mod tests {
 
             // Test getters with null
             let net = dash_spv_ffi_config_get_network(std::ptr::null());
-            assert_eq!(net as i32, FFINetwork::Dash as i32); // Returns default
+            assert_eq!(net as i32, FFINetwork::Mainnet as i32); // Returns default
 
             // Test destroy with null (should be safe)
             dash_spv_ffi_config_destroy(std::ptr::null_mut());

--- a/dash-spv-ffi/tests/unit/test_error_handling.rs
+++ b/dash-spv-ffi/tests/unit/test_error_handling.rs
@@ -154,7 +154,7 @@ mod tests {
         // Use a valid enum value to avoid UB in Rust tests. If invalid raw inputs
         // need to be tested, do so from a C test or add a raw-int FFI entrypoint.
         unsafe {
-            let config = dash_spv_ffi_config_new(FFINetwork::Dash);
+            let config = dash_spv_ffi_config_new(FFINetwork::Mainnet);
             assert!(!config.is_null());
             dash_spv_ffi_config_destroy(config);
         }

--- a/dash-spv-ffi/tests/unit/test_type_conversions.rs
+++ b/dash-spv-ffi/tests/unit/test_type_conversions.rs
@@ -61,7 +61,7 @@ mod tests {
     fn test_network_conversions() {
         // Test all network conversions
         let networks = [
-            (FFINetwork::Dash, dashcore::Network::Dash),
+            (FFINetwork::Mainnet, dashcore::Network::Mainnet),
             (FFINetwork::Testnet, dashcore::Network::Testnet),
             (FFINetwork::Regtest, dashcore::Network::Regtest),
             (FFINetwork::Devnet, dashcore::Network::Devnet),

--- a/dash-spv/src/chain/chain_work.rs
+++ b/dash-spv/src/chain/chain_work.rs
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn test_chain_work_from_header() {
-        let genesis = genesis_block(Network::Dash).header;
+        let genesis = genesis_block(Network::Mainnet).header;
         let work = ChainWork::from_header(&genesis);
         assert!(!work.is_zero());
     }

--- a/dash-spv/src/client/config.rs
+++ b/dash-spv/src/client/config.rs
@@ -77,7 +77,7 @@ pub struct ClientConfig {
 impl Default for ClientConfig {
     fn default() -> Self {
         Self {
-            network: Network::Dash,
+            network: Network::Mainnet,
             peers: vec![],
             restrict_to_configured_peers: false,
             storage_path: PathBuf::from("./dash-spv-storage"),
@@ -110,7 +110,7 @@ impl ClientConfig {
 
     /// Create a configuration for mainnet.
     pub fn mainnet() -> Self {
-        Self::new(Network::Dash)
+        Self::new(Network::Mainnet)
     }
 
     /// Create a configuration for testnet.
@@ -221,7 +221,7 @@ impl ClientConfig {
     /// Explicit peers can still be added via add_peer() or configuration.
     fn default_peers_for_network(network: Network) -> Vec<SocketAddr> {
         match network {
-            Network::Dash | Network::Testnet => {
+            Network::Mainnet | Network::Testnet => {
                 // Return empty to trigger immediate DNS discovery
                 // DNS seeds will be used: dnsseed.dash.org (mainnet), testnet-seed.dashdot.io (testnet)
                 vec![]

--- a/dash-spv/src/client/config_test.rs
+++ b/dash-spv/src/client/config_test.rs
@@ -12,7 +12,7 @@ mod tests {
     fn test_default_config() {
         let config = ClientConfig::default();
 
-        assert_eq!(config.network, Network::Dash);
+        assert_eq!(config.network, Network::Mainnet);
         assert!(config.peers.is_empty());
         assert_eq!(config.validation_mode, ValidationMode::Full);
         assert!(config.enable_filters);
@@ -30,7 +30,7 @@ mod tests {
     #[test]
     fn test_network_specific_configs() {
         let mainnet = ClientConfig::mainnet();
-        assert_eq!(mainnet.network, Network::Dash);
+        assert_eq!(mainnet.network, Network::Mainnet);
         assert!(mainnet.peers.is_empty()); // Should use DNS discovery
 
         let testnet = ClientConfig::testnet();

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -65,7 +65,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         > = Managers::default();
 
         let checkpoints = match config.network {
-            dashcore::Network::Dash => mainnet_checkpoints(),
+            dashcore::Network::Mainnet => mainnet_checkpoints(),
             dashcore::Network::Testnet => testnet_checkpoints(),
             _ => Vec::new(),
         };
@@ -262,7 +262,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         if let Some(start_height) = config.start_from_height {
             // Get checkpoints for this network
             let checkpoints = match config.network {
-                dashcore::Network::Dash => crate::chain::checkpoints::mainnet_checkpoints(),
+                dashcore::Network::Mainnet => crate::chain::checkpoints::mainnet_checkpoints(),
                 dashcore::Network::Testnet => crate::chain::checkpoints::testnet_checkpoints(),
                 _ => vec![],
             };

--- a/dash-spv/src/main.rs
+++ b/dash-spv/src/main.rs
@@ -149,7 +149,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Parse network
     let network_str = matches.get_one::<String>("network").ok_or("Missing network argument")?;
     let network = match network_str.as_str() {
-        "mainnet" => Network::Dash,
+        "mainnet" => Network::Mainnet,
         "testnet" => Network::Testnet,
         "regtest" => Network::Regtest,
         n => return Err(format!("Invalid network: {}", n).into()),

--- a/dash-spv/src/mempool_filter.rs
+++ b/dash-spv/src/mempool_filter.rs
@@ -195,7 +195,7 @@ mod tests {
             2, // Small limit for testing
             mempool_state.clone(),
             HashSet::new(),
-            Network::Dash,
+            Network::Mainnet,
         );
 
         // Should fetch any transaction when under limit
@@ -246,7 +246,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_is_transaction_relevant_with_address() {
-        let network = Network::Dash;
+        let network = Network::Mainnet;
 
         let addr1 = Address::dummy(network, 0);
         let addr2 = Address::dummy(network, 1);
@@ -273,7 +273,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_is_transaction_relevant_with_script() {
-        let network = Network::Dash;
+        let network = Network::Mainnet;
 
         let addr1 = Address::dummy(network, 0);
         let addr2 = Address::dummy(network, 1);
@@ -300,7 +300,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_is_transaction_relevant_with_outpoint() {
-        let network = Network::Dash;
+        let network = Network::Mainnet;
 
         let addr1 = Address::dummy(network, 0);
 
@@ -346,7 +346,7 @@ mod tests {
             3, // Very small limit
             mempool_state.clone(),
             HashSet::new(),
-            Network::Dash,
+            Network::Mainnet,
         );
 
         // Should not be at capacity initially
@@ -391,7 +391,7 @@ mod tests {
             1000,
             mempool_state.clone(),
             HashSet::new(),
-            Network::Dash,
+            Network::Mainnet,
         );
 
         // Add some transactions with different ages
@@ -458,7 +458,7 @@ mod tests {
             1000,
             mempool_state,
             HashSet::new(),
-            Network::Dash,
+            Network::Mainnet,
         );
 
         // BloomFilter strategy should always return true (actual filtering is done by network layer)
@@ -470,7 +470,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_address_with_earliest_height() {
-        let network = Network::Dash;
+        let network = Network::Mainnet;
         let addr1 = Address::dummy(network, 0);
         let addr2 = Address::dummy(network, 1);
 

--- a/dash-spv/src/network/discovery.rs
+++ b/dash-spv/src/network/discovery.rs
@@ -32,7 +32,7 @@ impl DnsDiscovery {
     /// Discover peers for the given network
     pub async fn discover_peers(&self, network: Network) -> Vec<SocketAddr> {
         let (seeds, port) = match network {
-            Network::Dash => (MAINNET_DNS_SEEDS, 9999),
+            Network::Mainnet => (MAINNET_DNS_SEEDS, 9999),
             Network::Testnet => (TESTNET_DNS_SEEDS, 19999),
             _ => {
                 log::debug!("No DNS seeds for {:?} network", network);
@@ -84,7 +84,7 @@ mod tests {
     #[ignore] // Requires network access
     async fn test_dns_discovery_mainnet() {
         let discovery = DnsDiscovery::new().await.expect("Failed to create DNS discovery for test");
-        let peers = discovery.discover_peers(Network::Dash).await;
+        let peers = discovery.discover_peers(Network::Mainnet).await;
 
         // Print discovered peers for debugging
         println!("Discovered {} mainnet peers:", peers.len());

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -10,7 +10,7 @@ mod peer_tests {
     fn test_peer_creation() {
         let addr = "127.0.0.1:9999".parse().unwrap();
         let timeout = Duration::from_secs(30);
-        let peer = Peer::new(addr, timeout, Network::Dash);
+        let peer = Peer::new(addr, timeout, Network::Mainnet);
 
         assert!(!peer.is_connected());
         assert_eq!(peer.address(), addr);

--- a/dash-spv/src/test_utils/network.rs
+++ b/dash-spv/src/test_utils/network.rs
@@ -179,6 +179,6 @@ impl NetworkManager for MockNetworkManager {
 impl Peer {
     pub fn dummy() -> Self {
         let addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
-        Peer::new(addr, Duration::from_secs(10), Network::Dash)
+        Peer::new(addr, Duration::from_secs(10), Network::Mainnet)
     }
 }

--- a/dash-spv/src/validation/header.rs
+++ b/dash-spv/src/validation/header.rs
@@ -133,7 +133,7 @@ mod tests {
     fn test_genesis_blocks() {
         let validator = BlockHeaderValidator::new();
 
-        for network in [Network::Dash, Network::Testnet, Network::Regtest] {
+        for network in [Network::Mainnet, Network::Testnet, Network::Regtest] {
             let genesis = HashedBlockHeader::from(genesis_block(network).header);
             assert!(
                 validator.validate(&[genesis]).is_ok(),

--- a/dash-spv/tests/handshake_test.rs
+++ b/dash-spv/tests/handshake_test.rs
@@ -13,12 +13,12 @@ async fn test_handshake_with_mainnet_peer() {
     let _ = env_logger::builder().filter_level(log::LevelFilter::Debug).is_test(true).try_init();
 
     let peer_addr: SocketAddr = "127.0.0.1:9999".parse().expect("Valid peer address");
-    let result = Peer::connect(peer_addr, 10, Network::Dash).await;
+    let result = Peer::connect(peer_addr, 10, Network::Mainnet).await;
 
     match result {
         Ok(mut connection) => {
             let mut handshake_manager = HandshakeManager::new(
-                Network::Dash,
+                Network::Mainnet,
                 MempoolStrategy::BloomFilter,
                 Some("handshake_test".parse().unwrap()),
             );
@@ -54,7 +54,7 @@ async fn test_handshake_timeout() {
     // This IP range is reserved for documentation and will never respond.
     let peer_addr: SocketAddr = "192.0.2.1:9999".parse().expect("Valid peer address");
     let start = std::time::Instant::now();
-    let result = Peer::connect(peer_addr, 2, Network::Dash).await;
+    let result = Peer::connect(peer_addr, 2, Network::Mainnet).await;
     let elapsed = start.elapsed();
 
     assert!(result.is_err(), "Connection should fail for unreachable peer");
@@ -73,7 +73,8 @@ async fn test_handshake_timeout() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_network_manager_creation() {
     let temp_dir = tempfile::TempDir::new().expect("Failed to create temporary directory");
-    let config = ClientConfig::new(Network::Dash).with_storage_path(temp_dir.path().to_path_buf());
+    let config =
+        ClientConfig::new(Network::Mainnet).with_storage_path(temp_dir.path().to_path_buf());
     let network = PeerNetworkManager::new(&config).await;
 
     assert!(network.is_ok(), "Network manager creation should succeed");
@@ -85,7 +86,7 @@ async fn test_network_manager_creation() {
 #[tokio::test]
 async fn test_multiple_connect_disconnect_cycles() {
     let peer_addr: SocketAddr = "127.0.0.1:9999".parse().expect("Valid peer address");
-    let mut connection = Peer::new(peer_addr, Duration::from_secs(10), Network::Dash);
+    let mut connection = Peer::new(peer_addr, Duration::from_secs(10), Network::Mainnet);
 
     // Try multiple connect/disconnect cycles
     for i in 1..=3 {

--- a/dash-spv/tests/peer_test.rs
+++ b/dash-spv/tests/peer_test.rs
@@ -217,7 +217,7 @@ mod unit_tests {
         let discovery = DnsDiscovery::new().await.unwrap();
 
         // Test mainnet discovery
-        let peers = discovery.discover_peers(Network::Dash).await;
+        let peers = discovery.discover_peers(Network::Mainnet).await;
         assert!(!peers.is_empty(), "Should discover mainnet peers");
 
         // All peers should use correct port
@@ -226,7 +226,7 @@ mod unit_tests {
         }
 
         // Test limited discovery
-        let limited = discovery.discover_peers_limited(Network::Dash, 5).await;
+        let limited = discovery.discover_peers_limited(Network::Mainnet, 5).await;
         assert!(limited.len() <= 5);
     }
 }

--- a/dash-spv/tests/test_handshake_logic.rs
+++ b/dash-spv/tests/test_handshake_logic.rs
@@ -6,7 +6,7 @@ use dashcore::Network;
 
 #[test]
 fn test_handshake_state_transitions() {
-    let mut handshake = HandshakeManager::new(Network::Dash, MempoolStrategy::BloomFilter, None);
+    let mut handshake = HandshakeManager::new(Network::Mainnet, MempoolStrategy::BloomFilter, None);
 
     // Initial state should be Init
     assert_eq!(*handshake.state(), HandshakeState::Init);

--- a/dash-spv/tests/transaction_calculation_test.rs
+++ b/dash-spv/tests/transaction_calculation_test.rs
@@ -19,7 +19,7 @@ fn test_transaction_62364518_net_amount_calculation() {
 
     let watched_address = Address::from_str("XjbaGWaGnvEtuQAUoBgDxJWe8ZNv45upG2")
         .unwrap()
-        .require_network(Network::Dash)
+        .require_network(Network::Mainnet)
         .unwrap();
 
     // Input values (all from the same watched address):
@@ -121,7 +121,7 @@ fn test_transaction_62364518_net_amount_calculation() {
 fn test_suspected_bug_only_first_input() {
     let watched_address = Address::from_str("XjbaGWaGnvEtuQAUoBgDxJWe8ZNv45upG2")
         .unwrap()
-        .require_network(Network::Dash)
+        .require_network(Network::Mainnet)
         .unwrap();
 
     // Same transaction data
@@ -179,7 +179,7 @@ fn test_suspected_bug_only_first_input() {
 fn test_multiple_inputs_single_output() {
     let watched_address = Address::from_str("XjbaGWaGnvEtuQAUoBgDxJWe8ZNv45upG2")
         .unwrap()
-        .require_network(Network::Dash)
+        .require_network(Network::Mainnet)
         .unwrap();
 
     // Simpler test case: consolidation transaction
@@ -212,7 +212,7 @@ fn test_multiple_inputs_single_output() {
 fn test_receive_only_transaction() {
     let receiver_address = Address::from_str("XjbaGWaGnvEtuQAUoBgDxJWe8ZNv45upG2")
         .unwrap()
-        .require_network(Network::Dash)
+        .require_network(Network::Mainnet)
         .unwrap();
 
     let mut balance_changes: HashMap<Address, i64> = HashMap::new();
@@ -232,7 +232,7 @@ fn test_receive_only_transaction() {
 fn test_spend_only_transaction() {
     let sender_address = Address::from_str("XjbaGWaGnvEtuQAUoBgDxJWe8ZNv45upG2")
         .unwrap()
-        .require_network(Network::Dash)
+        .require_network(Network::Mainnet)
         .unwrap();
 
     let mut balance_changes: HashMap<Address, i64> = HashMap::new();

--- a/dash/embedded/src/main.rs
+++ b/dash/embedded/src/main.rs
@@ -46,7 +46,7 @@ fn main() -> ! {
 
     // Derive address
     let pubkey = pk.public_key(&secp);
-    let address = Address::p2wpkh(&pubkey, Network::Dash).unwrap();
+    let address = Address::p2wpkh(&pubkey, Network::Mainnet).unwrap();
     hprintln!("Address: {}", address).unwrap();
 
     assert_eq!(address.to_string(), "ds1qpx9t9pzzl4qsydmhyt6ctrxxjd4ep549jaqrtd".to_string());

--- a/dash/examples/handshake.rs
+++ b/dash/examples/handshake.rs
@@ -30,7 +30,7 @@ fn main() {
     let version_message = build_version_message(address);
 
     let first_message = message::RawNetworkMessage {
-        magic: Network::Dash.magic(),
+        magic: Network::Mainnet.magic(),
         payload: version_message,
     };
 
@@ -50,7 +50,7 @@ fn main() {
                     println!("Received version message: {:?}", reply.payload);
 
                     let second_message = message::RawNetworkMessage {
-                        magic: Network::Dash.magic(),
+                        magic: Network::Mainnet.magic(),
                         payload: message::NetworkMessage::Verack,
                     };
 

--- a/dash/src/address.rs
+++ b/dash/src/address.rs
@@ -31,7 +31,7 @@
 //! let public_key = PublicKey::new(s.generate_keypair(&mut rand::thread_rng()).1);
 //!
 //! // Generate pay-to-pubkey-hash address.
-//! let address = Address::p2pkh(&public_key, Network::Dash);
+//! let address = Address::p2pkh(&public_key, Network::Mainnet);
 //! # }
 //! ```
 //!
@@ -732,15 +732,15 @@ struct AddressInner {
 ///
 /// // variant 1
 /// let address: Address<NetworkUnchecked> = "XxMZ412shTuxDKUBdNfxMeLr4KhtfJjRv5".parse().unwrap();
-/// let address: Address<NetworkChecked> = address.require_network(Network::Dash).unwrap();
+/// let address: Address<NetworkChecked> = address.require_network(Network::Mainnet).unwrap();
 ///
 /// // variant 2
 /// let address: Address = Address::from_str("XxMZ412shTuxDKUBdNfxMeLr4KhtfJjRv5").unwrap()
-///                .require_network(Network::Dash).unwrap();
+///                .require_network(Network::Mainnet).unwrap();
 ///
 /// // variant 3
 /// let address: Address<NetworkChecked> = "XxMZ412shTuxDKUBdNfxMeLr4KhtfJjRv5".parse::<Address<_>>()
-///                .unwrap().require_network(Network::Dash).unwrap();
+///                .unwrap().require_network(Network::Mainnet).unwrap();
 /// ```
 ///
 /// ### Formatting addresses
@@ -838,7 +838,7 @@ impl<'de> serde::Deserialize<'de> for Address<NetworkChecked> {
         // For NetworkChecked, we need to assume a network. This is a limitation
         // of deserializing without network context. Users should use Address<NetworkUnchecked>
         // for serde when the network is not known at compile time.
-        addr_unchecked.require_network(Network::Dash).map_err(D::Error::custom)
+        addr_unchecked.require_network(Network::Mainnet).map_err(D::Error::custom)
     }
 }
 
@@ -992,15 +992,15 @@ impl<V: NetworkValidation> Address<V> {
     /// Format the address for the usage by `Debug` and `Display` implementations.
     fn fmt_internal(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let p2pkh_prefix = match self.network() {
-            Network::Dash => PUBKEY_ADDRESS_PREFIX_MAIN,
+            Network::Mainnet => PUBKEY_ADDRESS_PREFIX_MAIN,
             Network::Testnet | Network::Devnet | Network::Regtest => PUBKEY_ADDRESS_PREFIX_TEST,
         };
         let p2sh_prefix = match self.network() {
-            Network::Dash => SCRIPT_ADDRESS_PREFIX_MAIN,
+            Network::Mainnet => SCRIPT_ADDRESS_PREFIX_MAIN,
             Network::Testnet | Network::Devnet | Network::Regtest => SCRIPT_ADDRESS_PREFIX_TEST,
         };
         let bech32_hrp = match self.network() {
-            Network::Dash => "ds",
+            Network::Mainnet => "ds",
             Network::Testnet | Network::Devnet => "tb",
             Network::Regtest => "dsrt",
         };
@@ -1233,10 +1233,10 @@ impl Address<NetworkUnchecked> {
     /// assert!(address.is_valid_for_network(Network::Regtest));
     /// assert!(address.is_valid_for_network(Network::Devnet));
     ///
-    /// assert_eq!(address.is_valid_for_network(Network::Dash), false);
+    /// assert_eq!(address.is_valid_for_network(Network::Mainnet), false);
     ///
     /// let address: Address<NetworkUnchecked> = "Xs6U2uPMzn4zyfTtEkDgXMFGm39RP1F7mv".parse().unwrap();
-    /// assert!(address.is_valid_for_network(Network::Dash));
+    /// assert!(address.is_valid_for_network(Network::Mainnet));
     /// assert_eq!(address.is_valid_for_network(Network::Testnet), false);
     /// ```
     pub fn is_valid_for_network(&self, network: Network) -> bool {
@@ -1247,7 +1247,7 @@ impl Address<NetworkUnchecked> {
 
         match (self.network(), network) {
             (a, b) if *a == b => true,
-            (Network::Dash, _) | (_, Network::Dash) => false,
+            (Network::Mainnet, _) | (_, Network::Mainnet) => false,
             (Network::Regtest, _) | (_, Network::Regtest) if !is_legacy => false,
             (Network::Testnet, _) | (Network::Regtest, _) | (Network::Devnet, _) => true,
         }
@@ -1335,7 +1335,7 @@ impl FromStr for Address<NetworkUnchecked> {
         // try bech32
         let bech32_network = match find_bech32_prefix(s) {
             // note that upper or lowercase is allowed but NOT mixed case
-            "ds" | "DS" => Some(Network::Dash),
+            "ds" | "DS" => Some(Network::Mainnet),
             "td" | "TD" => Some(Network::Testnet), // this may also be a devnet
             "dsrt" | "DSRT" => Some(Network::Regtest),
             _ => None,
@@ -1378,10 +1378,10 @@ impl FromStr for Address<NetworkUnchecked> {
 
         let (network, payload) = match data[0] {
             PUBKEY_ADDRESS_PREFIX_MAIN => {
-                (Network::Dash, Payload::PubkeyHash(PubkeyHash::from_slice(&data[1..]).unwrap()))
+                (Network::Mainnet, Payload::PubkeyHash(PubkeyHash::from_slice(&data[1..]).unwrap()))
             }
             SCRIPT_ADDRESS_PREFIX_MAIN => {
-                (Network::Dash, Payload::ScriptHash(ScriptHash::from_slice(&data[1..]).unwrap()))
+                (Network::Mainnet, Payload::ScriptHash(ScriptHash::from_slice(&data[1..]).unwrap()))
             }
             PUBKEY_ADDRESS_PREFIX_TEST => {
                 (Network::Testnet, Payload::PubkeyHash(PubkeyHash::from_slice(&data[1..]).unwrap()))
@@ -1401,15 +1401,15 @@ impl FromStr for Address<NetworkUnchecked> {
 // impl fmt::Display for Address {
 //     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
 //         let p2pkh_prefix = match self.network {
-//             Network::Dash => PUBKEY_ADDRESS_PREFIX_MAIN,
+//             Network::Mainnet => PUBKEY_ADDRESS_PREFIX_MAIN,
 //             Network::Testnet | Network::Devnet | Network::Regtest => PUBKEY_ADDRESS_PREFIX_TEST,
 //         };
 //         let p2sh_prefix = match self.network {
-//             Network::Dash => SCRIPT_ADDRESS_PREFIX_MAIN,
+//             Network::Mainnet => SCRIPT_ADDRESS_PREFIX_MAIN,
 //             Network::Testnet | Network::Devnet | Network::Regtest => SCRIPT_ADDRESS_PREFIX_TEST,
 //         };
 //         let bech32_hrp = match self.network {
-//             Network::Dash => "ds",
+//             Network::Mainnet => "ds",
 //             Network::Testnet | Network::Devnet => "td",
 //             Network::Regtest => "dsrt",
 //         };
@@ -1462,7 +1462,7 @@ mod tests {
     use secp256k1::XOnlyPublicKey;
 
     use super::*;
-    use crate::Network::{Dash, Testnet};
+    use crate::Network::{Mainnet, Testnet};
     use crate::crypto::key::PublicKey;
 
     fn roundtrips(addr: &Address) {
@@ -1491,7 +1491,7 @@ mod tests {
     #[test]
     fn test_p2pkh_address_58() {
         let addr = Address::new(
-            Dash,
+            Mainnet,
             Payload::PubkeyHash("162c5ea71c0b23f5b9022ef047c4a86470a5b070".parse().unwrap()),
         );
 
@@ -1507,7 +1507,7 @@ mod tests {
     #[test]
     fn test_p2pkh_from_key() {
         let key = "048d5141948c1702e8c95f438815794b87f706a8d4cd2bffad1dc1570971032c9b6042a0431ded2478b5c9cf2d81c124a5e57347a3c63ef0e7716cf54d613ba183".parse::<PublicKey>().unwrap();
-        let addr = Address::p2pkh(&key, Dash);
+        let addr = Address::p2pkh(&key, Mainnet);
         assert_eq!(&addr.to_string(), "XyzL4FHjYiiQk9uhm6yCM4ewbkboBggYyo");
 
         let key = "03df154ebfcf29d29cc10d5c2565018bce2d9edbab267c31d2caf44a63056cf99f"
@@ -1522,7 +1522,7 @@ mod tests {
     #[test]
     fn test_p2sh_address_58() {
         let addr = Address::new(
-            Dash,
+            Mainnet,
             Payload::ScriptHash("162c5ea71c0b23f5b9022ef047c4a86470a5b070".parse().unwrap()),
         );
 
@@ -1557,14 +1557,14 @@ mod tests {
         let mut key = "033bc8c83c52df5712229a2f72206d90192366c36428cb0c12b6af98324d97bfbc"
             .parse::<PublicKey>()
             .unwrap();
-        let addr = Address::p2wpkh(&key, Dash).unwrap();
+        let addr = Address::p2wpkh(&key, Mainnet).unwrap();
         assert_eq!(&addr.to_string(), "bc1qvzvkjn4q3nszqxrv3nraga2r822xjty3ykvkuw");
         assert_eq!(addr.address_type(), Some(AddressType::P2wpkh));
         roundtrips(&addr);
 
         // Test uncompressed pubkey
         key.compressed = false;
-        assert_eq!(Address::p2wpkh(&key, Dash), Err(Error::UncompressedPubkey));
+        assert_eq!(Address::p2wpkh(&key, Mainnet), Err(Error::UncompressedPubkey));
     }
 
     #[ignore]
@@ -1572,7 +1572,7 @@ mod tests {
     fn test_p2wsh() {
         // stolen from Dash transaction 5df912fda4becb1c29e928bec8d64d93e9ba8efa9b5b405bd683c86fd2c65667
         let script = ScriptBuf::from_hex("52210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae").unwrap();
-        let addr = Address::p2wsh(&script, Dash);
+        let addr = Address::p2wsh(&script, Mainnet);
         assert_eq!(
             &addr.to_string(),
             "bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej"
@@ -1587,21 +1587,21 @@ mod tests {
         let mut key = "026c468be64d22761c30cd2f12cbc7de255d592d7904b1bab07236897cc4c2e766"
             .parse::<PublicKey>()
             .unwrap();
-        let addr = Address::p2shwpkh(&key, Dash).unwrap();
+        let addr = Address::p2shwpkh(&key, Mainnet).unwrap();
         assert_eq!(&addr.to_string(), "7pu4bhf1eANQdvBoPH2FcDtDpMu4c7ZNuN");
         assert_eq!(addr.address_type(), Some(AddressType::P2sh));
         roundtrips(&addr);
 
         // Test uncompressed pubkey
         key.compressed = false;
-        assert_eq!(Address::p2wpkh(&key, Dash), Err(Error::UncompressedPubkey));
+        assert_eq!(Address::p2wpkh(&key, Mainnet), Err(Error::UncompressedPubkey));
     }
 
     #[test]
     fn test_p2shwsh() {
         // stolen from Dash transaction f9ee2be4df05041d0e0a35d7caa3157495ca4f93b233234c9967b6901dacf7a9
         let script = ScriptBuf::from_hex("522103e5529d8eaa3d559903adb2e881eb06c86ac2574ffa503c45f4e942e2a693b33e2102e5f10fcdcdbab211e0af6a481f5532536ec61a5fdbf7183770cf8680fe729d8152ae").unwrap();
-        let addr = Address::p2shwsh(&script, Dash);
+        let addr = Address::p2shwsh(&script, Mainnet);
         assert_eq!(&addr.to_string(), "7WxUWa53KVEhSdBWwoB7LYMr2VedMZqoqt");
         assert_eq!(addr.address_type(), Some(AddressType::P2sh));
         roundtrips(&addr);
@@ -1614,7 +1614,7 @@ mod tests {
             "654f6ea368e0acdfd92976b7c2103a1b26313f430654f6ea368e0acdfd92976b7c2103a1b26313f4"
         );
         let witness_prog = WitnessProgram::new(WitnessVersion::V13, program.to_vec()).unwrap();
-        let addr = Address::new(Dash, Payload::WitnessProgram(witness_prog));
+        let addr = Address::new(Mainnet, Payload::WitnessProgram(witness_prog));
         roundtrips(&addr);
     }
 
@@ -1662,7 +1662,7 @@ mod tests {
         for (address, expected_type) in &addresses {
             let addr = Address::from_str(address)
                 .unwrap()
-                .require_network(Network::Dash)
+                .require_network(Network::Mainnet)
                 .expect("mainnet");
             assert_eq!(&addr.address_type(), expected_type);
         }
@@ -1852,7 +1852,7 @@ mod tests {
         for el in
             ["Xxb77sLZJZMUeYdf3TpWNoRFgEvjQkoi2q", "XanpivH7JqvtWsCkjB5vXqoGBhv4XGBRJn"].iter()
         {
-            let addr = Address::from_str(el).unwrap().require_network(Dash).expect("mainnet");
+            let addr = Address::from_str(el).unwrap().require_network(Mainnet).expect("mainnet");
             assert_eq!(addr.to_qr_uri(), format!("dash:{}", el));
         }
 
@@ -1881,9 +1881,9 @@ mod tests {
             .collect::<Vec<_>>();
 
         const LEGACY_EQUIVALENCE_CLASSES: &[&[Network]] =
-            &[&[Network::Dash], &[Network::Testnet, Network::Regtest, Network::Devnet]];
+            &[&[Network::Mainnet], &[Network::Testnet, Network::Regtest, Network::Devnet]];
         const SEGWIT_EQUIVALENCE_CLASSES: &[&[Network]] =
-            &[&[Network::Dash], &[Network::Regtest], &[Network::Testnet, Network::Devnet]];
+            &[&[Network::Mainnet], &[Network::Regtest], &[Network::Testnet, Network::Devnet]];
 
         fn test_addr_type(payloads: &[Payload], equivalence_classes: &[&[Network]]) {
             for pl in payloads {
@@ -1921,7 +1921,7 @@ mod tests {
         )
         .unwrap();
         let secp = Secp256k1::verification_only();
-        let address = Address::p2tr(&secp, internal_key, None, Network::Dash);
+        let address = Address::p2tr(&secp, internal_key, None, Network::Mainnet);
         assert_eq!(
             address.to_string(),
             "ds1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqq9xzlq"
@@ -1936,7 +1936,7 @@ mod tests {
         let address_string = "bc1qhvd6suvqzjcu9pxjhrwhtrlj85ny3n2mqql5w4";
         let address = Address::from_str(address_string)
             .expect("address")
-            .require_network(Network::Dash)
+            .require_network(Network::Mainnet)
             .expect("mainnet");
 
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
@@ -1957,7 +1957,7 @@ mod tests {
         let address_string = "7fH3aFXJ5TWv5eNScx7m4FCf3XD27mXYHq";
         let address = Address::from_str(address_string)
             .expect("address")
-            .require_network(Network::Dash)
+            .require_network(Network::Mainnet)
             .expect("mainnet");
 
         let pubkey_string = "0347ff3dacd07a1f43805ec6808e801505a6e18245178609972a68afbc2777ff2b";
@@ -1978,7 +1978,7 @@ mod tests {
         let address_string = "XgjvsEewx8SHii5SFYM856eU2qGrJuZ3AN";
         let address = Address::from_str(address_string)
             .expect("address")
-            .require_network(Network::Dash)
+            .require_network(Network::Mainnet)
             .expect("mainnet");
 
         let pubkey_string = "0370be7922711cf8e19923d40126d1fb1a7300d873019abd58c7984aeff44f8ce4";
@@ -1999,7 +1999,7 @@ mod tests {
         let address_string = "Xo6KeXZcaKyZCEMGioNYnsrPskpUZAZFhr";
         let address = Address::from_str(address_string)
             .expect("address")
-            .require_network(Network::Dash)
+            .require_network(Network::Mainnet)
             .expect("testnet");
 
         let pubkey_string = "04e96e22004e3db93530de27ccddfdf1463975d2138ac018fc3e7ba1a2e5e0aad8e424d0b55e2436eb1d0dcd5cb2b8bcc6d53412c22f358de57803a6a655fbbd04";
@@ -2022,13 +2022,13 @@ mod tests {
         let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
         let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
         let tweaked_pubkey = TweakedPublicKey::dangerous_assume_tweaked(xonly_pubkey);
-        let address = Address::p2tr_tweaked(tweaked_pubkey, Network::Dash);
+        let address = Address::p2tr_tweaked(tweaked_pubkey, Network::Mainnet);
 
         assert_eq!(
             address,
             Address::from_str("bc1pgllnmtxs0g058qz7c6qgaqq4qknwrqj9z7rqn9e2dzhmcfmhlu4sfadf5e")
                 .expect("address")
-                .require_network(Network::Dash)
+                .require_network(Network::Mainnet)
                 .expect("mainnet")
         );
 
@@ -2049,13 +2049,13 @@ mod tests {
         let pubkey = PublicKey::from_str(pubkey_string).expect("pubkey");
         let xonly_pubkey = XOnlyPublicKey::from(pubkey.inner);
         let tweaked_pubkey = TweakedPublicKey::dangerous_assume_tweaked(xonly_pubkey);
-        let address = Address::p2tr_tweaked(tweaked_pubkey, Network::Dash);
+        let address = Address::p2tr_tweaked(tweaked_pubkey, Network::Mainnet);
 
         assert_eq!(
             address,
             Address::from_str("bc1pgllnmtxs0g058qz7c6qgaqq4qknwrqj9z7rqn9e2dzhmcfmhlu4sfadf5e")
                 .expect("address")
-                .require_network(Network::Dash)
+                .require_network(Network::Mainnet)
                 .expect("mainnet")
         );
 
@@ -2074,10 +2074,10 @@ mod tests {
             ScriptBuf::from_hex("001161458e330389cd0437ee9fe3641d70cc18").unwrap();
         let expected = Err(Error::UnrecognizedScript);
 
-        assert_eq!(Address::from_script(&bad_p2wpkh, Network::Dash), expected);
-        assert_eq!(Address::from_script(&bad_p2wsh, Network::Dash), expected);
+        assert_eq!(Address::from_script(&bad_p2wpkh, Network::Mainnet), expected);
+        assert_eq!(Address::from_script(&bad_p2wsh, Network::Mainnet), expected);
         assert_eq!(
-            Address::from_script(&invalid_segwitv0_script, Network::Dash),
+            Address::from_script(&invalid_segwitv0_script, Network::Mainnet),
             Err(Error::InvalidSegwitV0ProgramLength(17))
         );
     }
@@ -2109,10 +2109,10 @@ mod tests {
             "bc1pgllnmtxs0g058qz7c6qgaqq4qknwrqj9z7rqn9e2dzhmcfmhlu4sfadf5e",
         ];
         for addr in &addresses {
-            let addr = Address::from_str(addr).unwrap().require_network(Network::Dash).unwrap();
+            let addr = Address::from_str(addr).unwrap().require_network(Network::Mainnet).unwrap();
             for another in &addresses {
                 let another =
-                    Address::from_str(another).unwrap().require_network(Network::Dash).unwrap();
+                    Address::from_str(another).unwrap().require_network(Network::Mainnet).unwrap();
                 assert_eq!(addr.matches_script_pubkey(&another.script_pubkey()), addr == another);
             }
         }

--- a/dash/src/bip143.rs
+++ b/dash/src/bip143.rs
@@ -206,7 +206,7 @@ mod tests {
 
     fn p2pkh_hex(pk: &str) -> Script {
         let pk: PublicKey = PublicKey::from_str(pk).unwrap();
-        let witness_script = Address::p2pkh(&pk, Network::Dash).script_pubkey();
+        let witness_script = Address::p2pkh(&pk, Network::Mainnet).script_pubkey();
         witness_script
     }
 

--- a/dash/src/blockdata/constants.rs
+++ b/dash/src/blockdata/constants.rs
@@ -112,7 +112,7 @@ pub fn genesis_block(network: Network) -> Block {
     let txdata = vec![dash_genesis_tx()];
 
     match network {
-        Network::Dash => {
+        Network::Mainnet => {
             // Mainnet merkle root - Note: bytes are reversed for internal representation
             let merkle_bytes =
                 hex!("c762a6567f3cc092f0684bb62b7e00a84890b990f07cc71a6bb58d64b98e02e0");
@@ -221,7 +221,7 @@ mod test {
 
     #[test]
     fn dash_genesis_full_block() {
-        let genesis_block = genesis_block(Network::Dash);
+        let genesis_block = genesis_block(Network::Mainnet);
 
         assert_eq!(genesis_block.header.version, block::Version::ONE);
         assert_eq!(genesis_block.header.prev_blockhash, Hash::all_zeros());

--- a/dash/src/blockdata/transaction/mod.rs
+++ b/dash/src/blockdata/transaction/mod.rs
@@ -899,7 +899,7 @@ mod tests {
         use crate::Network;
         use crate::blockdata::constants;
 
-        let genesis = constants::genesis_block(Network::Dash);
+        let genesis = constants::genesis_block(Network::Mainnet);
         assert!(genesis.txdata[0].is_coin_base());
         let tx_bytes = Vec::from_hex("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
         let tx: Transaction = deserialize(&tx_bytes).unwrap();

--- a/dash/src/blockdata/transaction/outpoint.rs
+++ b/dash/src/blockdata/transaction/outpoint.rs
@@ -97,7 +97,7 @@ impl OutPoint {
     /// use dashcore::blockdata::constants::genesis_block;
     /// use dashcore::Network;
     ///
-    /// let block = genesis_block(Network::Dash);
+    /// let block = genesis_block(Network::Mainnet);
     /// let tx = &block.txdata[0];
     ///
     /// // Coinbase transactions don't have any previous output.

--- a/dash/src/consensus/params.rs
+++ b/dash/src/consensus/params.rs
@@ -66,8 +66,8 @@ impl Params {
     /// Creates parameters set for the given network.
     pub fn new(network: Network) -> Self {
         match network {
-            Network::Dash => Params {
-                network: Network::Dash,
+            Network::Mainnet => Params {
+                network: Network::Mainnet,
                 bip16_time: 1333238400,                 // Apr 1 2012
                 bip34_height: 227931, // 000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8
                 bip65_height: 388381, // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0

--- a/dash/src/crypto/key.rs
+++ b/dash/src/crypto/key.rs
@@ -405,7 +405,7 @@ impl PrivateKey {
     pub fn fmt_wif(&self, fmt: &mut dyn Write) -> fmt::Result {
         let mut ret = [0; 34];
         ret[0] = match self.network {
-            Network::Dash => 204,
+            Network::Mainnet => 204,
             Network::Testnet | Network::Devnet | Network::Regtest => 239,
         };
         ret[1..33].copy_from_slice(&self.inner[..]);
@@ -439,7 +439,7 @@ impl PrivateKey {
         };
 
         let network = match data[0] {
-            204 => Network::Dash,
+            204 => Network::Mainnet,
             239 => Network::Testnet,
             x => {
                 return Err(Error::Base58(base58::Error::InvalidAddressVersion(x)));
@@ -819,7 +819,7 @@ mod tests {
     use secp256k1::Secp256k1;
 
     use super::*;
-    use crate::Network::{Dash, Testnet};
+    use crate::Network::{Mainnet, Testnet};
     use crate::address::Address;
     use crate::io;
 
@@ -845,7 +845,7 @@ mod tests {
         // mainnet uncompressed
         let sk =
             PrivateKey::from_wif("7sU7MdjMtaLYxC4ec2z1zkhzZVBwRzZUcU6gJRzJ94s6UzAwA8c").unwrap();
-        assert_eq!(sk.network, Dash);
+        assert_eq!(sk.network, Mainnet);
         assert!(!sk.compressed);
         assert_eq!(&sk.to_wif(), "7sU7MdjMtaLYxC4ec2z1zkhzZVBwRzZUcU6gJRzJ94s6UzAwA8c");
 

--- a/dash/src/crypto/sighash.rs
+++ b/dash/src/crypto/sighash.rs
@@ -1755,7 +1755,7 @@ mod tests {
 
     fn p2pkh_hex(pk: &str) -> ScriptBuf {
         let pk: PublicKey = PublicKey::from_str(pk).unwrap();
-        Address::p2pkh(&pk, Network::Dash).script_pubkey()
+        Address::p2pkh(&pk, Network::Mainnet).script_pubkey()
     }
 
     #[test]

--- a/dash/src/network/constants.rs
+++ b/dash/src/network/constants.rs
@@ -27,7 +27,7 @@
 //! use dashcore::Network;
 //! use dashcore::consensus::encode::serialize;
 //!
-//! let network = Network::Dash;
+//! let network = Network::Mainnet;
 //! let bytes = serialize(&network.magic());
 //!
 //! assert_eq!(&bytes[..], &[0xBF, 0x0C, 0x6B, 0xBD]);
@@ -73,7 +73,7 @@ use bincode_derive::{Decode, Encode};
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub enum Network {
     /// Dash mainnet, the production network for real transactions.
-    Dash,
+    Mainnet,
     /// Dash public test network for protocol-level testing without real funds.
     Testnet,
     /// Dash development network, an isolated environment for feature development and testing.
@@ -90,13 +90,13 @@ impl Network {
     /// ```rust
     /// use dashcore::Network;
     ///
-    /// assert_eq!(Some(Network::Dash), Network::from_magic(0xBD6B0CBF));
+    /// assert_eq!(Some(Network::Mainnet), Network::from_magic(0xBD6B0CBF));
     /// assert_eq!(None, Network::from_magic(0xFFFFFFFF));
     /// ```
     pub fn from_magic(magic: u32) -> Option<Network> {
         // Note: any new entries here must be added to `magic` below
         match magic {
-            0xBD6B0CBF => Some(Network::Dash),
+            0xBD6B0CBF => Some(Network::Mainnet),
             0xFFCAE2CE => Some(Network::Testnet),
             0xCEFFCAE2 => Some(Network::Devnet),
             0xDCB7C1FC => Some(Network::Regtest),
@@ -112,13 +112,13 @@ impl Network {
     /// ```rust
     /// use dashcore::Network;
     ///
-    /// let network = Network::Dash;
+    /// let network = Network::Mainnet;
     /// assert_eq!(network.magic(), 0xBD6B0CBF);
     /// ```
     pub fn magic(self) -> u32 {
         // Note: any new entries here must be added to `from_magic` above
         match self {
-            Network::Dash => 0xBD6B0CBF,
+            Network::Mainnet => 0xBD6B0CBF,
             Network::Testnet => 0xFFCAE2CE,
             Network::Devnet => 0xCEFFCAE2,
             Network::Regtest => 0xDCB7C1FC,
@@ -127,7 +127,7 @@ impl Network {
 
     pub fn known_genesis_block_hash(&self) -> Option<BlockHash> {
         match self {
-            Network::Dash => {
+            Network::Mainnet => {
                 let mut block_hash =
                     hex::decode("00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6")
                         .expect("expected valid hex");
@@ -154,7 +154,7 @@ impl Network {
 
     pub fn v20_activation_height(&self) -> u32 {
         match self {
-            Network::Dash => 1_987_776,
+            Network::Mainnet => 1_987_776,
             Network::Testnet => 905_100,
             // Devnet and regtest activate V20 immediately
             _ => 0,
@@ -165,7 +165,7 @@ impl Network {
 impl fmt::Display for Network {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Network::Dash => write!(f, "dash"),
+            Network::Mainnet => write!(f, "mainnet"),
             Network::Testnet => write!(f, "testnet"),
             Network::Devnet => write!(f, "devnet"),
             Network::Regtest => write!(f, "regtest"),
@@ -178,7 +178,7 @@ impl std::str::FromStr for Network {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "dash" | "mainnet" => Ok(Network::Dash),
+            "mainnet" | "main" => Ok(Network::Mainnet),
             "testnet" | "test" => Ok(Network::Testnet),
             "devnet" | "dev" => Ok(Network::Devnet),
             "regtest" => Ok(Network::Regtest),
@@ -369,7 +369,7 @@ mod tests {
 
     #[test]
     fn test_network_magic() {
-        assert_eq!(Network::Dash.magic(), 0xBD6B0CBF);
+        assert_eq!(Network::Mainnet.magic(), 0xBD6B0CBF);
         assert_eq!(Network::Testnet.magic(), 0xFFCAE2CE);
         assert_eq!(Network::Devnet.magic(), 0xCEFFCAE2);
         assert_eq!(Network::Regtest.magic(), 0xDCB7C1FC);
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_network_from_magic() {
-        assert_eq!(Network::from_magic(0xBD6B0CBF), Some(Network::Dash));
+        assert_eq!(Network::from_magic(0xBD6B0CBF), Some(Network::Mainnet));
         assert_eq!(Network::from_magic(0xFFCAE2CE), Some(Network::Testnet));
         assert_eq!(Network::from_magic(0xCEFFCAE2), Some(Network::Devnet));
         assert_eq!(Network::from_magic(0xDCB7C1FC), Some(Network::Regtest));
@@ -386,7 +386,7 @@ mod tests {
 
     #[test]
     fn test_network_display() {
-        assert_eq!(Network::Dash.to_string(), "dash");
+        assert_eq!(Network::Mainnet.to_string(), "mainnet");
         assert_eq!(Network::Testnet.to_string(), "testnet");
         assert_eq!(Network::Devnet.to_string(), "devnet");
         assert_eq!(Network::Regtest.to_string(), "regtest");
@@ -394,8 +394,7 @@ mod tests {
 
     #[test]
     fn test_network_from_str() {
-        assert_eq!("dash".parse::<Network>().unwrap(), Network::Dash);
-        assert_eq!("mainnet".parse::<Network>().unwrap(), Network::Dash);
+        assert_eq!("mainnet".parse::<Network>().unwrap(), Network::Mainnet);
         assert_eq!("testnet".parse::<Network>().unwrap(), Network::Testnet);
         assert_eq!("test".parse::<Network>().unwrap(), Network::Testnet);
         assert_eq!("devnet".parse::<Network>().unwrap(), Network::Devnet);
@@ -406,12 +405,12 @@ mod tests {
 
     #[test]
     fn serialize_test() {
-        assert_eq!(serialize(&Network::Dash.magic()), &[0xbf, 0x0c, 0x6b, 0xbd]);
+        assert_eq!(serialize(&Network::Mainnet.magic()), &[0xbf, 0x0c, 0x6b, 0xbd]);
         assert_eq!(serialize(&Network::Testnet.magic()), &[0xce, 0xe2, 0xca, 0xff]);
         assert_eq!(serialize(&Network::Devnet.magic()), &[0xe2, 0xca, 0xff, 0xce]);
         assert_eq!(serialize(&Network::Regtest.magic()), &[0xfc, 0xc1, 0xb7, 0xdc]);
 
-        assert_eq!(deserialize(&[0xbf, 0x0c, 0x6b, 0xbd]).ok(), Some(Network::Dash.magic()));
+        assert_eq!(deserialize(&[0xbf, 0x0c, 0x6b, 0xbd]).ok(), Some(Network::Mainnet.magic()));
         assert_eq!(deserialize(&[0xce, 0xe2, 0xca, 0xff]).ok(), Some(Network::Testnet.magic()));
         assert_eq!(deserialize(&[0xe2, 0xca, 0xff, 0xce]).ok(), Some(Network::Devnet.magic()));
         assert_eq!(deserialize(&[0xfc, 0xc1, 0xb7, 0xdc]).ok(), Some(Network::Regtest.magic()));

--- a/dash/src/network/message.rs
+++ b/dash/src/network/message.rs
@@ -1001,7 +1001,7 @@ mod test {
         // Test encoding and decoding SendDsq(true)
         let msg_true = NetworkMessage::SendDsq(true);
         let raw_msg = RawNetworkMessage {
-            magic: crate::Network::Dash.magic(),
+            magic: crate::Network::Mainnet.magic(),
             payload: msg_true,
         };
 
@@ -1022,7 +1022,7 @@ mod test {
         // Test encoding and decoding SendDsq(false)
         let msg_false = NetworkMessage::SendDsq(false);
         let raw_msg = RawNetworkMessage {
-            magic: crate::Network::Dash.magic(),
+            magic: crate::Network::Mainnet.magic(),
             payload: msg_false,
         };
 

--- a/dash/src/sign_message.rs
+++ b/dash/src/sign_message.rs
@@ -268,14 +268,14 @@ mod tests {
         assert!(pubkey.compressed);
         assert_eq!(pubkey.inner, secp256k1::PublicKey::from_secret_key(&secp, &privkey));
 
-        let p2pkh = Address::p2pkh(&pubkey, Network::Dash);
+        let p2pkh = Address::p2pkh(&pubkey, Network::Mainnet);
         assert_eq!(signature2.is_signed_by_address(&secp, &p2pkh, msg_hash), Ok(true));
-        let p2wpkh = Address::p2wpkh(&pubkey, Network::Dash).unwrap();
+        let p2wpkh = Address::p2wpkh(&pubkey, Network::Mainnet).unwrap();
         assert_eq!(
             signature2.is_signed_by_address(&secp, &p2wpkh, msg_hash),
             Err(MessageSignatureError::UnsupportedAddressType(AddressType::P2wpkh))
         );
-        let p2shwpkh = Address::p2shwpkh(&pubkey, Network::Dash).unwrap();
+        let p2shwpkh = Address::p2shwpkh(&pubkey, Network::Mainnet).unwrap();
         assert_eq!(
             signature2.is_signed_by_address(&secp, &p2shwpkh, msg_hash),
             Err(MessageSignatureError::UnsupportedAddressType(AddressType::P2sh))
@@ -304,7 +304,7 @@ mod tests {
         let pubkey = PublicKey::from_slice(&base64::decode(pubkey_base64).expect("base64 string"))
             .expect("pubkey slice");
 
-        let p2pkh = Address::p2pkh(&pubkey, Network::Dash);
+        let p2pkh = Address::p2pkh(&pubkey, Network::Mainnet);
         assert_eq!(signature.is_signed_by_address(&secp, &p2pkh, msg_hash), Ok(false));
     }
 }

--- a/dash/src/sml/llmq_type/network.rs
+++ b/dash/src/sml/llmq_type/network.rs
@@ -16,7 +16,7 @@ pub trait NetworkLLMQExt {
 impl NetworkLLMQExt for Network {
     fn is_llmq_type(&self) -> LLMQType {
         match self {
-            Network::Dash => LLMQType::Llmqtype50_60,
+            Network::Mainnet => LLMQType::Llmqtype50_60,
             Network::Testnet => LLMQType::Llmqtype50_60,
             Network::Devnet => LLMQType::LlmqtypeDevnet,
             Network::Regtest => LLMQType::LlmqtypeTestInstantSend,
@@ -25,7 +25,7 @@ impl NetworkLLMQExt for Network {
 
     fn isd_llmq_type(&self) -> LLMQType {
         match self {
-            Network::Dash => LLMQType::Llmqtype60_75,
+            Network::Mainnet => LLMQType::Llmqtype60_75,
             Network::Testnet => LLMQType::Llmqtype60_75,
             Network::Devnet => LLMQType::LlmqtypeDevnetDIP0024,
             Network::Regtest => LLMQType::LlmqtypeTestDIP0024,
@@ -34,7 +34,7 @@ impl NetworkLLMQExt for Network {
 
     fn chain_locks_type(&self) -> LLMQType {
         match self {
-            Network::Dash => LLMQType::Llmqtype400_60,
+            Network::Mainnet => LLMQType::Llmqtype400_60,
             Network::Testnet => LLMQType::Llmqtype50_60,
             Network::Devnet => LLMQType::LlmqtypeDevnet,
             Network::Regtest => LLMQType::LlmqtypeTest,
@@ -43,7 +43,7 @@ impl NetworkLLMQExt for Network {
 
     fn platform_type(&self) -> LLMQType {
         match self {
-            Network::Dash => LLMQType::Llmqtype100_67,
+            Network::Mainnet => LLMQType::Llmqtype100_67,
             Network::Testnet => LLMQType::Llmqtype25_67,
             Network::Devnet => LLMQType::LlmqtypeDevnet,
             Network::Regtest => LLMQType::LlmqtypeTest,
@@ -53,7 +53,7 @@ impl NetworkLLMQExt for Network {
     /// Get all enabled LLMQ types for this network
     fn enabled_llmq_types(&self) -> Vec<LLMQType> {
         match self {
-            Network::Dash => vec![
+            Network::Mainnet => vec![
                 LLMQType::Llmqtype50_60,  // InstantSend
                 LLMQType::Llmqtype60_75,  // InstantSend DIP24 (rotating)
                 LLMQType::Llmqtype400_60, // ChainLocks
@@ -129,7 +129,7 @@ impl NetworkLLMQExt for Network {
     /// Check if a quorum type should be skipped at the given height
     fn should_skip_quorum_type(&self, llmq_type: &LLMQType, height: u32) -> bool {
         match (self, llmq_type) {
-            (Network::Dash, LLMQType::Llmqtype100_67) => height < 1_888_888, // Platform activation on mainnet
+            (Network::Mainnet, LLMQType::Llmqtype100_67) => height < 1_888_888, // Platform activation on mainnet
             (Network::Testnet, LLMQType::Llmqtype25_67) => height < 1_289_520, // Platform activation on testnet
             _ => false,
         }
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_enabled_llmq_types_mainnet() {
-        let network = Network::Dash;
+        let network = Network::Mainnet;
         let types = network.enabled_llmq_types();
 
         assert!(types.contains(&LLMQType::Llmqtype50_60));
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn test_should_skip_platform_quorum() {
-        let network = Network::Dash;
+        let network = Network::Mainnet;
 
         // Platform quorum should be skipped before activation height
         assert!(network.should_skip_quorum_type(&LLMQType::Llmqtype100_67, 1_888_887));

--- a/dash/src/sml/masternode_list/apply_diff.rs
+++ b/dash/src/sml/masternode_list/apply_diff.rs
@@ -181,7 +181,7 @@ mod tests {
         let base_list = MasternodeList::try_from_with_block_hash_lookup(
             base_diff,
             |_| Some(2_227_096),
-            Network::Dash,
+            Network::Mainnet,
         )
         .expect("expected to create base list");
 
@@ -193,9 +193,9 @@ mod tests {
 
         // Height 2241332 is post-V20 on mainnet (1,987,776)
         let post_v20_height = 2_241_332;
-        assert!(post_v20_height >= Network::Dash.v20_activation_height());
+        assert!(post_v20_height >= Network::Mainnet.v20_activation_height());
 
-        let result = base_list.apply_diff(diff, post_v20_height, None, Network::Dash);
+        let result = base_list.apply_diff(diff, post_v20_height, None, Network::Mainnet);
 
         assert!(
             matches!(result, Err(SmlError::IncompleteSignatureSet)),
@@ -214,7 +214,7 @@ mod tests {
         let base_list = MasternodeList::try_from_with_block_hash_lookup(
             base_diff,
             |_| Some(base_height),
-            Network::Dash,
+            Network::Mainnet,
         )
         .expect("expected to create base list");
 
@@ -229,9 +229,9 @@ mod tests {
 
         // Use a pre-V20 height on mainnet
         let pre_v20_height = 1_900_000u32;
-        assert!(pre_v20_height < Network::Dash.v20_activation_height());
+        assert!(pre_v20_height < Network::Mainnet.v20_activation_height());
 
-        let result = base_list.apply_diff(diff, pre_v20_height, None, Network::Dash);
+        let result = base_list.apply_diff(diff, pre_v20_height, None, Network::Mainnet);
 
         assert!(
             result.is_ok(),

--- a/dash/src/sml/masternode_list/from_diff.rs
+++ b/dash/src/sml/masternode_list/from_diff.rs
@@ -171,12 +171,12 @@ mod tests {
 
         // Height 2227096 is post-V20 on mainnet (1,987,776)
         let post_v20_height = 2_227_096;
-        assert!(post_v20_height >= Network::Dash.v20_activation_height());
+        assert!(post_v20_height >= Network::Mainnet.v20_activation_height());
 
         let result = MasternodeList::try_from_with_block_hash_lookup(
             diff,
             |_| Some(post_v20_height),
-            Network::Dash,
+            Network::Mainnet,
         );
 
         assert!(
@@ -197,12 +197,12 @@ mod tests {
 
         // Use a pre-V20 height on mainnet (V20 at 1,987,776)
         let pre_v20_height = 1_900_000;
-        assert!(pre_v20_height < Network::Dash.v20_activation_height());
+        assert!(pre_v20_height < Network::Mainnet.v20_activation_height());
 
         let result = MasternodeList::try_from_with_block_hash_lookup(
             diff,
             |_| Some(pre_v20_height),
-            Network::Dash,
+            Network::Mainnet,
         );
 
         assert!(

--- a/dash/src/sml/masternode_list_engine/mod.rs
+++ b/dash/src/sml/masternode_list_engine/mod.rs
@@ -193,7 +193,7 @@ impl Default for MasternodeListEngine {
             known_snapshots: Default::default(),
             rotated_quorums_per_cycle: Default::default(),
             quorum_statuses: Default::default(),
-            network: Network::Dash,
+            network: Network::Mainnet,
         }
     }
 }
@@ -1197,7 +1197,7 @@ mod tests {
         // This one is serialized not with bincode, but with core consensus
         let diff: MnListDiff = deserialize(mn_list_diff_bytes).expect("expected to deserialize");
         let mut masternode_list_engine =
-            MasternodeListEngine::initialize_with_diff_to_height(diff, 2227096, Network::Dash)
+            MasternodeListEngine::initialize_with_diff_to_height(diff, 2227096, Network::Mainnet)
                 .expect("expected to start engine");
 
         let mn_list_diff_bytes_2: &[u8] =
@@ -1283,7 +1283,7 @@ mod tests {
         // This one is serialized not with bincode, but with core consensus
         let diff: MnListDiff = deserialize(mn_list_diff_bytes).expect("expected to deserialize");
         let mut masternode_list_engine =
-            MasternodeListEngine::initialize_with_diff_to_height(diff, 2227096, Network::Dash)
+            MasternodeListEngine::initialize_with_diff_to_height(diff, 2227096, Network::Mainnet)
                 .expect("expected to start engine");
 
         let block_container_bytes: &[u8] =
@@ -1444,7 +1444,7 @@ mod tests {
             include_bytes!("../../../tests/data/test_DML_diffs/mn_list_diff_0_2227096.bin");
         let diff: MnListDiff = deserialize(mn_list_diff_bytes).expect("expected to deserialize");
         let mut masternode_list_engine =
-            MasternodeListEngine::initialize_with_diff_to_height(diff, 2227096, Network::Dash)
+            MasternodeListEngine::initialize_with_diff_to_height(diff, 2227096, Network::Mainnet)
                 .expect("expected to start engine");
 
         let block_container_bytes: &[u8] =

--- a/dash/src/taproot.rs
+++ b/dash/src/taproot.rs
@@ -2200,7 +2200,7 @@ mod test {
 
             let tweak = TapTweakHash::from_key_and_tweak(internal_key, merkle_root);
             let (output_key, _parity) = internal_key.tap_tweak(secp, merkle_root);
-            let addr = Address::p2tr(secp, internal_key, merkle_root, Network::Dash);
+            let addr = Address::p2tr(secp, internal_key, merkle_root, Network::Mainnet);
             let spk = addr.script_pubkey();
 
             assert_eq!(expected_output_key, output_key.to_inner());

--- a/fuzz/fuzz_targets/dash/deserialize_script.rs
+++ b/fuzz/fuzz_targets/dash/deserialize_script.rs
@@ -38,7 +38,7 @@ fn do_test(data: &[u8]) {
         assert_eq!(data, &encode::serialize(&script)[..]);
 
         // Check if valid address and if that address roundtrips.
-        if let Ok(addr) = Address::from_script(&script, Network::Dash) {
+        if let Ok(addr) = Address::from_script(&script, Network::Mainnet) {
             assert_eq!(addr.script_pubkey(), script);
         }
     }

--- a/key-wallet-ffi/FFI_API.md
+++ b/key-wallet-ffi/FFI_API.md
@@ -2346,10 +2346,10 @@ account_get_network(account: *const FFIAccount) -> FFINetwork
 ```
 
 **Description:**
-Get the network of an account  # Safety  - `account` must be a valid pointer to an FFIAccount instance - Returns `FFINetwork::Dash` if the account is null
+Get the network of an account  # Safety  - `account` must be a valid pointer to an FFIAccount instance - Returns `FFINetwork::Mainnet` if the account is null
 
 **Safety:**
-- `account` must be a valid pointer to an FFIAccount instance - Returns `FFINetwork::Dash` if the account is null
+- `account` must be a valid pointer to an FFIAccount instance - Returns `FFINetwork::Mainnet` if the account is null
 
 **Module:** `account`
 
@@ -3171,10 +3171,10 @@ managed_core_account_get_network(account: *const FFIManagedCoreAccount,) -> FFIN
 ```
 
 **Description:**
-Get the network of a managed account  # Safety  - `account` must be a valid pointer to an FFIManagedCoreAccount instance - Returns `FFINetwork::Dash` if the account is null
+Get the network of a managed account  # Safety  - `account` must be a valid pointer to an FFIManagedCoreAccount instance - Returns `FFINetwork::Mainnet` if the account is null
 
 **Safety:**
-- `account` must be a valid pointer to an FFIManagedCoreAccount instance - Returns `FFINetwork::Dash` if the account is null
+- `account` must be a valid pointer to an FFIManagedCoreAccount instance - Returns `FFINetwork::Mainnet` if the account is null
 
 **Module:** `managed_account`
 
@@ -3363,10 +3363,10 @@ managed_platform_account_get_network(account: *const FFIManagedPlatformAccount,)
 ```
 
 **Description:**
-Get the network of a managed platform account  # Safety  - `account` must be a valid pointer to an FFIManagedPlatformAccount instance - Returns `FFINetwork::Dash` if the account is null
+Get the network of a managed platform account  # Safety  - `account` must be a valid pointer to an FFIManagedPlatformAccount instance - Returns `FFINetwork::Mainnet` if the account is null
 
 **Safety:**
-- `account` must be a valid pointer to an FFIManagedPlatformAccount instance - Returns `FFINetwork::Dash` if the account is null
+- `account` must be a valid pointer to an FFIManagedPlatformAccount instance - Returns `FFINetwork::Mainnet` if the account is null
 
 **Module:** `managed_account`
 

--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -106,7 +106,7 @@ typedef enum {
  FFI Network type (single network)
  */
 typedef enum {
-    DASH = 0,
+    MAINNET = 0,
     TESTNET = 1,
     REGTEST = 2,
     DEVNET = 3,
@@ -976,7 +976,7 @@ FFIAccountResult wallet_get_top_up_account_with_registration_index(const FFIWall
  # Safety
 
  - `account` must be a valid pointer to an FFIAccount instance
- - Returns `FFINetwork::Dash` if the account is null
+ - Returns `FFINetwork::Mainnet` if the account is null
  */
  FFINetwork account_get_network(const FFIAccount *account) ;
 
@@ -1030,7 +1030,7 @@ FFIAccountResult wallet_get_top_up_account_with_registration_index(const FFIWall
  # Safety
 
  - `account` must be a valid pointer to an FFIBLSAccount instance
- - Returns `FFINetwork::Dash` if the account is null
+ - Returns `FFINetwork::Mainnet` if the account is null
  */
  FFINetwork bls_account_get_network(const FFIBLSAccount *account) ;
 
@@ -1087,7 +1087,7 @@ FFIAccountType bls_account_get_account_type(const FFIBLSAccount *account,
  # Safety
 
  - `account` must be a valid pointer to an FFIEdDSAAccount instance
- - Returns `FFINetwork::Dash` if the account is null
+ - Returns `FFINetwork::Mainnet` if the account is null
  */
  FFINetwork eddsa_account_get_network(const FFIEdDSAAccount *account) ;
 
@@ -2512,7 +2512,7 @@ FFIManagedCoreAccountResult managed_wallet_get_dashpay_external_account(const FF
  # Safety
 
  - `account` must be a valid pointer to an FFIManagedCoreAccount instance
- - Returns `FFINetwork::Dash` if the account is null
+ - Returns `FFINetwork::Mainnet` if the account is null
  */
  FFINetwork managed_core_account_get_network(const FFIManagedCoreAccount *account) ;
 
@@ -2740,7 +2740,7 @@ FFIManagedPlatformAccountResult managed_wallet_get_platform_payment_account(cons
  # Safety
 
  - `account` must be a valid pointer to an FFIManagedPlatformAccount instance
- - Returns `FFINetwork::Dash` if the account is null
+ - Returns `FFINetwork::Mainnet` if the account is null
  */
  FFINetwork managed_platform_account_get_network(const FFIManagedPlatformAccount *account) ;
 

--- a/key-wallet-ffi/src/account.rs
+++ b/key-wallet-ffi/src/account.rs
@@ -231,11 +231,11 @@ pub unsafe extern "C" fn account_get_extended_public_key_as_string(
 /// # Safety
 ///
 /// - `account` must be a valid pointer to an FFIAccount instance
-/// - Returns `FFINetwork::Dash` if the account is null
+/// - Returns `FFINetwork::Mainnet` if the account is null
 #[no_mangle]
 pub unsafe extern "C" fn account_get_network(account: *const FFIAccount) -> FFINetwork {
     if account.is_null() {
-        return FFINetwork::Dash;
+        return FFINetwork::Mainnet;
     }
 
     let account = &*account;
@@ -342,12 +342,12 @@ pub unsafe extern "C" fn bls_account_get_extended_public_key_as_string(
 /// # Safety
 ///
 /// - `account` must be a valid pointer to an FFIBLSAccount instance
-/// - Returns `FFINetwork::Dash` if the account is null
+/// - Returns `FFINetwork::Mainnet` if the account is null
 #[cfg(feature = "bls")]
 #[no_mangle]
 pub unsafe extern "C" fn bls_account_get_network(account: *const FFIBLSAccount) -> FFINetwork {
     if account.is_null() {
-        return FFINetwork::Dash;
+        return FFINetwork::Mainnet;
     }
 
     let account = &*account;
@@ -459,12 +459,12 @@ pub unsafe extern "C" fn eddsa_account_get_extended_public_key_as_string(
 /// # Safety
 ///
 /// - `account` must be a valid pointer to an FFIEdDSAAccount instance
-/// - Returns `FFINetwork::Dash` if the account is null
+/// - Returns `FFINetwork::Mainnet` if the account is null
 #[cfg(feature = "eddsa")]
 #[no_mangle]
 pub unsafe extern "C" fn eddsa_account_get_network(account: *const FFIEdDSAAccount) -> FFINetwork {
     if account.is_null() {
-        return FFINetwork::Dash;
+        return FFINetwork::Mainnet;
     }
 
     let account = &*account;

--- a/key-wallet-ffi/src/account_tests.rs
+++ b/key-wallet-ffi/src/account_tests.rs
@@ -205,7 +205,7 @@ mod tests {
             assert!(xpub.is_null());
 
             let network = account_get_network(ptr::null());
-            assert_eq!(network, crate::FFINetwork::Dash);
+            assert_eq!(network, crate::FFINetwork::Mainnet);
 
             let wallet_id = account_get_parent_wallet_id(ptr::null());
             assert!(wallet_id.is_null());

--- a/key-wallet-ffi/src/derivation_tests.rs
+++ b/key-wallet-ffi/src/derivation_tests.rs
@@ -571,7 +571,7 @@ mod tests {
 
         // Test with Mainnet
         let xprv_main = unsafe {
-            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Dash, &mut error)
+            derivation_new_master_key(seed.as_ptr(), seed.len(), FFINetwork::Mainnet, &mut error)
         };
         assert!(!xprv_main.is_null());
         assert_eq!(error.code, FFIErrorCode::Success);

--- a/key-wallet-ffi/src/lib_tests.rs
+++ b/key-wallet-ffi/src/lib_tests.rs
@@ -156,7 +156,7 @@ mod tests {
         assert!(parsed.is_ok());
 
         // Should fail with mainnet (different prefix)
-        let parsed = Address::from_string(addr_str.clone(), Network::Dash);
+        let parsed = Address::from_string(addr_str.clone(), Network::Mainnet);
         assert!(parsed.is_err());
     }
 }

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -482,13 +482,13 @@ pub unsafe extern "C" fn managed_wallet_get_dashpay_external_account(
 /// # Safety
 ///
 /// - `account` must be a valid pointer to an FFIManagedCoreAccount instance
-/// - Returns `FFINetwork::Dash` if the account is null
+/// - Returns `FFINetwork::Mainnet` if the account is null
 #[no_mangle]
 pub unsafe extern "C" fn managed_core_account_get_network(
     account: *const FFIManagedCoreAccount,
 ) -> FFINetwork {
     if account.is_null() {
-        return FFINetwork::Dash;
+        return FFINetwork::Mainnet;
     }
 
     let account = &*account;
@@ -1157,13 +1157,13 @@ pub unsafe extern "C" fn managed_wallet_get_platform_payment_account(
 /// # Safety
 ///
 /// - `account` must be a valid pointer to an FFIManagedPlatformAccount instance
-/// - Returns `FFINetwork::Dash` if the account is null
+/// - Returns `FFINetwork::Mainnet` if the account is null
 #[no_mangle]
 pub unsafe extern "C" fn managed_platform_account_get_network(
     account: *const FFIManagedPlatformAccount,
 ) -> FFINetwork {
     if account.is_null() {
-        return FFINetwork::Dash;
+        return FFINetwork::Mainnet;
     }
 
     let account = &*account;
@@ -1665,7 +1665,7 @@ mod tests {
         unsafe {
             // Test null account for get_network
             let network = managed_core_account_get_network(ptr::null());
-            assert_eq!(network, FFINetwork::Dash);
+            assert_eq!(network, FFINetwork::Mainnet);
 
             let mut index_out: c_uint = 0;
             let account_type = managed_core_account_get_account_type(ptr::null(), &mut index_out);

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FFINetwork {
-    Dash = 0,
+    Mainnet = 0,
     Testnet = 1,
     Regtest = 2,
     Devnet = 3,
@@ -17,7 +17,7 @@ pub enum FFINetwork {
 #[no_mangle]
 pub extern "C" fn ffi_network_get_name(network: FFINetwork) -> *const c_char {
     match network {
-        FFINetwork::Dash => c"dash".as_ptr() as *const c_char,
+        FFINetwork::Mainnet => c"mainnet".as_ptr() as *const c_char,
         FFINetwork::Testnet => c"testnet".as_ptr() as *const c_char,
         FFINetwork::Regtest => c"regtest".as_ptr() as *const c_char,
         FFINetwork::Devnet => c"devnet".as_ptr() as *const c_char,
@@ -27,7 +27,7 @@ pub extern "C" fn ffi_network_get_name(network: FFINetwork) -> *const c_char {
 impl From<FFINetwork> for Network {
     fn from(net: FFINetwork) -> Self {
         match net {
-            FFINetwork::Dash => Network::Dash,
+            FFINetwork::Mainnet => Network::Mainnet,
             FFINetwork::Testnet => Network::Testnet,
             FFINetwork::Regtest => Network::Regtest,
             FFINetwork::Devnet => Network::Devnet,
@@ -38,11 +38,11 @@ impl From<FFINetwork> for Network {
 impl From<Network> for FFINetwork {
     fn from(net: Network) -> Self {
         match net {
-            Network::Dash => FFINetwork::Dash,
+            Network::Mainnet => FFINetwork::Mainnet,
             Network::Testnet => FFINetwork::Testnet,
             Network::Regtest => FFINetwork::Regtest,
             Network::Devnet => FFINetwork::Devnet,
-            _ => FFINetwork::Dash,
+            _ => FFINetwork::Mainnet,
         }
     }
 }

--- a/key-wallet-ffi/src/wallet_manager.rs
+++ b/key-wallet-ffi/src/wallet_manager.rs
@@ -801,7 +801,7 @@ pub unsafe extern "C" fn wallet_manager_network(
 ) -> FFINetwork {
     if manager.is_null() {
         FFIError::set_error(error, FFIErrorCode::InvalidInput, "Manager is null".to_string());
-        return FFINetwork::Dash; // Default fallback
+        return FFINetwork::Mainnet; // Default fallback
     }
 
     let manager_ref = &*manager;

--- a/key-wallet-ffi/tests/debug_addr.rs
+++ b/key-wallet-ffi/tests/debug_addr.rs
@@ -12,7 +12,7 @@ fn test_debug_address() {
 
             // Try different networks
             for network in &[
-                dashcore::Network::Dash,
+                dashcore::Network::Mainnet,
                 dashcore::Network::Testnet,
                 dashcore::Network::Regtest,
                 dashcore::Network::Devnet,

--- a/key-wallet-ffi/tests/integration_test.rs
+++ b/key-wallet-ffi/tests/integration_test.rs
@@ -131,7 +131,7 @@ fn test_derivation_paths() {
 
     // Account path
     let success = key_wallet_ffi::derivation::derivation_bip44_account_path(
-        FFINetwork::Dash,
+        FFINetwork::Mainnet,
         0,
         path_buffer.as_mut_ptr() as *mut std::os::raw::c_char,
         path_buffer.len(),
@@ -149,7 +149,7 @@ fn test_derivation_paths() {
     // Payment path
     path_buffer.fill(0);
     let success = key_wallet_ffi::derivation::derivation_bip44_payment_path(
-        FFINetwork::Dash,
+        FFINetwork::Mainnet,
         0,
         false,
         5,

--- a/key-wallet/CLAUDE.md
+++ b/key-wallet/CLAUDE.md
@@ -237,7 +237,7 @@ while !stage.should_stop(index, gap_limit) {
 ### 3. Ignoring Network Types
 **Wrong**: Mixing mainnet and testnet
 ```rust
-let address = Address::from_script(&script, Network::Dash)?;
+let address = Address::from_script(&script, Network::Mainnet)?;
 // Using on testnet without checking
 ```
 

--- a/key-wallet/README.md
+++ b/key-wallet/README.md
@@ -67,7 +67,7 @@ let mnemonic = Mnemonic::generate(24, Language::English)?;
 println!("Mnemonic: {}", mnemonic.phrase());
 
 // Create wallet from mnemonic
-let wallet = Wallet::from_mnemonic(mnemonic.clone(), None, Network::Dash)?;
+let wallet = Wallet::from_mnemonic(mnemonic.clone(), None, Network::Mainnet)?;
 
 // Get wallet ID (unique identifier)
 println!("Wallet ID: {:?}", hex::encode(wallet.wallet_id));
@@ -81,7 +81,7 @@ use key_wallet::managed_account::ManagedAccount;
 
 // Create a standard BIP44 account
 let account = wallet.create_account(
-    Network::Dash,
+    Network::Mainnet,
     AccountType::Standard {
         index: 0,
         standard_account_type: StandardAccountType::BIP44Account,
@@ -130,7 +130,7 @@ for i in 0..100 {
 ```rust
 // Create CoinJoin account for privacy
 let coinjoin_account = wallet.create_account(
-    Network::Dash,
+    Network::Mainnet,
     AccountType::Standard {
         index: 0,
         standard_account_type: StandardAccountType::CoinJoinAccount,
@@ -151,7 +151,7 @@ let pool_1_address = coinjoin_account.derive_address_at_pool(1, 0)?;
     
     // Create identity authentication key
     let identity_account = wallet.create_account(
-        Network::Dash,
+        Network::Mainnet,
         AccountType::IdentityAuthentication {
             identity_index: 0,
             key_index: 0,
@@ -176,7 +176,7 @@ let tx: Transaction = get_transaction_from_network();
 
 let result = wallet_info.check_transaction(
     &tx,
-    Network::Dash,
+    Network::Mainnet,
     TransactionContext::Mempool,
     Some(&wallet), // Update state if transaction is ours
 );

--- a/key-wallet/examples/basic_usage.rs
+++ b/key-wallet/examples/basic_usage.rs
@@ -26,7 +26,7 @@ fn main() -> core::result::Result<(), Box<dyn std::error::Error>> {
 
     // 3. Create master key
     println!("\n3. Creating master key...");
-    let master = ExtendedPrivKey::new_master(Network::Dash, &seed)?;
+    let master = ExtendedPrivKey::new_master(Network::Mainnet, &seed)?;
     let secp = secp256k1::Secp256k1::new();
     let master_pub = ExtendedPubKey::from_priv(&secp, &master);
     println!("   Master public key: {}", master_pub);
@@ -54,7 +54,7 @@ fn main() -> core::result::Result<(), Box<dyn std::error::Error>> {
         let addr_key = account.derive_priv(&secp, &receive_path)?;
         let addr_xpub = ExtendedPubKey::from_priv(&secp, &addr_key);
         let addr =
-            Address::p2pkh(&dashcore::PublicKey::new(addr_xpub.public_key), DashNetwork::Dash);
+            Address::p2pkh(&dashcore::PublicKey::new(addr_xpub.public_key), DashNetwork::Mainnet);
         println!("     {}: {}", i, addr);
     }
 
@@ -68,7 +68,7 @@ fn main() -> core::result::Result<(), Box<dyn std::error::Error>> {
         let addr_key = account.derive_priv(&secp, &change_path)?;
         let addr_xpub = ExtendedPubKey::from_priv(&secp, &addr_key);
         let addr =
-            Address::p2pkh(&dashcore::PublicKey::new(addr_xpub.public_key), DashNetwork::Dash);
+            Address::p2pkh(&dashcore::PublicKey::new(addr_xpub.public_key), DashNetwork::Mainnet);
         println!("     {}: {}", i, addr);
     }
 
@@ -100,7 +100,7 @@ fn main() -> core::result::Result<(), Box<dyn std::error::Error>> {
     match Address::<dashcore::address::NetworkUnchecked>::from_str(test_address) {
         Ok(parsed) => {
             // NetworkUnchecked addresses need to be converted to check network
-            if let Ok(checked) = parsed.clone().require_network(DashNetwork::Dash) {
+            if let Ok(checked) = parsed.clone().require_network(DashNetwork::Mainnet) {
                 println!("   Parsed address: {}", checked);
                 println!("   Type: {:?}", checked.address_type());
                 println!("   Network: Dash");

--- a/key-wallet/src/account/account_type.rs
+++ b/key-wallet/src/account/account_type.rs
@@ -257,7 +257,7 @@ impl AccountType {
 
     /// Get the derivation path for this account type
     pub fn derivation_path(&self, network: Network) -> Result<DerivationPath, crate::error::Error> {
-        let coin_type = if network == Network::Dash {
+        let coin_type = if network == Network::Mainnet {
             5
         } else {
             1
@@ -301,7 +301,7 @@ impl AccountType {
             Self::IdentityRegistration => {
                 // Base path without index - actual key index added when deriving
                 match network {
-                    Network::Dash => {
+                    Network::Mainnet => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_REGISTRATION_PATH_MAINNET))
                     }
                     Network::Testnet | Network::Devnet | Network::Regtest => {
@@ -315,7 +315,7 @@ impl AccountType {
             } => {
                 // Base path with registration index - actual key index added when deriving
                 let base_path = match network {
-                    Network::Dash => crate::dip9::IDENTITY_TOPUP_PATH_MAINNET,
+                    Network::Mainnet => crate::dip9::IDENTITY_TOPUP_PATH_MAINNET,
                     Network::Testnet | Network::Devnet | Network::Regtest => {
                         crate::dip9::IDENTITY_TOPUP_PATH_TESTNET
                     }
@@ -331,7 +331,7 @@ impl AccountType {
             Self::IdentityTopUpNotBoundToIdentity => {
                 // Base path without registration index - actual key index added when deriving
                 match network {
-                    Network::Dash => {
+                    Network::Mainnet => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_TOPUP_PATH_MAINNET))
                     }
                     Network::Testnet | Network::Devnet | Network::Regtest => {
@@ -343,7 +343,7 @@ impl AccountType {
             Self::IdentityInvitation => {
                 // Base path without index - actual key index added when deriving
                 match network {
-                    Network::Dash => {
+                    Network::Mainnet => {
                         Ok(DerivationPath::from(crate::dip9::IDENTITY_INVITATION_PATH_MAINNET))
                     }
                     Network::Testnet | Network::Devnet | Network::Regtest => {
@@ -355,7 +355,7 @@ impl AccountType {
             Self::AssetLockAddressTopUp => {
                 // Base path without index - actual key index added when deriving
                 match network {
-                    Network::Dash => {
+                    Network::Mainnet => {
                         Ok(DerivationPath::from(crate::dip9::ASSET_LOCK_ADDRESS_TOPUP_PATH_MAINNET))
                     }
                     Network::Testnet | Network::Devnet | Network::Regtest => {
@@ -367,7 +367,7 @@ impl AccountType {
             Self::AssetLockShieldedAddressTopUp => {
                 // Base path without index - actual key index added when deriving
                 match network {
-                    Network::Dash => Ok(DerivationPath::from(
+                    Network::Mainnet => Ok(DerivationPath::from(
                         crate::dip9::ASSET_LOCK_SHIELDED_ADDRESS_TOPUP_PATH_MAINNET,
                     )),
                     Network::Testnet | Network::Devnet | Network::Regtest => {
@@ -425,7 +425,9 @@ impl AccountType {
             } => {
                 // Base DashPay root + account 0' + user_id/friend_id (non-hardened per DIP-14/DIP-15)
                 let mut path = match network {
-                    Network::Dash => DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_MAINNET),
+                    Network::Mainnet => {
+                        DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_MAINNET)
+                    }
                     Network::Testnet | Network::Devnet | Network::Regtest => {
                         DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_TESTNET)
                     }
@@ -447,7 +449,9 @@ impl AccountType {
             } => {
                 // Base DashPay root + account 0' + friend_id/user_id (non-hardened per DIP-14/DIP-15)
                 let mut path = match network {
-                    Network::Dash => DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_MAINNET),
+                    Network::Mainnet => {
+                        DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_MAINNET)
+                    }
                     Network::Testnet | Network::Devnet | Network::Regtest => {
                         DerivationPath::from(crate::dip9::DASHPAY_ROOT_PATH_TESTNET)
                     }
@@ -469,7 +473,7 @@ impl AccountType {
                 // DIP-17: m/9'/coin_type'/17'/account'/key_class'
                 // The leaf index is non-hardened and appended during address generation
                 let mut path = match network {
-                    Network::Dash => {
+                    Network::Mainnet => {
                         DerivationPath::from(crate::dip9::PLATFORM_PAYMENT_ROOT_PATH_MAINNET)
                     }
                     Network::Testnet | Network::Devnet | Network::Regtest => {

--- a/key-wallet/src/bip32.rs
+++ b/key-wallet/src/bip32.rs
@@ -994,7 +994,7 @@ impl From<KeyDerivationType> for u32 {
 impl DerivationPath {
     pub fn bip_44_account(network: Network, account: u32) -> Self {
         let mut root_derivation_path: DerivationPath = match network {
-            Network::Dash => DASH_BIP44_PATH_MAINNET,
+            Network::Mainnet => DASH_BIP44_PATH_MAINNET,
             _ => DASH_BIP44_PATH_TESTNET,
         }
         .into();
@@ -1010,7 +1010,7 @@ impl DerivationPath {
         address_index: u32,
     ) -> Self {
         let mut root_derivation_path: DerivationPath = match network {
-            Network::Dash => DASH_BIP44_PATH_MAINNET,
+            Network::Mainnet => DASH_BIP44_PATH_MAINNET,
             _ => DASH_BIP44_PATH_TESTNET,
         }
         .into();
@@ -1029,7 +1029,7 @@ impl DerivationPath {
     }
     pub fn coinjoin_path(network: Network, account: u32) -> Self {
         let mut root_derivation_path: DerivationPath = match network {
-            Network::Dash => COINJOIN_PATH_MAINNET,
+            Network::Mainnet => COINJOIN_PATH_MAINNET,
             _ => COINJOIN_PATH_TESTNET,
         }
         .into();
@@ -1042,7 +1042,7 @@ impl DerivationPath {
     /// This might have been used in the past
     pub fn identity_registration_path_child_non_hardened(network: Network, index: u32) -> Self {
         let mut root_derivation_path: DerivationPath = match network {
-            Network::Dash => IDENTITY_REGISTRATION_PATH_MAINNET,
+            Network::Mainnet => IDENTITY_REGISTRATION_PATH_MAINNET,
             _ => IDENTITY_REGISTRATION_PATH_TESTNET,
         }
         .into();
@@ -1054,7 +1054,7 @@ impl DerivationPath {
 
     pub fn identity_registration_path(network: Network, index: u32) -> Self {
         let mut root_derivation_path: DerivationPath = match network {
-            Network::Dash => IDENTITY_REGISTRATION_PATH_MAINNET,
+            Network::Mainnet => IDENTITY_REGISTRATION_PATH_MAINNET,
             _ => IDENTITY_REGISTRATION_PATH_TESTNET,
         }
         .into();
@@ -1066,7 +1066,7 @@ impl DerivationPath {
 
     pub fn identity_top_up_path(network: Network, identity_index: u32, top_up_index: u32) -> Self {
         let mut root_derivation_path: DerivationPath = match network {
-            Network::Dash => IDENTITY_TOPUP_PATH_MAINNET,
+            Network::Mainnet => IDENTITY_TOPUP_PATH_MAINNET,
             _ => IDENTITY_TOPUP_PATH_TESTNET,
         }
         .into();
@@ -1083,7 +1083,7 @@ impl DerivationPath {
 
     pub fn identity_invitation_path(network: Network, index: u32) -> Self {
         let mut root_derivation_path: DerivationPath = match network {
-            Network::Dash => IDENTITY_INVITATION_PATH_MAINNET,
+            Network::Mainnet => IDENTITY_INVITATION_PATH_MAINNET,
             _ => IDENTITY_INVITATION_PATH_TESTNET,
         }
         .into();
@@ -1095,7 +1095,7 @@ impl DerivationPath {
 
     pub fn asset_lock_address_top_up_path(network: Network, index: u32) -> Self {
         let mut root_derivation_path: DerivationPath = match network {
-            Network::Dash => ASSET_LOCK_ADDRESS_TOPUP_PATH_MAINNET,
+            Network::Mainnet => ASSET_LOCK_ADDRESS_TOPUP_PATH_MAINNET,
             _ => ASSET_LOCK_ADDRESS_TOPUP_PATH_TESTNET,
         }
         .into();
@@ -1107,7 +1107,7 @@ impl DerivationPath {
 
     pub fn asset_lock_shielded_address_top_up_path(network: Network, index: u32) -> Self {
         let mut root_derivation_path: DerivationPath = match network {
-            Network::Dash => ASSET_LOCK_SHIELDED_ADDRESS_TOPUP_PATH_MAINNET,
+            Network::Mainnet => ASSET_LOCK_SHIELDED_ADDRESS_TOPUP_PATH_MAINNET,
             _ => ASSET_LOCK_SHIELDED_ADDRESS_TOPUP_PATH_TESTNET,
         }
         .into();
@@ -1124,7 +1124,7 @@ impl DerivationPath {
         key_index: u32,
     ) -> Self {
         let mut root_derivation_path: DerivationPath = match network {
-            Network::Dash => IDENTITY_AUTHENTICATION_PATH_MAINNET,
+            Network::Mainnet => IDENTITY_AUTHENTICATION_PATH_MAINNET,
             _ => IDENTITY_AUTHENTICATION_PATH_TESTNET,
         }
         .into();
@@ -1619,7 +1619,7 @@ impl ExtendedPrivKey {
         }
 
         let network = match data {
-            [0x04u8, 0x88, 0xAD, 0xE4, ..] => Network::Dash,
+            [0x04u8, 0x88, 0xAD, 0xE4, ..] => Network::Mainnet,
             [0x04u8, 0x35, 0x83, 0x94, ..] => Network::Testnet,
             [b0, b1, b2, b3, ..] => return Err(Error::UnknownVersion([*b0, *b1, *b2, *b3])),
             _ => unreachable!("length checked above"),
@@ -1644,7 +1644,7 @@ impl ExtendedPrivKey {
         let mut ret = [0; 78];
         ret[0..4].copy_from_slice(
             &match self.network {
-                Network::Dash => [0x04, 0x88, 0xAD, 0xE4],
+                Network::Mainnet => [0x04, 0x88, 0xAD, 0xE4],
                 _ => [0x04, 0x35, 0x83, 0x94], // Testnet/Devnet/Regtest/Unknown
             }[..],
         );
@@ -1665,7 +1665,7 @@ impl ExtendedPrivKey {
 
         let version = &data[0..4];
         let network = match version {
-            [0x0Eu8, 0xEC, 0xF0, 0x2E] => Network::Dash, // Mainnet private
+            [0x0Eu8, 0xEC, 0xF0, 0x2E] => Network::Mainnet, // Mainnet private
             [0x0Eu8, 0xED, 0x27, 0x74] => Network::Testnet, // Testnet private
             [b0, b1, b2, b3] => return Err(Error::UnknownVersion([*b0, *b1, *b2, *b3])),
             _ => unreachable!("length checked above"),
@@ -1707,7 +1707,7 @@ impl ExtendedPrivKey {
 
         // Version bytes
         let version: [u8; 4] = match self.network {
-            Network::Dash => [0x0E, 0xEC, 0xF0, 0x2E],
+            Network::Mainnet => [0x0E, 0xEC, 0xF0, 0x2E],
             _ => [0x0E, 0xED, 0x27, 0x74], // Testnet/Devnet/Regtest/Unknown
         };
         ret[0..4].copy_from_slice(&version);
@@ -1911,7 +1911,7 @@ impl ExtendedPubKey {
         }
 
         let network = match data {
-            [0x04u8, 0x88, 0xB2, 0x1E, ..] => Network::Dash,
+            [0x04u8, 0x88, 0xB2, 0x1E, ..] => Network::Mainnet,
             [0x04u8, 0x35, 0x87, 0xCF, ..] => Network::Testnet,
             [b0, b1, b2, b3, ..] => return Err(Error::UnknownVersion([*b0, *b1, *b2, *b3])),
             _ => unreachable!("length checked above"),
@@ -1936,7 +1936,7 @@ impl ExtendedPubKey {
         let mut ret = [0; 78];
         ret[0..4].copy_from_slice(
             &match self.network {
-                Network::Dash => [0x04u8, 0x88, 0xB2, 0x1E],
+                Network::Mainnet => [0x04u8, 0x88, 0xB2, 0x1E],
                 _ => [0x04u8, 0x35, 0x87, 0xCF], // Testnet/Devnet/Regtest/Unknown
             }[..],
         );
@@ -1954,7 +1954,7 @@ impl ExtendedPubKey {
 
         // Version bytes
         let version: [u8; 4] = match self.network {
-            Network::Dash => [0x0E, 0xEC, 0xEF, 0xC5],
+            Network::Mainnet => [0x0E, 0xEC, 0xEF, 0xC5],
             _ => [0x0E, 0xED, 0x27, 0x0B], // Testnet/Devnet/Regtest/Unknown
         };
         ret[0..4].copy_from_slice(&version);
@@ -2006,7 +2006,7 @@ impl ExtendedPubKey {
 
         let version = &data[0..4];
         let network = match version {
-            [0x0Eu8, 0xEC, 0xEF, 0xC5] => Network::Dash, // Mainnet public
+            [0x0Eu8, 0xEC, 0xEF, 0xC5] => Network::Mainnet, // Mainnet public
             [0x0Eu8, 0xED, 0x27, 0x0B] => Network::Testnet, // Testnet public
             [b0, b1, b2, b3] => return Err(Error::UnknownVersion([*b0, *b1, *b2, *b3])),
             _ => unreachable!("length checked above"),
@@ -2104,7 +2104,7 @@ mod tests {
 
     use super::ChildNumber::{Hardened, Normal};
     use super::*;
-    use dashcore::Network::{self, Dash};
+    use dashcore::Network::{self, Mainnet};
 
     #[test]
     fn test_parse_derivation_path() {
@@ -2292,7 +2292,7 @@ mod tests {
         // m
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m".parse().unwrap(),
             "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
@@ -2302,7 +2302,7 @@ mod tests {
         // m/0h
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m/0h".parse().unwrap(),
             "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
@@ -2312,7 +2312,7 @@ mod tests {
         // m/0h/1
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m/0h/1".parse().unwrap(),
             "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs",
@@ -2322,7 +2322,7 @@ mod tests {
         // m/0h/1/2h
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m/0h/1/2h".parse().unwrap(),
             "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
@@ -2332,7 +2332,7 @@ mod tests {
         // m/0h/1/2h/2
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m/0h/1/2h/2".parse().unwrap(),
             "xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334",
@@ -2342,7 +2342,7 @@ mod tests {
         // m/0h/1/2h/2/1000000000
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m/0h/1/2h/2/1000000000".parse().unwrap(),
             "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76",
@@ -2358,7 +2358,7 @@ mod tests {
         // m
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m".parse().unwrap(),
             "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U",
@@ -2368,7 +2368,7 @@ mod tests {
         // m/0
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m/0".parse().unwrap(),
             "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt",
@@ -2378,7 +2378,7 @@ mod tests {
         // m/0/2147483647h
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m/0/2147483647h".parse().unwrap(),
             "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9",
@@ -2388,7 +2388,7 @@ mod tests {
         // m/0/2147483647h/1
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m/0/2147483647h/1".parse().unwrap(),
             "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef",
@@ -2398,7 +2398,7 @@ mod tests {
         // m/0/2147483647h/1/2147483646h
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m/0/2147483647h/1/2147483646h".parse().unwrap(),
             "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc",
@@ -2408,7 +2408,7 @@ mod tests {
         // m/0/2147483647h/1/2147483646h/2
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m/0/2147483647h/1/2147483646h/2".parse().unwrap(),
             "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j",
@@ -2424,7 +2424,7 @@ mod tests {
         // m
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m".parse().unwrap(),
             "xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6",
@@ -2434,7 +2434,7 @@ mod tests {
         // m/0h
         test_path(
             &secp,
-            Dash,
+            Mainnet,
             &seed,
             "m/0h".parse().unwrap(),
             "xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L",
@@ -2500,7 +2500,7 @@ mod tests {
         }
 
         let xpriv = ExtendedPrivKey {
-            network: Network::Dash,
+            network: Network::Mainnet,
             depth: 0,
             parent_fingerprint: Default::default(),
             child_number: ChildNumber::Normal { index: 0 },
@@ -2603,13 +2603,13 @@ mod tests {
 
     #[test]
     fn test_bip_44_account_path() {
-        let path = DerivationPath::bip_44_account(Network::Dash, 0);
+        let path = DerivationPath::bip_44_account(Network::Mainnet, 0);
         assert_eq!(path.to_string(), "m/44'/5'/0'");
     }
 
     #[test]
     fn test_bip_44_payment_path() {
-        let path = DerivationPath::bip_44_payment_path(Network::Dash, 0, true, 0);
+        let path = DerivationPath::bip_44_payment_path(Network::Mainnet, 0, true, 0);
         assert_eq!(path.to_string(), "m/44'/5'/0'/1/0");
 
         let path = DerivationPath::bip_44_payment_path(Network::Testnet, 1, false, 42);
@@ -2618,7 +2618,7 @@ mod tests {
 
     #[test]
     fn test_coinjoin_path() {
-        let path = DerivationPath::coinjoin_path(Network::Dash, 0);
+        let path = DerivationPath::coinjoin_path(Network::Mainnet, 0);
         assert_eq!(path.to_string(), "m/9'/5'/4'/0'");
 
         let path = DerivationPath::coinjoin_path(Network::Testnet, 1);
@@ -2627,7 +2627,7 @@ mod tests {
 
     #[test]
     fn test_identity_registration_path() {
-        let path = DerivationPath::identity_registration_path(Network::Dash, 10);
+        let path = DerivationPath::identity_registration_path(Network::Mainnet, 10);
         assert_eq!(path.to_string(), "m/9'/5'/5'/1'/10'");
     }
 
@@ -2639,13 +2639,13 @@ mod tests {
 
     #[test]
     fn test_identity_invitation_path() {
-        let path = DerivationPath::identity_invitation_path(Network::Dash, 15);
+        let path = DerivationPath::identity_invitation_path(Network::Mainnet, 15);
         assert_eq!(path.to_string(), "m/9'/5'/5'/3'/15'");
     }
 
     #[test]
     fn test_asset_lock_address_top_up_path() {
-        let path = DerivationPath::asset_lock_address_top_up_path(Network::Dash, 7);
+        let path = DerivationPath::asset_lock_address_top_up_path(Network::Mainnet, 7);
         assert_eq!(path.to_string(), "m/9'/5'/5'/4'/7'");
 
         let path = DerivationPath::asset_lock_address_top_up_path(Network::Testnet, 0);
@@ -2654,7 +2654,7 @@ mod tests {
 
     #[test]
     fn test_asset_lock_shielded_address_top_up_path() {
-        let path = DerivationPath::asset_lock_shielded_address_top_up_path(Network::Dash, 3);
+        let path = DerivationPath::asset_lock_shielded_address_top_up_path(Network::Mainnet, 3);
         assert_eq!(path.to_string(), "m/9'/5'/5'/5'/3'");
 
         let path = DerivationPath::asset_lock_shielded_address_top_up_path(Network::Testnet, 1);
@@ -2664,7 +2664,7 @@ mod tests {
     #[test]
     fn test_identity_authentication_path() {
         let path = DerivationPath::identity_authentication_path(
-            Network::Dash,
+            Network::Mainnet,
             KeyDerivationType::ECDSA,
             1,
             2,
@@ -2682,11 +2682,11 @@ mod tests {
 
     #[test]
     fn test_derive_priv_ecdsa_for_master_seed() {
-        let path = DerivationPath::bip_44_account(Network::Dash, 0);
+        let path = DerivationPath::bip_44_account(Network::Mainnet, 0);
         let sk = path
             .derive_priv_ecdsa_for_master_seed(
                 hex::decode(HEX_SEED).unwrap().as_ref(),
-                Network::Dash,
+                Network::Mainnet,
             )
             .unwrap();
         assert_eq!(
@@ -2698,11 +2698,11 @@ mod tests {
 
     #[test]
     fn test_derive_pub_ecdsa_for_master_seed() {
-        let path = DerivationPath::bip_44_account(Network::Dash, 0);
+        let path = DerivationPath::bip_44_account(Network::Mainnet, 0);
         let pk = path
             .derive_pub_ecdsa_for_master_seed(
                 hex::decode(HEX_SEED).unwrap().as_ref(),
-                Network::Dash,
+                Network::Mainnet,
             )
             .unwrap();
         assert_eq!(
@@ -2714,11 +2714,11 @@ mod tests {
 
     #[test]
     fn test_derive_priv_ecdsa_payment_change_key() {
-        let path = DerivationPath::bip_44_payment_path(Network::Dash, 0, true, 3);
+        let path = DerivationPath::bip_44_payment_path(Network::Mainnet, 0, true, 3);
         let sk = path
             .derive_priv_ecdsa_for_master_seed(
                 hex::decode(HEX_SEED).unwrap().as_ref(),
-                Network::Dash,
+                Network::Mainnet,
             )
             .unwrap();
         assert_eq!(sk.to_string(), "xprvA4FGorKLZVC4VT3Lf2UZS3hYZBpc8wGmmyyo5HPTUS8RcyX1yw2qHddBZVxn1u4NVduXDob1sKnx3d9e5wdY3VP8qibq7CgMqPhjUoV5G2K");
@@ -2727,11 +2727,11 @@ mod tests {
 
     #[test]
     fn test_derive_priv_ecdsa_payment_main_key() {
-        let path = DerivationPath::bip_44_payment_path(Network::Dash, 0, false, 3);
+        let path = DerivationPath::bip_44_payment_path(Network::Mainnet, 0, false, 3);
         let sk = path
             .derive_priv_ecdsa_for_master_seed(
                 hex::decode(HEX_SEED).unwrap().as_ref(),
-                Network::Dash,
+                Network::Mainnet,
             )
             .unwrap();
         assert_eq!(sk.to_string(), "xprvA4F8hpkJuhhk4xqnnmY44WiVwUVPMdbF9VHE8vVmAiF6NyVXNmnyg5KnZF4VibNUuycJs6Dov4YBLm6bT2qGa81B5HHgqhUvixW2Qcgg5AE");
@@ -2740,11 +2740,11 @@ mod tests {
 
     #[test]
     fn test_derive_pub_ecdsa_payment_change_key() {
-        let path = DerivationPath::bip_44_payment_path(Network::Dash, 0, true, 3);
+        let path = DerivationPath::bip_44_payment_path(Network::Mainnet, 0, true, 3);
         let sk = path
             .derive_pub_ecdsa_for_master_seed(
                 hex::decode(HEX_SEED).unwrap().as_ref(),
-                Network::Dash,
+                Network::Mainnet,
             )
             .unwrap();
         assert_eq!(
@@ -2755,11 +2755,11 @@ mod tests {
 
     #[test]
     fn test_derive_pub_ecdsa_payment_external_key() {
-        let path = DerivationPath::bip_44_payment_path(Network::Dash, 0, false, 3);
+        let path = DerivationPath::bip_44_payment_path(Network::Mainnet, 0, false, 3);
         let sk = path
             .derive_pub_ecdsa_for_master_seed(
                 hex::decode(HEX_SEED).unwrap().as_ref(),
-                Network::Dash,
+                Network::Mainnet,
             )
             .unwrap();
         assert_eq!(

--- a/key-wallet/src/bip38.rs
+++ b/key-wallet/src/bip38.rs
@@ -86,7 +86,7 @@ impl Bip38EncryptedKey {
         // Try to determine network from address hash
         // In BIP38, bytes 3-6 are the address hash
         // We'll default to mainnet for now
-        let network = Network::Dash;
+        let network = Network::Mainnet;
 
         Ok(Self {
             data,
@@ -482,7 +482,7 @@ impl Bip38Builder {
         Self {
             password: None,
             compressed: false,
-            network: Network::Dash,
+            network: Network::Mainnet,
             lot: None,
             sequence: None,
         }
@@ -563,7 +563,8 @@ mod tests {
         .unwrap();
 
         let encrypted =
-            encrypt_private_key(&private_key, "TestingOneTwoThree", false, Network::Dash).unwrap();
+            encrypt_private_key(&private_key, "TestingOneTwoThree", false, Network::Mainnet)
+                .unwrap();
 
         // Decrypt and verify
         let decrypted = encrypted.decrypt("TestingOneTwoThree").unwrap();
@@ -590,7 +591,7 @@ mod tests {
             &private_key,
             password,
             true, // compressed
-            Network::Dash,
+            Network::Mainnet,
         )
         .unwrap();
 
@@ -624,14 +625,15 @@ mod tests {
 
         // Test uncompressed
         let uncompressed =
-            encrypt_private_key(&private_key, password, false, Network::Dash).unwrap();
+            encrypt_private_key(&private_key, password, false, Network::Mainnet).unwrap();
 
         assert!(!uncompressed.compressed);
         let decrypted_uncomp = uncompressed.decrypt(password).unwrap();
         assert_eq!(private_key.secret_bytes(), decrypted_uncomp.secret_bytes());
 
         // Test compressed
-        let compressed = encrypt_private_key(&private_key, password, true, Network::Dash).unwrap();
+        let compressed =
+            encrypt_private_key(&private_key, password, true, Network::Mainnet).unwrap();
 
         assert!(compressed.compressed);
         let decrypted_comp = compressed.decrypt(password).unwrap();
@@ -695,7 +697,7 @@ mod tests {
 
         let public_key = PublicKey::from_secret_key(&secp, &private_key);
         let dash_pubkey = dashcore::PublicKey::new(public_key);
-        let dash_network = dashcore::Network::Dash;
+        let dash_network = Network::Mainnet;
         let address = Address::p2pkh(&dash_pubkey, dash_network);
         let hash = address_hash_from_address(&address);
 

--- a/key-wallet/src/bip38_tests.rs
+++ b/key-wallet/src/bip38_tests.rs
@@ -26,7 +26,7 @@ mod tests {
         let compressed = false;
 
         // Encrypt the private key
-        let encrypted = encrypt_private_key(&private_key, password, compressed, Network::Dash)
+        let encrypted = encrypt_private_key(&private_key, password, compressed, Network::Mainnet)
             .expect("Encryption should succeed");
 
         // The encrypted key should start with "6" in base58 (BIP38 encrypted keys)
@@ -59,7 +59,7 @@ mod tests {
         let password = "Satoshi";
         let compressed = true;
 
-        let encrypted = encrypt_private_key(&private_key, password, compressed, Network::Dash)
+        let encrypted = encrypt_private_key(&private_key, password, compressed, Network::Mainnet)
             .expect("Encryption should succeed");
 
         let encrypted_str = encrypted.to_base58();
@@ -107,7 +107,7 @@ mod tests {
 
         // Encrypt with correct password
         let encrypted =
-            encrypt_private_key(&private_key, correct_password, compressed, Network::Dash)
+            encrypt_private_key(&private_key, correct_password, compressed, Network::Mainnet)
                 .expect("Encryption should succeed");
 
         // Try to decrypt with wrong password
@@ -148,7 +148,7 @@ mod tests {
             // Test both compressed and uncompressed
             for compressed in [true, false] {
                 let encrypted =
-                    encrypt_private_key(&private_key, password, compressed, Network::Dash)
+                    encrypt_private_key(&private_key, password, compressed, Network::Mainnet)
                         .expect("Encryption should succeed");
 
                 // Verify the encrypted key format
@@ -179,7 +179,7 @@ mod tests {
         ];
 
         for password in unicode_passwords {
-            let encrypted = encrypt_private_key(&private_key, password, false, Network::Dash)
+            let encrypted = encrypt_private_key(&private_key, password, false, Network::Mainnet)
                 .expect("Encryption with Unicode password should succeed");
 
             let decrypted = encrypted
@@ -200,7 +200,7 @@ mod tests {
         let compressed = false;
 
         let encrypted_mainnet =
-            encrypt_private_key(&private_key, password, compressed, Network::Dash)
+            encrypt_private_key(&private_key, password, compressed, Network::Mainnet)
                 .expect("Mainnet encryption should succeed");
 
         let encrypted_testnet =
@@ -230,7 +230,7 @@ mod tests {
 
         // Empty password (should work but not recommended)
         let private_key = SecretKey::from_slice(&[0x99u8; 32]).unwrap();
-        let encrypted = encrypt_private_key(&private_key, "", false, Network::Dash)
+        let encrypted = encrypt_private_key(&private_key, "", false, Network::Mainnet)
             .expect("Empty password should work");
         let decrypted = encrypted.decrypt("").unwrap();
         assert_eq!(decrypted, private_key);
@@ -238,7 +238,7 @@ mod tests {
         // Very long password
         let long_password = "a".repeat(1000);
         let encrypted_long =
-            encrypt_private_key(&private_key, &long_password, false, Network::Dash)
+            encrypt_private_key(&private_key, &long_password, false, Network::Mainnet)
                 .expect("Long password should work");
         let decrypted_long = encrypted_long.decrypt(&long_password).unwrap();
         assert_eq!(decrypted_long, private_key);
@@ -246,7 +246,7 @@ mod tests {
         // Password with special characters
         let special_password = "!@#$%^&*()_+-=[]{}|;':\",./<>?`~";
         let encrypted_special =
-            encrypt_private_key(&private_key, special_password, false, Network::Dash)
+            encrypt_private_key(&private_key, special_password, false, Network::Mainnet)
                 .expect("Special characters should work");
         let decrypted_special = encrypted_special.decrypt(special_password).unwrap();
         assert_eq!(decrypted_special, private_key);
@@ -283,8 +283,9 @@ mod tests {
                     let compressed = rng.gen_bool(0.5);
 
                     // Encrypt
-                    let encrypted = encrypt_private_key(&key, &password, compressed, Network::Dash)
-                        .expect("Encryption should succeed");
+                    let encrypted =
+                        encrypt_private_key(&key, &password, compressed, Network::Mainnet)
+                            .expect("Encryption should succeed");
 
                     // Decrypt
                     let decrypted =
@@ -326,7 +327,7 @@ mod tests {
         let password = "PerformanceTest";
 
         let start = Instant::now();
-        let encrypted = encrypt_private_key(&private_key, password, false, Network::Dash)
+        let encrypted = encrypt_private_key(&private_key, password, false, Network::Mainnet)
             .expect("Encryption should succeed");
         let encrypt_duration = start.elapsed();
 

--- a/key-wallet/src/derivation.rs
+++ b/key-wallet/src/derivation.rs
@@ -98,7 +98,7 @@ impl HDWallet {
     /// Get a standard BIP44 account key
     pub fn bip44_account(&self, account: u32) -> Result<ExtendedPrivKey> {
         let path = match self.master_key.network {
-            crate::Network::Dash => crate::dip9::DASH_BIP44_PATH_MAINNET,
+            crate::Network::Mainnet => crate::dip9::DASH_BIP44_PATH_MAINNET,
             Network::Testnet | Network::Devnet | Network::Regtest => {
                 crate::dip9::DASH_BIP44_PATH_TESTNET
             }
@@ -117,7 +117,7 @@ impl HDWallet {
     /// Get a CoinJoin account key
     pub fn coinjoin_account(&self, account: u32) -> Result<ExtendedPrivKey> {
         let path = match self.master_key.network {
-            crate::Network::Dash => crate::dip9::COINJOIN_PATH_MAINNET,
+            crate::Network::Mainnet => crate::dip9::COINJOIN_PATH_MAINNET,
             Network::Testnet | Network::Devnet | Network::Regtest => {
                 crate::dip9::COINJOIN_PATH_TESTNET
             }
@@ -140,7 +140,7 @@ impl HDWallet {
         key_index: u32,
     ) -> Result<ExtendedPrivKey> {
         let path = match self.master_key.network {
-            crate::Network::Dash => crate::dip9::IDENTITY_AUTHENTICATION_PATH_MAINNET,
+            crate::Network::Mainnet => crate::dip9::IDENTITY_AUTHENTICATION_PATH_MAINNET,
             Network::Testnet | Network::Devnet | Network::Regtest => {
                 crate::dip9::IDENTITY_AUTHENTICATION_PATH_TESTNET
             }
@@ -337,7 +337,7 @@ impl DerivationPathBuilder {
         // For now, just use BIP44 derivation
         // m/44'/coin_type'/account'/0/0
         let coin_type = match network {
-            Network::Dash => 5,
+            Network::Mainnet => 5,
             Network::Testnet | Network::Devnet | Network::Regtest => 1,
             _ => 5, // Default to Dash
         };
@@ -455,7 +455,7 @@ mod tests {
         ).unwrap();
 
         let seed = mnemonic.to_seed("");
-        let wallet = HDWallet::from_seed(&seed, crate::Network::Dash).unwrap();
+        let wallet = HDWallet::from_seed(&seed, crate::Network::Mainnet).unwrap();
 
         // Test BIP44 account derivation
         let account0 = wallet.bip44_account(0).unwrap();
@@ -472,7 +472,7 @@ mod tests {
         let secp = secp256k1::Secp256k1::new();
 
         // Create master key
-        let master_key = ExtendedPrivKey::new_master(crate::Network::Dash, &seed).unwrap();
+        let master_key = ExtendedPrivKey::new_master(crate::Network::Mainnet, &seed).unwrap();
 
         // Test m/0'/1/2' path (from DashSync test)
         let path = DerivationPath::from(vec![
@@ -529,7 +529,7 @@ mod tests {
         let secp = secp256k1::Secp256k1::new();
 
         // Test master key serialization (m)
-        let master_key = ExtendedPrivKey::new_master(crate::Network::Dash, &seed).unwrap();
+        let master_key = ExtendedPrivKey::new_master(crate::Network::Mainnet, &seed).unwrap();
         let master_xprv = master_key.to_string();
         let master_xpub = ExtendedPubKey::from_priv(&secp, &master_key).to_string();
 
@@ -596,7 +596,7 @@ mod tests {
         ).unwrap();
 
         let seed = mnemonic.to_seed("");
-        let wallet = HDWallet::from_seed(&seed, crate::Network::Dash).unwrap();
+        let wallet = HDWallet::from_seed(&seed, crate::Network::Mainnet).unwrap();
         let secp = secp256k1::Secp256k1::new();
 
         // Test identity authentication derivation (purpose 9' for Dash Platform)

--- a/key-wallet/src/derivation_slip10.rs
+++ b/key-wallet/src/derivation_slip10.rs
@@ -153,8 +153,8 @@ impl ExtendedEd25519PrivKey {
 
         // Version bytes (4 bytes) - Custom for Ed25519
         match self.network {
-            Network::Dash => result.extend_from_slice(&[0x03, 0xB8, 0xC0, 0x0C]), // Custom version
-            _ => result.extend_from_slice(&[0x03, 0xB8, 0xC0, 0x0D]),             // Testnet version
+            Network::Mainnet => result.extend_from_slice(&[0x03, 0xB8, 0xC0, 0x0C]), // Custom version
+            _ => result.extend_from_slice(&[0x03, 0xB8, 0xC0, 0x0D]), // Testnet version
         }
 
         // Depth (1 byte)
@@ -184,7 +184,7 @@ impl ExtendedEd25519PrivKey {
 
         // Check version and determine network
         let network = match &data[0..4] {
-            [0x03, 0xB8, 0xC0, 0x0C] => Network::Dash,
+            [0x03, 0xB8, 0xC0, 0x0C] => Network::Mainnet,
             [0x03, 0xB8, 0xC0, 0x0D] => Network::Testnet,
             version => {
                 let mut v = [0u8; 4];
@@ -301,7 +301,7 @@ impl ExtendedEd25519PubKey {
 
         // Version bytes (4 bytes) - Custom for Ed25519 public
         match self.network {
-            Network::Dash => result.extend_from_slice(&[0x03, 0xB8, 0xC4, 0x3E]), // Custom public version
+            Network::Mainnet => result.extend_from_slice(&[0x03, 0xB8, 0xC4, 0x3E]), // Custom public version
             _ => result.extend_from_slice(&[0x03, 0xB8, 0xC4, 0x3F]), // Testnet public version
         }
 
@@ -332,7 +332,7 @@ impl ExtendedEd25519PubKey {
 
         // Check version and determine network
         let network = match &data[0..4] {
-            [0x03, 0xB8, 0xC4, 0x3E] => Network::Dash,
+            [0x03, 0xB8, 0xC4, 0x3E] => Network::Mainnet,
             [0x03, 0xB8, 0xC4, 0x3F] => Network::Testnet,
             version => {
                 let mut v = [0u8; 4];
@@ -720,7 +720,7 @@ mod test {
     }
 
     fn derive_ed25519_private_key(seed: &[u8], indexes: &[u32]) -> [u8; 32] {
-        let master = ExtendedEd25519PrivKey::new_master(Network::Dash, seed).unwrap();
+        let master = ExtendedEd25519PrivKey::new_master(Network::Mainnet, seed).unwrap();
 
         let mut current = master;
         for &index in indexes {

--- a/key-wallet/src/managed_account/address_pool.rs
+++ b/key-wallet/src/managed_account/address_pool.rs
@@ -1031,7 +1031,7 @@ impl AddressPoolBuilder {
             base_path: None,
             pool_type: AddressPoolType::External,
             gap_limit: DEFAULT_EXTERNAL_GAP_LIMIT,
-            network: Network::Dash,
+            network: Network::Mainnet,
             address_type: AddressType::P2pkh,
             key_source: None,
         }

--- a/key-wallet/src/psbt/mod.rs
+++ b/key-wallet/src/psbt/mod.rs
@@ -900,7 +900,7 @@ mod tests {
         let mut hd_keypaths: BTreeMap<secp256k1::PublicKey, KeySource> = Default::default();
 
         let mut sk: ExtendedPrivKey =
-            ExtendedPrivKey::new_master(key_wallet::Network::Dash, &seed).unwrap();
+            ExtendedPrivKey::new_master(key_wallet::Network::Mainnet, &seed).unwrap();
 
         let fprint = sk.fingerprint(secp);
 

--- a/key-wallet/src/tests/account_tests.rs
+++ b/key-wallet/src/tests/account_tests.rs
@@ -406,7 +406,7 @@ fn test_account_network_consistency() {
     );
 
     // Test creating account with different network
-    let dash_mainnet = Network::Dash;
+    let dash_mainnet = Network::Mainnet;
     let mainnet_account =
         Account::from_xpriv(Some([0u8; 32]), account_type, account_key, dash_mainnet).unwrap();
 

--- a/key-wallet/src/tests/backup_restore_tests.rs
+++ b/key-wallet/src/tests/backup_restore_tests.rs
@@ -203,7 +203,7 @@ fn test_multi_network_backup_restore() {
     .unwrap();
 
     // Create separate wallets for each network
-    let networks = vec![Network::Testnet, Network::Dash, Network::Devnet];
+    let networks = vec![Network::Testnet, Network::Mainnet, Network::Devnet];
     let mut wallets = Vec::new();
 
     for network in &networks {

--- a/key-wallet/src/tests/edge_case_tests.rs
+++ b/key-wallet/src/tests/edge_case_tests.rs
@@ -92,7 +92,7 @@ fn test_network_mismatch_handling() {
     // Create wallet for mainnet with same mnemonic
     let mainnet_wallet = Wallet::from_mnemonic(
         mnemonic,
-        Network::Dash,
+        Network::Mainnet,
         crate::wallet::initialization::WalletAccountCreationOptions::Default,
     )
     .unwrap();
@@ -102,7 +102,7 @@ fn test_network_mismatch_handling() {
 
     // But networks should be different
     assert_eq!(testnet_wallet.network, Network::Testnet);
-    assert_eq!(mainnet_wallet.network, Network::Dash);
+    assert_eq!(mainnet_wallet.network, Network::Mainnet);
 }
 
 #[test]

--- a/key-wallet/src/tests/integration_tests.rs
+++ b/key-wallet/src/tests/integration_tests.rs
@@ -59,7 +59,7 @@ fn test_separate_wallets_per_network() {
 
     let mut mainnet_wallet = Wallet::from_mnemonic(
         mnemonic.clone(),
-        Network::Dash,
+        Network::Mainnet,
         crate::wallet::initialization::WalletAccountCreationOptions::None,
     )
     .unwrap();
@@ -109,7 +109,7 @@ fn test_separate_wallets_per_network() {
     assert_eq!(testnet_wallet.network, Network::Testnet);
     assert_eq!(testnet_wallet.accounts.standard_bip44_accounts.len(), 3);
 
-    assert_eq!(mainnet_wallet.network, Network::Dash);
+    assert_eq!(mainnet_wallet.network, Network::Mainnet);
     assert_eq!(mainnet_wallet.accounts.standard_bip44_accounts.len(), 2);
 
     assert_eq!(devnet_wallet.network, Network::Devnet);

--- a/key-wallet/src/wallet/mod.rs
+++ b/key-wallet/src/wallet/mod.rs
@@ -295,7 +295,7 @@ mod tests {
 
         let wallet = Wallet::from_mnemonic(
             mnemonic,
-            Network::Dash,
+            Network::Mainnet,
             initialization::WalletAccountCreationOptions::Default,
         )
         .unwrap();

--- a/key-wallet/tests/address_tests.rs
+++ b/key-wallet/tests/address_tests.rs
@@ -14,9 +14,9 @@ fn test_p2pkh_address_creation() {
     let dash_pubkey = dashcore::PublicKey::new(public_key);
 
     // Create P2PKH address
-    let address = Address::p2pkh(&dash_pubkey, DashNetwork::Dash);
+    let address = Address::p2pkh(&dash_pubkey, DashNetwork::Mainnet);
 
-    assert_eq!(*address.network(), DashNetwork::Dash);
+    assert_eq!(*address.network(), DashNetwork::Mainnet);
     assert_eq!(address.address_type(), Some(AddressType::P2pkh));
 
     // Check that it generates a valid Dash address (starts with 'X')
@@ -31,9 +31,9 @@ fn test_p2sh_address_creation() {
     let script = ScriptBuf::from_hex("76a914").unwrap();
 
     // Create P2SH address
-    let address = Address::p2sh(&script, DashNetwork::Dash).unwrap();
+    let address = Address::p2sh(&script, DashNetwork::Mainnet).unwrap();
 
-    assert_eq!(*address.network(), DashNetwork::Dash);
+    assert_eq!(*address.network(), DashNetwork::Mainnet);
     assert_eq!(address.address_type(), Some(AddressType::P2sh));
 
     // Check that it generates a valid Dash P2SH address (starts with '7')
@@ -72,11 +72,11 @@ fn test_address_parsing() {
     // Create a mainnet address
     let privkey_mainnet = PrivateKey {
         compressed: true,
-        network: DashNetwork::Dash,
+        network: DashNetwork::Mainnet,
         inner: dashcore::secp256k1::SecretKey::from_slice(&[0x01; 32]).unwrap(),
     };
     let pubkey_mainnet = privkey_mainnet.public_key(&secp);
-    let mainnet_address = Address::p2pkh(&pubkey_mainnet, DashNetwork::Dash);
+    let mainnet_address = Address::p2pkh(&pubkey_mainnet, DashNetwork::Mainnet);
 
     // Test round-trip for mainnet
     let mainnet_str = mainnet_address.to_string();
@@ -84,8 +84,8 @@ fn test_address_parsing() {
 
     let parsed_mainnet =
         Address::<dashcore::address::NetworkUnchecked>::from_str(&mainnet_str).unwrap();
-    let checked_mainnet = parsed_mainnet.require_network(DashNetwork::Dash).unwrap();
-    assert_eq!(*checked_mainnet.network(), DashNetwork::Dash);
+    let checked_mainnet = parsed_mainnet.require_network(DashNetwork::Mainnet).unwrap();
+    assert_eq!(*checked_mainnet.network(), DashNetwork::Mainnet);
     assert_eq!(checked_mainnet.address_type(), Some(AddressType::P2pkh));
 
     // Create a testnet address
@@ -118,12 +118,12 @@ fn test_address_roundtrip() {
     let dash_pubkey = dashcore::PublicKey::new(public_key);
 
     // Create address
-    let address = Address::p2pkh(&dash_pubkey, DashNetwork::Dash);
+    let address = Address::p2pkh(&dash_pubkey, DashNetwork::Mainnet);
     let addr_str = address.to_string();
 
     // Parse it back
     let parsed = Address::<dashcore::address::NetworkUnchecked>::from_str(&addr_str).unwrap();
-    let checked = parsed.require_network(DashNetwork::Dash).unwrap();
+    let checked = parsed.require_network(DashNetwork::Mainnet).unwrap();
 
     // Compare
     assert_eq!(address, checked);

--- a/key-wallet/tests/bip32_tests.rs
+++ b/key-wallet/tests/bip32_tests.rs
@@ -10,7 +10,7 @@ fn test_extended_key_derivation() {
 
     // Test vector from BIP32
     let seed = hex::decode("000102030405060708090a0b0c0d0e0f").unwrap();
-    let master = ExtendedPrivKey::new_master(Network::Dash, &seed).unwrap();
+    let master = ExtendedPrivKey::new_master(Network::Mainnet, &seed).unwrap();
 
     // m/0'
     let child = master.ckd_priv(&secp, ChildNumber::from_hardened_idx(0).unwrap()).unwrap();
@@ -39,7 +39,7 @@ fn test_derivation_path_parsing() {
 #[test]
 fn test_extended_key_serialization() {
     let seed = hex::decode("000102030405060708090a0b0c0d0e0f").unwrap();
-    let master = ExtendedPrivKey::new_master(Network::Dash, &seed).unwrap();
+    let master = ExtendedPrivKey::new_master(Network::Mainnet, &seed).unwrap();
 
     // Serialize and deserialize
     let serialized = master.to_string();
@@ -57,7 +57,7 @@ fn test_extended_key_serialization() {
 fn test_public_key_derivation() {
     let secp = Secp256k1::new();
     let seed = hex::decode("000102030405060708090a0b0c0d0e0f").unwrap();
-    let master = ExtendedPrivKey::new_master(Network::Dash, &seed).unwrap();
+    let master = ExtendedPrivKey::new_master(Network::Mainnet, &seed).unwrap();
     let master_pub = ExtendedPubKey::from_priv(&secp, &master);
 
     // Can derive non-hardened child from public key
@@ -74,7 +74,7 @@ fn test_public_key_derivation() {
 fn test_fingerprint_calculation() {
     let secp = Secp256k1::new();
     let seed = hex::decode("000102030405060708090a0b0c0d0e0f").unwrap();
-    let master = ExtendedPrivKey::new_master(Network::Dash, &seed).unwrap();
+    let master = ExtendedPrivKey::new_master(Network::Mainnet, &seed).unwrap();
 
     let child = master.ckd_priv(&secp, ChildNumber::from_normal_idx(0).unwrap()).unwrap();
     let master_fingerprint = master.fingerprint(&secp);

--- a/key-wallet/tests/derivation_tests.rs
+++ b/key-wallet/tests/derivation_tests.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 #[test]
 fn test_hd_wallet_creation() {
     let seed = [0u8; 64];
-    let wallet = HDWallet::from_seed(&seed, Network::Dash).unwrap();
+    let wallet = HDWallet::from_seed(&seed, Network::Mainnet).unwrap();
 
     // Master key should be at depth 0
     assert_eq!(wallet.master_key().depth, 0);
@@ -24,7 +24,7 @@ fn test_bip44_account_derivation() {
     ).unwrap();
 
     let seed = mnemonic.to_seed("");
-    let wallet = HDWallet::from_seed(&seed, Network::Dash).unwrap();
+    let wallet = HDWallet::from_seed(&seed, Network::Mainnet).unwrap();
 
     // Derive first account
     let account0 = wallet.bip44_account(0).unwrap();
@@ -41,7 +41,7 @@ fn test_bip44_account_derivation() {
 #[test]
 fn test_coinjoin_account_derivation() {
     let seed = [0u8; 64];
-    let wallet = HDWallet::from_seed(&seed, Network::Dash).unwrap();
+    let wallet = HDWallet::from_seed(&seed, Network::Mainnet).unwrap();
 
     // Derive CoinJoin account
     let coinjoin_account = wallet.coinjoin_account(0).unwrap();
@@ -51,7 +51,7 @@ fn test_coinjoin_account_derivation() {
 #[test]
 fn test_identity_key_derivation() {
     let seed = [0u8; 64];
-    let wallet = HDWallet::from_seed(&seed, Network::Dash).unwrap();
+    let wallet = HDWallet::from_seed(&seed, Network::Mainnet).unwrap();
 
     // Derive identity authentication key
     let identity_key = wallet.identity_authentication_key(0, 0).unwrap();
@@ -61,7 +61,7 @@ fn test_identity_key_derivation() {
 #[test]
 fn test_custom_path_derivation() {
     let seed = [0u8; 64];
-    let wallet = HDWallet::from_seed(&seed, Network::Dash).unwrap();
+    let wallet = HDWallet::from_seed(&seed, Network::Mainnet).unwrap();
 
     // Derive custom path
     let path = DerivationPath::from_str("m/0/1/2").unwrap();
@@ -72,7 +72,7 @@ fn test_custom_path_derivation() {
 #[test]
 fn test_account_address_derivation() {
     let seed = [0u8; 64];
-    let wallet = HDWallet::from_seed(&seed, Network::Dash).unwrap();
+    let wallet = HDWallet::from_seed(&seed, Network::Mainnet).unwrap();
 
     // Get account
     let account = wallet.bip44_account(0).unwrap();
@@ -97,7 +97,7 @@ fn test_account_address_derivation() {
 #[test]
 fn test_public_key_derivation() {
     let seed = [0u8; 64];
-    let wallet = HDWallet::from_seed(&seed, Network::Dash).unwrap();
+    let wallet = HDWallet::from_seed(&seed, Network::Mainnet).unwrap();
 
     // Derive public key directly
     let path = DerivationPath::from_str("m/44'/5'/0'/0/0").unwrap();
@@ -138,7 +138,7 @@ fn test_dip17_platform_payment_vector1_mainnet() {
     .unwrap();
 
     let seed = mnemonic.to_seed("");
-    let wallet = HDWallet::from_seed(&seed, Network::Dash).unwrap();
+    let wallet = HDWallet::from_seed(&seed, Network::Mainnet).unwrap();
 
     // Derive Platform Payment key: m/9'/5'/17'/0'/0'/0
     let path = DerivationPath::from_str("m/9'/5'/17'/0'/0'/0").unwrap();
@@ -220,7 +220,7 @@ fn test_dip17_platform_payment_vector2() {
 
     // Test mainnet
     let seed = mnemonic.to_seed("");
-    let wallet_mainnet = HDWallet::from_seed(&seed, Network::Dash).unwrap();
+    let wallet_mainnet = HDWallet::from_seed(&seed, Network::Mainnet).unwrap();
     let path_mainnet = DerivationPath::from_str("m/9'/5'/17'/0'/0'/1").unwrap();
     let xprv_mainnet = wallet_mainnet.derive(&path_mainnet).unwrap();
 
@@ -282,7 +282,7 @@ fn test_dip17_platform_payment_vector3_non_default_key_class() {
 
     // Test mainnet with key_class' = 1'
     let seed = mnemonic.to_seed("");
-    let wallet_mainnet = HDWallet::from_seed(&seed, Network::Dash).unwrap();
+    let wallet_mainnet = HDWallet::from_seed(&seed, Network::Mainnet).unwrap();
     let path_mainnet = DerivationPath::from_str("m/9'/5'/17'/0'/1'/0").unwrap();
     let xprv_mainnet = wallet_mainnet.derive(&path_mainnet).unwrap();
 

--- a/key-wallet/tests/mnemonic_tests.rs
+++ b/key-wallet/tests/mnemonic_tests.rs
@@ -45,8 +45,8 @@ fn test_mnemonic_to_extended_key() {
     let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
     let mnemonic = Mnemonic::from_phrase(phrase, Language::English).unwrap();
 
-    let xprv = mnemonic.to_extended_key("", Network::Dash).unwrap();
-    assert_eq!(xprv.network, Network::Dash);
+    let xprv = mnemonic.to_extended_key("", Network::Mainnet).unwrap();
+    assert_eq!(xprv.network, Network::Mainnet);
     assert_eq!(xprv.depth, 0);
 }
 


### PR DESCRIPTION
Align the network names with Dash Core. Finally! This bugged me since i started to work on this repo haha. 

Based on: 
- #499 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the primary network identifier from "Dash" to "Mainnet" across the SDK and FFI surfaces.

* **Bug Fixes**
  * Default network fallback for null/unspecified inputs now returns Mainnet instead of the previous identifier.

* **Documentation**
  * Updated docs and examples to list and display "Mainnet" where the main network is referenced.

* **Tests**
  * Updated all test suites to align with the Mainnet identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->