### PR TITLE
refactor: default to `relay=false` in P2P handshake

### DIFF
--- a/dash-spv/src/network/handshake.rs
+++ b/dash-spv/src/network/handshake.rs
@@ -10,7 +10,6 @@ use dashcore::network::message_network::VersionMessage;
 use dashcore::Network;
 // Hash trait not needed in current implementation
 
-use crate::client::config::MempoolStrategy;
 use crate::error::{NetworkError, NetworkResult};
 use crate::network::peer::Peer;
 use crate::network::Message;
@@ -40,17 +39,12 @@ pub struct HandshakeManager {
     version_received: bool,
     verack_received: bool,
     version_sent: bool,
-    mempool_strategy: MempoolStrategy,
     user_agent: Option<String>,
 }
 
 impl HandshakeManager {
     /// Create a new handshake manager.
-    pub fn new(
-        network: Network,
-        mempool_strategy: MempoolStrategy,
-        user_agent: Option<String>,
-    ) -> Self {
+    pub fn new(network: Network, user_agent: Option<String>) -> Self {
         Self {
             _network: network,
             state: HandshakeState::Init,
@@ -60,7 +54,6 @@ impl HandshakeManager {
             version_received: false,
             verack_received: false,
             version_sent: false,
-            mempool_strategy,
             user_agent,
         }
     }
@@ -291,11 +284,8 @@ impl HandshakeManager {
             sender: dashcore::network::address::Address::new(&local_addr, services),
             nonce: rand::random(),
             user_agent: ua,
-            start_height: 0, // SPV client starts at 0
-            relay: match self.mempool_strategy {
-                MempoolStrategy::FetchAll => true, // Want all transactions for FetchAll strategy
-                _ => false,                        // Don't want relay for other strategies
-            },
+            start_height: 0,              // SPV client starts at 0
+            relay: false,                 // relay enabled on demand via filterload/filterclear
             mn_auth_challenge: [0; 32],   // Not a masternode
             masternode_connection: false, // Not connecting to masternode
         })

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -10,7 +10,6 @@ use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio::task::JoinSet;
 use tokio::time;
 
-use crate::client::config::MempoolStrategy;
 use crate::client::ClientConfig;
 use crate::error::{NetworkError, NetworkResult, SpvError as Error};
 use crate::network::addrv2::AddrV2Handler;
@@ -61,8 +60,6 @@ pub struct PeerNetworkManager {
     current_sync_peer: Arc<Mutex<Option<SocketAddr>>>,
     /// Data directory for storage
     data_dir: PathBuf,
-    /// Mempool strategy from config
-    mempool_strategy: MempoolStrategy,
     /// Optional user agent to advertise
     user_agent: Option<String>,
     /// Exclusive mode: restrict to configured peers only (no DNS or peer store)
@@ -115,7 +112,6 @@ impl PeerNetworkManager {
             initial_peers: config.peers.clone(),
             current_sync_peer: Arc::new(Mutex::new(None)),
             data_dir,
-            mempool_strategy: config.mempool_strategy,
             user_agent: config.user_agent.clone(),
             exclusive_mode,
             connected_peer_count: Arc::new(AtomicUsize::new(0)),
@@ -233,7 +229,6 @@ impl PeerNetworkManager {
         let addrv2_handler = self.addrv2_handler.clone();
         let shutdown_token = self.shutdown_token.clone();
         let reputation_manager = self.reputation_manager.clone();
-        let mempool_strategy = self.mempool_strategy;
         let user_agent = self.user_agent.clone();
         let connected_peer_count = self.connected_peer_count.clone();
         let headers2_disabled = self.headers2_disabled.clone();
@@ -263,8 +258,7 @@ impl PeerNetworkManager {
             match connect_result {
                 Ok(mut peer) => {
                     // Perform handshake
-                    let mut handshake_manager =
-                        HandshakeManager::new(network, mempool_strategy, user_agent);
+                    let mut handshake_manager = HandshakeManager::new(network, user_agent);
                     match handshake_manager.perform_handshake(&mut peer).await {
                         Ok(_) => {
                             log::info!("Successfully connected to {}", addr);
@@ -1309,7 +1303,6 @@ impl Clone for PeerNetworkManager {
             initial_peers: self.initial_peers.clone(),
             current_sync_peer: self.current_sync_peer.clone(),
             data_dir: self.data_dir.clone(),
-            mempool_strategy: self.mempool_strategy,
             user_agent: self.user_agent.clone(),
             exclusive_mode: self.exclusive_mode,
             connected_peer_count: self.connected_peer_count.clone(),

--- a/dash-spv/tests/handshake_test.rs
+++ b/dash-spv/tests/handshake_test.rs
@@ -3,7 +3,6 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use dash_spv::client::config::MempoolStrategy;
 use dash_spv::network::{HandshakeManager, NetworkManager, Peer, PeerNetworkManager};
 use dash_spv::{ClientConfig, Network};
 
@@ -17,11 +16,8 @@ async fn test_handshake_with_mainnet_peer() {
 
     match result {
         Ok(mut connection) => {
-            let mut handshake_manager = HandshakeManager::new(
-                Network::Mainnet,
-                MempoolStrategy::BloomFilter,
-                Some("handshake_test".parse().unwrap()),
-            );
+            let mut handshake_manager =
+                HandshakeManager::new(Network::Mainnet, Some("handshake_test".parse().unwrap()));
             handshake_manager.perform_handshake(&mut connection).await.expect("Handshake failed");
             println!("✓ Handshake successful with peer {}", peer_addr);
             assert!(

--- a/dash-spv/tests/test_handshake_logic.rs
+++ b/dash-spv/tests/test_handshake_logic.rs
@@ -1,12 +1,11 @@
 //! Unit tests for handshake logic
 
-use dash_spv::client::config::MempoolStrategy;
 use dash_spv::network::{HandshakeManager, HandshakeState};
 use dashcore::Network;
 
 #[test]
 fn test_handshake_state_transitions() {
-    let mut handshake = HandshakeManager::new(Network::Mainnet, MempoolStrategy::BloomFilter, None);
+    let mut handshake = HandshakeManager::new(Network::Mainnet, None);
 
     // Initial state should be Init
     assert_eq!(*handshake.state(), HandshakeState::Init);


### PR DESCRIPTION
Just always default to `false`. The new coming mempool implementation will enable it on demand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified network handshake and peer manager initialization by removing an internal mempool configuration, reducing connection setup complexity.
  * Handshake relay behavior is now fixed (no mempool-driven variation), producing more predictable peer negotiation.

* **Tests**
  * Updated handshake tests to align with the simplified initialization and relay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->