### PR TITLE
ci: re-enable `carryforward` flags (#543)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,7 +21,7 @@ comment:
 
 flag_management:
   default_rules:
-    carryforward: false
+    carryforward: true
 
 flags:
   core:


### PR DESCRIPTION
This reverts commit e6e6964776706c96035e3eb311b7c02991c57e85.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration settings to enhance flag carryforward behavior tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->