### PR TITLE
feat: wallet transaction confirmation lifecycle

### DIFF
--- a/key-wallet-ffi/examples/check_transaction.c
+++ b/key-wallet-ffi/examples/check_transaction.c
@@ -15,8 +15,9 @@ typedef enum {
 
 typedef enum {
     Mempool = 0,
-    InBlock = 1,
-    InChainLockedBlock = 2
+    InstantSend = 1,
+    InBlock = 2,
+    InChainLockedBlock = 3
 } FFITransactionContext;
 
 typedef struct {

--- a/key-wallet-ffi/include/key_wallet_ffi.h
+++ b/key-wallet-ffi/include/key_wallet_ffi.h
@@ -178,13 +178,17 @@ typedef enum {
      */
     MEMPOOL = 0,
     /*
+     Transaction is in the mempool with an InstantSend lock
+     */
+    INSTANT_SEND = 1,
+    /*
      Transaction is in a block at the given height
      */
-    IN_BLOCK = 1,
+    IN_BLOCK = 2,
     /*
      Transaction is in a chain-locked block at the given height
      */
-    IN_CHAIN_LOCKED_BLOCK = 2,
+    IN_CHAIN_LOCKED_BLOCK = 3,
 } FFITransactionContext;
 
 /*

--- a/key-wallet-ffi/src/transaction.rs
+++ b/key-wallet-ffi/src/transaction.rs
@@ -462,6 +462,7 @@ pub unsafe extern "C" fn wallet_check_transaction(
                     },
                 }
             }
+            FFITransactionContext::InstantSend => TransactionContext::InstantSend,
         };
 
         // Create a ManagedWalletInfo from the wallet

--- a/key-wallet-ffi/src/transaction.rs
+++ b/key-wallet-ffi/src/transaction.rs
@@ -485,8 +485,9 @@ pub unsafe extern "C" fn wallet_check_transaction(
         };
 
         // Block on the async check_transaction call
-        let check_result = tokio::runtime::Handle::current()
-            .block_on(managed_info.check_core_transaction(&tx, context, wallet_mut, update_state));
+        let check_result = tokio::runtime::Handle::current().block_on(
+            managed_info.check_core_transaction(&tx, context, wallet_mut, update_state, true),
+        );
 
         // If we updated state, we need to update the wallet's managed info
         // Note: This would require storing ManagedWalletInfo in FFIWallet

--- a/key-wallet-ffi/src/transaction_checking.rs
+++ b/key-wallet-ffi/src/transaction_checking.rs
@@ -183,6 +183,7 @@ pub unsafe extern "C" fn managed_wallet_check_transaction(
                 },
             }
         }
+        FFITransactionContext::InstantSend => TransactionContext::InstantSend,
     };
 
     // Check the transaction - wallet is now required
@@ -615,7 +616,8 @@ mod tests {
     fn test_transaction_context_conversion() {
         // Test that FFI transaction context values match expectations
         assert_eq!(FFITransactionContext::Mempool as u32, 0);
-        assert_eq!(FFITransactionContext::InBlock as u32, 1);
-        assert_eq!(FFITransactionContext::InChainLockedBlock as u32, 2);
+        assert_eq!(FFITransactionContext::InstantSend as u32, 1);
+        assert_eq!(FFITransactionContext::InBlock as u32, 2);
+        assert_eq!(FFITransactionContext::InChainLockedBlock as u32, 3);
     }
 }

--- a/key-wallet-ffi/src/transaction_checking.rs
+++ b/key-wallet-ffi/src/transaction_checking.rs
@@ -209,8 +209,9 @@ pub unsafe extern "C" fn managed_wallet_check_transaction(
     };
 
     // Block on the async check_transaction call
-    let check_result = tokio::runtime::Handle::current()
-        .block_on(managed_wallet.check_core_transaction(&tx, context, wallet_mut, update_state));
+    let check_result = tokio::runtime::Handle::current().block_on(
+        managed_wallet.check_core_transaction(&tx, context, wallet_mut, update_state, true),
+    );
 
     // Convert the result to FFI format
     let affected_accounts = if check_result.affected_accounts.is_empty() {

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -1,5 +1,6 @@
 //! Common types for FFI interface
 
+use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::{Network, Wallet};
 use std::os::raw::{c_char, c_uint};
 use std::sync::Arc;
@@ -712,10 +713,27 @@ impl FFIWalletAccountCreationOptions {
 pub enum FFITransactionContext {
     /// Transaction is in the mempool (unconfirmed)
     Mempool = 0,
+    /// Transaction is in the mempool with an InstantSend lock
+    InstantSend = 1,
     /// Transaction is in a block at the given height
-    InBlock = 1,
+    InBlock = 2,
     /// Transaction is in a chain-locked block at the given height
-    InChainLockedBlock = 2,
+    InChainLockedBlock = 3,
+}
+
+impl From<TransactionContext> for FFITransactionContext {
+    fn from(ctx: TransactionContext) -> Self {
+        match ctx {
+            TransactionContext::Mempool => FFITransactionContext::Mempool,
+            TransactionContext::InstantSend => FFITransactionContext::InstantSend,
+            TransactionContext::InBlock {
+                ..
+            } => FFITransactionContext::InBlock,
+            TransactionContext::InChainLockedBlock {
+                ..
+            } => FFITransactionContext::InChainLockedBlock,
+        }
+    }
 }
 
 /// FFI-compatible transaction context details
@@ -764,9 +782,7 @@ impl FFITransactionContextDetails {
     }
 
     /// Convert to the native TransactionContext
-    pub fn to_transaction_context(&self) -> key_wallet::transaction_checking::TransactionContext {
-        use key_wallet::transaction_checking::TransactionContext;
-
+    pub fn to_transaction_context(&self) -> TransactionContext {
         match self.context_type {
             FFITransactionContext::Mempool => TransactionContext::Mempool,
             FFITransactionContext::InBlock => {
@@ -815,6 +831,7 @@ impl FFITransactionContextDetails {
                     },
                 }
             }
+            FFITransactionContext::InstantSend => TransactionContext::InstantSend,
         }
     }
 }

--- a/key-wallet-ffi/src/wallet_manager.rs
+++ b/key-wallet-ffi/src/wallet_manager.rs
@@ -780,7 +780,9 @@ pub unsafe extern "C" fn wallet_manager_process_transaction(
     // Process the transaction using async runtime
     let result = manager_ref.runtime.block_on(async {
         let mut manager_guard = manager_ref.manager.write().await;
-        manager_guard.check_transaction_in_all_wallets(&tx, context, update_state_if_found).await
+        manager_guard
+            .check_transaction_in_all_wallets(&tx, context, update_state_if_found, true)
+            .await
     });
 
     FFIError::set_success(error);

--- a/key-wallet-manager/src/wallet_manager/mod.rs
+++ b/key-wallet-manager/src/wallet_manager/mod.rs
@@ -499,6 +499,7 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         tx: &Transaction,
         context: TransactionContext,
         update_state_if_found: bool,
+        update_balance: bool,
     ) -> CheckTransactionsResult {
         let mut result = CheckTransactionsResult::default();
 
@@ -513,7 +514,13 @@ impl<T: WalletInfoInterface> WalletManager<T> {
 
             if let (Some(wallet), Some(wallet_info)) = (wallet_opt, wallet_info_opt) {
                 let check_result = wallet_info
-                    .check_core_transaction(tx, context, wallet, update_state_if_found)
+                    .check_core_transaction(
+                        tx,
+                        context,
+                        wallet,
+                        update_state_if_found,
+                        update_balance,
+                    )
                     .await;
 
                 // If the transaction is relevant

--- a/key-wallet-manager/src/wallet_manager/process_block.rs
+++ b/key-wallet-manager/src/wallet_manager/process_block.rs
@@ -31,7 +31,8 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
                 timestamp: Some(timestamp),
             };
 
-            let check_result = self.check_transaction_in_all_wallets(tx, context, true).await;
+            let check_result =
+                self.check_transaction_in_all_wallets(tx, context, true, false).await;
 
             if !check_result.affected_wallets.is_empty() {
                 if check_result.is_new_transaction {
@@ -53,10 +54,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         let context = TransactionContext::Mempool;
 
         // Check transaction against all wallets
-        self.check_transaction_in_all_wallets(
-            tx, context, true, // update state
-        )
-        .await;
+        self.check_transaction_in_all_wallets(tx, context, true, true).await;
     }
 
     fn monitored_addresses(&self) -> Vec<Address> {

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -384,6 +384,11 @@ impl ManagedCoreAccount {
         account_match: &AccountMatch,
         context: TransactionContext,
     ) -> bool {
+        if !self.transactions.contains_key(&tx.txid()) {
+            self.record_transaction(tx, account_match, context);
+            return true;
+        }
+
         let mut changed = false;
         if let Some(tx_record) = self.transactions.get_mut(&tx.txid()) {
             if !tx_record.is_confirmed() {

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -352,6 +352,8 @@ impl ManagedCoreAccount {
                                 tx.is_coin_base(),
                             );
                             utxo.is_confirmed = context.confirmed();
+                            utxo.is_instantlocked =
+                                matches!(context, TransactionContext::InstantSend);
                             self.utxos.insert(outpoint, utxo);
                         }
                     }
@@ -372,6 +374,30 @@ impl ManagedCoreAccount {
             }
             _ => {}
         }
+    }
+
+    /// Re-process an existing transaction with updated context (e.g., mempool→block confirmation)
+    /// and potentially new address matches from gap limit rescans.
+    pub(crate) fn confirm_transaction(
+        &mut self,
+        tx: &Transaction,
+        account_match: &AccountMatch,
+        context: TransactionContext,
+    ) -> bool {
+        let mut changed = false;
+        if let Some(tx_record) = self.transactions.get_mut(&tx.txid()) {
+            if !tx_record.is_confirmed() {
+                if let (Some(height), Some(hash)) = (context.block_height(), context.block_hash()) {
+                    tx_record.mark_confirmed(height, hash);
+                    changed = true;
+                }
+                if let Some(ts) = context.timestamp() {
+                    tx_record.timestamp = ts as u64;
+                }
+            }
+        }
+        self.update_utxos(tx, account_match, context);
+        changed
     }
 
     /// Record a new transaction and update UTXOs for spendable account types
@@ -397,6 +423,19 @@ impl ManagedCoreAccount {
         self.transactions.insert(tx.txid(), tx_record);
 
         self.update_utxos(tx, account_match, context);
+    }
+
+    /// Mark all UTXOs belonging to a transaction as InstantSend-locked.
+    /// Returns `true` if any UTXO was newly marked.
+    pub(crate) fn mark_utxos_instant_send(&mut self, txid: &Txid) -> bool {
+        let mut any_changed = false;
+        for utxo in self.utxos.values_mut() {
+            if utxo.outpoint.txid == *txid && !utxo.is_instantlocked {
+                utxo.is_instantlocked = true;
+                any_changed = true;
+            }
+        }
+        any_changed
     }
 
     /// Update the account balance

--- a/key-wallet/src/test_utils/wallet.rs
+++ b/key-wallet/src/test_utils/wallet.rs
@@ -74,7 +74,7 @@ impl TestWalletContext {
     }
 
     /// Processes a transaction: runs `check_core_transaction` with `update_state = true`.
-    pub async fn check_transaction_and_update_balance(
+    pub async fn check_transaction(
         &mut self,
         tx: &Transaction,
         context: TransactionContext,
@@ -88,7 +88,7 @@ impl TestWalletContext {
         let tx = Transaction::dummy(&self.receive_address, 0..1, &[amount]);
 
         let result =
-            self.check_transaction_and_update_balance(&tx, TransactionContext::Mempool).await;
+            self.check_transaction(&tx, TransactionContext::Mempool).await;
         assert!(result.is_relevant);
         assert!(result.is_new_transaction);
 

--- a/key-wallet/src/test_utils/wallet.rs
+++ b/key-wallet/src/test_utils/wallet.rs
@@ -79,7 +79,7 @@ impl TestWalletContext {
         tx: &Transaction,
         context: TransactionContext,
     ) -> TransactionCheckResult {
-        self.managed_wallet.check_core_transaction(tx, context, &mut self.wallet, true).await
+        self.managed_wallet.check_core_transaction(tx, context, &mut self.wallet, true, true).await
     }
 
     /// Funds the wallet's receive address via a mempool transaction and
@@ -87,8 +87,7 @@ impl TestWalletContext {
     pub async fn with_mempool_funding(mut self, amount: u64) -> (Self, Transaction) {
         let tx = Transaction::dummy(&self.receive_address, 0..1, &[amount]);
 
-        let result =
-            self.check_transaction(&tx, TransactionContext::Mempool).await;
+        let result = self.check_transaction(&tx, TransactionContext::Mempool).await;
         assert!(result.is_relevant);
         assert!(result.is_new_transaction);
 

--- a/key-wallet/src/test_utils/wallet.rs
+++ b/key-wallet/src/test_utils/wallet.rs
@@ -8,7 +8,6 @@ use crate::transaction_checking::{
 };
 use crate::utxo::Utxo;
 use crate::wallet::initialization::WalletAccountCreationOptions;
-use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use crate::wallet::{ManagedWalletInfo, Wallet};
 use crate::ExtendedPubKey;
 
@@ -74,17 +73,13 @@ impl TestWalletContext {
         self.bip44_account().utxos.values().next().expect("Should have UTXO")
     }
 
-    /// Processes a transaction: runs `check_core_transaction` with `update_state = true`
-    /// and refreshes the cached balance for relevant results.
+    /// Processes a transaction: runs `check_core_transaction` with `update_state = true`.
     pub async fn check_transaction_and_update_balance(
         &mut self,
         tx: &Transaction,
         context: TransactionContext,
     ) -> TransactionCheckResult {
-        let result =
-            self.managed_wallet.check_core_transaction(tx, context, &mut self.wallet, true).await;
-        self.managed_wallet.update_balance();
-        result
+        self.managed_wallet.check_core_transaction(tx, context, &mut self.wallet, true).await
     }
 
     /// Funds the wallet's receive address via a mempool transaction and

--- a/key-wallet/src/test_utils/wallet.rs
+++ b/key-wallet/src/test_utils/wallet.rs
@@ -1,6 +1,14 @@
-use dashcore::{Address, Network};
+use dashcore::blockdata::transaction::Transaction;
+use dashcore::{Address, Network, Txid};
 
+use crate::managed_account::transaction_record::TransactionRecord;
+use crate::managed_account::ManagedCoreAccount;
+use crate::transaction_checking::{
+    TransactionCheckResult, TransactionContext, WalletTransactionChecker,
+};
+use crate::utxo::Utxo;
 use crate::wallet::initialization::WalletAccountCreationOptions;
+use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use crate::wallet::{ManagedWalletInfo, Wallet};
 use crate::ExtendedPubKey;
 
@@ -49,5 +57,46 @@ impl TestWalletContext {
             receive_address,
             xpub,
         }
+    }
+
+    /// Returns the first BIP44 managed account (immutable).
+    pub fn bip44_account(&self) -> &ManagedCoreAccount {
+        self.managed_wallet.first_bip44_managed_account().expect("Should have BIP44 account")
+    }
+
+    /// Returns a transaction record by txid from the first BIP44 account.
+    pub fn transaction(&self, txid: &Txid) -> &TransactionRecord {
+        self.bip44_account().transactions.get(txid).expect("Should have transaction")
+    }
+
+    /// Returns the first UTXO from the first BIP44 account.
+    pub fn first_utxo(&self) -> &Utxo {
+        self.bip44_account().utxos.values().next().expect("Should have UTXO")
+    }
+
+    /// Processes a transaction: runs `check_core_transaction` with `update_state = true`
+    /// and refreshes the cached balance for relevant results.
+    pub async fn check_transaction_and_update_balance(
+        &mut self,
+        tx: &Transaction,
+        context: TransactionContext,
+    ) -> TransactionCheckResult {
+        let result =
+            self.managed_wallet.check_core_transaction(tx, context, &mut self.wallet, true).await;
+        self.managed_wallet.update_balance();
+        result
+    }
+
+    /// Funds the wallet's receive address via a mempool transaction and
+    /// asserts it was accepted. Returns the context and the funding transaction.
+    pub async fn with_mempool_funding(mut self, amount: u64) -> (Self, Transaction) {
+        let tx = Transaction::dummy(&self.receive_address, 0..1, &[amount]);
+
+        let result =
+            self.check_transaction_and_update_balance(&tx, TransactionContext::Mempool).await;
+        assert!(result.is_relevant);
+        assert!(result.is_new_transaction);
+
+        (self, tx)
     }
 }

--- a/key-wallet/src/transaction_checking/account_checker.rs
+++ b/key-wallet/src/transaction_checking/account_checker.rs
@@ -289,7 +289,7 @@ impl ManagedAccountCollection {
     ) -> TransactionCheckResult {
         let mut result = TransactionCheckResult {
             is_relevant: false,
-            is_new_transaction: true,
+            is_new_transaction: false,
             affected_accounts: Vec::new(),
             total_received: 0,
             total_sent: 0,

--- a/key-wallet/src/transaction_checking/transaction_router/tests/asset_unlock.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/asset_unlock.rs
@@ -117,7 +117,8 @@ async fn test_asset_unlock_transaction_routing() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result =
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
     // The transaction should be recognized as relevant
     assert!(result.is_relevant, "Asset unlock transaction should be recognized as relevant");
@@ -178,7 +179,8 @@ async fn test_asset_unlock_routing_to_bip32_account() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result =
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
     // Should be recognized as relevant
     assert!(result.is_relevant, "Asset unlock transaction to BIP32 account should be relevant");

--- a/key-wallet/src/transaction_checking/transaction_router/tests/coinbase.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/coinbase.rs
@@ -72,6 +72,7 @@ async fn test_coinbase_transaction_routing_to_bip44_receive_address() {
             context,
             &mut wallet,
             true, // update state
+            true, // update balance
         )
         .await;
 
@@ -136,6 +137,7 @@ async fn test_coinbase_transaction_routing_to_bip44_change_address() {
             context,
             &mut wallet,
             true, // update state
+            true, // update balance
         )
         .await;
 
@@ -193,7 +195,7 @@ async fn test_update_state_flag_behavior() {
 
     // First check with update_state = false
     let result1 =
-        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, false).await;
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, false, true).await;
 
     assert!(result1.is_relevant);
 
@@ -221,6 +223,7 @@ async fn test_update_state_flag_behavior() {
             context,
             &mut wallet,
             true, // update state
+            true, // update balance
         )
         .await;
 
@@ -324,8 +327,9 @@ async fn test_coinbase_transaction_with_payload_routing() {
         timestamp: Some(1234567890),
     };
 
-    let result =
-        managed_wallet_info.check_core_transaction(&coinbase_tx, context, &mut wallet, true).await;
+    let result = managed_wallet_info
+        .check_core_transaction(&coinbase_tx, context, &mut wallet, true, true)
+        .await;
 
     assert!(result.is_relevant, "Coinbase with payload should be relevant");
     assert_eq!(result.total_received, 5000000000, "Should have received block reward");

--- a/key-wallet/src/transaction_checking/transaction_router/tests/identity_transactions.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/identity_transactions.rs
@@ -123,7 +123,8 @@ async fn test_identity_registration_account_routing() {
     };
 
     // First check without updating state
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result =
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
     println!(
         "Identity registration transaction result: is_relevant={}, received={}, credit_conversion={}",
@@ -205,6 +206,7 @@ async fn test_normal_payment_to_identity_address_not_detected() {
             context,
             &mut wallet,
             true, // update state
+            true, // update balance
         )
         .await;
 

--- a/key-wallet/src/transaction_checking/transaction_router/tests/provider.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/provider.rs
@@ -233,7 +233,8 @@ async fn test_provider_registration_transaction_routing_check_owner_only() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result =
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
     println!(
         "Provider registration transaction result: is_relevant={}, received={}",
@@ -369,7 +370,8 @@ async fn test_provider_registration_transaction_routing_check_voting_only() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result =
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
     println!(
         "Provider registration transaction result (voting): is_relevant={}, received={}",
@@ -506,7 +508,8 @@ async fn test_provider_registration_transaction_routing_check_operator_only() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result =
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
     println!(
         "Provider registration transaction result (operator): is_relevant={}, received={}",
@@ -710,7 +713,8 @@ async fn test_provider_registration_transaction_routing_check_platform_only() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result =
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
     println!(
         "Provider registration transaction result (platform): is_relevant={}, received={}",
@@ -833,7 +837,8 @@ async fn test_provider_update_registrar_with_voting_and_operator() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result =
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
     // Should be recognized as relevant due to voting and operator keys
     assert!(result.is_relevant, "Provider update registrar should be relevant");
@@ -927,7 +932,8 @@ async fn test_provider_revocation_classification_and_routing() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result =
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
     // Should be recognized as relevant due to collateral return
     assert!(result.is_relevant, "Provider revocation with collateral return should be relevant");

--- a/key-wallet/src/transaction_checking/transaction_router/tests/routing.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/routing.rs
@@ -60,6 +60,7 @@ async fn test_transaction_routing_to_bip44_account() {
             context,
             &mut wallet,
             true, // update state
+            true, // update balance
         )
         .await;
 
@@ -123,7 +124,8 @@ async fn test_transaction_routing_to_bip32_account() {
     };
 
     // Check with update_state = false
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, false).await;
+    let result =
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, false, true).await;
 
     // The transaction should be recognized as relevant
     assert!(result.is_relevant, "Transaction should be relevant to the BIP32 account");
@@ -148,6 +150,7 @@ async fn test_transaction_routing_to_bip32_account() {
             context,
             &mut wallet,
             true, // update state
+            true, // update balance
         )
         .await;
 
@@ -242,7 +245,8 @@ async fn test_transaction_routing_to_coinjoin_account() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result =
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
     // This test may fail if CoinJoin detection is not properly implemented
     println!(
@@ -351,6 +355,7 @@ async fn test_transaction_affects_multiple_accounts() {
             context,
             &mut wallet,
             true, // update state
+            true, // update balance
         )
         .await;
 
@@ -368,7 +373,7 @@ async fn test_transaction_affects_multiple_accounts() {
 
     // Test with update_state = false to ensure state isn't modified
     let result2 =
-        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, false).await;
+        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, false, true).await;
 
     assert_eq!(
         result2.total_received, result.total_received,

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -5,6 +5,7 @@
 
 pub(crate) use super::account_checker::TransactionCheckResult;
 use super::transaction_router::TransactionRouter;
+use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use crate::wallet::managed_wallet_info::ManagedWalletInfo;
 use crate::{KeySource, Wallet};
 use async_trait::async_trait;
@@ -189,6 +190,7 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                         account.mark_utxos_instant_send(&txid);
                     }
                 }
+                self.update_balance();
                 return result;
             }
             // Only proceed if the new context is a block confirmation
@@ -255,6 +257,8 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                 "New wallet transaction detected"
             );
         }
+
+        self.update_balance();
 
         result
     }

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -917,7 +917,7 @@ mod tests {
             timestamp: Some(1700000000),
         };
 
-        let result = ctx.check_transaction_and_update_balance(&tx, block_context).await;
+        let result = ctx.check_transaction(&tx, block_context).await;
         assert!(result.is_relevant);
         assert!(!result.is_new_transaction, "Re-processing should mark as existing");
 
@@ -948,7 +948,7 @@ mod tests {
 
         // Stage 2: IS lock
         let result =
-            ctx.check_transaction_and_update_balance(&tx, TransactionContext::InstantSend).await;
+            ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
         assert!(result.is_relevant);
         assert!(!result.is_new_transaction);
         assert_eq!(ctx.managed_wallet.balance().spendable(), 200_000);
@@ -960,7 +960,7 @@ mod tests {
 
         // Duplicate IS lock should be a no-op
         let result_dup =
-            ctx.check_transaction_and_update_balance(&tx, TransactionContext::InstantSend).await;
+            ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
         assert!(result_dup.is_relevant);
         assert!(!result_dup.is_new_transaction);
         assert_eq!(ctx.managed_wallet.balance().spendable(), 200_000);
@@ -972,7 +972,7 @@ mod tests {
             block_hash: Some(block_hash),
             timestamp: Some(1700000000),
         };
-        let result = ctx.check_transaction_and_update_balance(&tx, block_context).await;
+        let result = ctx.check_transaction(&tx, block_context).await;
         assert!(!result.is_new_transaction);
         assert!(ctx.transaction(&txid).is_confirmed());
         assert_eq!(ctx.transaction(&txid).height, Some(1000));
@@ -985,7 +985,7 @@ mod tests {
             block_hash: Some(block_hash),
             timestamp: Some(1700000000),
         };
-        let result = ctx.check_transaction_and_update_balance(&tx, cl_context).await;
+        let result = ctx.check_transaction(&tx, cl_context).await;
         assert!(!result.is_new_transaction);
         assert_eq!(ctx.managed_wallet.balance().spendable(), 200_000);
         assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
@@ -993,7 +993,7 @@ mod tests {
         // Stage 5: late IS lock on already-confirmed tx should be ignored
         let balance_before = ctx.managed_wallet.balance();
         let result =
-            ctx.check_transaction_and_update_balance(&tx, TransactionContext::InstantSend).await;
+            ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
         assert!(result.is_relevant);
         assert!(!result.is_new_transaction);
         assert_eq!(ctx.managed_wallet.balance().spendable(), balance_before.spendable());
@@ -1008,7 +1008,7 @@ mod tests {
 
         // Arrive directly as IS (skipping plain mempool)
         let result =
-            ctx.check_transaction_and_update_balance(&tx, TransactionContext::InstantSend).await;
+            ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
         assert!(result.is_relevant);
         assert!(result.is_new_transaction);
         assert_eq!(result.total_received, 150_000);
@@ -1020,7 +1020,7 @@ mod tests {
 
         // A follow-up IS lock should be a no-op
         let result2 =
-            ctx.check_transaction_and_update_balance(&tx, TransactionContext::InstantSend).await;
+            ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
         assert!(!result2.is_new_transaction);
         assert_eq!(ctx.managed_wallet.balance().spendable(), 150_000);
         assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -13,10 +13,12 @@ use dashcore::prelude::CoreBlockHeight;
 use dashcore::BlockHash;
 
 /// Context for transaction processing
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransactionContext {
     /// Transaction is in the mempool (unconfirmed)
     Mempool,
+    /// Transaction is in the mempool with an InstantSend lock
+    InstantSend,
     /// Transaction is in a block at the given height
     InBlock {
         height: u32,
@@ -35,6 +37,7 @@ impl std::fmt::Display for TransactionContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TransactionContext::Mempool => write!(f, "mempool"),
+            TransactionContext::InstantSend => write!(f, "instant send"),
             TransactionContext::InBlock {
                 height,
                 ..
@@ -60,7 +63,7 @@ impl TransactionContext {
     /// Returns the block height if confirmed.
     pub(crate) fn block_height(&self) -> Option<CoreBlockHeight> {
         match self {
-            TransactionContext::Mempool => None,
+            TransactionContext::Mempool | TransactionContext::InstantSend => None,
             TransactionContext::InBlock {
                 height,
                 ..
@@ -74,7 +77,7 @@ impl TransactionContext {
     /// Returns the block hash if confirmed.
     pub(crate) fn block_hash(&self) -> Option<BlockHash> {
         match self {
-            TransactionContext::Mempool => None,
+            TransactionContext::Mempool | TransactionContext::InstantSend => None,
             TransactionContext::InBlock {
                 block_hash,
                 ..
@@ -88,7 +91,7 @@ impl TransactionContext {
     /// Returns the block time if confirmed.
     pub(crate) fn timestamp(&self) -> Option<u32> {
         match self {
-            TransactionContext::Mempool => None,
+            TransactionContext::Mempool | TransactionContext::InstantSend => None,
             TransactionContext::InBlock {
                 timestamp,
                 ..
@@ -148,14 +151,49 @@ impl WalletTransactionChecker for ManagedWalletInfo {
 
         // Check if this transaction already exists in any affected account
         let txid = tx.txid();
+        let mut is_new = true;
         for account_match in &result.affected_accounts {
             if let Some(account) =
                 self.accounts.get_by_account_type_match(&account_match.account_type_match)
             {
                 if account.transactions.contains_key(&txid) {
-                    result.is_new_transaction = false;
+                    is_new = false;
+                    break;
+                }
+            }
+        }
+        result.is_new_transaction = is_new;
+
+        if !is_new {
+            // IS lock on a transaction that is already confirmed is stale — ignore
+            if context == TransactionContext::InstantSend {
+                if !self.instant_send_locks.insert(txid) {
                     return result;
                 }
+                // Only accept IS transitions for unconfirmed transactions
+                let already_confirmed = result.affected_accounts.iter().any(|am| {
+                    self.accounts
+                        .get_by_account_type_match(&am.account_type_match)
+                        .and_then(|a| a.transactions.get(&txid))
+                        .map_or(false, |r| r.is_confirmed())
+                });
+                if already_confirmed {
+                    return result;
+                }
+                // Mark UTXOs as IS-locked in affected accounts
+                for account_match in &result.affected_accounts {
+                    if let Some(account) = self
+                        .accounts
+                        .get_by_account_type_match_mut(&account_match.account_type_match)
+                    {
+                        account.mark_utxos_instant_send(&txid);
+                    }
+                }
+                return result;
+            }
+            // Only proceed if the new context is a block confirmation
+            if !context.confirmed() {
+                return result;
             }
         }
 
@@ -167,7 +205,11 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                 continue;
             };
 
-            account.record_transaction(tx, &account_match, context);
+            if is_new {
+                account.record_transaction(tx, &account_match, context);
+            } else {
+                account.confirm_transaction(tx, &account_match, context);
+            }
 
             for address_info in account_match.account_type_match.all_involved_addresses() {
                 account.mark_address_used(&address_info.address);
@@ -196,17 +238,23 @@ impl WalletTransactionChecker for ManagedWalletInfo {
             }
         }
 
-        self.increment_transactions();
+        if is_new {
+            // Populate dedup sets when a tx arrives with an initial IS status
+            if context == TransactionContext::InstantSend {
+                self.instant_send_locks.insert(txid);
+            }
+            self.increment_transactions();
 
-        let wallet_net = result.total_received as i64 - result.total_sent as i64;
-        tracing::info!(
-            txid = %tx.txid(),
-            context = %context,
-            net_change = wallet_net,
-            received = result.total_received,
-            sent = result.total_sent,
-            "New wallet transaction detected"
-        );
+            let wallet_net = result.total_received as i64 - result.total_sent as i64;
+            tracing::info!(
+                txid = %tx.txid(),
+                context = %context,
+                net_change = wallet_net,
+                received = result.total_received,
+                sent = result.total_sent,
+                "New wallet transaction detected"
+            );
+        }
 
         result
     }
@@ -729,6 +777,12 @@ mod tests {
             managed_wallet.metadata.total_transactions, total_tx_count_before,
             "total_transactions should not increase on rescan"
         );
+
+        // Verify UTXO state is unchanged after rescan
+        assert_eq!(managed_account.utxos.len(), 1, "Should still have exactly one UTXO");
+        let utxo = managed_account.utxos.values().next().expect("Should have UTXO");
+        assert!(utxo.is_confirmed);
+        assert_eq!(utxo.txout.value, 100_000);
     }
 
     /// Test that UTXO is not created when a spending tx has already been stored
@@ -836,5 +890,135 @@ mod tests {
             "UTXO should be from spend_tx (change), not funding_tx"
         );
         assert_eq!(utxo.txout.value, 50_000, "UTXO value should be 50k (change amount)");
+    }
+
+    /// Test that a mempool transaction gets confirmed when later seen in a block
+    #[tokio::test]
+    async fn test_mempool_transaction_confirmed_by_block() {
+        let (mut ctx, tx) = TestWalletContext::new_random().with_mempool_funding(200_000).await;
+        let txid = tx.txid();
+
+        // Verify unconfirmed state
+        assert!(!ctx.transaction(&txid).is_confirmed(), "Mempool tx should be unconfirmed");
+        assert_eq!(ctx.transaction(&txid).height, None);
+        assert!(!ctx.first_utxo().is_confirmed, "Mempool UTXO should be unconfirmed");
+
+        let total_tx_before = ctx.managed_wallet.metadata.total_transactions;
+
+        // Same transaction now seen in a block
+        let block_hash = BlockHash::from_slice(&[5u8; 32]).expect("Should create block hash");
+        let block_context = TransactionContext::InBlock {
+            height: 500,
+            block_hash: Some(block_hash),
+            timestamp: Some(1700000000),
+        };
+
+        let result = ctx.check_transaction_and_update_balance(&tx, block_context).await;
+        assert!(result.is_relevant);
+        assert!(!result.is_new_transaction, "Re-processing should mark as existing");
+
+        // Verify confirmed state
+        let record = ctx.transaction(&txid);
+        assert!(record.is_confirmed(), "Tx should now be confirmed");
+        assert_eq!(record.height, Some(500));
+        assert_eq!(record.block_hash, Some(block_hash));
+        assert_eq!(record.timestamp, 1700000000);
+        assert!(ctx.first_utxo().is_confirmed, "UTXO should now be confirmed");
+
+        assert_eq!(
+            ctx.managed_wallet.metadata.total_transactions, total_tx_before,
+            "total_transactions should not increase for confirmation of existing tx"
+        );
+    }
+
+    /// Test the full lifecycle: mempool -> IS -> block -> chain-locked block -> late IS
+    #[tokio::test]
+    async fn test_full_confirmation_lifecycle() {
+        let (mut ctx, tx) = TestWalletContext::new_random().with_mempool_funding(200_000).await;
+        let txid = tx.txid();
+
+        // Stage 1: mempool (already done in setup)
+        assert_eq!(ctx.managed_wallet.balance().unconfirmed(), 200_000);
+        assert_eq!(ctx.managed_wallet.balance().spendable(), 0);
+        assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
+
+        // Stage 2: IS lock
+        let result =
+            ctx.check_transaction_and_update_balance(&tx, TransactionContext::InstantSend).await;
+        assert!(result.is_relevant);
+        assert!(!result.is_new_transaction);
+        assert_eq!(ctx.managed_wallet.balance().spendable(), 200_000);
+        assert_eq!(ctx.managed_wallet.balance().unconfirmed(), 0);
+        assert!(ctx.first_utxo().is_instantlocked);
+        assert!(!ctx.first_utxo().is_confirmed);
+        assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
+        assert!(ctx.managed_wallet.instant_send_locks.contains(&txid));
+
+        // Duplicate IS lock should be a no-op
+        let result_dup =
+            ctx.check_transaction_and_update_balance(&tx, TransactionContext::InstantSend).await;
+        assert!(result_dup.is_relevant);
+        assert!(!result_dup.is_new_transaction);
+        assert_eq!(ctx.managed_wallet.balance().spendable(), 200_000);
+
+        // Stage 3: block confirmation
+        let block_hash = BlockHash::from_slice(&[10u8; 32]).expect("hash");
+        let block_context = TransactionContext::InBlock {
+            height: 1000,
+            block_hash: Some(block_hash),
+            timestamp: Some(1700000000),
+        };
+        let result = ctx.check_transaction_and_update_balance(&tx, block_context).await;
+        assert!(!result.is_new_transaction);
+        assert!(ctx.transaction(&txid).is_confirmed());
+        assert_eq!(ctx.transaction(&txid).height, Some(1000));
+        assert!(ctx.first_utxo().is_confirmed);
+        assert_eq!(ctx.managed_wallet.balance().spendable(), 200_000);
+
+        // Stage 4: chain-locked block (rescan with stronger context)
+        let cl_context = TransactionContext::InChainLockedBlock {
+            height: 1000,
+            block_hash: Some(block_hash),
+            timestamp: Some(1700000000),
+        };
+        let result = ctx.check_transaction_and_update_balance(&tx, cl_context).await;
+        assert!(!result.is_new_transaction);
+        assert_eq!(ctx.managed_wallet.balance().spendable(), 200_000);
+        assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
+
+        // Stage 5: late IS lock on already-confirmed tx should be ignored
+        let balance_before = ctx.managed_wallet.balance();
+        let result =
+            ctx.check_transaction_and_update_balance(&tx, TransactionContext::InstantSend).await;
+        assert!(result.is_relevant);
+        assert!(!result.is_new_transaction);
+        assert_eq!(ctx.managed_wallet.balance().spendable(), balance_before.spendable());
+    }
+
+    /// Test that a new transaction arriving directly with IS context populates the dedup set
+    #[tokio::test]
+    async fn test_new_transaction_with_instantsend_context() {
+        let mut ctx = TestWalletContext::new_random();
+        let tx = Transaction::dummy(&ctx.receive_address, 0..1, &[150_000]);
+        let txid = tx.txid();
+
+        // Arrive directly as IS (skipping plain mempool)
+        let result =
+            ctx.check_transaction_and_update_balance(&tx, TransactionContext::InstantSend).await;
+        assert!(result.is_relevant);
+        assert!(result.is_new_transaction);
+        assert_eq!(result.total_received, 150_000);
+
+        // Should be IS-locked and spendable immediately
+        assert!(ctx.first_utxo().is_instantlocked);
+        assert_eq!(ctx.managed_wallet.balance().spendable(), 150_000);
+        assert!(ctx.managed_wallet.instant_send_locks.contains(&txid));
+
+        // A follow-up IS lock should be a no-op
+        let result2 =
+            ctx.check_transaction_and_update_balance(&tx, TransactionContext::InstantSend).await;
+        assert!(!result2.is_new_transaction);
+        assert_eq!(ctx.managed_wallet.balance().spendable(), 150_000);
+        assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
     }
 }

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -117,6 +117,10 @@ pub trait WalletTransactionChecker {
     /// If `update_state` is true, updates account state (transactions, UTXOs, balances, addresses).
     /// If `update_state` is false, only checks relevance without modifying state (useful for previews).
     ///
+    /// If `update_balance` is true, refreshes the cached wallet balance after mutations.
+    /// Callers that batch multiple transactions (e.g. block processing) can pass `false`
+    /// and refresh once at the end via `update_synced_height`.
+    ///
     /// The context parameter indicates where the transaction comes from (mempool, block, etc.)
     ///
     async fn check_core_transaction(
@@ -125,6 +129,7 @@ pub trait WalletTransactionChecker {
         context: TransactionContext,
         wallet: &mut Wallet,
         update_state: bool,
+        update_balance: bool,
     ) -> TransactionCheckResult;
 }
 
@@ -136,6 +141,7 @@ impl WalletTransactionChecker for ManagedWalletInfo {
         context: TransactionContext,
         wallet: &mut Wallet,
         update_state: bool,
+        update_balance: bool,
     ) -> TransactionCheckResult {
         // Classify the transaction
         let tx_type = TransactionRouter::classify_transaction(tx);
@@ -190,7 +196,9 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                         account.mark_utxos_instant_send(&txid);
                     }
                 }
-                self.update_balance();
+                if update_balance {
+                    self.update_balance();
+                }
                 return result;
             }
             // Only proceed if the new context is a block confirmation
@@ -258,7 +266,9 @@ impl WalletTransactionChecker for ManagedWalletInfo {
             );
         }
 
-        self.update_balance();
+        if update_balance {
+            self.update_balance();
+        }
 
         result
     }
@@ -302,7 +312,7 @@ mod tests {
 
         let mut wallet_mut = wallet;
         let result =
-            managed_wallet.check_core_transaction(&tx, context, &mut wallet_mut, true).await;
+            managed_wallet.check_core_transaction(&tx, context, &mut wallet_mut, true, true).await;
 
         // Should return default result with no relevance
         assert!(!result.is_relevant);
@@ -383,7 +393,7 @@ mod tests {
 
             // This should exercise BIP32 account branch in the update logic
             let result =
-                managed_wallet.check_core_transaction(&tx, context, &mut wallet, true).await;
+                managed_wallet.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
             // Should be relevant since it's our address
             assert!(result.is_relevant);
@@ -420,7 +430,7 @@ mod tests {
 
             // This should exercise CoinJoin account branch in the update logic
             let result =
-                managed_wallet.check_core_transaction(&tx, context, &mut wallet, true).await;
+                managed_wallet.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
             // Since this is not a coinjoin looking transaction, we should not pick up on it.
             assert!(!result.is_relevant);
@@ -467,8 +477,9 @@ mod tests {
             timestamp: Some(1234567890),
         };
 
-        let result =
-            managed_wallet.check_core_transaction(&coinbase_tx, context, &mut wallet, true).await;
+        let result = managed_wallet
+            .check_core_transaction(&coinbase_tx, context, &mut wallet, true, true)
+            .await;
         // Set synced_height to block where coinbase was received to trigger balance updates.
         managed_wallet.update_synced_height(block_height);
 
@@ -523,7 +534,7 @@ mod tests {
         };
 
         let funding_result = managed_wallet
-            .check_core_transaction(&funding_tx, funding_context, &mut wallet, true)
+            .check_core_transaction(&funding_tx, funding_context, &mut wallet, true, true)
             .await;
         assert!(funding_result.is_relevant, "Funding transaction must be relevant");
         assert_eq!(funding_result.total_received, funding_value);
@@ -559,7 +570,7 @@ mod tests {
         };
 
         let spend_result = managed_wallet
-            .check_core_transaction(&spend_tx, spend_context, &mut wallet, true)
+            .check_core_transaction(&spend_tx, spend_context, &mut wallet, true, true)
             .await;
 
         assert!(spend_result.is_relevant, "Spend transaction should be detected");
@@ -621,8 +632,9 @@ mod tests {
         };
 
         // Process the coinbase transaction
-        let result =
-            managed_wallet.check_core_transaction(&coinbase_tx, context, &mut wallet, true).await;
+        let result = managed_wallet
+            .check_core_transaction(&coinbase_tx, context, &mut wallet, true, true)
+            .await;
         // Set synced_height to block where coinbase was received to trigger balance updates.
         managed_wallet.update_synced_height(block_height);
 
@@ -699,7 +711,8 @@ mod tests {
         // Test with Mempool context
         let context = TransactionContext::Mempool;
 
-        let result = managed_wallet.check_core_transaction(&tx, context, &mut wallet, true).await;
+        let result =
+            managed_wallet.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
         // Should be relevant
         assert!(result.is_relevant);
@@ -734,7 +747,8 @@ mod tests {
         };
 
         // First processing - should be marked as new
-        let result1 = managed_wallet.check_core_transaction(&tx, context, &mut wallet, true).await;
+        let result1 =
+            managed_wallet.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
         assert!(result1.is_relevant, "Transaction should be relevant");
         assert!(
@@ -758,7 +772,8 @@ mod tests {
         );
 
         // Second processing (simulating rescan) - should be marked as existing
-        let result2 = managed_wallet.check_core_transaction(&tx, context, &mut wallet, true).await;
+        let result2 =
+            managed_wallet.check_core_transaction(&tx, context, &mut wallet, true, true).await;
 
         assert!(result2.is_relevant, "Transaction should still be relevant on rescan");
         assert!(
@@ -839,7 +854,7 @@ mod tests {
         };
 
         let spend_result = managed_wallet
-            .check_core_transaction(&spend_tx, spend_context, &mut wallet, true)
+            .check_core_transaction(&spend_tx, spend_context, &mut wallet, true, true)
             .await;
 
         // Spending tx should be detected because of the change output
@@ -868,7 +883,7 @@ mod tests {
         };
 
         let fund_result = managed_wallet
-            .check_core_transaction(&funding_tx, fund_context, &mut wallet, true)
+            .check_core_transaction(&funding_tx, fund_context, &mut wallet, true, true)
             .await;
 
         // Funding tx should be detected
@@ -947,8 +962,7 @@ mod tests {
         assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
 
         // Stage 2: IS lock
-        let result =
-            ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
+        let result = ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
         assert!(result.is_relevant);
         assert!(!result.is_new_transaction);
         assert_eq!(ctx.managed_wallet.balance().spendable(), 200_000);
@@ -959,8 +973,7 @@ mod tests {
         assert!(ctx.managed_wallet.instant_send_locks.contains(&txid));
 
         // Duplicate IS lock should be a no-op
-        let result_dup =
-            ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
+        let result_dup = ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
         assert!(result_dup.is_relevant);
         assert!(!result_dup.is_new_transaction);
         assert_eq!(ctx.managed_wallet.balance().spendable(), 200_000);
@@ -992,8 +1005,7 @@ mod tests {
 
         // Stage 5: late IS lock on already-confirmed tx should be ignored
         let balance_before = ctx.managed_wallet.balance();
-        let result =
-            ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
+        let result = ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
         assert!(result.is_relevant);
         assert!(!result.is_new_transaction);
         assert_eq!(ctx.managed_wallet.balance().spendable(), balance_before.spendable());
@@ -1007,8 +1019,7 @@ mod tests {
         let txid = tx.txid();
 
         // Arrive directly as IS (skipping plain mempool)
-        let result =
-            ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
+        let result = ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
         assert!(result.is_relevant);
         assert!(result.is_new_transaction);
         assert_eq!(result.total_received, 150_000);
@@ -1019,8 +1030,7 @@ mod tests {
         assert!(ctx.managed_wallet.instant_send_locks.contains(&txid));
 
         // A follow-up IS lock should be a no-op
-        let result2 =
-            ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
+        let result2 = ctx.check_transaction(&tx, TransactionContext::InstantSend).await;
         assert!(!result2.is_new_transaction);
         assert_eq!(ctx.managed_wallet.balance().spendable(), 150_000);
         assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
@@ -1084,8 +1094,7 @@ mod tests {
         let txid = tx.txid();
 
         // First, process the tx as mempool to get the AccountMatch
-        let result =
-            ctx.check_transaction(&tx, TransactionContext::Mempool).await;
+        let result = ctx.check_transaction(&tx, TransactionContext::Mempool).await;
         assert!(result.is_relevant);
         let account_match = result.affected_accounts[0].clone();
 

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -1021,4 +1021,146 @@ mod tests {
         assert_eq!(ctx.managed_wallet.balance().spendable(), 150_000);
         assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
     }
+
+    /// Test that `confirm_transaction` backfills a `TransactionRecord` when the account
+    /// doesn't already have it. This covers the case where a block confirmation is processed
+    /// on an account that missed the initial mempool recording (e.g., due to gap limit
+    /// expansion revealing new address matches).
+    #[tokio::test]
+    async fn test_confirm_transaction_backfills_missing_record() {
+        let (mut ctx, tx) = TestWalletContext::new_random().with_mempool_funding(300_000).await;
+        let txid = tx.txid();
+
+        // Simulate the account missing the mempool record by removing it
+        let account = ctx
+            .managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("Should have BIP44 account");
+        assert!(account.transactions.contains_key(&txid));
+        account.transactions.remove(&txid);
+        assert!(!account.transactions.contains_key(&txid));
+
+        // Now process the same tx as a block confirmation.
+        // Since the wallet's `check_core_transaction` still sees no record,
+        // `is_new` will be true and `record_transaction` is called directly.
+        // To exercise `confirm_transaction`'s backfill, we need the wallet
+        // to think this is NOT new. Re-insert into a second processing path:
+        // first re-add as mempool so `is_new` becomes false, then remove again
+        // and confirm via block.
+        //
+        // Cleaner approach: test `confirm_transaction` directly on the account.
+        let block_hash = BlockHash::from_slice(&[7u8; 32]).expect("hash");
+        let block_context = TransactionContext::InBlock {
+            height: 800,
+            block_hash: Some(block_hash),
+            timestamp: Some(1700000000),
+        };
+
+        // Re-check the transaction: check_core_transaction will see no record in any
+        // account, so it will treat it as new and call `record_transaction`. This still
+        // validates the end-to-end path works after the record was lost.
+        let result = ctx.check_transaction(&tx, block_context).await;
+        assert!(result.is_relevant);
+        assert!(result.is_new_transaction, "Wallet should treat missing record as new");
+
+        let record = ctx.transaction(&txid);
+        assert!(record.is_confirmed());
+        assert_eq!(record.height, Some(800));
+        assert_eq!(record.block_hash, Some(block_hash));
+        assert_eq!(record.timestamp, 1700000000);
+        assert!(ctx.first_utxo().is_confirmed);
+    }
+
+    /// Test `confirm_transaction` backfill directly on `ManagedCoreAccount` when the
+    /// account has no prior record of the transaction.
+    #[tokio::test]
+    async fn test_managed_account_confirm_backfills_missing_transaction() {
+        let mut ctx = TestWalletContext::new_random();
+        let tx = Transaction::dummy(&ctx.receive_address, 0..1, &[250_000]);
+        let txid = tx.txid();
+
+        // First, process the tx as mempool to get the AccountMatch
+        let result =
+            ctx.check_transaction(&tx, TransactionContext::Mempool).await;
+        assert!(result.is_relevant);
+        let account_match = result.affected_accounts[0].clone();
+
+        // Remove the transaction record (simulating a missing account scenario)
+        let account = ctx
+            .managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("Should have BIP44 account");
+        account.transactions.remove(&txid);
+        account.utxos.clear();
+        assert!(!account.transactions.contains_key(&txid));
+        assert!(account.utxos.is_empty());
+
+        // Call `confirm_transaction` directly — the backfill path should create the record
+        let block_hash = BlockHash::from_slice(&[9u8; 32]).expect("hash");
+        let block_context = TransactionContext::InBlock {
+            height: 600,
+            block_hash: Some(block_hash),
+            timestamp: Some(1700000000),
+        };
+        let changed = account.confirm_transaction(&tx, &account_match, block_context);
+        assert!(changed, "Should return true when backfilling a missing record");
+
+        // Verify the transaction was recorded with block context
+        let record = account.transactions.get(&txid).expect("Should have backfilled record");
+        assert!(record.is_confirmed());
+        assert_eq!(record.height, Some(600));
+        assert_eq!(record.block_hash, Some(block_hash));
+        assert_eq!(record.timestamp, 1700000000);
+        assert_eq!(record.net_amount, 250_000);
+
+        // Verify UTXO was also created
+        assert_eq!(account.utxos.len(), 1);
+        let utxo = account.utxos.values().next().expect("Should have UTXO");
+        assert_eq!(utxo.outpoint.txid, txid);
+        assert_eq!(utxo.txout.value, 250_000);
+        assert!(utxo.is_confirmed);
+    }
+
+    /// Test that `confirm_transaction` still works normally when the record already exists.
+    #[tokio::test]
+    async fn test_managed_account_confirm_existing_transaction() {
+        let (mut ctx, tx) = TestWalletContext::new_random().with_mempool_funding(180_000).await;
+        let txid = tx.txid();
+
+        // Get the AccountMatch from the initial processing
+        let account = ctx
+            .managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("Should have BIP44 account");
+        assert!(account.transactions.contains_key(&txid));
+        assert!(!account.transactions.get(&txid).unwrap().is_confirmed());
+
+        // Build a dummy AccountMatch for the confirm call
+        let result = ctx.managed_wallet.accounts.check_transaction(
+            &tx,
+            &TransactionRouter::get_relevant_account_types(
+                &TransactionRouter::classify_transaction(&tx),
+            ),
+        );
+        let account_match = result.affected_accounts[0].clone();
+
+        let block_hash = BlockHash::from_slice(&[11u8; 32]).expect("hash");
+        let block_context = TransactionContext::InBlock {
+            height: 700,
+            block_hash: Some(block_hash),
+            timestamp: Some(1700000000),
+        };
+
+        let account = ctx
+            .managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("Should have BIP44 account");
+        let changed = account.confirm_transaction(&tx, &account_match, block_context);
+        assert!(changed, "Should return true when confirming unconfirmed tx");
+
+        let record = account.transactions.get(&txid).expect("Should have record");
+        assert!(record.is_confirmed());
+        assert_eq!(record.height, Some(700));
+        assert_eq!(record.block_hash, Some(block_hash));
+    }
 }

--- a/key-wallet/src/wallet/managed_wallet_info/mod.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/mod.rs
@@ -20,8 +20,10 @@ use crate::account::ManagedAccountCollection;
 use crate::Network;
 use alloc::string::String;
 use dashcore::prelude::CoreBlockHeight;
+use dashcore::Txid;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 /// Information about a managed wallet
 ///
@@ -45,6 +47,9 @@ pub struct ManagedWalletInfo {
     pub accounts: ManagedAccountCollection,
     /// Cached wallet core balance - should be updated when accounts change
     pub balance: WalletCoreBalance,
+    /// Transactions that have received an InstantSend lock.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub(crate) instant_send_locks: HashSet<Txid>,
 }
 
 impl ManagedWalletInfo {
@@ -58,6 +63,7 @@ impl ManagedWalletInfo {
             metadata: WalletMetadata::default(),
             accounts: ManagedAccountCollection::new(),
             balance: WalletCoreBalance::default(),
+            instant_send_locks: HashSet::new(),
         }
     }
 
@@ -71,6 +77,7 @@ impl ManagedWalletInfo {
             metadata: WalletMetadata::default(),
             accounts: ManagedAccountCollection::new(),
             balance: WalletCoreBalance::default(),
+            instant_send_locks: HashSet::new(),
         }
     }
 
@@ -84,6 +91,7 @@ impl ManagedWalletInfo {
             metadata: WalletMetadata::default(),
             accounts: ManagedAccountCollection::from_account_collection(&wallet.accounts),
             balance: WalletCoreBalance::default(),
+            instant_send_locks: HashSet::new(),
         }
     }
 

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -240,6 +240,9 @@ impl WalletInfoInterface for ManagedWalletInfo {
                 any_changed = true;
             }
         }
+        if any_changed {
+            self.update_balance();
+        }
         any_changed
     }
 }

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -90,6 +90,10 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Update chain state and process any matured transactions
     /// This should be called when the chain tip advances to a new height
     fn update_synced_height(&mut self, current_height: u32);
+
+    /// Mark UTXOs for a transaction as InstantSend-locked across all accounts.
+    /// Returns `true` if any UTXO was newly marked.
+    fn mark_instant_send_utxos(&mut self, txid: &Txid) -> bool;
 }
 
 /// Default implementation for ManagedWalletInfo
@@ -227,5 +231,15 @@ impl WalletInfoInterface for ManagedWalletInfo {
         self.metadata.synced_height = current_height;
         // Update cached balance
         self.update_balance();
+    }
+
+    fn mark_instant_send_utxos(&mut self, txid: &Txid) -> bool {
+        let mut any_changed = false;
+        for account in self.accounts.all_accounts_mut() {
+            if account.mark_utxos_instant_send(txid) {
+                any_changed = true;
+            }
+        }
+        any_changed
     }
 }


### PR DESCRIPTION
Add `InstantSend` transaction context and transaction state management
so wallet transactions can transition through confirmation stages
(mempool → InstantSend → block → chain-locked block).

Key changes:
- Add `TransactionContext::InstantSend` variant with FFI support
- Track known transactions to avoid double-counting
- Add `confirm_transaction()` for mempool→block transitions
- Add IS lock dedup set to prevent redundant processing
- Update balance after any UTXO state change
- Add `status_changed` field to `TransactionCheckResult`
- Add `TestWalletContext::with_mempool_funding()` helper
- Add more relevant tests


Based on: 
- #538 
- #539 
- #542 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added InstantSend support and expanded transaction lifecycle tracking (mempool → instant-send → in-block → chain-locked).
  * Added ability to reprocess/confirm transactions and mark UTXOs as instant-locked.
  * Optionally update wallet balances during transaction checks.

* **Tests**
  * Expanded test coverage for InstantSend lifecycles, rescan/UTXO persistence, and balance-update paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->