### PR TITLE
test: consolidate test transaction creation

### DIFF
--- a/dash/src/test_utils/transaction.rs
+++ b/dash/src/test_utils/transaction.rs
@@ -3,6 +3,17 @@ use std::ops::Range;
 use crate::{Address, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid, Witness};
 
 impl Transaction {
+    /// Creates a transaction with no inputs or outputs.
+    pub fn empty() -> Transaction {
+        Transaction {
+            version: 1,
+            lock_time: 0,
+            input: Vec::new(),
+            output: Vec::new(),
+            special_transaction_payload: None,
+        }
+    }
+
     pub fn dummy(
         address: &Address,
         inputs_ids_range: Range<u8>,

--- a/dash/src/test_utils/transaction.rs
+++ b/dash/src/test_utils/transaction.rs
@@ -4,7 +4,7 @@ use crate::{Address, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid, Witnes
 
 impl Transaction {
     /// Creates a transaction with no inputs or outputs.
-    pub fn empty() -> Transaction {
+    pub fn dummy_empty() -> Transaction {
         Transaction {
             version: 1,
             lock_time: 0,

--- a/key-wallet/src/managed_account/transaction_record.rs
+++ b/key-wallet/src/managed_account/transaction_record.rs
@@ -139,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_transaction_record_creation() {
-        let tx = Transaction::empty();
+        let tx = Transaction::dummy_empty();
         let record = TransactionRecord::new(tx.clone(), 1234567890, 50000, true);
 
         assert_eq!(record.txid, tx.txid());
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn test_confirmations_calculation() {
-        let tx = Transaction::empty();
+        let tx = Transaction::dummy_empty();
         let mut record = TransactionRecord::new(tx, 1234567890, 50000, true);
 
         // Unconfirmed transaction
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_incoming_outgoing() {
-        let tx = Transaction::empty();
+        let tx = Transaction::dummy_empty();
 
         let incoming = TransactionRecord::new(tx.clone(), 1234567890, 50000, false);
         assert!(incoming.is_incoming());
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn test_confirmed_transaction_creation() {
-        let tx = Transaction::empty();
+        let tx = Transaction::dummy_empty();
         let block_hash = BlockHash::all_zeros();
         let record =
             TransactionRecord::new_confirmed(tx.clone(), 100, block_hash, 1234567890, 50000, true);
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_mark_unconfirmed() {
-        let tx = Transaction::empty();
+        let tx = Transaction::dummy_empty();
         let block_hash = BlockHash::all_zeros();
         let mut record =
             TransactionRecord::new_confirmed(tx, 100, block_hash, 1234567890, 50000, true);
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_labels_and_fees() {
-        let tx = Transaction::empty();
+        let tx = Transaction::dummy_empty();
         let mut record = TransactionRecord::new(tx, 1234567890, -50000, true);
 
         assert_eq!(record.fee, None);

--- a/key-wallet/src/managed_account/transaction_record.rs
+++ b/key-wallet/src/managed_account/transaction_record.rs
@@ -137,20 +137,9 @@ mod tests {
     use super::*;
     use dashcore::hashes::Hash;
 
-    fn create_test_transaction() -> Transaction {
-        // Create a minimal test transaction
-        Transaction {
-            version: 1,
-            lock_time: 0,
-            input: Vec::new(),
-            output: Vec::new(),
-            special_transaction_payload: None,
-        }
-    }
-
     #[test]
     fn test_transaction_record_creation() {
-        let tx = create_test_transaction();
+        let tx = Transaction::empty();
         let record = TransactionRecord::new(tx.clone(), 1234567890, 50000, true);
 
         assert_eq!(record.txid, tx.txid());
@@ -162,7 +151,7 @@ mod tests {
 
     #[test]
     fn test_confirmations_calculation() {
-        let tx = create_test_transaction();
+        let tx = Transaction::empty();
         let mut record = TransactionRecord::new(tx, 1234567890, 50000, true);
 
         // Unconfirmed transaction
@@ -187,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_incoming_outgoing() {
-        let tx = create_test_transaction();
+        let tx = Transaction::empty();
 
         let incoming = TransactionRecord::new(tx.clone(), 1234567890, 50000, false);
         assert!(incoming.is_incoming());
@@ -202,7 +191,7 @@ mod tests {
 
     #[test]
     fn test_confirmed_transaction_creation() {
-        let tx = create_test_transaction();
+        let tx = Transaction::empty();
         let block_hash = BlockHash::all_zeros();
         let record =
             TransactionRecord::new_confirmed(tx.clone(), 100, block_hash, 1234567890, 50000, true);
@@ -214,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_mark_unconfirmed() {
-        let tx = create_test_transaction();
+        let tx = Transaction::empty();
         let block_hash = BlockHash::all_zeros();
         let mut record =
             TransactionRecord::new_confirmed(tx, 100, block_hash, 1234567890, 50000, true);
@@ -230,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_labels_and_fees() {
-        let tx = create_test_transaction();
+        let tx = Transaction::empty();
         let mut record = TransactionRecord::new(tx, 1234567890, -50000, true);
 
         assert_eq!(record.fee, None);

--- a/key-wallet/src/transaction_checking/transaction_router/tests/asset_unlock.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/asset_unlock.rs
@@ -1,6 +1,6 @@
 //! Tests for asset unlock transaction handling
 
-use super::helpers::create_test_transaction;
+use super::helpers::test_addr;
 use crate::test_utils::TestWalletContext;
 use crate::transaction_checking::transaction_router::{
     AccountTypeToCheck, TransactionRouter, TransactionType,
@@ -10,9 +10,10 @@ use dashcore::blockdata::transaction::special_transaction::asset_unlock::qualifi
 use dashcore::blockdata::transaction::special_transaction::asset_unlock::request_info::AssetUnlockRequestInfo;
 use dashcore::blockdata::transaction::special_transaction::asset_unlock::unqualified_asset_unlock::AssetUnlockBasePayload;
 use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
+use dashcore::blockdata::transaction::Transaction;
 use dashcore::bls_sig_utils::BLSSignature;
 use dashcore::hashes::Hash;
-use dashcore::{BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid};
+use dashcore::{BlockHash, OutPoint, ScriptBuf, TxIn, TxOut, Txid};
 
 #[test]
 fn test_asset_unlock_routing() {
@@ -35,7 +36,8 @@ fn test_asset_unlock_routing() {
 #[test]
 fn test_asset_unlock_classification() {
     // Test that AssetUnlock transactions are properly classified
-    let mut tx = create_test_transaction(1, vec![100_000_000]);
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000_000]);
 
     // Create an asset unlock payload
     let base = AssetUnlockBasePayload {
@@ -75,7 +77,7 @@ async fn test_asset_unlock_transaction_routing() {
     } = TestWalletContext::new_random();
 
     // Create an asset unlock transaction
-    let tx = Transaction {
+    let tx = dashcore::Transaction {
         version: 3, // Version 3 for special transactions
         lock_time: 0,
         input: vec![TxIn {
@@ -146,7 +148,8 @@ async fn test_asset_unlock_routing_to_bip32_account() {
     } = TestWalletContext::new_random();
 
     // Create an asset unlock transaction to our address
-    let mut tx = create_test_transaction(0, vec![]);
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..0, &[]);
     tx.output.push(TxOut {
         value: 200_000_000, // 2 DASH unlocked
         script_pubkey: address.script_pubkey(),

--- a/key-wallet/src/transaction_checking/transaction_router/tests/classification.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/classification.rs
@@ -11,6 +11,7 @@ use dashcore::blockdata::transaction::special_transaction::provider_update_regis
 use dashcore::blockdata::transaction::special_transaction::provider_update_revocation::ProviderUpdateRevocationPayload;
 use dashcore::blockdata::transaction::special_transaction::provider_update_service::ProviderUpdateServicePayload;
 use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
+use dashcore::blockdata::transaction::Transaction;
 use dashcore::bls_sig_utils::{BLSPublicKey, BLSSignature};
 use dashcore::hash_types::{MerkleRootMasternodeList, MerkleRootQuorums};
 use dashcore::hashes::Hash;
@@ -19,16 +20,19 @@ use dashcore::Txid;
 #[test]
 fn test_classify_standard_transaction() {
     // Standard payment with 1 input, 2 outputs
-    let tx = create_test_transaction(1, vec![50_000_000, 49_000_000]);
+    let addr = test_addr();
+    let tx = Transaction::dummy(&addr, 0..1, &[50_000_000, 49_000_000]);
     assert_eq!(TransactionRouter::classify_transaction(&tx), TransactionType::Standard);
 }
 
 #[test]
 fn test_classify_coinjoin_transaction() {
     // CoinJoin with multiple inputs and denomination outputs
-    let tx = create_test_transaction(
-        5,
-        vec![
+    let addr = test_addr();
+    let tx = Transaction::dummy(
+        &addr,
+        0..5,
+        &[
             100_000_000, // 1 DASH denomination
             100_000_000, // 1 DASH denomination
             10_000_000,  // 0.1 DASH denomination
@@ -48,16 +52,19 @@ fn test_classify_asset_lock_transaction() {
 #[test]
 fn test_not_coinjoin_few_inputs() {
     // Not enough inputs to be CoinJoin
-    let tx = create_test_transaction(2, vec![100_000_000, 100_000_000]);
+    let addr = test_addr();
+    let tx = Transaction::dummy(&addr, 0..2, &[100_000_000, 100_000_000]);
     assert_eq!(TransactionRouter::classify_transaction(&tx), TransactionType::Standard);
 }
 
 #[test]
 fn test_not_coinjoin_no_denominations() {
     // Many inputs/outputs but no standard denominations
-    let tx = create_test_transaction(
-        4,
-        vec![
+    let addr = test_addr();
+    let tx = Transaction::dummy(
+        &addr,
+        0..4,
+        &[
             123_456_789, // Non-standard amount
             987_654_321, // Non-standard amount
             555_555_555, // Non-standard amount
@@ -69,7 +76,8 @@ fn test_not_coinjoin_no_denominations() {
 
 #[test]
 fn test_classify_provider_update_registrar_transaction() {
-    let mut tx = create_test_transaction(1, vec![100_000_000]);
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000_000]);
     // Create a provider update registrar payload
     let payload = ProviderUpdateRegistrarPayload {
         version: 1,
@@ -92,7 +100,8 @@ fn test_classify_provider_update_registrar_transaction() {
 
 #[test]
 fn test_classify_provider_update_service_transaction() {
-    let mut tx = create_test_transaction(1, vec![100_000_000]);
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000_000]);
     // Create a provider update service payload
     let payload = ProviderUpdateServicePayload {
         version: 1,
@@ -118,7 +127,8 @@ fn test_classify_provider_update_service_transaction() {
 
 #[test]
 fn test_classify_provider_update_revocation_transaction() {
-    let mut tx = create_test_transaction(1, vec![100_000_000]);
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000_000]);
     // Create a provider update revocation payload
     let payload = ProviderUpdateRevocationPayload {
         version: 1,
@@ -138,7 +148,8 @@ fn test_classify_provider_update_revocation_transaction() {
 
 #[test]
 fn test_classify_asset_unlock_transaction() {
-    let mut tx = create_test_transaction(1, vec![100_000_000]);
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000_000]);
     // Create an asset unlock payload
     let base = AssetUnlockBasePayload {
         version: 1,
@@ -161,7 +172,8 @@ fn test_classify_asset_unlock_transaction() {
 
 #[test]
 fn test_classify_coinbase_transaction() {
-    let mut tx = create_test_transaction(1, vec![100_000_000]);
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000_000]);
     // Create a coinbase payload
     let payload = CoinbasePayload {
         version: 3,

--- a/key-wallet/src/transaction_checking/transaction_router/tests/coinbase.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/coinbase.rs
@@ -1,5 +1,6 @@
 //! Tests for coinbase transaction handling
 
+use super::helpers::test_addr;
 use crate::test_utils::TestWalletContext;
 use crate::transaction_checking::transaction_router::{
     AccountTypeToCheck, TransactionRouter, TransactionType,
@@ -10,7 +11,7 @@ use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
 use dashcore::bls_sig_utils::BLSSignature;
 use dashcore::hash_types::{MerkleRootMasternodeList, MerkleRootQuorums};
 use dashcore::hashes::Hash;
-use dashcore::{BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid};
+use dashcore::{BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
 
 /// Helper to create a coinbase transaction
 fn create_coinbase_transaction() -> Transaction {
@@ -30,28 +31,6 @@ fn create_coinbase_transaction() -> Transaction {
         }],
         output: vec![TxOut {
             value: 5000000000, // 50 DASH block reward
-            script_pubkey: ScriptBuf::new(),
-        }],
-        special_transaction_payload: None,
-    }
-}
-
-/// Helper to create a basic transaction
-fn create_basic_transaction() -> Transaction {
-    Transaction {
-        version: 2,
-        lock_time: 0,
-        input: vec![TxIn {
-            previous_output: OutPoint {
-                txid: Txid::from_byte_array([1u8; 32]),
-                vout: 0,
-            },
-            script_sig: ScriptBuf::new(),
-            sequence: 0xffffffff,
-            witness: dashcore::Witness::default(),
-        }],
-        output: vec![TxOut {
-            value: 100000,
             script_pubkey: ScriptBuf::new(),
         }],
         special_transaction_payload: None,
@@ -197,7 +176,8 @@ async fn test_update_state_flag_behavior() {
     };
 
     // Create a test transaction
-    let mut tx = create_basic_transaction();
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000]);
     tx.output.push(TxOut {
         value: 75000,
         script_pubkey: address.script_pubkey(),
@@ -268,7 +248,8 @@ async fn test_update_state_flag_behavior() {
 #[test]
 fn test_coinbase_classification() {
     // Test that coinbase transactions are properly classified
-    let mut tx = create_basic_transaction();
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000]);
 
     // Create a coinbase payload
     let payload = CoinbasePayload {

--- a/key-wallet/src/transaction_checking/transaction_router/tests/coinjoin.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/coinjoin.rs
@@ -4,13 +4,16 @@ use super::helpers::*;
 use crate::transaction_checking::transaction_router::{
     AccountTypeToCheck, TransactionRouter, TransactionType,
 };
+use dashcore::blockdata::transaction::Transaction;
 
 #[test]
 fn test_coinjoin_mixing_round() {
     // Standard CoinJoin mixing round
-    let tx = create_test_transaction(
-        6, // Multiple participants
-        vec![
+    let addr = test_addr();
+    let tx = Transaction::dummy(
+        &addr,
+        0..6, // Multiple participants
+        &[
             10_000_000, // 0.1 DASH denomination
             10_000_000, // 0.1 DASH denomination
             10_000_000, // 0.1 DASH denomination
@@ -31,9 +34,11 @@ fn test_coinjoin_mixing_round() {
 #[test]
 fn test_coinjoin_with_multiple_denominations() {
     // CoinJoin with mixed denominations
-    let tx = create_test_transaction(
-        8,
-        vec![
+    let addr = test_addr();
+    let tx = Transaction::dummy(
+        &addr,
+        0..8,
+        &[
             100_000_000, // 1 DASH
             100_000_000, // 1 DASH
             10_000_000,  // 0.1 DASH
@@ -55,9 +60,11 @@ fn test_coinjoin_with_multiple_denominations() {
 #[test]
 fn test_coinjoin_threshold_exactly_half_denominations() {
     // Edge case: exactly half outputs are denominations
-    let tx = create_test_transaction(
-        4,
-        vec![
+    let addr = test_addr();
+    let tx = Transaction::dummy(
+        &addr,
+        0..4,
+        &[
             100_000_000, // Denomination
             100_000_000, // Denomination
             50_000_000,  // Non-denomination
@@ -73,9 +80,11 @@ fn test_coinjoin_threshold_exactly_half_denominations() {
 #[test]
 fn test_not_coinjoin_just_under_threshold() {
     // Just under 50% denominations
-    let tx = create_test_transaction(
-        3,
-        vec![
+    let addr = test_addr();
+    let tx = Transaction::dummy(
+        &addr,
+        0..3,
+        &[
             100_000_000, // Denomination
             50_000_000,  // Non-denomination
             75_000_000,  // Non-denomination

--- a/key-wallet/src/transaction_checking/transaction_router/tests/helpers.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/helpers.rs
@@ -1,50 +1,22 @@
 //! Helper functions for transaction router tests
 
-use dashcore::blockdata::script::ScriptBuf;
 use dashcore::blockdata::transaction::special_transaction::asset_lock::AssetLockPayload;
 use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
-use dashcore::blockdata::transaction::{OutPoint, Transaction};
-use dashcore::hashes::Hash;
-use dashcore::{TxIn, TxOut, Txid, Witness};
+use dashcore::blockdata::transaction::Transaction;
+use dashcore::{Address, Network, TxOut};
 
-/// Helper function to create a test transaction with specified inputs and outputs
-pub fn create_test_transaction(num_inputs: usize, outputs: Vec<u64>) -> Transaction {
-    let inputs = (0..num_inputs)
-        .map(|i| TxIn {
-            previous_output: OutPoint {
-                txid: Txid::from_slice(&[i as u8; 32]).unwrap(),
-                vout: 0,
-            },
-            script_sig: ScriptBuf::new(),
-            sequence: 0xffffffff,
-            witness: Witness::default(),
-        })
-        .collect();
-
-    let outputs = outputs
-        .into_iter()
-        .map(|value| TxOut {
-            value,
-            script_pubkey: ScriptBuf::new(),
-        })
-        .collect();
-
-    Transaction {
-        version: 2,
-        lock_time: 0,
-        input: inputs,
-        output: outputs,
-        special_transaction_payload: None,
-    }
+/// Returns a deterministic test address for creating dummy transactions.
+pub fn test_addr() -> Address {
+    Address::dummy(Network::Regtest, 0)
 }
 
 /// Helper to create an asset lock transaction (used for identity operations)
 pub fn create_asset_lock_transaction(inputs: usize, output_value: u64) -> Transaction {
-    let mut tx = create_test_transaction(inputs, vec![output_value]);
-    // Create a simple asset lock payload with one credit output
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..inputs as u8, &[output_value]);
     let credit_output = TxOut {
         value: output_value,
-        script_pubkey: ScriptBuf::new(),
+        script_pubkey: addr.script_pubkey(),
     };
     let payload = AssetLockPayload {
         version: 1,

--- a/key-wallet/src/transaction_checking/transaction_router/tests/identity_transactions.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/identity_transactions.rs
@@ -12,30 +12,9 @@ use crate::Network;
 use dashcore::blockdata::script::ScriptBuf;
 use dashcore::blockdata::transaction::special_transaction::asset_lock::AssetLockPayload;
 use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
+use dashcore::blockdata::transaction::Transaction;
 use dashcore::hashes::Hash;
-use dashcore::{BlockHash, OutPoint, Transaction, TxIn, TxOut, Txid};
-
-/// Helper to create a basic transaction
-fn create_basic_transaction() -> Transaction {
-    Transaction {
-        version: 2,
-        lock_time: 0,
-        input: vec![TxIn {
-            previous_output: OutPoint {
-                txid: Txid::from_byte_array([1u8; 32]),
-                vout: 0,
-            },
-            script_sig: ScriptBuf::new(),
-            sequence: 0xffffffff,
-            witness: dashcore::Witness::default(),
-        }],
-        output: vec![TxOut {
-            value: 100000,
-            script_pubkey: ScriptBuf::new(),
-        }],
-        special_transaction_payload: None,
-    }
-}
+use dashcore::{BlockHash, OutPoint, TxIn, TxOut, Txid};
 
 #[test]
 fn test_identity_registration() {
@@ -86,7 +65,7 @@ async fn test_identity_registration_account_routing() {
     use dashcore::opcodes;
     use dashcore::script::Builder;
 
-    let tx = Transaction {
+    let tx = dashcore::Transaction {
         version: 3, // Version 3 for special transactions
         lock_time: 0,
         input: vec![TxIn {
@@ -204,8 +183,9 @@ async fn test_normal_payment_to_identity_address_not_detected() {
         )
     });
 
-    // Create a NORMAL transaction (not a special transaction) to the identity address
-    let mut normal_tx = create_basic_transaction();
+    // Create a normal transaction (not a special transaction) to the identity address
+    let addr = test_addr();
+    let mut normal_tx = Transaction::dummy(&addr, 0..1, &[100_000]);
     normal_tx.output.push(TxOut {
         value: 50000,
         script_pubkey: address.script_pubkey(),
@@ -271,9 +251,11 @@ fn test_identity_topup() {
 #[test]
 fn test_multiple_topups_single_transaction() {
     // Asset lock with multiple outputs for bulk top-ups
-    let mut tx = create_test_transaction(
-        2,
-        vec![
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(
+        &addr,
+        0..2,
+        &[
             25_000_000, // Top-up 1
             25_000_000, // Top-up 2
             25_000_000, // Top-up 3

--- a/key-wallet/src/transaction_checking/transaction_router/tests/provider.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/provider.rs
@@ -15,14 +15,16 @@ use dashcore::blockdata::transaction::special_transaction::provider_update_regis
 use dashcore::blockdata::transaction::special_transaction::provider_update_revocation::ProviderUpdateRevocationPayload;
 use dashcore::blockdata::transaction::special_transaction::provider_update_service::ProviderUpdateServicePayload;
 use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
+use dashcore::blockdata::transaction::Transaction;
 use dashcore::bls_sig_utils::BLSSignature;
 use dashcore::hashes::Hash;
-use dashcore::{BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid};
+use dashcore::{BlockHash, OutPoint, ScriptBuf, TxIn, TxOut, Txid};
 
 #[test]
 fn test_provider_update_registrar_classification() {
     // Test ProviderUpdateRegistrar classification
-    let mut tx = create_test_transaction(1, vec![100_000_000]);
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000_000]);
 
     let payload = ProviderUpdateRegistrarPayload {
         version: 1,
@@ -50,7 +52,8 @@ fn test_provider_update_registrar_classification() {
 #[test]
 fn test_provider_update_service_classification() {
     // Test ProviderUpdateService classification
-    let mut tx = create_test_transaction(1, vec![100_000_000]);
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000_000]);
 
     let payload = ProviderUpdateServicePayload {
         version: 1,
@@ -81,7 +84,8 @@ fn test_provider_update_service_classification() {
 #[test]
 fn test_provider_update_revocation_classification() {
     // Test ProviderUpdateRevocation classification
-    let mut tx = create_test_transaction(1, vec![100_000_000]);
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000_000]);
 
     let payload = ProviderUpdateRevocationPayload {
         version: 1,
@@ -169,7 +173,7 @@ async fn test_provider_registration_transaction_routing_check_owner_only() {
         });
 
     // Create a ProRegTx transaction
-    let tx = Transaction {
+    let tx = dashcore::Transaction {
         version: 3, // Version 3 for special transactions
         lock_time: 0,
         input: vec![TxIn {
@@ -305,7 +309,7 @@ async fn test_provider_registration_transaction_routing_check_voting_only() {
         });
 
     // Create a ProRegTx transaction
-    let tx = Transaction {
+    let tx = dashcore::Transaction {
         version: 3, // Version 3 for special transactions
         lock_time: 0,
         input: vec![TxIn {
@@ -442,7 +446,7 @@ async fn test_provider_registration_transaction_routing_check_operator_only() {
         });
 
     // Create a ProRegTx transaction
-    let tx = Transaction {
+    let tx = dashcore::Transaction {
         version: 3, // Version 3 for special transactions
         lock_time: 0,
         input: vec![TxIn {
@@ -641,7 +645,7 @@ async fn test_provider_registration_transaction_routing_check_platform_only() {
         });
 
     // Create a ProRegTx transaction with platform fields (HighPerformance/EvoNode)
-    let tx = Transaction {
+    let tx = dashcore::Transaction {
         version: 3, // Version 3 for special transactions
         lock_time: 0,
         input: vec![TxIn {
@@ -735,7 +739,8 @@ async fn test_provider_registration_transaction_routing_check_platform_only() {
 
 #[test]
 fn test_provider_update_service_with_operator_key() {
-    let mut tx = create_test_transaction(1, vec![100_000_000]);
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000_000]);
 
     // Create provider update service payload
     use dashcore::blockdata::transaction::special_transaction::provider_update_service::ProviderUpdateServicePayload;
@@ -800,7 +805,8 @@ async fn test_provider_update_registrar_with_voting_and_operator() {
         .next_bls_operator_key(None, true)
         .expect("expected operator key");
 
-    let mut tx = create_test_transaction(1, vec![100_000_000]);
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000_000]);
 
     // Create provider update registrar payload
     use dashcore::blockdata::transaction::special_transaction::provider_update_registrar::ProviderUpdateRegistrarPayload;
@@ -873,7 +879,8 @@ async fn test_provider_revocation_classification_and_routing() {
         .next_receive_address(Some(&xpub), true)
         .expect("Failed to generate receive address");
 
-    let mut tx = create_test_transaction(1, vec![1_000_000_000]); // 10 DASH returned collateral
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[1_000_000_000]); // 10 DASH returned collateral
 
     // Add output for returned collateral
     tx.output.push(TxOut {

--- a/key-wallet/src/transaction_checking/transaction_router/tests/routing.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/routing.rs
@@ -1,5 +1,6 @@
 //! Tests for transaction routing logic
 
+use super::helpers::test_addr;
 use crate::account::{AccountType, StandardAccountType};
 use crate::managed_account::address_pool::KeySource;
 use crate::managed_account::managed_account_type::ManagedAccountType;
@@ -11,30 +12,9 @@ use crate::transaction_checking::{TransactionContext, WalletTransactionChecker};
 use crate::wallet::initialization::WalletAccountCreationOptions;
 use crate::wallet::{ManagedWalletInfo, Wallet};
 use crate::Network;
+use dashcore::blockdata::transaction::Transaction;
 use dashcore::hashes::Hash;
-use dashcore::{BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid};
-
-/// Helper to create a basic transaction
-fn create_basic_transaction() -> Transaction {
-    Transaction {
-        version: 2,
-        lock_time: 0,
-        input: vec![TxIn {
-            previous_output: OutPoint {
-                txid: Txid::from_byte_array([1u8; 32]),
-                vout: 0,
-            },
-            script_sig: ScriptBuf::new(),
-            sequence: 0xffffffff,
-            witness: dashcore::Witness::default(),
-        }],
-        output: vec![TxOut {
-            value: 100000,
-            script_pubkey: ScriptBuf::new(),
-        }],
-        special_transaction_payload: None,
-    }
-}
+use dashcore::{BlockHash, ScriptBuf, TxOut};
 
 #[test]
 fn test_standard_transaction_routing() {
@@ -55,7 +35,8 @@ async fn test_transaction_routing_to_bip44_account() {
     } = TestWalletContext::new_random();
 
     // Create a transaction that sends to this address
-    let mut tx = create_basic_transaction();
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000]);
 
     // Add an output to our address
     tx.output.push(TxOut {
@@ -123,7 +104,8 @@ async fn test_transaction_routing_to_bip32_account() {
     };
 
     // Create a transaction that sends to this address
-    let mut tx = create_basic_transaction();
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000]);
 
     // Add an output to our address
     tx.output.push(TxOut {
@@ -235,7 +217,8 @@ async fn test_transaction_routing_to_coinjoin_account() {
     };
 
     // Create a CoinJoin-like transaction (multiple inputs/outputs with same denominations)
-    let mut tx = create_basic_transaction();
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000]);
 
     // Add multiple outputs with CoinJoin denominations
     tx.output.push(TxOut {
@@ -336,7 +319,8 @@ async fn test_transaction_affects_multiple_accounts() {
         .expect("Failed to generate receive address for BIP32 account");
 
     // Create a transaction that sends to multiple accounts
-    let mut tx = create_basic_transaction();
+    let addr = test_addr();
+    let mut tx = Transaction::dummy(&addr, 0..1, &[100_000]);
 
     // Add outputs to different accounts
     tx.output.push(TxOut {

--- a/key-wallet/src/transaction_checking/transaction_router/tests/standard_transactions.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/standard_transactions.rs
@@ -4,13 +4,16 @@ use super::helpers::*;
 use crate::transaction_checking::transaction_router::{
     AccountTypeToCheck, TransactionRouter, TransactionType,
 };
+use dashcore::blockdata::transaction::Transaction;
 
 #[test]
 fn test_single_input_two_outputs_payment() {
     // Typical payment: 1 input -> payment + change
-    let tx = create_test_transaction(
-        1,
-        vec![
+    let addr = test_addr();
+    let tx = Transaction::dummy(
+        &addr,
+        0..1,
+        &[
             25_000_000, // Payment amount
             74_900_000, // Change (minus fee)
         ],
@@ -27,9 +30,11 @@ fn test_single_input_two_outputs_payment() {
 #[test]
 fn test_multiple_inputs_single_output_consolidation() {
     // Consolidation: multiple inputs -> single output
-    let tx = create_test_transaction(
-        5,
-        vec![
+    let addr = test_addr();
+    let tx = Transaction::dummy(
+        &addr,
+        0..5,
+        &[
             499_900_000, // Consolidated amount minus fee
         ],
     );
@@ -47,9 +52,11 @@ fn test_multiple_inputs_single_output_consolidation() {
 fn test_many_inputs_same_account() {
     // Spending many small UTXOs from same account
     // 10 small inputs -> payment + change
-    let tx = create_test_transaction(
-        10,
-        vec![
+    let addr = test_addr();
+    let tx = Transaction::dummy(
+        &addr,
+        0..10,
+        &[
             75_000_000, // Payment
             24_950_000, // Change
         ],
@@ -67,9 +74,11 @@ fn test_many_inputs_same_account() {
 #[test]
 fn test_payment_to_multiple_recipients() {
     // Batch payment: 1 input -> multiple recipients + change
-    let tx = create_test_transaction(
-        1,
-        vec![
+    let addr = test_addr();
+    let tx = Transaction::dummy(
+        &addr,
+        0..1,
+        &[
             10_000_000, // Recipient 1
             15_000_000, // Recipient 2
             20_000_000, // Recipient 3

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -227,28 +227,6 @@ mod tests {
     use dashcore::{Address, BlockHash, TxIn, Txid};
     use dashcore_hashes::Hash;
 
-    /// Create a test transaction that sends to a given address
-    fn create_transaction_to_address(address: &Address, amount: u64) -> Transaction {
-        Transaction {
-            version: 2,
-            lock_time: 0,
-            input: vec![TxIn {
-                previous_output: OutPoint {
-                    txid: Txid::from_byte_array([1u8; 32]),
-                    vout: 0,
-                },
-                script_sig: ScriptBuf::new(),
-                sequence: 0xffffffff,
-                witness: dashcore::Witness::new(),
-            }],
-            output: vec![TxOut {
-                value: amount,
-                script_pubkey: address.script_pubkey(),
-            }],
-            special_transaction_payload: None,
-        }
-    }
-
     /// Test wallet checker with unrelated transaction
     #[tokio::test]
     async fn test_wallet_checker_unrelated_transaction() {
@@ -266,7 +244,7 @@ mod tests {
             &dashcore::PublicKey::from_slice(&[0x02; 33]).expect("Should create pubkey"),
             network,
         );
-        let tx = create_transaction_to_address(&dummy_address, 100_000);
+        let tx = Transaction::dummy(&dummy_address, 0..1, &[100_000]);
 
         let context = TransactionContext::Mempool;
 
@@ -341,7 +319,7 @@ mod tests {
         };
 
         if let (Some(_xpub), Some(address)) = (bip32_xpub, bip32_address) {
-            let tx = create_transaction_to_address(&address, 50_000);
+            let tx = Transaction::dummy(&address, 0..1, &[50_000]);
 
             let context = TransactionContext::InBlock {
                 height: 100000,
@@ -378,7 +356,7 @@ mod tests {
         };
 
         if let (Some(_xpub), Some(address)) = (coinjoin_xpub, coinjoin_address) {
-            let tx = create_transaction_to_address(&address, 75_000);
+            let tx = Transaction::dummy(&address, 0..1, &[75_000]);
 
             let context = TransactionContext::InChainLockedBlock {
                 height: 100001,
@@ -485,7 +463,7 @@ mod tests {
 
         // Fund the wallet with a transaction paying to the receive address
         let funding_value = 50_000_000u64;
-        let funding_tx = create_transaction_to_address(&receive_address, funding_value);
+        let funding_tx = Transaction::dummy(&receive_address, 0..1, &[funding_value]);
         let funding_context = TransactionContext::InBlock {
             height: 1,
             block_hash: Some(BlockHash::from_slice(&[2u8; 32]).expect("Should create block hash")),
@@ -664,7 +642,7 @@ mod tests {
             receive_address: address,
             ..
         } = TestWalletContext::new_random();
-        let tx = create_transaction_to_address(&address, 100_000);
+        let tx = Transaction::dummy(&address, 0..1, &[100_000]);
 
         // Test with Mempool context
         let context = TransactionContext::Mempool;
@@ -695,7 +673,7 @@ mod tests {
             receive_address: address,
             ..
         } = TestWalletContext::new_random();
-        let tx = create_transaction_to_address(&address, 100_000);
+        let tx = Transaction::dummy(&address, 0..1, &[100_000]);
 
         let context = TransactionContext::InBlock {
             height: 100,
@@ -770,7 +748,7 @@ mod tests {
             .expect("Should get change address");
 
         // Create the funding transaction
-        let funding_tx = create_transaction_to_address(&receive_address, 100_000);
+        let funding_tx = Transaction::dummy(&receive_address, 0..1, &[100_000]);
 
         // Create a spending transaction that:
         // 1. Spends the funding tx's output


### PR DESCRIPTION
- Add `Transaction::empty()` for creating transactions with no inputs/outputs, replacing the private `create_test_transaction()` in `transaction_record.rs`
- Remove `create_transaction_to_address` from `key-wallet/src/test_utils/wallet.rs` and replace all call sites in `wallet_checker` tests with `Transaction::dummy`
- Remove `create_test_transaction` from router test helpers and replace all call sites across all router test files with `Transaction::dummy`
- Add `test_addr()` helper in router test helpers to reduce verbosity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated and simplified transaction test setup across suites for improved maintainability.
  * Switched tests to a shared address-based dummy-transaction approach and added an empty-transaction constructor for tests.
  * Removed multiple bespoke local test helpers in favor of unified helpers, reducing boilerplate and standardizing test data and imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->