### PR TITLE
chore: make `codecov/project` wait for all uploads

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,8 @@
+codecov:
+  notify:
+    # Must match the number of coverage-uploading groups (core, spv, wallet, ffi, rpc)
+    after_n_builds: 5
+
 coverage:
   status:
     project:


### PR DESCRIPTION
The default `wait_for_ci` doesn't seem to do its job properly.. since the `codecov/project` action currently races to false after the first uploads it seems. Even though it recovers once all uploads were done, with this change it just waits for the reporting until all uploads are done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage notification configuration to adjust notification timing and align with the coverage upload schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->