### PR TITLE
feat: add `--mempool-strategy` CLI argument

### DIFF
--- a/dash-spv/src/client/config.rs
+++ b/dash-spv/src/client/config.rs
@@ -1,5 +1,6 @@
 //! Configuration management for the Dash SPV client.
 
+use clap::ValueEnum;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
@@ -9,7 +10,7 @@ use dashcore::Network;
 use crate::types::ValidationMode;
 
 /// Strategy for handling mempool (unconfirmed) transactions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum MempoolStrategy {
     /// Fetch all announced transactions (high bandwidth, sees all transactions).
     FetchAll,

--- a/dash-spv/src/lib.rs
+++ b/dash-spv/src/lib.rs
@@ -68,6 +68,7 @@ pub mod types;
 pub mod validation;
 
 // Re-export main types for convenience
+pub use client::config::MempoolStrategy;
 pub use client::{ClientConfig, DashSpvClient};
 pub use error::{
     LoggingError, LoggingResult, NetworkError, SpvError, StorageError, SyncError, ValidationError,

--- a/dash-spv/src/main.rs
+++ b/dash-spv/src/main.rs
@@ -6,7 +6,7 @@ use std::process;
 use std::sync::Arc;
 
 use clap::{Arg, Command};
-use dash_spv::{ClientConfig, DashSpvClient, LevelFilter, Network};
+use dash_spv::{ClientConfig, DashSpvClient, LevelFilter, MempoolStrategy, Network};
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet_manager::wallet_manager::WalletManager;
 use tokio_util::sync::CancellationToken;
@@ -89,6 +89,14 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                 .long("no-mempool")
                 .help("Disable mempool transaction tracking")
                 .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("mempool-strategy")
+                .long("mempool-strategy")
+                .value_name("STRATEGY")
+                .help("Mempool strategy: fetch-all (higher bandwidth / more privacy) or bloom-filter (efficient / less privacy)")
+                .value_parser(clap::value_parser!(MempoolStrategy))
+                .default_value("bloom-filter"),
         )
         .arg(
             Arg::new("validation-mode")
@@ -249,6 +257,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
     if matches.get_flag("no-mempool") {
         config.enable_mempool_tracking = false;
+    } else {
+        let mempool_strategy = *matches
+            .get_one::<MempoolStrategy>("mempool-strategy")
+            .expect("mempool-strategy has default value");
+        config = config.with_mempool_tracking(mempool_strategy);
     }
 
     // Set start height if specified


### PR DESCRIPTION
Exposes `MempoolStrategy` selection (fetch-all, bloom-filter) via the CLI so users can choose between (higher bandwidth / more private) full relay sync and (more efficient / less private) BIP37 bloom-filtered mempool sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `--mempool-strategy` command-line option to configure mempool tracking behavior, with a default value of bloom-filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->