### PR TITLE
refactor: extract `snapshot_balances`/`emit_balance_changes` helpers

### DIFF
--- a/key-wallet-manager/src/wallet_manager/mod.rs
+++ b/key-wallet-manager/src/wallet_manager/mod.rs
@@ -1015,6 +1015,30 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         }
         addresses
     }
+
+    /// Snapshot the current balance of every managed wallet.
+    pub(crate) fn snapshot_balances(&self) -> Vec<(WalletId, WalletCoreBalance)> {
+        self.wallet_infos.iter().map(|(id, info)| (*id, info.balance())).collect()
+    }
+
+    /// Emit `BalanceUpdated` events for wallets whose balance differs from the snapshot.
+    pub(crate) fn emit_balance_changes(&self, old_balances: &[(WalletId, WalletCoreBalance)]) {
+        for (wallet_id, old_balance) in old_balances {
+            if let Some(info) = self.wallet_infos.get(wallet_id) {
+                let new_balance = info.balance();
+                if *old_balance != new_balance {
+                    let event = WalletEvent::BalanceUpdated {
+                        wallet_id: *wallet_id,
+                        spendable: new_balance.spendable(),
+                        unconfirmed: new_balance.unconfirmed(),
+                        immature: new_balance.immature(),
+                        locked: new_balance.locked(),
+                    };
+                    let _ = self.event_sender.send(event);
+                }
+            }
+        }
+    }
 }
 
 /// Wallet manager errors

--- a/key-wallet-manager/src/wallet_manager/process_block.rs
+++ b/key-wallet-manager/src/wallet_manager/process_block.rs
@@ -114,25 +114,13 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
     fn update_synced_height(&mut self, height: CoreBlockHeight) {
         self.synced_height = height;
 
-        // Update each wallet and emit BalanceUpdated events if balance changed
-        for (wallet_id, info) in self.wallet_infos.iter_mut() {
-            let old_balance = info.balance();
-            info.update_synced_height(height);
-            let new_balance = info.balance();
+        let snapshot = self.snapshot_balances();
 
-            // Emit event if balance changed
-            #[cfg(feature = "std")]
-            if old_balance != new_balance {
-                let event = WalletEvent::BalanceUpdated {
-                    wallet_id: *wallet_id,
-                    spendable: new_balance.spendable(),
-                    unconfirmed: new_balance.unconfirmed(),
-                    immature: new_balance.immature(),
-                    locked: new_balance.locked(),
-                };
-                let _ = self.event_sender.send(event);
-            }
+        for (_wallet_id, info) in self.wallet_infos.iter_mut() {
+            info.update_synced_height(height);
         }
+
+        self.emit_balance_changes(&snapshot);
     }
 
     fn filter_committed_height(&self) -> CoreBlockHeight {


### PR DESCRIPTION
To avoid cloning the same pattern in other places in other coming PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal balance change tracking mechanism by implementing a snapshot-based approach for wallet balance updates, improving efficiency of balance event processing without impacting the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->