### PR TITLE
feat: log wallet events in the client's run loop

### DIFF
--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -29,6 +29,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
 
         let mut sync_coordinator_tick_interval = tokio::time::interval(SYNC_COORDINATOR_TICK_MS);
         let mut progress_updates = self.sync_coordinator.lock().await.subscribe_progress();
+        let mut wallet_events = self.wallet.read().await.subscribe_events();
 
         let error = loop {
             // Check if we should stop
@@ -48,6 +49,18 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
                         }
                         Err(_) => {
                             tracing::warn!("Progress channel closed.");
+                            break None
+                        }
+                    }
+                }
+                result = wallet_events.recv() => {
+                    match result {
+                        Ok(event) => {
+                            tracing::info!("Wallet event: {}", event.description());
+                            None
+                        }
+                        Err(e) => {
+                            tracing::warn!("Wallet events channel error: {e}");
                             break None
                         }
                     }

--- a/key-wallet-manager/src/test_utils/wallet.rs
+++ b/key-wallet-manager/src/test_utils/wallet.rs
@@ -1,28 +1,36 @@
-use crate::{wallet_interface::WalletInterface, BlockProcessingResult};
+use crate::{wallet_interface::WalletInterface, BlockProcessingResult, WalletEvent};
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, Block, Transaction, Txid};
 use std::{collections::BTreeMap, sync::Arc};
-use tokio::sync::Mutex;
+use tokio::sync::{broadcast, Mutex};
 
 // Type alias for transaction effects map
 type TransactionEffectsMap = Arc<Mutex<BTreeMap<Txid, (i64, Vec<String>)>>>;
 
-#[derive(Default)]
 pub struct MockWallet {
     processed_blocks: Arc<Mutex<Vec<(dashcore::BlockHash, u32)>>>,
     processed_transactions: Arc<Mutex<Vec<dashcore::Txid>>>,
     // Map txid -> (net_amount, addresses)
     effects: TransactionEffectsMap,
     synced_height: CoreBlockHeight,
+    event_sender: broadcast::Sender<WalletEvent>,
+}
+
+impl Default for MockWallet {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MockWallet {
     pub fn new() -> Self {
+        let (event_sender, _) = broadcast::channel(16);
         Self {
             processed_blocks: Arc::new(Mutex::new(Vec::new())),
             processed_transactions: Arc::new(Mutex::new(Vec::new())),
             effects: Arc::new(Mutex::new(BTreeMap::new())),
             synced_height: 0,
+            event_sender,
         }
     }
 
@@ -78,18 +86,30 @@ impl WalletInterface for MockWallet {
     fn update_synced_height(&mut self, height: CoreBlockHeight) {
         self.synced_height = height;
     }
+
+    fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent> {
+        self.event_sender.subscribe()
+    }
 }
 
 /// Mock wallet that returns false for filter checks
-#[derive(Default)]
 pub struct NonMatchingMockWallet {
     synced_height: CoreBlockHeight,
+    event_sender: broadcast::Sender<WalletEvent>,
+}
+
+impl Default for NonMatchingMockWallet {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl NonMatchingMockWallet {
     pub fn new() -> Self {
+        let (event_sender, _) = broadcast::channel(16);
         Self {
             synced_height: 0,
+            event_sender,
         }
     }
 }
@@ -112,6 +132,10 @@ impl WalletInterface for NonMatchingMockWallet {
 
     fn update_synced_height(&mut self, height: CoreBlockHeight) {
         self.synced_height = height;
+    }
+
+    fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent> {
+        self.event_sender.subscribe()
     }
 
     async fn describe(&self) -> String {

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -2,11 +2,13 @@
 //!
 //! This module defines the trait that SPV clients use to interact with wallets.
 
+use crate::WalletEvent;
 use alloc::string::String;
 use alloc::vec::Vec;
 use async_trait::async_trait;
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, Block, Transaction, Txid};
+use tokio::sync::broadcast;
 
 /// Result of processing a block through the wallet
 #[derive(Debug, Default, Clone)]
@@ -89,6 +91,9 @@ pub trait WalletInterface: Send + Sync + 'static {
             self.update_synced_height(height);
         }
     }
+
+    /// Subscribe to wallet events (e.g. transactions received, balance changes).
+    fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent>;
 
     /// Provide a human-readable description of the wallet implementation.
     ///

--- a/key-wallet-manager/src/wallet_manager/process_block.rs
+++ b/key-wallet-manager/src/wallet_manager/process_block.rs
@@ -1,4 +1,5 @@
 use crate::wallet_interface::{BlockProcessingResult, WalletInterface};
+use crate::WalletEvent;
 use crate::WalletManager;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -9,6 +10,7 @@ use dashcore::{Address, Block, Transaction};
 use key_wallet::transaction_checking::transaction_router::TransactionRouter;
 use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+use tokio::sync::broadcast;
 
 #[async_trait]
 impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletManager<T> {
@@ -121,7 +123,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             // Emit event if balance changed
             #[cfg(feature = "std")]
             if old_balance != new_balance {
-                let event = crate::WalletEvent::BalanceUpdated {
+                let event = WalletEvent::BalanceUpdated {
                     wallet_id: *wallet_id,
                     spendable: new_balance.spendable(),
                     unconfirmed: new_balance.unconfirmed(),
@@ -142,6 +144,10 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         if height > self.synced_height {
             self.update_synced_height(height);
         }
+    }
+
+    fn subscribe_events(&self) -> broadcast::Receiver<WalletEvent> {
+        self.event_sender.subscribe()
     }
 
     async fn describe(&self) -> String {


### PR DESCRIPTION
Handle and log wallet events in the client's run loop. I think it's good to have when investigating issues from logfiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wallet event subscription so clients can receive real-time wallet events (e.g., balance changes, transactions).
  * Sync now listens for and logs wallet events, integrating event-driven updates alongside existing progress and tick updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->