### PR TITLE
test: extract wallet setup into `TestWalletContext`

### DIFF
--- a/key-wallet/src/test_utils/mod.rs
+++ b/key-wallet/src/test_utils/mod.rs
@@ -1,3 +1,5 @@
 mod account;
 mod utxo;
 mod wallet;
+
+pub use wallet::TestWalletContext;

--- a/key-wallet/src/test_utils/wallet.rs
+++ b/key-wallet/src/test_utils/wallet.rs
@@ -1,9 +1,53 @@
-use dashcore::Network;
+use dashcore::{Address, Network};
 
-use crate::wallet::ManagedWalletInfo;
+use crate::wallet::initialization::WalletAccountCreationOptions;
+use crate::wallet::{ManagedWalletInfo, Wallet};
+use crate::ExtendedPubKey;
 
 impl ManagedWalletInfo {
     pub fn dummy(id: u8) -> Self {
         ManagedWalletInfo::new(Network::Regtest, [id; 32])
+    }
+}
+
+/// Pre-built wallet context for transaction checking tests.
+///
+/// Provides a testnet wallet with a default BIP44 account, a pre-derived
+/// receive address, and the corresponding extended public key.
+pub struct TestWalletContext {
+    pub managed_wallet: ManagedWalletInfo,
+    pub wallet: Wallet,
+    pub receive_address: Address,
+    pub xpub: ExtendedPubKey,
+}
+
+impl TestWalletContext {
+    /// Creates a new random testnet wallet with a BIP44 account and one
+    /// pre-derived receive address.
+    pub fn new_random() -> Self {
+        let wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
+            .expect("Should create wallet");
+        let mut managed_wallet =
+            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
+
+        let xpub = wallet
+            .accounts
+            .standard_bip44_accounts
+            .get(&0)
+            .expect("Should have BIP44 account")
+            .account_xpub;
+
+        let receive_address = managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("Should have managed account")
+            .next_receive_address(Some(&xpub), true)
+            .expect("Should get address");
+
+        Self {
+            managed_wallet,
+            wallet,
+            receive_address,
+            xpub,
+        }
     }
 }

--- a/key-wallet/src/transaction_checking/transaction_router/tests/asset_unlock.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/asset_unlock.rs
@@ -1,13 +1,11 @@
 //! Tests for asset unlock transaction handling
 
 use super::helpers::create_test_transaction;
+use crate::test_utils::TestWalletContext;
 use crate::transaction_checking::transaction_router::{
     AccountTypeToCheck, TransactionRouter, TransactionType,
 };
 use crate::transaction_checking::{TransactionContext, WalletTransactionChecker};
-use crate::wallet::initialization::WalletAccountCreationOptions;
-use crate::wallet::{ManagedWalletInfo, Wallet};
-use crate::Network;
 use dashcore::blockdata::transaction::special_transaction::asset_unlock::qualified_asset_unlock::AssetUnlockPayload;
 use dashcore::blockdata::transaction::special_transaction::asset_unlock::request_info::AssetUnlockRequestInfo;
 use dashcore::blockdata::transaction::special_transaction::asset_unlock::unqualified_asset_unlock::AssetUnlockBasePayload;
@@ -69,28 +67,12 @@ fn test_asset_unlock_classification() {
 
 #[tokio::test]
 async fn test_asset_unlock_transaction_routing() {
-    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
-        .expect("Failed to create wallet with default options");
-
-    let mut managed_wallet_info =
-        ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
-
-    // Get the BIP44 account
-    let account = wallet
-        .accounts
-        .standard_bip44_accounts
-        .get(&0)
-        .expect("Expected BIP44 account at index 0 to exist");
-    let xpub = account.account_xpub;
-
-    let managed_account = managed_wallet_info
-        .first_bip44_managed_account_mut()
-        .expect("Failed to get first BIP44 managed account");
-
-    // Get an address from standard account (where unlocked funds go)
-    let address = managed_account
-        .next_receive_address(Some(&xpub), true)
-        .expect("Failed to generate receive address");
+    let TestWalletContext {
+        managed_wallet: mut managed_wallet_info,
+        mut wallet,
+        receive_address: address,
+        ..
+    } = TestWalletContext::new_random();
 
     // Create an asset unlock transaction
     let tx = Transaction {
@@ -156,28 +138,12 @@ async fn test_asset_unlock_transaction_routing() {
 
 #[tokio::test]
 async fn test_asset_unlock_routing_to_bip32_account() {
-    // Test AssetUnlock routing to BIP32 accounts
-
-    // Create wallet with default options (includes both BIP44 and BIP32)
-    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
-        .expect("Failed to create wallet");
-
-    let mut managed_wallet_info =
-        ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
-
-    // Get address from BIP44 account (we'll use BIP44 to test the routing)
-    let managed_account = managed_wallet_info
-        .first_bip44_managed_account_mut()
-        .expect("Failed to get first BIP44 managed account");
-
-    // Get the account's xpub from wallet
-    let account =
-        wallet.accounts.standard_bip44_accounts.get(&0).expect("Expected BIP44 account at index 0");
-    let xpub = account.account_xpub;
-
-    let address = managed_account
-        .next_receive_address(Some(&xpub), true)
-        .expect("Failed to generate receive address");
+    let TestWalletContext {
+        managed_wallet: mut managed_wallet_info,
+        mut wallet,
+        receive_address: address,
+        ..
+    } = TestWalletContext::new_random();
 
     // Create an asset unlock transaction to our address
     let mut tx = create_test_transaction(0, vec![]);

--- a/key-wallet/src/transaction_checking/transaction_router/tests/coinbase.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/coinbase.rs
@@ -1,12 +1,10 @@
 //! Tests for coinbase transaction handling
 
+use crate::test_utils::TestWalletContext;
 use crate::transaction_checking::transaction_router::{
     AccountTypeToCheck, TransactionRouter, TransactionType,
 };
 use crate::transaction_checking::{TransactionContext, WalletTransactionChecker};
-use crate::wallet::initialization::WalletAccountCreationOptions;
-use crate::wallet::{ManagedWalletInfo, Wallet};
-use crate::Network;
 use dashcore::blockdata::transaction::special_transaction::coinbase::CoinbasePayload;
 use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
 use dashcore::bls_sig_utils::BLSSignature;
@@ -62,29 +60,12 @@ fn create_basic_transaction() -> Transaction {
 
 #[tokio::test]
 async fn test_coinbase_transaction_routing_to_bip44_receive_address() {
-    // Create a wallet with a BIP44 account
-    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
-        .expect("Failed to create wallet with BIP44 account for coinbase test");
-
-    let mut managed_wallet_info =
-        ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
-
-    // Get the account's xpub for address derivation from the wallet's first BIP44 account
-    let account = wallet
-        .accounts
-        .standard_bip44_accounts
-        .get(&0)
-        .expect("Failed to get BIP44 account at index 0");
-    let xpub = account.account_xpub;
-
-    let managed_account = managed_wallet_info
-        .first_bip44_managed_account_mut()
-        .expect("Failed to get first BIP44 managed account");
-
-    // Get a receive address from the BIP44 account
-    let receive_address = managed_account
-        .next_receive_address(Some(&xpub), true)
-        .expect("Failed to generate receive address from BIP44 account");
+    let TestWalletContext {
+        managed_wallet: mut managed_wallet_info,
+        mut wallet,
+        receive_address,
+        ..
+    } = TestWalletContext::new_random();
 
     // Create a coinbase transaction that pays to our receive address
     let mut coinbase_tx = create_coinbase_transaction();
@@ -136,27 +117,17 @@ async fn test_coinbase_transaction_routing_to_bip44_receive_address() {
 
 #[tokio::test]
 async fn test_coinbase_transaction_routing_to_bip44_change_address() {
-    // Create a wallet with a BIP44 account
-    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
-        .expect("Failed to create wallet with BIP44 account for coinbase change test");
-
-    let mut managed_wallet_info =
-        ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
-
-    // Get the account's xpub for address derivation
-    let account = wallet
-        .accounts
-        .standard_bip44_accounts
-        .get(&0)
-        .expect("Failed to get BIP44 account at index 0");
-    let xpub = account.account_xpub;
-
-    let managed_account = managed_wallet_info
-        .first_bip44_managed_account_mut()
-        .expect("Failed to get first BIP44 managed account");
+    let TestWalletContext {
+        managed_wallet: mut managed_wallet_info,
+        mut wallet,
+        xpub,
+        ..
+    } = TestWalletContext::new_random();
 
     // Get a change address from the BIP44 account
-    let change_address = managed_account
+    let change_address = managed_wallet_info
+        .first_bip44_managed_account_mut()
+        .expect("Failed to get first BIP44 managed account")
         .next_change_address(Some(&xpub), true)
         .expect("Failed to generate change address from BIP44 account");
 
@@ -210,29 +181,19 @@ async fn test_coinbase_transaction_routing_to_bip44_change_address() {
 
 #[tokio::test]
 async fn test_update_state_flag_behavior() {
-    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
-        .expect("Failed to create wallet with default options");
-    let mut managed_wallet_info =
-        ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
+    let TestWalletContext {
+        managed_wallet: mut managed_wallet_info,
+        mut wallet,
+        receive_address: address,
+        ..
+    } = TestWalletContext::new_random();
 
-    let account = wallet
-        .accounts
-        .standard_bip44_accounts
-        .get(&0)
-        .expect("Expected BIP44 account at index 0 to exist");
-    let xpub = account.account_xpub;
-
-    // Get an address and initial state
-    let (address, initial_balance, initial_tx_count) = {
+    // Capture initial state
+    let (initial_balance, initial_tx_count) = {
         let managed_account = managed_wallet_info
             .first_bip44_managed_account_mut()
             .expect("Failed to get first BIP44 managed account");
-        let address = managed_account
-            .next_receive_address(Some(&xpub), true)
-            .expect("Failed to generate receive address");
-        let balance = managed_account.balance.spendable();
-        let tx_count = managed_account.transactions.len();
-        (address, balance, tx_count)
+        (managed_account.balance.spendable(), managed_account.transactions.len())
     };
 
     // Create a test transaction
@@ -345,25 +306,12 @@ fn test_coinbase_routing() {
 
 #[tokio::test]
 async fn test_coinbase_transaction_with_payload_routing() {
-    // Test coinbase with special payload routing to BIP44 account
-    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
-        .expect("Failed to create wallet");
-
-    let mut managed_wallet_info =
-        ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
-
-    // Get address from BIP44 account
-    let account =
-        wallet.accounts.standard_bip44_accounts.get(&0).expect("Expected BIP44 account at index 0");
-    let xpub = account.account_xpub;
-
-    let managed_account = managed_wallet_info
-        .first_bip44_managed_account_mut()
-        .expect("Failed to get first BIP44 managed account");
-
-    let address = managed_account
-        .next_receive_address(Some(&xpub), true)
-        .expect("Failed to generate receive address");
+    let TestWalletContext {
+        managed_wallet: mut managed_wallet_info,
+        mut wallet,
+        receive_address: address,
+        ..
+    } = TestWalletContext::new_random();
 
     // Create coinbase transaction with special payload
     let mut coinbase_tx = create_coinbase_transaction();

--- a/key-wallet/src/transaction_checking/transaction_router/tests/routing.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/routing.rs
@@ -3,6 +3,7 @@
 use crate::account::{AccountType, StandardAccountType};
 use crate::managed_account::address_pool::KeySource;
 use crate::managed_account::managed_account_type::ManagedAccountType;
+use crate::test_utils::TestWalletContext;
 use crate::transaction_checking::transaction_router::{
     AccountTypeToCheck, TransactionRouter, TransactionType,
 };
@@ -46,29 +47,12 @@ fn test_standard_transaction_routing() {
 
 #[tokio::test]
 async fn test_transaction_routing_to_bip44_account() {
-    // Create a wallet with a BIP44 account
-    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
-        .expect("Failed to create wallet with default options");
-
-    let mut managed_wallet_info =
-        ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
-
-    // Get the account's xpub for address derivation from the wallet's first BIP44 account
-    let account = wallet
-        .accounts
-        .standard_bip44_accounts
-        .get(&0)
-        .expect("Expected BIP44 account at index 0 to exist");
-    let xpub = account.account_xpub;
-
-    let managed_account = managed_wallet_info
-        .first_bip44_managed_account_mut()
-        .expect("Failed to get first BIP44 managed account");
-
-    // Get an address from the BIP44 account
-    let address = managed_account
-        .next_receive_address(Some(&xpub), true)
-        .expect("Failed to generate receive address");
+    let TestWalletContext {
+        managed_wallet: mut managed_wallet_info,
+        mut wallet,
+        receive_address: address,
+        ..
+    } = TestWalletContext::new_random();
 
     // Create a transaction that sends to this address
     let mut tx = create_basic_transaction();

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -215,6 +215,7 @@ impl WalletTransactionChecker for ManagedWalletInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::TestWalletContext;
     use crate::wallet::initialization::WalletAccountCreationOptions;
     use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
     use crate::wallet::{ManagedWalletInfo, Wallet};
@@ -400,23 +401,12 @@ mod tests {
     /// Test coinbase transaction handling for immature transaction logic
     #[tokio::test]
     async fn test_wallet_checker_coinbase_immature_handling() {
-        let network = Network::Testnet;
-        let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
-            .expect("Should create wallet");
-
-        let mut managed_wallet =
-            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
-
-        // Get a wallet address
-        let account =
-            wallet.accounts.standard_bip44_accounts.get(&0).expect("Should have BIP44 account");
-        let xpub = account.account_xpub;
-
-        let address = managed_wallet
-            .first_bip44_managed_account_mut()
-            .expect("Should have managed account")
-            .next_receive_address(Some(&xpub), true)
-            .expect("Should get address");
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address: address,
+            ..
+        } = TestWalletContext::new_random();
 
         // Create a coinbase transaction
         let coinbase_tx = Transaction {
@@ -486,22 +476,12 @@ mod tests {
     /// Test that spending a wallet-owned UTXO without creating change is detected
     #[tokio::test]
     async fn test_wallet_checker_detects_spend_only_transaction() {
-        let network = Network::Testnet;
-        let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
-            .expect("Should create wallet");
-
-        let mut managed_wallet =
-            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
-
-        // Prepare a managed BIP44 account and derive a receive address
-        let wallet_account =
-            wallet.accounts.standard_bip44_accounts.get(&0).expect("Should have BIP44 account");
-
-        let receive_address = managed_wallet
-            .first_bip44_managed_account_mut()
-            .expect("Should have managed account")
-            .next_receive_address(Some(&wallet_account.account_xpub), true)
-            .expect("Should derive receive address");
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address,
+            ..
+        } = TestWalletContext::new_random();
 
         // Fund the wallet with a transaction paying to the receive address
         let funding_value = 50_000_000u64;
@@ -521,7 +501,7 @@ mod tests {
         // Build a spend transaction that sends funds to an external address only
         let external_address = Address::p2pkh(
             &dashcore::PublicKey::from_slice(&[0x02; 33]).expect("Should create pubkey"),
-            network,
+            Network::Testnet,
         );
         let spend_tx = Transaction {
             version: 2,
@@ -575,25 +555,12 @@ mod tests {
     /// Test the full coinbase maturity flow - immature to mature transition
     #[tokio::test]
     async fn test_wallet_checker_immature_transaction_flow() {
-        use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
-
-        let network = Network::Testnet;
-        let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
-            .expect("Should create wallet");
-
-        let mut managed_wallet =
-            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
-
-        // Get a wallet address
-        let account =
-            wallet.accounts.standard_bip44_accounts.get(&0).expect("Should have BIP44 account");
-        let xpub = account.account_xpub;
-
-        let address = managed_wallet
-            .first_bip44_managed_account_mut()
-            .expect("Should have managed account")
-            .next_receive_address(Some(&xpub), true)
-            .expect("Should get address");
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address: address,
+            ..
+        } = TestWalletContext::new_random();
 
         // Create a coinbase transaction
         let coinbase_tx = Transaction {
@@ -691,24 +658,12 @@ mod tests {
     /// Test mempool context for timestamp/height handling
     #[tokio::test]
     async fn test_wallet_checker_mempool_context() {
-        let network = Network::Testnet;
-        let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
-            .expect("Should create wallet");
-
-        let mut managed_wallet =
-            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
-
-        // Get a wallet address
-        let account =
-            wallet.accounts.standard_bip44_accounts.get(&0).expect("Should have BIP44 account");
-        let xpub = account.account_xpub;
-
-        let address = managed_wallet
-            .first_bip44_managed_account_mut()
-            .expect("Should have managed account")
-            .next_receive_address(Some(&xpub), true)
-            .expect("Should get address");
-
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address: address,
+            ..
+        } = TestWalletContext::new_random();
         let tx = create_transaction_to_address(&address, 100_000);
 
         // Test with Mempool context
@@ -734,24 +689,12 @@ mod tests {
     /// Test that rescanning a block marks transactions as existing
     #[tokio::test]
     async fn test_transaction_rescan_marks_as_existing() {
-        let network = Network::Testnet;
-        let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
-            .expect("Should create wallet");
-
-        let mut managed_wallet =
-            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
-
-        // Get a wallet address
-        let account =
-            wallet.accounts.standard_bip44_accounts.get(&0).expect("Should have BIP44 account");
-        let xpub = account.account_xpub;
-
-        let address = managed_wallet
-            .first_bip44_managed_account_mut()
-            .expect("Should have managed account")
-            .next_receive_address(Some(&xpub), true)
-            .expect("Should get address");
-
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address: address,
+            ..
+        } = TestWalletContext::new_random();
         let tx = create_transaction_to_address(&address, 100_000);
 
         let context = TransactionContext::InBlock {
@@ -813,23 +756,12 @@ mod tests {
     /// Test that UTXO is not created when a spending tx has already been stored
     #[tokio::test]
     async fn test_utxo_not_created_when_already_spent() {
-        let network = Network::Testnet;
-        let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
-            .expect("Should create wallet");
-
-        let mut managed_wallet =
-            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
-
-        // Get wallet addresses (we need two - one for receive, one for change)
-        let account =
-            wallet.accounts.standard_bip44_accounts.get(&0).expect("Should have BIP44 account");
-        let xpub = account.account_xpub;
-
-        let receive_address = managed_wallet
-            .first_bip44_managed_account_mut()
-            .expect("Should have managed account")
-            .next_receive_address(Some(&xpub), true)
-            .expect("Should get address");
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address,
+            xpub,
+        } = TestWalletContext::new_random();
 
         let change_address = managed_wallet
             .first_bip44_managed_account_mut()


### PR DESCRIPTION
Add `TestWalletContext` struct to `test_utils::wallet` providing a pre-built testnet wallet with BIP44 account, receive address, and xpub. Replace duplicated wallet setup code across `wallet_checker`, `routing`, `coinbase`, and `asset_unlock` test modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved wallet setup utilities to support more consistent and maintainable testing across transaction validation modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->