### PR TITLE
ci: disable `carryforward` flags to flush stale data

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,7 +21,7 @@ comment:
 
 flag_management:
   default_rules:
-    carryforward: true
+    carryforward: false
 
 flags:
   core:


### PR DESCRIPTION
Stale carryforward flags from a previous per-crate flag config are inflating the session count and causing premature codecov status checks. Disabling carryforward temporarily so a clean CI run establishes fresh baseline data for the current flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to adjust carryforward settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->