### PR TITLE
feat: format wallet event amounts as DASH

### DIFF
--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -6,7 +6,7 @@
 use crate::wallet_manager::WalletId;
 use alloc::string::String;
 use alloc::vec::Vec;
-use dashcore::{Address, Txid};
+use dashcore::{Address, Amount, SignedAmount, Txid};
 
 /// Events emitted by the wallet manager.
 ///
@@ -51,17 +51,25 @@ impl WalletEvent {
                 amount,
                 ..
             } => {
-                format!("TransactionReceived(txid={}, amount={})", txid, amount)
+                format!(
+                    "TransactionReceived(txid={}, amount={})",
+                    txid,
+                    SignedAmount::from_sat(*amount)
+                )
             }
             WalletEvent::BalanceUpdated {
                 spendable,
                 unconfirmed,
                 immature,
+                locked,
                 ..
             } => {
                 format!(
-                    "BalanceUpdated(spendable={}, unconfirmed={}, immature={})",
-                    spendable, unconfirmed, immature
+                    "BalanceUpdated(spendable={}, unconfirmed={}, immature={}, locked={})",
+                    Amount::from_sat(*spendable),
+                    Amount::from_sat(*unconfirmed),
+                    Amount::from_sat(*immature),
+                    Amount::from_sat(*locked)
                 )
             }
         }


### PR DESCRIPTION
Use `Amount` and `SignedAmount` for better readable logging output in wallet event descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet balance tracking now includes a separate locked amount field, providing clearer visibility into spendable versus locked funds.
  * Transaction amount formatting has been improved for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->