### PR TITLE
ci: add PR title prefix enforcement

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,12 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
   request_changes_workflow: true
+  path_instructions:
+    - path: "**"
+      instructions: |
+        Check whether the PR title prefix allowed in the pr-title.yml workflow
+        accurately describes the changes. Flag e.g. if a PR labeled "fix" appears to add
+        new functionality, if a "feat" PR only refactors existing code, or if a
+        "chore" PR contains logic changes that should be a "feat" or "fix".
+        If a PR mixes unrelated concerns (e.g., a bug fix bundled with a refactor
+        or new feature), suggest splitting it into separate focused PRs.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,30 @@
+name: PR Title Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            refactor
+            test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ We use the standard fork-and-PR model:
 5. Open a PR early for feedback; keep the description clear and scoped.
 
 Commits should explain the why and the what. Conventional Commits are encouraged.
+PR titles must use one of the following prefixes (enforced by CI):
+`build`, `chore`, `ci`, `docs`, `feat`, `fix`, `refactor`, `test`.
 
 
 ## Preparing PRs


### PR DESCRIPTION
Add a GitHub Action that validates PR titles start with an allowed prefix followed by an optional scope and colon. Also add a CodeRabbit review instruction to flag when the chosen prefix doesn't match the actual changes.

Based on: 
- #531 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated CI validation to enforce semantic pull request title prefixes (build, chore, ci, docs, feat, fix, refactor, test) and suggest splitting mixed-change PRs.

* **Documentation**
  * Updated contribution guidelines to require the new PR title prefix policy and explain expected prefixes and workflow consequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->