### PR TITLE
chore: use target 0% for `codecov/patch`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,9 +6,7 @@ coverage:
         threshold: 2%
     patch:
       default:
-        target: auto
-        threshold: 2%
-        informational: true
+        target: 0%
 
 comment:
   layout: "diff, flags, files"


### PR DESCRIPTION
While the `informational: true` was unblocking merges the `target`/`threshold` still causing the check to show as failed/red which is misleading. With this the patch coverage should become truly informational.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration settings to refine how coverage targets are evaluated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->