### PR TITLE
ci: re-disable `carryforward` flags

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,7 +21,7 @@ comment:
 
 flag_management:
   default_rules:
-    carryforward: true
+    carryforward: false
 
 flags:
   core:


### PR DESCRIPTION
Didn't work. Maybe it need few runs inbetween to get rid of all stale carryforward data so lets try again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Modified default flag carryforward setting - flags will no longer persist across builds by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->