### PR TITLE
refactor: simplify `HandshakeManager` to accept `relay`

### DIFF
--- a/dash-spv/src/network/handshake.rs
+++ b/dash-spv/src/network/handshake.rs
@@ -10,7 +10,6 @@ use dashcore::network::message_network::VersionMessage;
 use dashcore::Network;
 // Hash trait not needed in current implementation
 
-use crate::client::config::MempoolStrategy;
 use crate::error::{NetworkError, NetworkResult};
 use crate::network::peer::Peer;
 use crate::network::Message;
@@ -40,17 +39,13 @@ pub struct HandshakeManager {
     version_received: bool,
     verack_received: bool,
     version_sent: bool,
-    mempool_strategy: MempoolStrategy,
+    relay: bool,
     user_agent: Option<String>,
 }
 
 impl HandshakeManager {
     /// Create a new handshake manager.
-    pub fn new(
-        network: Network,
-        mempool_strategy: MempoolStrategy,
-        user_agent: Option<String>,
-    ) -> Self {
+    pub fn new(network: Network, relay: bool, user_agent: Option<String>) -> Self {
         Self {
             _network: network,
             state: HandshakeState::Init,
@@ -60,7 +55,7 @@ impl HandshakeManager {
             version_received: false,
             verack_received: false,
             version_sent: false,
-            mempool_strategy,
+            relay,
             user_agent,
         }
     }
@@ -292,10 +287,7 @@ impl HandshakeManager {
             nonce: rand::random(),
             user_agent: ua,
             start_height: 0, // SPV client starts at 0
-            relay: match self.mempool_strategy {
-                MempoolStrategy::FetchAll => true, // Want all transactions for FetchAll strategy
-                _ => false,                        // Don't want relay for other strategies
-            },
+            relay: self.relay,
             mn_auth_challenge: [0; 32],   // Not a masternode
             masternode_connection: false, // Not connecting to masternode
         })

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -233,7 +233,7 @@ impl PeerNetworkManager {
         let addrv2_handler = self.addrv2_handler.clone();
         let shutdown_token = self.shutdown_token.clone();
         let reputation_manager = self.reputation_manager.clone();
-        let mempool_strategy = self.mempool_strategy;
+        let relay = self.mempool_strategy != MempoolStrategy::BloomFilter;
         let user_agent = self.user_agent.clone();
         let connected_peer_count = self.connected_peer_count.clone();
         let headers2_disabled = self.headers2_disabled.clone();
@@ -263,8 +263,7 @@ impl PeerNetworkManager {
             match connect_result {
                 Ok(mut peer) => {
                     // Perform handshake
-                    let mut handshake_manager =
-                        HandshakeManager::new(network, mempool_strategy, user_agent);
+                    let mut handshake_manager = HandshakeManager::new(network, relay, user_agent);
                     match handshake_manager.perform_handshake(&mut peer).await {
                         Ok(_) => {
                             log::info!("Successfully connected to {}", addr);

--- a/dash-spv/tests/handshake_test.rs
+++ b/dash-spv/tests/handshake_test.rs
@@ -3,7 +3,6 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use dash_spv::client::config::MempoolStrategy;
 use dash_spv::network::{HandshakeManager, NetworkManager, Peer, PeerNetworkManager};
 use dash_spv::{ClientConfig, Network};
 
@@ -19,7 +18,7 @@ async fn test_handshake_with_mainnet_peer() {
         Ok(mut connection) => {
             let mut handshake_manager = HandshakeManager::new(
                 Network::Mainnet,
-                MempoolStrategy::BloomFilter,
+                false,
                 Some("handshake_test".parse().unwrap()),
             );
             handshake_manager.perform_handshake(&mut connection).await.expect("Handshake failed");

--- a/dash-spv/tests/test_handshake_logic.rs
+++ b/dash-spv/tests/test_handshake_logic.rs
@@ -1,12 +1,11 @@
 //! Unit tests for handshake logic
 
-use dash_spv::client::config::MempoolStrategy;
 use dash_spv::network::{HandshakeManager, HandshakeState};
 use dashcore::Network;
 
 #[test]
 fn test_handshake_state_transitions() {
-    let mut handshake = HandshakeManager::new(Network::Mainnet, MempoolStrategy::BloomFilter, None);
+    let mut handshake = HandshakeManager::new(Network::Mainnet, false, None);
 
     // Initial state should be Init
     assert_eq!(*handshake.state(), HandshakeState::Init);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the network handshake configuration mechanism by replacing a strategy parameter with a relay toggle flag, reducing API complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->