### PR TITLE
ci: drop `tools` CI test group

### DIFF
--- a/.github/ci-groups.yml
+++ b/.github/ci-groups.yml
@@ -22,13 +22,7 @@ groups:
     - dashcore-rpc
     - dashcore-rpc-json
 
-  tools:
-    - dash-fuzz
-
-# Groups excluded from coverage collection
-no_coverage:
-  - tools
-
 # Crates intentionally not tested (with reason)
 excluded:
   - integration_test  # Requires live Dash node
+  - dash-fuzz  # Honggfuzz binary targets, tested by fuzz.yml

--- a/.github/scripts/ci_config.py
+++ b/.github/scripts/ci_config.py
@@ -113,20 +113,14 @@ def run_group_tests(args):
     crates = groups[args.group] or []
     failed = []
     coverage = getattr(args, "coverage", False)
-    no_coverage = config.get("no_coverage", []) or []
 
-    if coverage and args.group not in no_coverage:
+    if coverage:
         github_output("crate_flags", args.group)
 
     for crate in crates:
-        # Skip dash-fuzz on Windows
-        if args.os == "windows-latest" and crate == "dash-fuzz":
-            github_notice(f"Skipping {crate} on Windows (honggfuzz not supported)")
-            continue
-
         github_group_start(f"Testing {crate}")
 
-        if coverage and args.group not in no_coverage:
+        if coverage:
             cmd = ["cargo", "llvm-cov", "--no-report", "-p", crate, "--all-features"]
         else:
             cmd = ["cargo", "test", "-p", crate, "--all-features"]


### PR DESCRIPTION
`dash-fuzz` contains only honggfuzz binary targets with no `#[test]` functions. It is already tested by the dedicated `fuzz.yml` workflow. Running it in the build-and-test matrix was a no-op on all 4 OS variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI configuration and coverage handling logic.
  * Removed conditional coverage gating, ensuring coverage is consistently applied when requested.
  * Streamlined build exclusion rules for improved CI consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->