### PR TITLE
ci: decouple `verify-groups` from test matrix

### DIFF
--- a/.github/scripts/ci_config.py
+++ b/.github/scripts/ci_config.py
@@ -11,6 +11,7 @@ Subcommands:
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -95,9 +96,34 @@ def verify_groups(args):
 
     print(f"All {len(workspace_crates)} workspace crates are assigned to test groups")
 
-    # Output groups for GitHub Actions matrix
-    github_output("groups", json.dumps(list(groups.keys())))
+    # Verify the hardcoded matrix in build-and-test.yml matches ci-groups.yml
+    workflow_file = Path(".github/workflows/build-and-test.yml")
+    expected = sorted(groups.keys())
 
+    try:
+        with open(workflow_file) as f:
+            content = f.read()
+    except FileNotFoundError:
+        github_error(f"Workflow file not found: {workflow_file}")
+        return 1
+
+    match = re.search(r'group:\s*\[([^\]]+)\]', content)
+    if not match:
+        github_error(f"No hardcoded group matrix found in {workflow_file}")
+        return 1
+
+    actual = sorted(
+        name.strip().strip('"').strip("'") for name in match.group(1).split(",")
+    )
+
+    if actual != expected:
+        github_error(
+            f"Hardcoded matrix {actual} does not match ci-groups.yml {expected}. "
+            f"Update the group list in {workflow_file}."
+        )
+        return 1
+
+    print(f"Hardcoded matrix matches ci-groups.yml: {expected}")
     return 0
 
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,9 +6,6 @@ on:
       os:
         required: true
         type: string
-      groups:
-        required: true
-        type: string
       coverage:
         required: false
         type: boolean
@@ -30,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: ${{ fromJson(inputs.groups) }}
+        group: ["core", "spv", "wallet", "ffi", "rpc"]
     env:
       RUST_BACKTRACE: 1
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,51 +45,40 @@ jobs:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --workspace --all-features --no-deps
 
-  verify-execution:
-    name: Verify Test Execution
+  verify-groups:
+    name: Verify Test Groups
     runs-on: ubuntu-latest
-    outputs:
-      groups: ${{ steps.verify.outputs.groups }}
     steps:
       - uses: actions/checkout@v6
       - run: pip install pyyaml
-      - name: Verify all crates are assigned and get matrix
-        id: verify
+      - name: Verify group config and hardcoded matrix
         run: python .github/scripts/ci_config.py verify-groups
 
   test-ubuntu:
     name: Ubuntu
-    needs: verify-execution
     uses: ./.github/workflows/build-and-test.yml
     with:
       os: ubuntu-latest
-      groups: ${{ needs.verify-execution.outputs.groups }}
       coverage: true
     secrets: inherit
 
   test-ubuntu-arm:
     name: Ubuntu ARM
-    needs: verify-execution
     uses: ./.github/workflows/build-and-test.yml
     with:
       os: ubuntu-22.04-arm
-      groups: ${{ needs.verify-execution.outputs.groups }}
 
   test-macos:
     name: macOS
-    needs: verify-execution
     uses: ./.github/workflows/build-and-test.yml
     with:
       os: macos-latest
-      groups: ${{ needs.verify-execution.outputs.groups }}
 
   test-windows:
     name: Windows
-    needs: verify-execution
     uses: ./.github/workflows/build-and-test.yml
     with:
       os: windows-latest
-      groups: ${{ needs.verify-execution.outputs.groups }}
 
   integrations_tests:
     name: Integration Tests


### PR DESCRIPTION
Move group listing into `build-and-test.yml` so test jobs start immediately instead of waiting for `verify-groups` to complete. `verify-groups` still runs in parallel as a validation guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build workflow to use a fixed set of test groups (core, spv, wallet, ffi, rpc) instead of dynamic matrix generation.
  * Enhanced configuration validation to ensure hardcoded test groups remain synchronized with defined group settings.
  * Simplified workflow structure by decoupling downstream test jobs from dynamically generated inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->