### PR TITLE
test: add 200 block regtest blockchain support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ permissions:
 env:
   DASHVERSION: "23.1.0"
   TEST_DATA_REPO: "dashpay/regtest-blockchain"
-  TEST_DATA_VERSION: "v0.0.2"
+  TEST_DATA_VERSION: "v0.0.3"
 
 jobs:
   test:

--- a/contrib/setup-dashd.py
+++ b/contrib/setup-dashd.py
@@ -2,12 +2,12 @@
 """Cross-platform setup script for dashd and test blockchain data.
 
 Downloads the Dash Core binary and regtest test data for integration tests.
-Outputs DASHD_PATH and DASHD_DATADIR lines suitable for appending to GITHUB_ENV
+Outputs DASHD_PATH and DASHD_TEST_DATA lines suitable for appending to GITHUB_ENV
 or evaluating in a shell.
 
 Environment variables:
     DASHVERSION        - Dash Core version (default: 23.1.0)
-    TEST_DATA_VERSION  - Test data release version (default: v0.0.2)
+    TEST_DATA_VERSION  - Test data release version (default: v0.0.3)
     TEST_DATA_REPO     - GitHub repo for test data (default: dashpay/regtest-blockchain)
     CACHE_DIR          - Cache directory (default: ~/.rust-dashcore-test)
 """
@@ -22,7 +22,7 @@ import zipfile
 
 # Keep these defaults in sync with .github/workflows/build-and-test.yml
 DASHVERSION = os.environ.get("DASHVERSION", "23.1.0")
-TEST_DATA_VERSION = os.environ.get("TEST_DATA_VERSION", "v0.0.2")
+TEST_DATA_VERSION = os.environ.get("TEST_DATA_VERSION", "v0.0.3")
 TEST_DATA_REPO = os.environ.get("TEST_DATA_REPO", "dashpay/regtest-blockchain")
 
 
@@ -115,23 +115,30 @@ def setup_dashd(cache_dir):
     return dashd_bin
 
 
-def setup_test_data(cache_dir):
-    """Download and extract test blockchain data. Returns the datadir path."""
-    test_data_dir = os.path.join(
-        cache_dir, f"regtest-blockchain-{TEST_DATA_VERSION}", "regtest-40000"
-    )
+VARIANTS = ["regtest-40000", "regtest-200"]
+
+
+def setup_test_data(cache_dir, variant):
+    """Download and extract a single test blockchain variant.
+
+    Args:
+        cache_dir: Root cache directory for all test assets.
+        variant: Directory name of the test data (e.g. "regtest-40000" or "regtest-200").
+    """
+    parent_dir = os.path.join(cache_dir, f"regtest-blockchain-{TEST_DATA_VERSION}")
+    test_data_dir = os.path.join(parent_dir, variant)
     blocks_dir = os.path.join(test_data_dir, "regtest", "blocks")
 
     if os.path.isdir(blocks_dir):
-        log(f"Test blockchain data {TEST_DATA_VERSION} already available")
-        return test_data_dir
+        log(f"Test blockchain data {variant} ({TEST_DATA_VERSION}) already available")
+        return
 
-    log(f"Downloading test blockchain data {TEST_DATA_VERSION}...")
-    parent_dir = os.path.join(cache_dir, f"regtest-blockchain-{TEST_DATA_VERSION}")
+    log(f"Downloading test blockchain data {variant} ({TEST_DATA_VERSION})...")
     os.makedirs(parent_dir, exist_ok=True)
 
-    archive_path = os.path.join(cache_dir, "regtest-40000.tar.gz")
-    url = f"https://github.com/{TEST_DATA_REPO}/releases/download/{TEST_DATA_VERSION}/regtest-40000.tar.gz"
+    archive_name = f"{variant}.tar.gz"
+    archive_path = os.path.join(cache_dir, archive_name)
+    url = f"https://github.com/{TEST_DATA_REPO}/releases/download/{TEST_DATA_VERSION}/{archive_name}"
     download(url, archive_path)
     extract(archive_path, parent_dir)
     os.remove(archive_path)
@@ -141,19 +148,20 @@ def setup_test_data(cache_dir):
 
     log(f"Downloaded test data to {test_data_dir}")
 
-    return test_data_dir
-
 
 def main():
     cache_dir = get_cache_dir()
     os.makedirs(cache_dir, exist_ok=True)
 
     dashd_path = setup_dashd(cache_dir)
-    datadir = setup_test_data(cache_dir)
+    for variant in VARIANTS:
+        setup_test_data(cache_dir, variant)
+
+    datadir = os.path.join(cache_dir, f"regtest-blockchain-{TEST_DATA_VERSION}")
 
     # Output lines for GITHUB_ENV or shell eval
     print(f"DASHD_PATH={dashd_path}")
-    print(f"DASHD_DATADIR={datadir}")
+    print(f"DASHD_TEST_DATA={datadir}")
 
 
 if __name__ == "__main__":

--- a/dash-spv-ffi/tests/dashd_sync/tests_basic.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_basic.rs
@@ -1,14 +1,14 @@
 use std::collections::HashSet;
 use std::sync::atomic::Ordering;
 
-use dash_spv::test_utils::DashdTestContext;
+use dash_spv::test_utils::{DashdTestContext, TestChain};
 
 use super::context::FFITestContext;
 
 #[test]
 fn test_wallet_sync_via_ffi() {
     let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    let Some(dashd) = rt.block_on(DashdTestContext::new()) else {
+    let Some(dashd) = rt.block_on(DashdTestContext::new(TestChain::Full)) else {
         eprintln!("Skipping test (dashd context unavailable)");
         return;
     };

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use dash_spv::test_utils::DashdTestContext;
+use dash_spv::test_utils::{DashdTestContext, TestChain};
 use dashcore::hashes::Hash;
 use dashcore::Amount;
 
@@ -10,7 +10,7 @@ use super::context::FFITestContext;
 #[test]
 fn test_all_callbacks_during_sync() {
     let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    let Some(dashd) = rt.block_on(DashdTestContext::new()) else {
+    let Some(dashd) = rt.block_on(DashdTestContext::new(TestChain::Minimal)) else {
         return;
     };
 
@@ -231,7 +231,7 @@ fn test_all_callbacks_during_sync() {
 #[test]
 fn test_callbacks_post_sync_transactions_and_disconnect() {
     let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    let Some(dashd) = rt.block_on(DashdTestContext::new()) else {
+    let Some(dashd) = rt.block_on(DashdTestContext::new(TestChain::Minimal)) else {
         return;
     };
     if !dashd.supports_mining {

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -10,7 +10,9 @@ use super::context::FFITestContext;
 #[test]
 fn test_all_callbacks_during_sync() {
     let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    let Some(dashd) = rt.block_on(DashdTestContext::new(TestChain::Minimal)) else {
+    // TODO: This should doesn't need a full chain but its currently flaky with the minimal chain
+    //       will be fixed once the flakiness is resolved.
+    let Some(dashd) = rt.block_on(DashdTestContext::new(TestChain::Full)) else {
         return;
     };
 

--- a/dash-spv-ffi/tests/dashd_sync/tests_restart.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_restart.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::Ordering;
 
-use dash_spv::test_utils::DashdTestContext;
+use dash_spv::test_utils::{DashdTestContext, TestChain};
 
 use super::context::FFITestContext;
 
@@ -8,7 +8,7 @@ use super::context::FFITestContext;
 #[test]
 fn test_ffi_restart_consistency() {
     let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    let Some(dashd) = rt.block_on(DashdTestContext::new()) else {
+    let Some(dashd) = rt.block_on(DashdTestContext::new(TestChain::Full)) else {
         eprintln!("Skipping test (dashd context unavailable)");
         return;
     };

--- a/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::Ordering;
 
-use dash_spv::test_utils::DashdTestContext;
+use dash_spv::test_utils::{DashdTestContext, TestChain};
 use dashcore::hashes::Hash;
 use dashcore::Amount;
 
@@ -13,7 +13,7 @@ use super::context::FFITestContext;
 #[test]
 fn test_ffi_sync_then_generate_blocks() {
     let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    let Some(dashd) = rt.block_on(DashdTestContext::new()) else {
+    let Some(dashd) = rt.block_on(DashdTestContext::new(TestChain::Minimal)) else {
         eprintln!("Skipping test (dashd context unavailable)");
         return;
     };
@@ -124,7 +124,7 @@ fn test_ffi_sync_then_generate_blocks() {
 #[test]
 fn test_ffi_multiple_transactions_in_single_block() {
     let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    let Some(dashd) = rt.block_on(DashdTestContext::new()) else {
+    let Some(dashd) = rt.block_on(DashdTestContext::new(TestChain::Minimal)) else {
         eprintln!("Skipping test (dashd context unavailable)");
         return;
     };
@@ -208,7 +208,7 @@ fn test_ffi_multiple_transactions_in_single_block() {
 #[test]
 fn test_ffi_multiple_transactions_across_blocks() {
     let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    let Some(dashd) = rt.block_on(DashdTestContext::new()) else {
+    let Some(dashd) = rt.block_on(DashdTestContext::new(TestChain::Minimal)) else {
         eprintln!("Skipping test (dashd context unavailable)");
         return;
     };

--- a/dash-spv/src/test_utils/context.rs
+++ b/dash-spv/src/test_utils/context.rs
@@ -10,6 +10,7 @@ use tempfile::TempDir;
 use tracing::info;
 
 use super::fs_helpers::{copy_dir, retain_test_dir};
+use super::node::TestChain;
 use super::{DashCoreConfig, DashCoreNode, WalletFile};
 
 /// Shared test infrastructure for dashd integration tests.
@@ -32,17 +33,24 @@ pub struct DashdTestContext {
 }
 
 impl DashdTestContext {
-    /// Create a new dashd test context.
+    /// Create a new dashd test context for the given chain variant.
     ///
-    /// Returns `None` if `SKIP_DASHD_TESTS` is set. Panics if required env vars
-    /// are missing or if dashd fails to start.
-    pub async fn new() -> Option<Self> {
+    /// Returns `None` if `SKIP_DASHD_TESTS` is set. Panics if the variant
+    /// directory is not available under `DASHD_TEST_DATA` or if dashd fails
+    /// to start.
+    pub async fn new(chain: TestChain) -> Option<Self> {
         if std::env::var("SKIP_DASHD_TESTS").is_ok() {
             eprintln!("Skipping dashd integration test (SKIP_DASHD_TESTS is set)");
             return None;
         }
 
-        let mut config = DashCoreConfig::from_env();
+        let config = DashCoreConfig::from_env(chain)
+            .unwrap_or_else(|| panic!("DASHD_TEST_DATA/{} not found", chain.variant_dir()));
+        Some(Self::create(config).await)
+    }
+
+    /// Shared initialization: copies the datadir, starts dashd, loads wallets.
+    async fn create(mut config: DashCoreConfig) -> Self {
         let datadir = TempDir::new().expect("failed to create temp dir");
         copy_dir(&config.datadir, datadir.path()).expect("failed to copy datadir");
         config.datadir = datadir.path().to_path_buf();
@@ -72,19 +80,20 @@ impl DashdTestContext {
             info!("RPC miner not available (tests requiring block generation will be skipped)");
         }
 
-        Some(DashdTestContext {
+        DashdTestContext {
             node,
             addr,
             initial_height,
             wallet,
             supports_mining,
             datadir,
-        })
+        }
     }
 }
 
 impl Drop for DashdTestContext {
     fn drop(&mut self) {
-        retain_test_dir(self.datadir.path(), "dashd");
+        let label = format!("dashd-{}", self.addr.port());
+        retain_test_dir(self.datadir.path(), &label);
     }
 }

--- a/dash-spv/src/test_utils/mod.rs
+++ b/dash-spv/src/test_utils/mod.rs
@@ -16,6 +16,6 @@ pub const SYNC_TIMEOUT: Duration = Duration::from_secs(180);
 pub use context::DashdTestContext;
 pub use fs_helpers::retain_test_dir;
 pub use network::{test_socket_address, MockNetworkManager};
-pub use node::{DashCoreNode, WalletFile};
+pub use node::{DashCoreNode, TestChain, WalletFile};
 
 pub(crate) use node::DashCoreConfig;

--- a/dash-spv/src/test_utils/node.rs
+++ b/dash-spv/src/test_utils/node.rs
@@ -31,6 +31,24 @@ fn find_available_port() -> u16 {
     panic!("failed to find an available port after {} attempts", MAX_PORT_ATTEMPTS);
 }
 
+/// Selects which pre-built regtest blockchain to use for integration tests.
+#[derive(Debug, Clone, Copy)]
+pub enum TestChain {
+    /// Full 40,000-block regtest chain (wallet integration tests).
+    Full,
+    /// Minimal 200-block regtest chain (faster tests).
+    Minimal,
+}
+
+impl TestChain {
+    pub(crate) fn variant_dir(self) -> &'static str {
+        match self {
+            TestChain::Full => "regtest-40000",
+            TestChain::Minimal => "regtest-200",
+        }
+    }
+}
+
 /// Configuration for Dash Core node.
 pub struct DashCoreConfig {
     /// Path to dashd binary
@@ -46,12 +64,13 @@ pub struct DashCoreConfig {
 }
 
 impl DashCoreConfig {
-    /// Create a config from environment variables with dynamically allocated ports.
+    /// Create a config for the given test chain variant under `DASHD_TEST_DATA`.
     ///
-    /// Reads `DASHD_PATH` and `DASHD_DATADIR`. Panics if either variable
-    /// is not set or if the dashd binary doesn't exist.
-    pub fn from_env() -> Self {
-        let error = "DASHD_PATH and DASHD_DATADIR environment variables are required. \
+    /// `DASHD_TEST_DATA` points to the root directory containing all variants
+    /// (e.g. `regtest-40000`, `regtest-200`). Returns `None` if the variant
+    /// directory doesn't exist. Panics if env vars are missing.
+    pub fn from_env(chain: TestChain) -> Option<Self> {
+        let error = "DASHD_PATH and DASHD_TEST_DATA environment variables are required. \
              Either run `eval $(python3 contrib/setup-dashd.py)` to set them up, \
              or set SKIP_DASHD_TESTS=1 to skip these tests. \
              In CI, the setup-dashd step in build-and-test.yml handles this automatically.";
@@ -63,15 +82,20 @@ impl DashCoreConfig {
             dashd_path.display()
         );
 
-        let datadir = std::env::var("DASHD_DATADIR").ok().map(PathBuf::from).expect(error);
+        let base_datadir = std::env::var("DASHD_TEST_DATA").ok().map(PathBuf::from).expect(error);
+        let datadir = base_datadir.join(chain.variant_dir());
 
-        Self {
+        if !datadir.exists() {
+            return None;
+        }
+
+        Some(Self {
             dashd_path,
             datadir,
             wallet: "default".to_string(),
             p2p_port: find_available_port(),
             rpc_port: find_available_port(),
-        }
+        })
     }
 }
 

--- a/dash-spv/tests/dashd_sync/setup.rs
+++ b/dash-spv/tests/dashd_sync/setup.rs
@@ -1,6 +1,6 @@
 use dash_spv::network::NetworkEvent;
 use dash_spv::storage::{PeerStorage, PersistentPeerStorage, PersistentStorage};
-use dash_spv::test_utils::{retain_test_dir, DashdTestContext};
+use dash_spv::test_utils::{retain_test_dir, DashdTestContext, TestChain};
 use dash_spv::{
     client::{ClientConfig, DashSpvClient},
     network::PeerNetworkManager,
@@ -51,14 +51,18 @@ impl TestContext {
     ///
     /// # Example
     /// ```rust
-    /// if let Some(context) = TestContext::new().await {
+    /// if let Some(context) = TestContext::new(TestChain::Full).await {
     ///     // Proceed with using the `context` for testing.
     /// } else {
     ///     eprintln!("Failed to create the test context");
     /// }
     /// ```
-    pub(super) async fn new() -> Option<Self> {
-        // Create storage dir first so we can set up per-test file logging
+    pub(super) async fn new(chain: TestChain) -> Option<Self> {
+        let dashd = DashdTestContext::new(chain).await?;
+        Some(Self::create(dashd))
+    }
+
+    fn create(dashd: DashdTestContext) -> Self {
         let storage_dir = TempDir::new().expect("Failed to create temporary directory");
         let log_dir = storage_dir.path().join("logs");
         let _log_guard = dash_spv::init_logging(dash_spv::LoggingConfig {
@@ -72,8 +76,6 @@ impl TestContext {
         })
         .expect("Failed to initialize test logging");
 
-        let dashd = DashdTestContext::new().await?;
-
         let client_config = create_test_config(storage_dir.path().to_path_buf(), dashd.addr);
 
         let (wallet, wallet_id) = create_test_wallet(&dashd.wallet.mnemonic, Network::Regtest);
@@ -85,14 +87,14 @@ impl TestContext {
             storage_dir.path().display(),
         );
 
-        Some(TestContext {
+        TestContext {
             dashd,
             storage_dir,
             client_config,
             wallet,
             wallet_id,
             _log_guard,
-        })
+        }
     }
     /// Spawns and initializes a new client instance asynchronously.
     pub(super) async fn spawn_new_client(&self) -> ClientHandle {

--- a/dash-spv/tests/dashd_sync/tests_basic.rs
+++ b/dash-spv/tests/dashd_sync/tests_basic.rs
@@ -10,10 +10,11 @@ use super::helpers::{count_wallet_transactions, get_spendable_balance, wait_for_
 use super::setup::{
     create_and_start_client, create_test_wallet, test_account_options, TestContext,
 };
+use dash_spv::test_utils::TestChain;
 
 #[tokio::test]
 async fn test_wallet_sync() {
-    let Some(ctx) = TestContext::new().await else {
+    let Some(ctx) = TestContext::new(TestChain::Full).await else {
         return;
     };
 
@@ -28,7 +29,7 @@ async fn test_wallet_sync() {
 /// transactions and zero balance, while headers and filters sync fully.
 #[tokio::test]
 async fn test_sync_empty_wallet() {
-    let Some(ctx) = TestContext::new().await else {
+    let Some(ctx) = TestContext::new(TestChain::Full).await else {
         return;
     };
 
@@ -74,7 +75,7 @@ async fn test_sync_empty_wallet() {
 /// transactions while the abandon wallet remains empty.
 #[tokio::test]
 async fn test_sync_two_wallets_same_client() {
-    let Some(ctx) = TestContext::new().await else {
+    let Some(ctx) = TestContext::new(TestChain::Full).await else {
         return;
     };
 

--- a/dash-spv/tests/dashd_sync/tests_disconnect.rs
+++ b/dash-spv/tests/dashd_sync/tests_disconnect.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use super::helpers::run_disconnect_loop;
 use super::setup::{create_and_start_client, create_non_exclusive_test_config, TestContext};
+use dash_spv::test_utils::TestChain;
 
 /// Verify sync completes successfully despite peer disconnections mid-sync.
 ///
@@ -11,7 +12,7 @@ use super::setup::{create_and_start_client, create_non_exclusive_test_config, Te
 /// (automatic reconnection). After all disconnections, waits for full sync.
 #[tokio::test]
 async fn test_sync_with_peer_disconnection() {
-    let Some(ctx) = TestContext::new().await else {
+    let Some(ctx) = TestContext::new(TestChain::Full).await else {
         return;
     };
 
@@ -29,7 +30,7 @@ async fn test_sync_with_peer_disconnection() {
 /// mechanism (known addresses + DNS fallback) instead of the exclusive peer list.
 #[tokio::test]
 async fn test_sync_with_peer_disconnection_non_exclusive() {
-    let Some(ctx) = TestContext::new().await else {
+    let Some(ctx) = TestContext::new(TestChain::Full).await else {
         return;
     };
 

--- a/dash-spv/tests/dashd_sync/tests_restart.rs
+++ b/dash-spv/tests/dashd_sync/tests_restart.rs
@@ -10,11 +10,12 @@ use super::helpers::{get_spendable_balance, is_progress_event, wait_for_sync};
 use dash_spv::test_utils::SYNC_TIMEOUT;
 
 use super::setup::{create_and_start_client, create_test_wallet, TestContext};
+use dash_spv::test_utils::TestChain;
 
 /// Verify sync state is identical after stopping and restarting with same storage.
 #[tokio::test]
 async fn test_sync_restart_consistency() {
-    let Some(ctx) = TestContext::new().await else {
+    let Some(ctx) = TestContext::new(TestChain::Full).await else {
         return;
     };
 
@@ -51,7 +52,7 @@ async fn test_sync_restart_consistency() {
 /// Verify correct rescan behavior when restarting with a fresh wallet but existing storage.
 #[tokio::test]
 async fn test_sync_restart_with_fresh_wallet() {
-    let Some(ctx) = TestContext::new().await else {
+    let Some(ctx) = TestContext::new(TestChain::Full).await else {
         return;
     };
 
@@ -97,7 +98,7 @@ async fn test_sync_restart_with_fresh_wallet() {
 /// full sync lifecycle.
 #[tokio::test]
 async fn test_sync_with_multiple_restarts() {
-    let Some(ctx) = TestContext::new().await else {
+    let Some(ctx) = TestContext::new(TestChain::Full).await else {
         return;
     };
 
@@ -162,7 +163,7 @@ async fn test_sync_with_multiple_restarts() {
 /// Uses a seeded RNG to sleep a random duration (50-500ms) after starting, then restarts.
 #[tokio::test]
 async fn test_sync_with_random_restarts() {
-    let Some(ctx) = TestContext::new().await else {
+    let Some(ctx) = TestContext::new(TestChain::Full).await else {
         return;
     };
 

--- a/dash-spv/tests/dashd_sync/tests_transaction.rs
+++ b/dash-spv/tests/dashd_sync/tests_transaction.rs
@@ -3,6 +3,7 @@ use dashcore::Amount;
 
 use super::helpers::wait_for_sync;
 use super::setup::TestContext;
+use dash_spv::test_utils::TestChain;
 
 /// Verify incremental sync works by generating blocks after initial sync.
 ///
@@ -10,7 +11,7 @@ use super::setup::TestContext;
 /// verifying wallet balance updates and height progression at each step.
 #[tokio::test]
 async fn test_sync_then_generate_blocks() {
-    let Some(ctx) = TestContext::new().await else {
+    let Some(ctx) = TestContext::new(TestChain::Minimal).await else {
         return;
     };
     if !ctx.dashd.supports_mining {
@@ -84,7 +85,7 @@ async fn test_sync_then_generate_blocks() {
 /// are all detected by the SPV client.
 #[tokio::test]
 async fn test_multiple_transactions_in_single_block() {
-    let Some(ctx) = TestContext::new().await else {
+    let Some(ctx) = TestContext::new(TestChain::Minimal).await else {
         return;
     };
     if !ctx.dashd.supports_mining {
@@ -158,7 +159,7 @@ async fn test_multiple_transactions_in_single_block() {
 /// incrementally by the SPV client.
 #[tokio::test]
 async fn test_multiple_transactions_across_blocks() {
-    let Some(ctx) = TestContext::new().await else {
+    let Some(ctx) = TestContext::new(TestChain::Minimal).await else {
         return;
     };
     if !ctx.dashd.supports_mining {


### PR DESCRIPTION
This improves the full rust dashd integration tests runtime on my MBP M2pro (including the coming mempool tests) from ~65s to ~35s.

The 40k chain is still included for better coverage in wallet integration tests where it matter but this PR also adjusts few other tests where the 40k chain is not needed.

Overview:
- Rename `DASHD_DATADIR` to `DASHD_TEST_DATA` (root containing all variants)
- Parameterize `setup-dashd.py` to download both `regtest-40000` and `regtest-200` variants into the shared root
- Add `DashCoreConfig::from_env_variant()` to select a data variant
- Extract shared init logic into `DashdTestContext::create()`
- Add new `TestChain` enum, integrate it into `DashdTestContext::new`
- Update `TEST_DATA_VERSION` to `v0.0.3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test infrastructure with support for multiple blockchain test chain configurations (Full and Minimal variants)
  * Improved test data management to handle multiple test data variants with per-variant downloads and environments
  * Updated test setup scripts for flexible test configuration handling
  * Upgraded test data version in GitHub Actions workflows (v0.0.2 → v0.0.3)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->