### PR TITLE
chore: drop unused `NetworkManager` functions

### DIFF
--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -30,7 +30,6 @@ use dashcore::network::address::{AddrV2, AddrV2Message};
 use dashcore::network::constants::ServiceFlags;
 use dashcore::network::message::NetworkMessage;
 use dashcore::network::message_headers2::CompressionState;
-use dashcore::prelude::CoreBlockHeight;
 use dashcore::Network;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::time::Instant;
@@ -1378,95 +1377,9 @@ impl NetworkManager for PeerNetworkManager {
         } // end match
     } // end send_message
 
-    async fn penalize_peer(&self, address: SocketAddr, score_change: i32, reason: &str) {
-        self.reputation_manager.update_reputation(address, score_change, reason).await;
-    }
-
-    async fn penalize_peer_invalid_chainlock(&self, address: SocketAddr, reason: &str) {
-        match self.disconnect_peer(&address, reason).await {
-            Ok(()) => {
-                log::warn!(
-                    "Peer {} disconnected for invalid ChainLock enforcement: {}",
-                    address,
-                    reason
-                );
-            }
-            Err(err) => {
-                log::error!(
-                    "Failed to disconnect peer {} after invalid ChainLock enforcement ({}): {}",
-                    address,
-                    reason,
-                    err
-                );
-            }
-        }
-
-        // Apply misbehavior score and a short temporary ban
-        self.reputation_manager
-            .update_reputation(address, misbehavior_scores::INVALID_CHAINLOCK, reason)
-            .await;
-
-        // Short ban: 10 minutes for relaying invalid ChainLock
-        self.reputation_manager
-            .temporary_ban_peer(address, Duration::from_secs(10 * 60), reason)
-            .await;
-    }
-
-    async fn penalize_peer_invalid_instantlock(&self, address: SocketAddr, reason: &str) {
-        // Apply misbehavior score and a short temporary ban
-        self.reputation_manager
-            .update_reputation(address, misbehavior_scores::INVALID_INSTANTLOCK, reason)
-            .await;
-
-        // Short ban: 10 minutes for relaying invalid InstantLock
-        self.reputation_manager
-            .temporary_ban_peer(address, Duration::from_secs(10 * 60), reason)
-            .await;
-
-        match self.disconnect_peer(&address, reason).await {
-            Ok(()) => {
-                log::warn!(
-                    "Peer {} disconnected for invalid InstantLock enforcement: {}",
-                    address,
-                    reason
-                );
-            }
-            Err(err) => {
-                log::error!(
-                    "Failed to disconnect peer {} after invalid InstantLock enforcement ({}): {}",
-                    address,
-                    reason,
-                    err
-                );
-            }
-        }
-    }
-
-    fn is_connected(&self) -> bool {
-        // Use cached counter to avoid blocking in async context
-        self.connected_peer_count.load(Ordering::Relaxed) > 0
-    }
-
     fn peer_count(&self) -> usize {
         // Use cached counter to avoid blocking in async context
         self.connected_peer_count.load(Ordering::Relaxed)
-    }
-
-    async fn get_peer_best_height(&self) -> Option<CoreBlockHeight> {
-        self.pool.get_best_height().await
-    }
-
-    async fn has_peer_with_service(&self, service_flags: ServiceFlags) -> bool {
-        let peers = self.pool.get_all_peers().await;
-
-        for (_, peer) in peers.iter() {
-            let peer_guard = peer.read().await;
-            if peer_guard.has_service(service_flags) {
-                return true;
-            }
-        }
-
-        false
     }
 
     fn subscribe_network_events(&self) -> broadcast::Receiver<NetworkEvent> {

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -27,7 +27,6 @@ use dashcore::network::message_blockdata::{GetHeadersMessage, Inventory};
 use dashcore::network::message_filter::{GetCFHeaders, GetCFilters};
 use dashcore::network::message_qrinfo::GetQRInfo;
 use dashcore::network::message_sml::GetMnListDiff;
-use dashcore::prelude::CoreBlockHeight;
 use dashcore::BlockHash;
 use dashcore_hashes::Hash;
 pub use handshake::{HandshakeManager, HandshakeState};
@@ -35,7 +34,6 @@ pub use manager::PeerNetworkManager;
 pub use message_dispatcher::{Message, MessageDispatcher};
 pub use message_type::MessageType;
 pub use peer::Peer;
-use std::net::SocketAddr;
 use tokio::sync::mpsc::UnboundedReceiver;
 
 const FILTER_TYPE_DEFAULT: u8 = 0;
@@ -153,20 +151,8 @@ pub trait NetworkManager: Send + Sync + 'static {
     /// Send a message to a peer.
     async fn send_message(&mut self, message: NetworkMessage) -> NetworkResult<()>;
 
-    /// Check if connected to any peers.
-    fn is_connected(&self) -> bool;
-
     /// Get the number of connected peers.
     fn peer_count(&self) -> usize;
-
-    /// Get the best block height reported by connected peers.
-    async fn get_peer_best_height(&self) -> Option<CoreBlockHeight>;
-
-    /// Check if any connected peer supports a specific service.
-    async fn has_peer_with_service(
-        &self,
-        service_flags: dashcore::network::constants::ServiceFlags,
-    ) -> bool;
 
     /// Request QRInfo from the network.
     ///
@@ -200,30 +186,6 @@ pub trait NetworkManager: Send + Sync + 'static {
         );
 
         Ok(())
-    }
-
-    /// Penalize a peer by address by adjusting reputation.
-    /// Default implementation is a no-op for managers without reputation.
-    async fn penalize_peer(&self, _address: SocketAddr, _score_change: i32, _reason: &str) {}
-
-    /// Penalize a peer by address for an invalid ChainLock.
-    async fn penalize_peer_invalid_chainlock(&self, address: SocketAddr, reason: &str) {
-        self.penalize_peer(
-            address,
-            crate::network::reputation::misbehavior_scores::INVALID_CHAINLOCK,
-            reason,
-        )
-        .await;
-    }
-
-    /// Penalize a peer by address for an invalid InstantLock.
-    async fn penalize_peer_invalid_instantlock(&self, peer_address: SocketAddr, reason: &str) {
-        self.penalize_peer(
-            peer_address,
-            crate::network::reputation::misbehavior_scores::INVALID_INSTANTLOCK,
-            reason,
-        )
-        .await;
     }
 
     /// Subscribe to network events (peer connections, disconnections).

--- a/dash-spv/src/test_utils/network.rs
+++ b/dash-spv/src/test_utils/network.rs
@@ -5,8 +5,6 @@ use crate::network::{
     RequestSender,
 };
 use async_trait::async_trait;
-use dashcore::network::constants::ServiceFlags;
-use dashcore::prelude::CoreBlockHeight;
 use dashcore::{
     block::Header as BlockHeader, network::message::NetworkMessage,
     network::message_blockdata::GetHeadersMessage, BlockHash, Network,
@@ -27,7 +25,6 @@ pub struct MockNetworkManager {
     connected: bool,
     connected_peer: SocketAddr,
     headers_chain: Vec<BlockHeader>,
-    peer_best_height: Option<u32>,
     message_dispatcher: MessageDispatcher,
     sent_messages: Vec<NetworkMessage>,
     /// Request sender for outgoing messages.
@@ -46,7 +43,6 @@ impl MockNetworkManager {
             connected: true,
             connected_peer: SocketAddr::new(std::net::Ipv4Addr::LOCALHOST.into(), 9999),
             headers_chain: Vec::new(),
-            peer_best_height: None,
             message_dispatcher: MessageDispatcher::default(),
             sent_messages: Vec::new(),
             request_tx,
@@ -167,25 +163,12 @@ impl NetworkManager for MockNetworkManager {
 
         Ok(())
     }
-
-    fn is_connected(&self) -> bool {
-        self.connected
-    }
-
     fn peer_count(&self) -> usize {
         if self.connected {
             1
         } else {
             0
         }
-    }
-
-    async fn get_peer_best_height(&self) -> Option<CoreBlockHeight> {
-        self.peer_best_height
-    }
-
-    async fn has_peer_with_service(&self, _service_flags: ServiceFlags) -> bool {
-        self.connected
     }
 
     fn subscribe_network_events(&self) -> broadcast::Receiver<NetworkEvent> {

--- a/dash-spv/tests/handshake_test.rs
+++ b/dash-spv/tests/handshake_test.rs
@@ -79,7 +79,6 @@ async fn test_network_manager_creation() {
     assert!(network.is_ok(), "Network manager creation should succeed");
     let network = network.unwrap();
 
-    assert!(!network.is_connected(), "Should start disconnected");
     assert_eq!(network.peer_count(), 0, "Should start with no peers");
 }
 


### PR DESCRIPTION
Cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the peer network management API by removing legacy peer penalization methods and peer status query utilities from the network manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->