### PR TITLE
ci: add `ready-for-review` label automation on CodeRabbit approval

### DIFF
--- a/.github/workflows/coderabbit-label.yml
+++ b/.github/workflows/coderabbit-label.yml
@@ -1,0 +1,29 @@
+name: CodeRabbit Review Label
+
+on:
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    if: github.event.review.user.login == 'coderabbitai[bot]'
+    steps:
+      - name: Add or remove ready-for-review label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_STATE: ${{ github.event.review.state }}
+          EVENT_ACTION: ${{ github.event.action }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ "$EVENT_ACTION" = "submitted" ] && [ "$REVIEW_STATE" = "approved" ]; then
+            echo "CodeRabbit approved, adding ready-for-review label."
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "ready-for-review"
+          elif [ "$EVENT_ACTION" = "dismissed" ] || [ "$REVIEW_STATE" = "changes_requested" ]; then
+            echo "CodeRabbit review dismissed or changes requested, removing ready-for-review label."
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "ready-for-review" || true
+          fi


### PR DESCRIPTION
Adds a workflow that listens to `pull_request_review` events and manages the `ready-for-review` label based on CodeRabbit's review state: added on approval, removed on dismissal or changes requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated label management for pull requests based on CodeRabbit review status, marking PRs as ready for review when approved and removing the label when changes are requested or reviews are dismissed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->