### PR TITLE
refactor: replace `ServiceFlags::from(1)` with `NETWORK`

### DIFF
--- a/dash-spv/src/network/addrv2.rs
+++ b/dash-spv/src/network/addrv2.rs
@@ -180,7 +180,7 @@ mod tests {
 
         // Test adding known address
         let addr = "192.168.1.1:9999".parse().expect("Failed to parse test address");
-        handler.add_known_address(addr, ServiceFlags::from(1)).await;
+        handler.add_known_address(addr, ServiceFlags::NETWORK).await;
 
         let known = handler.get_known_addresses().await;
         assert_eq!(known.len(), 1);
@@ -207,21 +207,21 @@ mod tests {
             // Valid: current time
             AddrV2Message {
                 time: now,
-                services: ServiceFlags::from(1),
+                services: ServiceFlags::NETWORK,
                 addr: AddrV2::Ipv4(ipv4_addr),
                 port: addr.port(),
             },
             // Invalid: too old (4 hours ago)
             AddrV2Message {
                 time: now.saturating_sub(14400),
-                services: ServiceFlags::from(1),
+                services: ServiceFlags::NETWORK,
                 addr: AddrV2::Ipv4(ipv4_addr),
                 port: addr.port(),
             },
             // Invalid: too far in future (20 minutes)
             AddrV2Message {
                 time: now + 1200,
-                services: ServiceFlags::from(1),
+                services: ServiceFlags::NETWORK,
                 addr: AddrV2::Ipv4(ipv4_addr),
                 port: addr.port(),
             },

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -301,7 +301,7 @@ impl PeerNetworkManager {
                             });
 
                             // Add to known addresses
-                            addrv2_handler.add_known_address(addr, ServiceFlags::from(1)).await;
+                            addrv2_handler.add_known_address(addr, ServiceFlags::NETWORK).await;
 
                             // // Start message reader for this peer
                             Self::start_peer_reader(

--- a/dash-spv/src/storage/peers.rs
+++ b/dash-spv/src/storage/peers.rs
@@ -177,7 +177,7 @@ mod tests {
             "192.168.1.1:9999".parse().expect("Failed to parse test address");
         let msg = AddrV2Message {
             time: 1234567890,
-            services: ServiceFlags::from(1),
+            services: ServiceFlags::NETWORK,
             addr: AddrV2::Ipv4(
                 addr.ip().to_string().parse().expect("Failed to parse IPv4 address"),
             ),

--- a/dash-spv/tests/peer_test.rs
+++ b/dash-spv/tests/peer_test.rs
@@ -201,7 +201,7 @@ mod unit_tests {
         assert!(handler.peer_supports_addrv2(&peer).await);
 
         // Test adding addresses
-        handler.add_known_address(peer, ServiceFlags::from(1)).await;
+        handler.add_known_address(peer, ServiceFlags::NETWORK).await;
         let known = handler.get_known_addresses().await;
         assert_eq!(known.len(), 1);
         assert_eq!(known[0].socket_addr().unwrap(), peer);


### PR DESCRIPTION
Avoid magic numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized internal flag constants for improved code consistency and maintainability across network peer handling and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->