### PR TITLE
ci: integrate Codecov test analytics via `cargo-nextest`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,5 @@
+[profile.ci]
+fail-fast = false
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,14 @@
+[test-groups]
+dashd-integration = { max-threads = 1 }
+
 [profile.ci]
 fail-fast = false
 
 [profile.ci.junit]
 path = "junit.xml"
+
+# dashd integration tests each start their own dashd process;
+# running them concurrently causes resource contention and crashes.
+[[profile.ci.overrides]]
+filter = 'binary(dashd_sync)'
+test-group = 'dashd-integration'

--- a/.github/scripts/ci_config.py
+++ b/.github/scripts/ci_config.py
@@ -156,12 +156,14 @@ def run_group_tests(args):
                     "cargo", "llvm-cov", "nextest",
                     "--no-report", "-p", crate, "--all-features",
                     "--profile", "ci",
+                    "--no-tests=pass",
                 ]
             else:
                 cmd = [
                     "cargo", "nextest", "run",
                     "-p", crate, "--all-features",
                     "--profile", "ci",
+                    "--no-tests=pass",
                 ]
             result = subprocess.run(cmd)
 
@@ -176,7 +178,12 @@ def run_group_tests(args):
         finally:
             github_group_end()
 
-    github_output("junit_dir", str(junit_dir))
+    junit_files = sorted(junit_dir.glob("junit-*.xml"))
+    if junit_files:
+        github_output(
+            "junit_files",
+            ",".join(str(f).replace("\\", "/") for f in junit_files),
+        )
 
     if failed:
         print("\n" + "=" * 40)

--- a/.github/scripts/ci_config.py
+++ b/.github/scripts/ci_config.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -143,21 +144,39 @@ def run_group_tests(args):
     if coverage:
         github_output("crate_flags", args.group)
 
+    junit_dir = Path("target/test-results")
+    junit_dir.mkdir(parents=True, exist_ok=True)
+
     for crate in crates:
         github_group_start(f"Testing {crate}")
 
         try:
             if coverage:
-                cmd = ["cargo", "llvm-cov", "--no-report", "-p", crate, "--all-features"]
+                cmd = [
+                    "cargo", "llvm-cov", "nextest",
+                    "--no-report", "-p", crate, "--all-features",
+                    "--profile", "ci",
+                ]
             else:
-                cmd = ["cargo", "test", "-p", crate, "--all-features"]
+                cmd = [
+                    "cargo", "nextest", "run",
+                    "-p", crate, "--all-features",
+                    "--profile", "ci",
+                ]
             result = subprocess.run(cmd)
+
+            # Collect JUnit XML per crate for Codecov test analytics
+            src = Path("target/nextest/ci/junit.xml")
+            if src.exists():
+                shutil.copy(src, junit_dir / f"junit-{crate}.xml")
 
             if result.returncode != 0:
                 failed.append(crate)
                 github_error(f"Test failed for {crate} on {args.os}")
         finally:
             github_group_end()
+
+    github_output("junit_dir", str(junit_dir))
 
     if failed:
         print("\n" + "=" * 40)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           shared-key: "test-${{ inputs.os }}-${{ matrix.group }}"
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Install cargo-llvm-cov
         if: inputs.coverage
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -81,6 +84,14 @@ jobs:
           flags: ${{ steps.tests.outputs.crate_flags }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: target/test-results/junit-*.xml
+          flags: ${{ matrix.group }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload failed dashd test logs
         if: failure() && (matrix.group == 'spv' || matrix.group == 'ffi')

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,10 +86,10 @@ jobs:
           fail_ci_if_error: true
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.tests.outputs.junit_files }}
         uses: codecov/test-results-action@v1
         with:
-          files: target/test-results/junit-*.xml
+          files: ${{ steps.tests.outputs.junit_files }}
           flags: ${{ matrix.group }}
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Switch CI test runner from `cargo test` to `cargo-nextest` to produce JUnit XML reports. Results are uploaded to Codecov's new test analytics feature for tracking test duration trends, failure rates, and flaky tests.