### PR TITLE
chore(dashcore): drop no-std supp in dashcore

### DIFF
--- a/dash-spv/Cargo.toml
+++ b/dash-spv/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.89"
 
 [dependencies]
 # Core Dash libraries
-dashcore = { path = "../dash", features = ["std", "serde", "core-block-hash-use-x11", "message_verification", "bls", "quorum_validation"] }
+dashcore = { path = "../dash", features = ["serde", "core-block-hash-use-x11", "message_verification", "bls", "quorum_validation"] }
 dashcore_hashes = { path = "../hashes" }
 key-wallet = { path = "../key-wallet" }
 key-wallet-manager = { path = "../key-wallet-manager" }

--- a/dash/Cargo.toml
+++ b/dash/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2024"
 
 # Please don't forget to add relevant features to docs.rs below
 [features]
-default = [ "std", "secp-recovery", "bincode" ]
+default = ["secp-recovery", "bincode" ]
 base64 = [ "base64-compat" ]
 rand-std = ["secp256k1/rand"]
 rand = ["secp256k1/rand"]
@@ -35,24 +35,15 @@ message_verification = ["bls"]
 bincode = [ "dep:bincode", "dep:bincode_derive", "dashcore_hashes/bincode" ]
 test-utils = []
 
-# At least one of std, no-std must be enabled.
-#
-# The no-std feature doesn't disable std - you need to turn off the std feature for that by disabling default.
-# Instead no-std enables additional features required for this crate to be usable without std.
-# As a result, both can be enabled without conflict.
-std = ["secp256k1/std", "bech32/std"]
-no-std = ["core2", "secp256k1/alloc"]
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 internals = { path = "../internals", package = "dashcore-private" }
-bech32 = { version = "0.9.1", default-features = false }
+bech32 = { version = "0.9.1" }
 dashcore_hashes = { path = "../hashes" }
-secp256k1 = { default-features = false, features = ["hashes"], version= "0.30.0" }
-core2 = { version = "0.4.0", optional = true, features = ["alloc"], default-features = false }
+secp256k1 = { features = ["hashes"], version= "0.30.0" }
 rustversion = { version="1.0.20"}
 serde = { version = "1.0.219", default-features = false, features = [ "derive", "alloc" ], optional = true }
 
@@ -84,15 +75,14 @@ key-wallet = { path = "../key-wallet" }
 
 [[example]]
 name = "handshake"
-required-features = ["std"]
 
 [[example]]
 name = "ecdsa-psbt"
-required-features = ["std", "bitcoinconsensus"]
+required-features = ["bitcoinconsensus"]
 
 [[example]]
 name = "taproot-psbt"
-required-features = ["std", "rand-std", "bitcoinconsensus"]
+required-features = ["rand-std", "bitcoinconsensus"]
 
 [[bench]]
 name = "transaction"

--- a/dash/src/address.rs
+++ b/dash/src/address.rs
@@ -140,7 +140,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/dash/src/amount.rs
+++ b/dash/src/amount.rs
@@ -188,7 +188,6 @@ impl fmt::Display for ParseAmountError {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for ParseAmountError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::ParseAmountError::*;
@@ -1615,7 +1614,6 @@ mod verification {
 #[cfg(test)]
 mod tests {
     use core::str::FromStr;
-    #[cfg(feature = "std")]
     use std::panic;
 
     #[cfg(feature = "serde")]
@@ -1666,7 +1664,6 @@ mod tests {
         assert_eq!(b, ssat(1));
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn test_overflows() {
         // panic on overflow

--- a/dash/src/base58.rs
+++ b/dash/src/base58.rs
@@ -90,7 +90,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 /// Vector-like object that holds the first 100 elements on the stack. If more space is needed it

--- a/dash/src/bip152.rs
+++ b/dash/src/bip152.rs
@@ -7,7 +7,6 @@
 
 use core::convert::{TryFrom, TryInto};
 use core::{convert, fmt, mem};
-#[cfg(feature = "std")]
 use std::error;
 
 use hashes::{Hash, sha256, siphash24};
@@ -37,7 +36,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
@@ -337,7 +335,6 @@ impl fmt::Display for TxIndexOutOfRangeError {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for TxIndexOutOfRangeError {}
 
 /// A [BlockTransactions] structure is used to provide some of the transactions

--- a/dash/src/bip158.rs
+++ b/dash/src/bip158.rs
@@ -78,7 +78,6 @@ impl Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
@@ -523,13 +522,7 @@ impl<'a, R: io::Read> BitStreamReader<'a, R> {
     /// ```
     pub fn read(&mut self, mut nbits: u8) -> Result<u64, io::Error> {
         if nbits > 64 {
-            #[cfg(feature = "std")]
             return Err(io::Error::other("can not read more than 64 bits at once"));
-            #[cfg(not(feature = "std"))]
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "can not read more than 64 bits at once",
-            ));
         }
         let mut data = 0u64;
         while nbits > 0 {
@@ -567,13 +560,7 @@ impl<'a, W: io::Write> BitStreamWriter<'a, W> {
     /// Writes nbits bits from data.
     pub fn write(&mut self, data: u64, mut nbits: u8) -> Result<usize, io::Error> {
         if nbits > 64 {
-            #[cfg(feature = "std")]
             return Err(io::Error::other("can not write more than 64 bits at once"));
-            #[cfg(not(feature = "std"))]
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "can not write more than 64 bits at once",
-            ));
         }
         let mut wrote = 0;
         while nbits > 0 {

--- a/dash/src/blockdata/block.rs
+++ b/dash/src/blockdata/block.rs
@@ -383,7 +383,6 @@ impl fmt::Display for Bip34Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Bip34Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Bip34Error::*;

--- a/dash/src/blockdata/locktime/absolute.rs
+++ b/dash/src/blockdata/locktime/absolute.rs
@@ -588,7 +588,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
@@ -655,7 +654,6 @@ impl fmt::Display for ConversionError {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for ConversionError {}
 
 /// Describes the two types of locking, lock-by-blockheight and lock-by-blocktime.
@@ -698,7 +696,6 @@ impl fmt::Display for OperationError {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for OperationError {}
 
 #[cfg(test)]

--- a/dash/src/blockdata/locktime/relative.rs
+++ b/dash/src/blockdata/locktime/relative.rs
@@ -331,7 +331,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/dash/src/blockdata/script/mod.rs
+++ b/dash/src/blockdata/script/mod.rs
@@ -48,14 +48,11 @@
 //! At the time of writing there's only one operation using the cache - `push_verify`, so the cache
 //! is minimal but we may extend it in the future if needed.
 
-use alloc::rc::Rc;
-#[cfg(all(not(feature = "std"), not(test), target_has_atomic = "ptr"))]
-use alloc::sync::Arc;
 use core::borrow::{Borrow, BorrowMut};
 use core::cmp::Ordering;
 use core::fmt;
 use core::ops::{Deref, DerefMut};
-#[cfg(feature = "std")]
+use std::rc::Rc;
 use std::sync::Arc;
 
 #[cfg(feature = "serde")]
@@ -787,7 +784,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/dash/src/blockdata/transaction/outpoint.rs
+++ b/dash/src/blockdata/transaction/outpoint.rs
@@ -21,7 +21,6 @@
 //!
 
 use core::fmt;
-#[cfg(feature = "std")]
 use std::error;
 
 #[cfg(feature = "bincode")]
@@ -201,7 +200,6 @@ impl fmt::Display for ParseOutPointError {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for ParseOutPointError {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {

--- a/dash/src/consensus/encode.rs
+++ b/dash/src/consensus/encode.rs
@@ -48,7 +48,6 @@ use crate::hash_types::{
 use crate::io::{self, Cursor, Read};
 use crate::network::message_qrinfo::QuorumSnapshot;
 use crate::network::message_sml::{DeletedQuorum, MnListDiff, QuorumCLSigObject};
-#[cfg(feature = "std")]
 use crate::network::{
     address::{AddrV2Message, Address},
     message_blockdata::Inventory,
@@ -171,7 +170,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
@@ -755,11 +753,8 @@ impl_vec!(MasternodeListEntry);
 impl_vec!(MnListDiff);
 impl_vec!(QuorumSnapshot);
 
-#[cfg(feature = "std")]
 impl_vec!(Inventory);
-#[cfg(feature = "std")]
 impl_vec!((u32, Address));
-#[cfg(feature = "std")]
 impl_vec!(AddrV2Message);
 
 pub(crate) fn consensus_encode_with_size<S: io::Write>(
@@ -1161,7 +1156,6 @@ mod tests {
 
     use super::*;
     use crate::consensus::{Decodable, Encodable, deserialize_partial};
-    #[cfg(feature = "std")]
     use crate::network::{Address, message_blockdata::Inventory};
     use crate::{TxIn, TxOut};
 
@@ -1455,9 +1449,7 @@ mod tests {
         test_len_is_max_vec::<TxIn>();
         test_len_is_max_vec::<Vec<u8>>();
         test_len_is_max_vec::<u64>();
-        #[cfg(feature = "std")]
         test_len_is_max_vec::<(u32, Address)>();
-        #[cfg(feature = "std")]
         test_len_is_max_vec::<Inventory>();
     }
 

--- a/dash/src/consensus/serde.rs
+++ b/dash/src/consensus/serde.rs
@@ -16,7 +16,6 @@ use serde::{Deserializer, Serializer};
 
 use super::encode::Error as ConsensusError;
 use super::{Decodable, Encodable};
-use crate::alloc::string::ToString;
 use crate::io;
 
 /// Hex-encoding strategy

--- a/dash/src/crypto/ecdsa.rs
+++ b/dash/src/crypto/ecdsa.rs
@@ -246,7 +246,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/dash/src/crypto/key.rs
+++ b/dash/src/crypto/key.rs
@@ -80,7 +80,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
@@ -194,17 +193,7 @@ impl PublicKey {
 
         reader.read_exact(&mut bytes[1..])?;
         Self::from_slice(bytes).map_err(|e| {
-            // Need a static string for core2
-            #[cfg(feature = "std")]
             let reason = e;
-            #[cfg(not(feature = "std"))]
-            let reason = match e {
-                Error::Base58(_) => "base58 error",
-                Error::Secp256k1(_) => "secp256k1 error",
-                Error::InvalidKeyPrefix(_) => "invalid key prefix",
-                Error::Hex(_) => "hex decoding error",
-                Error::InvalidHexLength(_) => "invalid hex string length",
-            };
             io::Error::new(io::ErrorKind::InvalidData, reason)
         })
     }
@@ -345,8 +334,7 @@ impl From<PublicKey> for PubkeyHash {
 }
 
 /// A Dash ECDSA private key
-#[derive(Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct PrivateKey {
     /// Whether this private key should be serialized as compressed
     pub compressed: bool,
@@ -459,13 +447,6 @@ impl PrivateKey {
 impl fmt::Display for PrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt_wif(f)
-    }
-}
-
-#[cfg(not(feature = "std"))]
-impl fmt::Debug for PrivateKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "[private key data]")
     }
 }
 

--- a/dash/src/crypto/sighash.rs
+++ b/dash/src/crypto/sighash.rs
@@ -278,7 +278,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use Error::*;

--- a/dash/src/crypto/taproot.rs
+++ b/dash/src/crypto/taproot.rs
@@ -91,7 +91,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;

--- a/dash/src/ephemerealdata/chain_lock.rs
+++ b/dash/src/ephemerealdata/chain_lock.rs
@@ -3,13 +3,10 @@
 //! reduces mining uncertenaty and mitigate 51% attack.
 //! This data structure represents a p2p message containing a data to verify such a lock.
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};
 use core::fmt::Debug;
 use hashes::{Hash, HashEngine};
-#[cfg(any(feature = "std", test))]
 pub use std::vec::Vec;
 
 use crate::bls_sig_utils::BLSSignature;

--- a/dash/src/ephemerealdata/instant_lock.rs
+++ b/dash/src/ephemerealdata/instant_lock.rs
@@ -2,13 +2,11 @@
 //! confirm transaction within 1 or 2 seconds. This data structure
 //! represents a p2p message containing a data to verify such a lock.
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
 #[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};
 use core::fmt::{Debug, Formatter};
 use hashes::{Hash, HashEngine};
-#[cfg(any(feature = "std", test))]
+#[cfg(test)]
 pub use std::vec::Vec;
 
 use crate::bls_sig_utils::BLSSignature;

--- a/dash/src/error.rs
+++ b/dash/src/error.rs
@@ -30,7 +30,6 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
@@ -54,12 +53,10 @@ impl From<encode::Error> for Error {
 macro_rules! impl_std_error {
     // No source available
     ($type:ty) => {
-        #[cfg(feature = "std")]
         impl std::error::Error for $type {}
     };
     // Struct with $field as source
     ($type:ty, $field:ident) => {
-        #[cfg(feature = "std")]
         impl std::error::Error for $type {
             fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
                 Some(&self.$field)

--- a/dash/src/lib.rs
+++ b/dash/src/lib.rs
@@ -30,7 +30,6 @@
 //!
 //! ## Available feature flags
 //!
-//! * `std` - the usual dependency on `std` (default).
 //! * `secp-recovery` - enables calculating public key from a signature and message.
 //! * `signer` - enables singing and validation ECDSA helpers.
 //! * `base64` - (dependency), enables encoding of PSBTs and message signatures.
@@ -39,11 +38,8 @@
 //! * `bincode` - (dependency), implements bincode serialization and deserialization.
 //! * `serde` - (dependency), implements `serde`-based serialization and deserialization.
 //! * `secp-lowmemory` - optimizations for low-memory devices.
-//! * `no-std` - enables additional features required for this crate to be usable
-//!   without std. Does **not** disable `std`. Depends on `core2`.
 //!
 
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // Experimental features we need.
 #![cfg_attr(bench, feature(test))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
@@ -51,9 +47,6 @@
 // #![warn(missing_docs)]
 // Instead of littering the codebase for non-fuzzing code just globally allow.
 #![cfg_attr(fuzzing, allow(dead_code, unused_imports))]
-
-#[cfg(not(any(feature = "std", feature = "no-std")))]
-compile_error!("at least one of the `std` or `no-std` features must be enabled");
 
 // Disable 16-bit support at least for now as we can't guarantee it yet.
 #[cfg(target_pointer_width = "16")]
@@ -123,18 +116,9 @@ pub mod string;
 pub mod taproot;
 pub mod util;
 
-// May depend on crate features and we don't want to bother with it
-#[allow(unused)]
-#[cfg(feature = "std")]
 use std::error::Error as StdError;
-#[cfg(feature = "std")]
-pub use std::io;
 
-#[allow(unused)]
-#[cfg(not(feature = "std"))]
-use core2::error::Error as StdError;
-#[cfg(not(feature = "std"))]
-use core2::io;
+pub use std::io;
 
 pub use crate::address::{Address, AddressType};
 pub use crate::amount::{Amount, Denomination, SignedAmount};
@@ -162,55 +146,13 @@ pub use crate::transaction::outpoint::OutPoint;
 pub use crate::transaction::txin::TxIn;
 pub use crate::transaction::txout::TxOut;
 
-#[cfg(not(feature = "std"))]
-mod io_extras {
-    /// A writer which will move data into the void.
-    pub struct Sink {
-        _priv: (),
-    }
-
-    /// Creates an instance of a writer which will successfully consume all data.
-    pub const fn sink() -> Sink {
-        Sink {
-            _priv: (),
-        }
-    }
-
-    impl core2::io::Write for Sink {
-        #[inline]
-        fn write(&mut self, buf: &[u8]) -> core2::io::Result<usize> {
-            Ok(buf.len())
-        }
-
-        #[inline]
-        fn flush(&mut self) -> core2::io::Result<()> {
-            Ok(())
-        }
-    }
-}
-
 #[rustfmt::skip]
 pub mod prelude {
-    #[cfg(all(not(feature = "std"), not(test)))]
-    pub use alloc::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, Cow, ToOwned}, slice, rc};
-
-    #[cfg(all(not(feature = "std"), not(test), target_has_atomic = "ptr"))]
-    pub use alloc::sync;
-
-    #[cfg(any(feature = "std", test))]
     pub use std::{string::{String, ToString}, vec::Vec, boxed::Box, borrow::{Borrow, Cow, ToOwned}, slice, rc, sync};
 
-    #[cfg(all(not(feature = "std"), not(test)))]
-    pub use alloc::collections::{BTreeMap, BTreeSet, btree_map, BinaryHeap};
-
-    #[cfg(any(feature = "std", test))]
     pub use std::collections::{BTreeMap, BTreeSet, btree_map, BinaryHeap};
 
-    #[cfg(feature = "std")]
     pub use std::io::sink;
-
-    #[cfg(not(feature = "std"))]
-    pub use crate::io_extras::sink;
 
     pub use internals::hex::display::DisplayHex;
 

--- a/dash/src/merkle_tree/block.rs
+++ b/dash/src/merkle_tree/block.rs
@@ -521,7 +521,6 @@ impl fmt::Display for MerkleBlockError {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for MerkleBlockError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::MerkleBlockError::*;

--- a/dash/src/network/mod.rs
+++ b/dash/src/network/mod.rs
@@ -22,34 +22,22 @@
 //!
 
 use core::fmt;
-#[cfg(feature = "std")]
 use std::error;
 
 use crate::io;
 
 pub mod constants;
 
-#[cfg(feature = "std")]
 pub mod address;
-#[cfg(feature = "std")]
 pub use self::address::Address;
-#[cfg(feature = "std")]
 pub mod message;
-#[cfg(feature = "std")]
 pub mod message_blockdata;
-#[cfg(feature = "std")]
 pub mod message_bloom;
-#[cfg(feature = "std")]
 pub mod message_compact_blocks;
-#[cfg(feature = "std")]
 pub mod message_filter;
-#[cfg(feature = "std")]
 pub mod message_headers2;
-#[cfg(feature = "std")]
 pub mod message_network;
-#[cfg(feature = "std")]
 pub mod message_qrinfo;
-#[cfg(feature = "std")]
 pub mod message_sml;
 
 /// Network error
@@ -80,7 +68,6 @@ impl From<io::Error> for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {

--- a/dash/src/pow.rs
+++ b/dash/src/pow.rs
@@ -104,7 +104,6 @@ impl Work {
     /// The result inherently suffers from a loss of precision and is, therefore, meant to be
     /// used mainly for informative and displaying purposes, similarly to Bitcoin Core's
     /// `log2_work` output in its logs.
-    #[cfg(feature = "std")]
     pub fn log2(self) -> f64 {
         self.0.to_f64().log2()
     }
@@ -731,7 +730,6 @@ impl fmt::Display for TryFromError {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for TryFromError {}
 
 impl Add for U256 {
@@ -1649,7 +1647,6 @@ mod tests {
         assert_eq!(back, target)
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn work_log2() {
         // Compare work log2 to historical Bitcoin Core values found in Core logs.

--- a/dash/src/sign_message.rs
+++ b/dash/src/sign_message.rs
@@ -73,7 +73,6 @@ mod message_signing {
         }
     }
 
-    #[cfg(feature = "std")]
     impl std::error::Error for MessageSignatureError {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             use self::MessageSignatureError::*;

--- a/dash/src/string.rs
+++ b/dash/src/string.rs
@@ -62,7 +62,6 @@ impl<E: fmt::Display> fmt::Display for FromHexError<E> {
     }
 }
 
-#[cfg(feature = "std")]
 impl<E> std::error::Error for FromHexError<E>
 where
     E: std::error::Error + 'static,

--- a/dash/src/taproot.rs
+++ b/dash/src/taproot.rs
@@ -640,7 +640,6 @@ impl core::fmt::Display for IncompleteBuilder {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for IncompleteBuilder {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::IncompleteBuilder::*;
@@ -679,7 +678,6 @@ impl core::fmt::Display for HiddenNodes {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for HiddenNodes {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::HiddenNodes::*;
@@ -1604,7 +1602,6 @@ impl fmt::Display for TaprootBuilderError {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for TaprootBuilderError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::TaprootBuilderError::*;
@@ -1666,7 +1663,6 @@ impl fmt::Display for TaprootError {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for TaprootError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::TaprootError::*;

--- a/internals/src/error.rs
+++ b/internals/src/error.rs
@@ -7,23 +7,12 @@
 //!
 
 /// Formats error.
-///
-/// If `std` feature is OFF appends error source (delimited by `: `). We do this because
-/// `e.source()` is only available in std builds, without this macro the error source is lost for
-/// no-std builds.
 #[macro_export]
 macro_rules! write_err {
     ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {
         {
-            #[cfg(feature = "std")]
-            {
-                let _ = &$source;   // Prevents clippy warnings.
-                write!($writer, $string $(, $args)*)
-            }
-            #[cfg(not(feature = "std"))]
-            {
-                write!($writer, concat!($string, ": {}") $(, $args)*, $source)
-            }
+            let _ = &$source;   // Prevents clippy warnings.
+            write!($writer, $string $(, $args)*)
         }
     }
 }

--- a/key-wallet-ffi/Cargo.toml
+++ b/key-wallet-ffi/Cargo.toml
@@ -22,7 +22,7 @@ bls = ["dashcore/bls", "key-wallet/bls"]
 [dependencies]
 key-wallet = { path = "../key-wallet", default-features = false, features = ["std"] }
 key-wallet-manager = { path = "../key-wallet-manager", features = ["std"] }
-dashcore = { path = "../dash", features = ["std"] }
+dashcore = { path = "../dash" }
 secp256k1 = { version = "0.30.0", features = ["global-context"] }
 tokio = { version = "1.32", features = ["rt-multi-thread", "sync"] }
 libc = "0.2"

--- a/key-wallet-manager/Cargo.toml
+++ b/key-wallet-manager/Cargo.toml
@@ -10,7 +10,7 @@ license = "CC0-1.0"
 
 [features]
 default = ["std", "bincode"]
-std = ["key-wallet/std", "dashcore/std", "secp256k1/std"]
+std = ["key-wallet/std", "secp256k1/std"]
 serde = ["dep:serde", "key-wallet/serde", "dashcore/serde"]
 getrandom = ["key-wallet/getrandom"]
 bincode = ["dep:bincode", "key-wallet/bincode"]
@@ -18,7 +18,7 @@ test-utils = []
 
 [dependencies]
 key-wallet = { path = "../key-wallet", default-features = false }
-dashcore = { path = "../dash", default-features = false }
+dashcore = { path = "../dash" }
 dashcore_hashes = { path = "../hashes" }
 secp256k1 = { version = "0.30.0", default-features = false, features = ["recovery"] }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }

--- a/rpc-json/Cargo.toml
+++ b/rpc-json/Cargo.toml
@@ -26,6 +26,6 @@ serde_repr = "0.1"
 hex = { version="0.4", features=["serde"]}
 
 key-wallet = { path = "../key-wallet", features=["serde"] }
-dashcore = { path = "../dash", features=["std", "secp-recovery", "rand-std", "signer", "serde"], default-features = false }
+dashcore = { path = "../dash", features=["secp-recovery", "rand-std", "signer", "serde"] }
 
 bincode = { version = "2.0.1", features = ["serde"] }


### PR DESCRIPTION
need hashes std to be dropped first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Library unified to a single standard-library (std) build, removing no-std conditional paths.
  * Error trait implementations simplified and standardized across the codebase, making error behavior more consistent.
  * Public prelude and re-exports consolidated to std types; some public modules were simplified or removed.

* **Chores**
  * Dependency and feature declarations updated across crates to align with the unified std build and optional features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->