### PR TITLE
chore(internals): remove unnecesary code in internals::macros

### DIFF
--- a/internals/src/macros.rs
+++ b/internals/src/macros.rs
@@ -5,43 +5,9 @@
 #[macro_export]
 macro_rules! impl_array_newtype {
     ($thing:ident, $ty:ty, $len:literal) => {
-        impl $thing {
-            /// Converts the object to a raw pointer.
-            #[inline]
-            pub fn as_ptr(&self) -> *const $ty {
-                let &$thing(ref dat) = self;
-                dat.as_ptr()
-            }
-
-            /// Converts the object to a mutable raw pointer.
-            #[inline]
-            pub fn as_mut_ptr(&mut self) -> *mut $ty {
-                let &mut $thing(ref mut dat) = self;
-                dat.as_mut_ptr()
-            }
-
-            /// Returns the length of the object as an array.
-            #[inline]
-            pub fn len(&self) -> usize {
-                $len
-            }
-
-            /// Returns whether the object, as an array, is empty. Always false.
-            #[inline]
-            pub fn is_empty(&self) -> bool {
-                false
-            }
-        }
-
         impl<'a> core::convert::From<[$ty; $len]> for $thing {
             fn from(data: [$ty; $len]) -> Self {
                 $thing(data)
-            }
-        }
-
-        impl<'a> core::convert::From<&'a [$ty; $len]> for $thing {
-            fn from(data: &'a [$ty; $len]) -> Self {
-                $thing(*data)
             }
         }
 
@@ -79,31 +45,6 @@ macro_rules! impl_array_newtype {
             }
         }
 
-        impl core::borrow::Borrow<[$ty; $len]> for $thing {
-            fn borrow(&self) -> &[$ty; $len] {
-                &self.0
-            }
-        }
-
-        impl core::borrow::BorrowMut<[$ty; $len]> for $thing {
-            fn borrow_mut(&mut self) -> &mut [$ty; $len] {
-                &mut self.0
-            }
-        }
-
-        // The following two are valid because `[T; N]: Borrow<[T]>`
-        impl core::borrow::Borrow<[$ty]> for $thing {
-            fn borrow(&self) -> &[$ty] {
-                &self.0
-            }
-        }
-
-        impl core::borrow::BorrowMut<[$ty]> for $thing {
-            fn borrow_mut(&mut self) -> &mut [$ty] {
-                &mut self.0
-            }
-        }
-
         impl<I> core::ops::Index<I> for $thing
         where
             [$ty]: core::ops::Index<I>,
@@ -128,12 +69,4 @@ macro_rules! debug_from_display {
             }
         }
     };
-}
-
-/// Asserts a boolean expression at compile time.
-#[macro_export]
-macro_rules! const_assert {
-    ($x:expr) => {{
-        const _: [(); 0 - !$x as usize] = [];
-    }};
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed several public convenience methods, trait-based conversions, and a compile-time assertion macro. This may affect code that relied on those conveniences.

* **Refactor**
  * Internal API surface simplified; no new user-facing features added.

---

Note: Review and update downstream usage if you depend on the removed conveniences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->