### PR TITLE
fix: unnecessary mutable Wallet against design

### DIFF
--- a/key-wallet-manager/src/wallet_manager/mod.rs
+++ b/key-wallet-manager/src/wallet_manager/mod.rs
@@ -506,9 +506,9 @@ impl<T: WalletInfoInterface> WalletManager<T> {
         let wallet_ids: Vec<WalletId> = self.wallets.keys().cloned().collect();
 
         for wallet_id in wallet_ids {
-            // Get mutable references to both wallet and wallet_info
+            // Get wallet (immutable) and wallet_info (mutable) references
             // We need to use split borrowing to get around Rust's borrow checker
-            let wallet_opt = self.wallets.get_mut(&wallet_id);
+            let wallet_opt = self.wallets.get(&wallet_id);
             let wallet_info_opt = self.wallet_infos.get_mut(&wallet_id);
 
             if let (Some(wallet), Some(wallet_info)) = (wallet_opt, wallet_info_opt) {

--- a/key-wallet/src/transaction_checking/transaction_router/tests/asset_unlock.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/asset_unlock.rs
@@ -71,7 +71,7 @@ fn test_asset_unlock_classification() {
 async fn test_asset_unlock_transaction_routing() {
     let TestWalletContext {
         managed_wallet: mut managed_wallet_info,
-        mut wallet,
+        wallet,
         receive_address: address,
         ..
     } = TestWalletContext::new_random();
@@ -117,7 +117,7 @@ async fn test_asset_unlock_transaction_routing() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_core_transaction(&tx, context, &wallet, true).await;
 
     // The transaction should be recognized as relevant
     assert!(result.is_relevant, "Asset unlock transaction should be recognized as relevant");
@@ -142,7 +142,7 @@ async fn test_asset_unlock_transaction_routing() {
 async fn test_asset_unlock_routing_to_bip32_account() {
     let TestWalletContext {
         managed_wallet: mut managed_wallet_info,
-        mut wallet,
+        wallet,
         receive_address: address,
         ..
     } = TestWalletContext::new_random();
@@ -178,7 +178,7 @@ async fn test_asset_unlock_routing_to_bip32_account() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_core_transaction(&tx, context, &wallet, true).await;
 
     // Should be recognized as relevant
     assert!(result.is_relevant, "Asset unlock transaction to BIP32 account should be relevant");

--- a/key-wallet/src/transaction_checking/transaction_router/tests/coinbase.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/coinbase.rs
@@ -41,7 +41,7 @@ fn create_coinbase_transaction() -> Transaction {
 async fn test_coinbase_transaction_routing_to_bip44_receive_address() {
     let TestWalletContext {
         managed_wallet: mut managed_wallet_info,
-        mut wallet,
+        wallet,
         receive_address,
         ..
     } = TestWalletContext::new_random();
@@ -70,7 +70,7 @@ async fn test_coinbase_transaction_routing_to_bip44_receive_address() {
         .check_core_transaction(
             &coinbase_tx,
             context,
-            &mut wallet,
+            &wallet,
             true, // update state
         )
         .await;
@@ -98,7 +98,7 @@ async fn test_coinbase_transaction_routing_to_bip44_receive_address() {
 async fn test_coinbase_transaction_routing_to_bip44_change_address() {
     let TestWalletContext {
         managed_wallet: mut managed_wallet_info,
-        mut wallet,
+        wallet,
         xpub,
         ..
     } = TestWalletContext::new_random();
@@ -134,7 +134,7 @@ async fn test_coinbase_transaction_routing_to_bip44_change_address() {
         .check_core_transaction(
             &coinbase_tx,
             context,
-            &mut wallet,
+            &wallet,
             true, // update state
         )
         .await;
@@ -162,7 +162,7 @@ async fn test_coinbase_transaction_routing_to_bip44_change_address() {
 async fn test_update_state_flag_behavior() {
     let TestWalletContext {
         managed_wallet: mut managed_wallet_info,
-        mut wallet,
+        wallet,
         receive_address: address,
         ..
     } = TestWalletContext::new_random();
@@ -192,8 +192,7 @@ async fn test_update_state_flag_behavior() {
     };
 
     // First check with update_state = false
-    let result1 =
-        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, false).await;
+    let result1 = managed_wallet_info.check_core_transaction(&tx, context, &wallet, false).await;
 
     assert!(result1.is_relevant);
 
@@ -217,10 +216,7 @@ async fn test_update_state_flag_behavior() {
     // Now check with update_state = true
     let result2 = managed_wallet_info
         .check_core_transaction(
-            &tx,
-            context,
-            &mut wallet,
-            true, // update state
+            &tx, context, &wallet, true, // update state
         )
         .await;
 
@@ -289,7 +285,7 @@ fn test_coinbase_routing() {
 async fn test_coinbase_transaction_with_payload_routing() {
     let TestWalletContext {
         managed_wallet: mut managed_wallet_info,
-        mut wallet,
+        wallet,
         receive_address: address,
         ..
     } = TestWalletContext::new_random();
@@ -325,7 +321,7 @@ async fn test_coinbase_transaction_with_payload_routing() {
     };
 
     let result =
-        managed_wallet_info.check_core_transaction(&coinbase_tx, context, &mut wallet, true).await;
+        managed_wallet_info.check_core_transaction(&coinbase_tx, context, &wallet, true).await;
 
     assert!(result.is_relevant, "Coinbase with payload should be relevant");
     assert_eq!(result.total_received, 5000000000, "Should have received block reward");

--- a/key-wallet/src/transaction_checking/transaction_router/tests/identity_transactions.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/identity_transactions.rs
@@ -123,7 +123,7 @@ async fn test_identity_registration_account_routing() {
     };
 
     // First check without updating state
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_core_transaction(&tx, context, &wallet, true).await;
 
     println!(
         "Identity registration transaction result: is_relevant={}, received={}, credit_conversion={}",
@@ -157,7 +157,7 @@ async fn test_identity_registration_account_routing() {
 async fn test_normal_payment_to_identity_address_not_detected() {
     let network = Network::Testnet;
 
-    let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
+    let wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
     let mut managed_wallet_info =
         ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
@@ -201,10 +201,7 @@ async fn test_normal_payment_to_identity_address_not_detected() {
 
     let result = managed_wallet_info
         .check_core_transaction(
-            &normal_tx,
-            context,
-            &mut wallet,
-            true, // update state
+            &normal_tx, context, &wallet, true, // update state
         )
         .await;
 

--- a/key-wallet/src/transaction_checking/transaction_router/tests/provider.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/provider.rs
@@ -132,7 +132,7 @@ async fn test_provider_registration_transaction_routing_check_owner_only() {
     let other_wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
-    let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
+    let wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut other_managed_wallet_info =
@@ -233,7 +233,7 @@ async fn test_provider_registration_transaction_routing_check_owner_only() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_core_transaction(&tx, context, &wallet, true).await;
 
     println!(
         "Provider registration transaction result: is_relevant={}, received={}",
@@ -268,7 +268,7 @@ async fn test_provider_registration_transaction_routing_check_voting_only() {
     let other_wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
-    let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
+    let wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut other_managed_wallet_info =
@@ -369,7 +369,7 @@ async fn test_provider_registration_transaction_routing_check_voting_only() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_core_transaction(&tx, context, &wallet, true).await;
 
     println!(
         "Provider registration transaction result (voting): is_relevant={}, received={}",
@@ -404,7 +404,7 @@ async fn test_provider_registration_transaction_routing_check_operator_only() {
     let other_wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
-    let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
+    let wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut other_managed_wallet_info =
@@ -506,7 +506,7 @@ async fn test_provider_registration_transaction_routing_check_operator_only() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_core_transaction(&tx, context, &wallet, true).await;
 
     println!(
         "Provider registration transaction result (operator): is_relevant={}, received={}",
@@ -586,7 +586,7 @@ async fn test_provider_registration_transaction_routing_check_platform_only() {
     let other_wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
-    let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
+    let wallet = Wallet::new_random(network, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut other_managed_wallet_info =
@@ -710,7 +710,7 @@ async fn test_provider_registration_transaction_routing_check_platform_only() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_core_transaction(&tx, context, &wallet, true).await;
 
     println!(
         "Provider registration transaction result (platform): is_relevant={}, received={}",
@@ -785,7 +785,7 @@ fn test_provider_update_service_with_operator_key() {
 #[tokio::test]
 async fn test_provider_update_registrar_with_voting_and_operator() {
     // Test provider update registrar classification and routing
-    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
+    let wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut managed_wallet_info =
@@ -833,7 +833,7 @@ async fn test_provider_update_registrar_with_voting_and_operator() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_core_transaction(&tx, context, &wallet, true).await;
 
     // Should be recognized as relevant due to voting and operator keys
     assert!(result.is_relevant, "Provider update registrar should be relevant");
@@ -857,7 +857,7 @@ async fn test_provider_update_registrar_with_voting_and_operator() {
 #[tokio::test]
 async fn test_provider_revocation_classification_and_routing() {
     // Test that provider revocation transactions are properly classified and routed
-    let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
+    let wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
         .expect("Failed to create wallet with default options");
 
     let mut managed_wallet_info =
@@ -927,7 +927,7 @@ async fn test_provider_revocation_classification_and_routing() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_core_transaction(&tx, context, &wallet, true).await;
 
     // Should be recognized as relevant due to collateral return
     assert!(result.is_relevant, "Provider revocation with collateral return should be relevant");

--- a/key-wallet/src/transaction_checking/transaction_router/tests/routing.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/routing.rs
@@ -29,7 +29,7 @@ fn test_standard_transaction_routing() {
 async fn test_transaction_routing_to_bip44_account() {
     let TestWalletContext {
         managed_wallet: mut managed_wallet_info,
-        mut wallet,
+        wallet,
         receive_address: address,
         ..
     } = TestWalletContext::new_random();
@@ -56,10 +56,7 @@ async fn test_transaction_routing_to_bip44_account() {
     // Check the transaction using the managed wallet info
     let result = managed_wallet_info
         .check_core_transaction(
-            &tx,
-            context,
-            &mut wallet,
-            true, // update state
+            &tx, context, &wallet, true, // update state
         )
         .await;
 
@@ -123,7 +120,7 @@ async fn test_transaction_routing_to_bip32_account() {
     };
 
     // Check with update_state = false
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, false).await;
+    let result = managed_wallet_info.check_core_transaction(&tx, context, &wallet, false).await;
 
     // The transaction should be recognized as relevant
     assert!(result.is_relevant, "Transaction should be relevant to the BIP32 account");
@@ -144,10 +141,7 @@ async fn test_transaction_routing_to_bip32_account() {
     // Now check with update_state = true
     let result = managed_wallet_info
         .check_core_transaction(
-            &tx,
-            context,
-            &mut wallet,
-            true, // update state
+            &tx, context, &wallet, true, // update state
         )
         .await;
 
@@ -242,7 +236,7 @@ async fn test_transaction_routing_to_coinjoin_account() {
         timestamp: Some(1234567890),
     };
 
-    let result = managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, true).await;
+    let result = managed_wallet_info.check_core_transaction(&tx, context, &wallet, true).await;
 
     // This test may fail if CoinJoin detection is not properly implemented
     println!(
@@ -347,10 +341,7 @@ async fn test_transaction_affects_multiple_accounts() {
     // Check the transaction
     let result = managed_wallet_info
         .check_core_transaction(
-            &tx,
-            context,
-            &mut wallet,
-            true, // update state
+            &tx, context, &wallet, true, // update state
         )
         .await;
 
@@ -367,8 +358,7 @@ async fn test_transaction_affects_multiple_accounts() {
     println!("Multi-account transaction result: accounts_affected={:?}", result.affected_accounts);
 
     // Test with update_state = false to ensure state isn't modified
-    let result2 =
-        managed_wallet_info.check_core_transaction(&tx, context, &mut wallet, false).await;
+    let result2 = managed_wallet_info.check_core_transaction(&tx, context, &wallet, false).await;
 
     assert_eq!(
         result2.total_received, result.total_received,

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -107,7 +107,7 @@ pub trait WalletTransactionChecker {
     /// Check if a transaction belongs to this wallet with optimized routing
     /// Only checks relevant account types based on transaction type
     ///
-    /// The mutable wallet reference is required to support address generation and potential
+    /// The wallet reference is used for address generation and potential
     /// platform queries (e.g., for DashPay transactions).
     ///
     /// If `update_state` is true, updates account state (transactions, UTXOs, balances, addresses).
@@ -119,7 +119,7 @@ pub trait WalletTransactionChecker {
         &mut self,
         tx: &Transaction,
         context: TransactionContext,
-        wallet: &mut Wallet,
+        wallet: &Wallet,
         update_state: bool,
     ) -> TransactionCheckResult;
 }
@@ -130,7 +130,7 @@ impl WalletTransactionChecker for ManagedWalletInfo {
         &mut self,
         tx: &Transaction,
         context: TransactionContext,
-        wallet: &mut Wallet,
+        wallet: &Wallet,
         update_state: bool,
     ) -> TransactionCheckResult {
         // Classify the transaction
@@ -248,9 +248,8 @@ mod tests {
 
         let context = TransactionContext::Mempool;
 
-        let mut wallet_mut = wallet;
-        let result =
-            managed_wallet.check_core_transaction(&tx, context, &mut wallet_mut, true).await;
+        let wallet_mut = wallet;
+        let result = managed_wallet.check_core_transaction(&tx, context, &wallet_mut, true).await;
 
         // Should return default result with no relevance
         assert!(!result.is_relevant);
@@ -330,8 +329,7 @@ mod tests {
             };
 
             // This should exercise BIP32 account branch in the update logic
-            let result =
-                managed_wallet.check_core_transaction(&tx, context, &mut wallet, true).await;
+            let result = managed_wallet.check_core_transaction(&tx, context, &wallet, true).await;
 
             // Should be relevant since it's our address
             assert!(result.is_relevant);
@@ -367,8 +365,7 @@ mod tests {
             };
 
             // This should exercise CoinJoin account branch in the update logic
-            let result =
-                managed_wallet.check_core_transaction(&tx, context, &mut wallet, true).await;
+            let result = managed_wallet.check_core_transaction(&tx, context, &wallet, true).await;
 
             // Since this is not a coinjoin looking transaction, we should not pick up on it.
             assert!(!result.is_relevant);
@@ -381,7 +378,7 @@ mod tests {
     async fn test_wallet_checker_coinbase_immature_handling() {
         let TestWalletContext {
             mut managed_wallet,
-            mut wallet,
+            wallet,
             receive_address: address,
             ..
         } = TestWalletContext::new_random();
@@ -416,7 +413,7 @@ mod tests {
         };
 
         let result =
-            managed_wallet.check_core_transaction(&coinbase_tx, context, &mut wallet, true).await;
+            managed_wallet.check_core_transaction(&coinbase_tx, context, &wallet, true).await;
         // Set synced_height to block where coinbase was received to trigger balance updates.
         managed_wallet.update_synced_height(block_height);
 
@@ -456,7 +453,7 @@ mod tests {
     async fn test_wallet_checker_detects_spend_only_transaction() {
         let TestWalletContext {
             mut managed_wallet,
-            mut wallet,
+            wallet,
             receive_address,
             ..
         } = TestWalletContext::new_random();
@@ -471,7 +468,7 @@ mod tests {
         };
 
         let funding_result = managed_wallet
-            .check_core_transaction(&funding_tx, funding_context, &mut wallet, true)
+            .check_core_transaction(&funding_tx, funding_context, &wallet, true)
             .await;
         assert!(funding_result.is_relevant, "Funding transaction must be relevant");
         assert_eq!(funding_result.total_received, funding_value);
@@ -506,9 +503,8 @@ mod tests {
             timestamp: Some(1_650_000_100),
         };
 
-        let spend_result = managed_wallet
-            .check_core_transaction(&spend_tx, spend_context, &mut wallet, true)
-            .await;
+        let spend_result =
+            managed_wallet.check_core_transaction(&spend_tx, spend_context, &wallet, true).await;
 
         assert!(spend_result.is_relevant, "Spend transaction should be detected");
         assert_eq!(spend_result.total_received, 0);
@@ -535,7 +531,7 @@ mod tests {
     async fn test_wallet_checker_immature_transaction_flow() {
         let TestWalletContext {
             mut managed_wallet,
-            mut wallet,
+            wallet,
             receive_address: address,
             ..
         } = TestWalletContext::new_random();
@@ -570,7 +566,7 @@ mod tests {
 
         // Process the coinbase transaction
         let result =
-            managed_wallet.check_core_transaction(&coinbase_tx, context, &mut wallet, true).await;
+            managed_wallet.check_core_transaction(&coinbase_tx, context, &wallet, true).await;
         // Set synced_height to block where coinbase was received to trigger balance updates.
         managed_wallet.update_synced_height(block_height);
 
@@ -638,7 +634,7 @@ mod tests {
     async fn test_wallet_checker_mempool_context() {
         let TestWalletContext {
             mut managed_wallet,
-            mut wallet,
+            wallet,
             receive_address: address,
             ..
         } = TestWalletContext::new_random();
@@ -647,7 +643,7 @@ mod tests {
         // Test with Mempool context
         let context = TransactionContext::Mempool;
 
-        let result = managed_wallet.check_core_transaction(&tx, context, &mut wallet, true).await;
+        let result = managed_wallet.check_core_transaction(&tx, context, &wallet, true).await;
 
         // Should be relevant
         assert!(result.is_relevant);
@@ -669,7 +665,7 @@ mod tests {
     async fn test_transaction_rescan_marks_as_existing() {
         let TestWalletContext {
             mut managed_wallet,
-            mut wallet,
+            wallet,
             receive_address: address,
             ..
         } = TestWalletContext::new_random();
@@ -682,7 +678,7 @@ mod tests {
         };
 
         // First processing - should be marked as new
-        let result1 = managed_wallet.check_core_transaction(&tx, context, &mut wallet, true).await;
+        let result1 = managed_wallet.check_core_transaction(&tx, context, &wallet, true).await;
 
         assert!(result1.is_relevant, "Transaction should be relevant");
         assert!(
@@ -706,7 +702,7 @@ mod tests {
         );
 
         // Second processing (simulating rescan) - should be marked as existing
-        let result2 = managed_wallet.check_core_transaction(&tx, context, &mut wallet, true).await;
+        let result2 = managed_wallet.check_core_transaction(&tx, context, &wallet, true).await;
 
         assert!(result2.is_relevant, "Transaction should still be relevant on rescan");
         assert!(
@@ -736,7 +732,7 @@ mod tests {
     async fn test_utxo_not_created_when_already_spent() {
         let TestWalletContext {
             mut managed_wallet,
-            mut wallet,
+            wallet,
             receive_address,
             xpub,
         } = TestWalletContext::new_random();
@@ -780,9 +776,8 @@ mod tests {
             timestamp: Some(1234567890),
         };
 
-        let spend_result = managed_wallet
-            .check_core_transaction(&spend_tx, spend_context, &mut wallet, true)
-            .await;
+        let spend_result =
+            managed_wallet.check_core_transaction(&spend_tx, spend_context, &wallet, true).await;
 
         // Spending tx should be detected because of the change output
         assert!(
@@ -809,9 +804,8 @@ mod tests {
             timestamp: Some(1234567880),
         };
 
-        let fund_result = managed_wallet
-            .check_core_transaction(&funding_tx, fund_context, &mut wallet, true)
-            .await;
+        let fund_result =
+            managed_wallet.check_core_transaction(&funding_tx, fund_context, &wallet, true).await;
 
         // Funding tx should be detected
         assert!(fund_result.is_relevant, "Funding transaction should be detected");


### PR DESCRIPTION
Wallet is supposed to be immutable by design. The `WalletTransactionChecker` trait wants to mutate it (but not actually mutate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced unnecessary mutability in transaction-checking internals by using immutable wallet references where possible.
  * Improved borrow semantics and stability without altering behavior or transaction outcomes.
  * No user-facing API changes.

* **Tests**
  * Updated tests to match the new immutability patterns to ensure continued correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->