### PR TITLE
chore: make `codecov/patch` informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,6 +8,7 @@ coverage:
       default:
         target: auto
         threshold: 2%
+        informational: true
 
 comment:
   layout: "diff, flags, files"


### PR DESCRIPTION
Let's make patch coverage checks informal for now to avoid simple changes like #505 getting blocked.

I generally think we should enforce it, but rather after we fixed the test coverage of the repo to be much higher than what is currently then it's less likely for changes like this to be flagged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration settings.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->