### PR TITLE
ci: use `runner.temp` for dashd log path instead of hardcoded `/tmp`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run tests
         id: tests
         env:
-          DASHD_TEST_RETAIN_DIR: ${{ (matrix.group == 'spv' || matrix.group == 'ffi') && '/tmp/dashd-test-logs' || '' }}
+          DASHD_TEST_RETAIN_DIR: ${{ (matrix.group == 'spv' || matrix.group == 'ffi') && format('{0}/dashd-test-logs', runner.temp) || '' }}
         run: >
           python .github/scripts/ci_config.py run-group ${{ matrix.group }}
           --os ${{ inputs.os }}
@@ -90,6 +90,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.group }}-test-logs-${{ inputs.os }}
-          path: /tmp/dashd-test-logs/
+          path: ${{ runner.temp }}/dashd-test-logs/
           retention-days: 7
           if-no-files-found: ignore


### PR DESCRIPTION
`runner.temp` resolves to the correct temporary directory on all platforms, making the artifact upload path portable across OSes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure to use dynamic temporary directories for log retention and artifact uploads, improving test environment consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->