### PR TITLE
ci: wrap test execution in `try`/`finally`

### DIFF
--- a/.github/scripts/ci_config.py
+++ b/.github/scripts/ci_config.py
@@ -120,17 +120,18 @@ def run_group_tests(args):
     for crate in crates:
         github_group_start(f"Testing {crate}")
 
-        if coverage:
-            cmd = ["cargo", "llvm-cov", "--no-report", "-p", crate, "--all-features"]
-        else:
-            cmd = ["cargo", "test", "-p", crate, "--all-features"]
-        result = subprocess.run(cmd)
+        try:
+            if coverage:
+                cmd = ["cargo", "llvm-cov", "--no-report", "-p", crate, "--all-features"]
+            else:
+                cmd = ["cargo", "test", "-p", crate, "--all-features"]
+            result = subprocess.run(cmd)
 
-        github_group_end()
-
-        if result.returncode != 0:
-            failed.append(crate)
-            github_error(f"Test failed for {crate} on {args.os}")
+            if result.returncode != 0:
+                failed.append(crate)
+                github_error(f"Test failed for {crate} on {args.os}")
+        finally:
+            github_group_end()
 
     if failed:
         print("\n" + "=" * 40)


### PR DESCRIPTION
`github_group_end()` must always run even if the subprocess raises an exception, otherwise GitHub Actions log groups become corrupted and test failures could be masked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration test infrastructure to improve reliability and consistent logging during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->