### PR TITLE
test: add polling wait for wallet callbacks in FFI test

### DIFF
--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -4,6 +4,7 @@ use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use dash_spv_ffi::*;
 
@@ -81,6 +82,23 @@ impl CallbackTracker {
     pub(super) fn assert_no_errors(&self) {
         let errors = self.errors.lock().unwrap();
         assert!(errors.is_empty(), "Unexpected sync errors: {:?}", *errors);
+    }
+
+    /// Polls until the given counter exceeds `baseline`, with a 10s timeout.
+    ///
+    /// Wallet event callbacks travel on a separate broadcast channel from sync
+    /// events, so `wait_for_sync` completing does not guarantee they have fired.
+    pub(super) fn wait_for_callback(&self, counter: &AtomicU32, baseline: u32, name: &str) {
+        let timeout = std::time::Instant::now() + Duration::from_secs(10);
+        while counter.load(Ordering::SeqCst) <= baseline {
+            assert!(
+                std::time::Instant::now() < timeout,
+                "Timed out waiting for {} callback (stuck at baseline {})",
+                name,
+                baseline
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
     }
 }
 

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -98,6 +98,10 @@ fn test_all_callbacks_during_sync() {
         );
         drop(connected_peers);
 
+        // Wait for wallet callbacks (they travel on a separate channel from sync events)
+        tracker.wait_for_callback(&tracker.transaction_received_count, 0, "transaction_received");
+        tracker.wait_for_callback(&tracker.balance_updated_count, 0, "balance_updated");
+
         // Validate wallet event callbacks (test wallet has transactions)
         let tx_received = tracker.transaction_received_count.load(Ordering::SeqCst);
         let balance_updated = tracker.balance_updated_count.load(Ordering::SeqCst);
@@ -266,6 +270,18 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         // Wait for incremental sync to complete
         ctx.wait_for_sync(dashd.initial_height + 1);
 
+        // Wait for wallet callbacks (they travel on a separate channel from sync events)
+        tracker.wait_for_callback(
+            &tracker.transaction_received_count,
+            tx_received_before,
+            "transaction_received",
+        );
+        tracker.wait_for_callback(
+            &tracker.balance_updated_count,
+            balance_updated_before,
+            "balance_updated",
+        );
+
         // Verify on_transaction_received fired for the new transaction
         let tx_received_after = tracker.transaction_received_count.load(Ordering::SeqCst);
         assert!(
@@ -298,14 +314,7 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         );
         drop(received_amounts);
 
-        // Verify on_balance_updated fired after the new transaction
         let balance_updated_after = tracker.balance_updated_count.load(Ordering::SeqCst);
-        assert!(
-            balance_updated_after > balance_updated_before,
-            "on_balance_updated should fire for post-sync transaction: {} -> {}",
-            balance_updated_before,
-            balance_updated_after
-        );
         tracing::info!(
             "Balance updated callback verified: {} -> {}",
             balance_updated_before,

--- a/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
@@ -47,6 +47,7 @@ fn test_ffi_sync_then_generate_blocks() {
 
         // Generate a block containing a wallet transaction and wait for sync.
         let cycle_before = ctx.tracker().last_sync_cycle.load(Ordering::SeqCst);
+        let tx_received_before = ctx.tracker().transaction_received_count.load(Ordering::SeqCst);
         let receive_address = ctx.get_receive_address(&wallet_id);
         let send_amount = Amount::from_sat(100_000_000);
         let txid = dashd.node.send_to_address(&receive_address, send_amount);
@@ -63,6 +64,13 @@ fn test_ffi_sync_then_generate_blocks() {
             "Single block should produce exactly one sync cycle: before={}, after={}",
             cycle_before,
             cycle_after_first
+        );
+
+        // Wait for wallet callback (travels on a separate channel from sync events)
+        ctx.tracker().wait_for_callback(
+            &ctx.tracker().transaction_received_count,
+            tx_received_before,
+            "transaction_received",
         );
 
         // Verify the transaction was received via wallet callback


### PR DESCRIPTION
Fix some flaky tests. They were reading wallet callback data immediately after `wait_for_sync` returned, but the wallet monitoring task may not have processed the event yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added callback synchronization mechanism with configurable timeout to ensure tests properly wait for wallet events before proceeding.
  * Updated test scenarios to wait for wallet notifications (transaction received, balance updated) alongside sync events.
  * Removed assertion that could fail intermittently, relying instead on explicit callback waits for test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->