### PR TITLE
ci: fix `gh api` review-state query in `ready-for-review` workflow 

### DIFF
--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -127,7 +127,7 @@ jobs:
             echo "=== Checking PR #$PR_NUMBER ==="
 
             # Check if CodeRabbit has approved
-            CODERABBIT_STATE=$(gh api --paginate --slurp "repos/$REPO/pulls/$PR_NUMBER/reviews" --jq '
+            CODERABBIT_STATE=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews" | jq -rs '
               add
               | map(select(.user.login == "coderabbitai[bot]"))
               | sort_by(.submitted_at)


### PR DESCRIPTION
`gh api` does not support combining `--slurp` with `--jq`. Pipe paginated output to `jq -rs` instead so pages are concatenated into a single array before the filter runs. 

This is issue was preventing the `ready-for-review` label from being added when CI completes after CodeRabbit approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow logic to normalize paginated review data client-side, improving reliability of automated review aggregation and ensuring consistent detection of the latest bot review state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->