### PR TITLE
fix: handle and propagate errors in event channel monitors

### DIFF
--- a/dash-spv/src/client/event_handler.rs
+++ b/dash-spv/src/client/event_handler.rs
@@ -65,6 +65,7 @@ where
                             on_failure.cancel();
                             break;
                         }
+                        Err(broadcast::error::RecvError::Lagged(_)) if shutdown.is_cancelled() => break,
                         Err(broadcast::error::RecvError::Lagged(n)) => {
                             let msg = format!("{} monitor lagged, missed {} events", name, n);
                             tracing::error!("{}", msg);

--- a/dash-spv/src/client/event_handler.rs
+++ b/dash-spv/src/client/event_handler.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use tokio::sync::{broadcast, watch};
+use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -36,13 +36,14 @@ impl EventHandler for () {}
 
 /// Spawns a task that monitors a broadcast channel and dispatches events to the handler.
 ///
-/// `on_failure` is cancelled if the receiver lags, signalling the run loop to stop.
+/// On failure, the error message is sent via `on_failure` so the coordinator can report
+/// it as the single source of error handling.
 pub(crate) fn spawn_broadcast_monitor<E, H, F>(
     name: &'static str,
     mut receiver: broadcast::Receiver<E>,
     handler: Arc<H>,
     shutdown: CancellationToken,
-    on_failure: CancellationToken,
+    on_failure: mpsc::Sender<String>,
     dispatch_fn: F,
 ) -> JoinHandle<()>
 where
@@ -61,16 +62,14 @@ where
                         Err(broadcast::error::RecvError::Closed) => {
                             let msg = format!("{} monitor channel closed unexpectedly", name);
                             tracing::error!("{}", msg);
-                            handler.on_error(&msg);
-                            on_failure.cancel();
+                            let _ = on_failure.try_send(msg);
                             break;
                         }
                         Err(broadcast::error::RecvError::Lagged(_)) if shutdown.is_cancelled() => break,
                         Err(broadcast::error::RecvError::Lagged(n)) => {
                             let msg = format!("{} monitor lagged, missed {} events", name, n);
                             tracing::error!("{}", msg);
-                            handler.on_error(&msg);
-                            on_failure.cancel();
+                            let _ = on_failure.try_send(msg);
                             break;
                         }
                     }
@@ -89,7 +88,7 @@ pub(crate) fn spawn_progress_monitor<H: EventHandler>(
     mut receiver: watch::Receiver<SyncProgress>,
     handler: Arc<H>,
     shutdown: CancellationToken,
-    on_failure: CancellationToken,
+    on_failure: mpsc::Sender<String>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         tracing::debug!("Progress monitoring task started");
@@ -103,10 +102,9 @@ pub(crate) fn spawn_progress_monitor<H: EventHandler>(
                         Ok(()) => handler.on_progress(&receiver.borrow_and_update()),
                         Err(_) if shutdown.is_cancelled() => break,
                         Err(_) => {
-                            let msg = "Progress monitor channel closed unexpectedly";
+                            let msg = "Progress monitor channel closed unexpectedly".to_string();
                             tracing::error!("{}", msg);
-                            handler.on_error(msg);
-                            on_failure.cancel();
+                            let _ = on_failure.try_send(msg);
                             break;
                         }
                     }
@@ -124,7 +122,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
-    use tokio::sync::{broadcast, watch};
+    use tokio::sync::{broadcast, mpsc, watch};
     use tokio_util::sync::CancellationToken;
 
     use super::{spawn_broadcast_monitor, spawn_progress_monitor, EventHandler};
@@ -191,13 +189,14 @@ mod tests {
         let (tx, rx) = broadcast::channel(16);
         let handler = Arc::new(RecordingHandler::new());
         let shutdown = CancellationToken::new();
+        let (failure_tx, _failure_rx) = mpsc::channel(1);
 
         let task = spawn_broadcast_monitor(
             "test",
             rx,
             handler.clone(),
             shutdown.clone(),
-            CancellationToken::new(),
+            failure_tx,
             |h: &RecordingHandler, event: &SyncEvent| h.on_sync_event(event),
         );
 
@@ -228,13 +227,14 @@ mod tests {
         let (_tx, rx) = broadcast::channel::<SyncEvent>(16);
         let handler = Arc::new(RecordingHandler::new());
         let shutdown = CancellationToken::new();
+        let (failure_tx, _failure_rx) = mpsc::channel(1);
 
         let task = spawn_broadcast_monitor(
             "test",
             rx,
             handler.clone(),
             shutdown.clone(),
-            CancellationToken::new(),
+            failure_tx,
             |h: &RecordingHandler, event: &SyncEvent| h.on_sync_event(event),
         );
 
@@ -249,14 +249,14 @@ mod tests {
         let (tx, rx) = broadcast::channel::<SyncEvent>(16);
         let handler = Arc::new(RecordingHandler::new());
         let shutdown = CancellationToken::new();
-        let on_failure = CancellationToken::new();
+        let (failure_tx, mut failure_rx) = mpsc::channel(1);
 
         let task = spawn_broadcast_monitor(
             "test",
             rx,
             handler.clone(),
             shutdown.clone(),
-            on_failure.clone(),
+            failure_tx,
             |h: &RecordingHandler, event: &SyncEvent| h.on_sync_event(event),
         );
 
@@ -264,8 +264,9 @@ mod tests {
         drop(tx);
         task.await.unwrap();
 
-        assert_eq!(handler.error_count.load(Ordering::SeqCst), 1);
-        assert!(on_failure.is_cancelled());
+        let msg = failure_rx.try_recv().expect("should have received failure message");
+        assert!(msg.contains("closed unexpectedly"));
+        assert_eq!(handler.error_count.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
@@ -273,7 +274,7 @@ mod tests {
         let (tx, rx) = broadcast::channel(2);
         let handler = Arc::new(RecordingHandler::new());
         let shutdown = CancellationToken::new();
-        let on_failure = CancellationToken::new();
+        let (failure_tx, mut failure_rx) = mpsc::channel(1);
 
         // Send more messages than the buffer can hold before spawning the monitor
         tx.send(SyncEvent::BlockHeadersStored {
@@ -294,17 +295,18 @@ mod tests {
             rx,
             handler.clone(),
             shutdown.clone(),
-            on_failure.clone(),
+            failure_tx,
             |h: &RecordingHandler, event: &SyncEvent| h.on_sync_event(event),
         );
 
         // The monitor should exit on its own due to the lagged error
         task.await.unwrap();
 
-        // No sync events should have been dispatched, but on_error must have fired
+        // No sync events should have been dispatched, failure sent via channel
         assert_eq!(handler.sync_count.load(Ordering::SeqCst), 0);
-        assert_eq!(handler.error_count.load(Ordering::SeqCst), 1);
-        assert!(on_failure.is_cancelled());
+        assert_eq!(handler.error_count.load(Ordering::SeqCst), 0);
+        let msg = failure_rx.try_recv().expect("should have received failure message");
+        assert!(msg.contains("lagged"));
     }
 
     #[tokio::test]
@@ -312,9 +314,9 @@ mod tests {
         let (tx, rx) = watch::channel(SyncProgress::default());
         let handler = Arc::new(RecordingHandler::new());
         let shutdown = CancellationToken::new();
+        let (failure_tx, _failure_rx) = mpsc::channel(1);
 
-        let task =
-            spawn_progress_monitor(rx, handler.clone(), shutdown.clone(), CancellationToken::new());
+        let task = spawn_progress_monitor(rx, handler.clone(), shutdown.clone(), failure_tx);
 
         // Give the task time to send initial progress
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -336,10 +338,9 @@ mod tests {
         let (tx, rx) = watch::channel(SyncProgress::default());
         let handler = Arc::new(RecordingHandler::new());
         let shutdown = CancellationToken::new();
-        let on_failure = CancellationToken::new();
+        let (failure_tx, mut failure_rx) = mpsc::channel(1);
 
-        let task =
-            spawn_progress_monitor(rx, handler.clone(), shutdown.clone(), on_failure.clone());
+        let task = spawn_progress_monitor(rx, handler.clone(), shutdown.clone(), failure_tx);
 
         // Give it time to send initial
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -348,10 +349,11 @@ mod tests {
         drop(tx);
         task.await.unwrap();
 
-        // At least the initial progress was sent, plus on_error fired
+        // At least the initial progress was sent, failure sent via channel
         assert!(handler.progress_count.load(Ordering::SeqCst) >= 1);
-        assert_eq!(handler.error_count.load(Ordering::SeqCst), 1);
-        assert!(on_failure.is_cancelled());
+        assert_eq!(handler.error_count.load(Ordering::SeqCst), 0);
+        let msg = failure_rx.try_recv().expect("should have received failure message");
+        assert!(msg.contains("closed unexpectedly"));
     }
 
     #[tokio::test]
@@ -359,13 +361,14 @@ mod tests {
         let (tx, rx) = broadcast::channel(16);
         let handler = Arc::new(RecordingHandler::new());
         let shutdown = CancellationToken::new();
+        let (failure_tx, _failure_rx) = mpsc::channel(1);
 
         let task = spawn_broadcast_monitor(
             "network",
             rx,
             handler.clone(),
             shutdown.clone(),
-            CancellationToken::new(),
+            failure_tx,
             |h: &RecordingHandler, event: &NetworkEvent| h.on_network_event(event),
         );
 

--- a/dash-spv/src/client/event_handler.rs
+++ b/dash-spv/src/client/event_handler.rs
@@ -35,11 +35,14 @@ pub trait EventHandler: Send + Sync + 'static {
 impl EventHandler for () {}
 
 /// Spawns a task that monitors a broadcast channel and dispatches events to the handler.
+///
+/// `on_failure` is cancelled if the receiver lags, signalling the run loop to stop.
 pub(crate) fn spawn_broadcast_monitor<E, H, F>(
     name: &'static str,
     mut receiver: broadcast::Receiver<E>,
     handler: Arc<H>,
     shutdown: CancellationToken,
+    on_failure: CancellationToken,
     dispatch_fn: F,
 ) -> JoinHandle<()>
 where
@@ -54,8 +57,21 @@ where
                 result = receiver.recv() => {
                     match result {
                         Ok(event) => dispatch_fn(&handler, &event),
-                        Err(broadcast::error::RecvError::Closed) => break,
-                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(broadcast::error::RecvError::Closed) if shutdown.is_cancelled() => break,
+                        Err(broadcast::error::RecvError::Closed) => {
+                            let msg = format!("{} monitor channel closed unexpectedly", name);
+                            tracing::error!("{}", msg);
+                            handler.on_error(&msg);
+                            on_failure.cancel();
+                            break;
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            let msg = format!("{} monitor lagged, missed {} events", name, n);
+                            tracing::error!("{}", msg);
+                            handler.on_error(&msg);
+                            on_failure.cancel();
+                            break;
+                        }
                     }
                 }
                 _ = shutdown.cancelled() => break,
@@ -72,6 +88,7 @@ pub(crate) fn spawn_progress_monitor<H: EventHandler>(
     mut receiver: watch::Receiver<SyncProgress>,
     handler: Arc<H>,
     shutdown: CancellationToken,
+    on_failure: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         tracing::debug!("Progress monitoring task started");
@@ -83,7 +100,14 @@ pub(crate) fn spawn_progress_monitor<H: EventHandler>(
                 result = receiver.changed() => {
                     match result {
                         Ok(()) => handler.on_progress(&receiver.borrow_and_update()),
-                        Err(_) => break,
+                        Err(_) if shutdown.is_cancelled() => break,
+                        Err(_) => {
+                            let msg = "Progress monitor channel closed unexpectedly";
+                            tracing::error!("{}", msg);
+                            handler.on_error(msg);
+                            on_failure.cancel();
+                            break;
+                        }
                     }
                 }
                 _ = shutdown.cancelled() => break,
@@ -172,6 +196,7 @@ mod tests {
             rx,
             handler.clone(),
             shutdown.clone(),
+            CancellationToken::new(),
             |h: &RecordingHandler, event: &SyncEvent| h.on_sync_event(event),
         );
 
@@ -208,6 +233,7 @@ mod tests {
             rx,
             handler.clone(),
             shutdown.clone(),
+            CancellationToken::new(),
             |h: &RecordingHandler, event: &SyncEvent| h.on_sync_event(event),
         );
 
@@ -218,28 +244,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn broadcast_monitor_exits_on_channel_close() {
+    async fn broadcast_monitor_fails_on_unexpected_channel_close() {
         let (tx, rx) = broadcast::channel::<SyncEvent>(16);
         let handler = Arc::new(RecordingHandler::new());
         let shutdown = CancellationToken::new();
+        let on_failure = CancellationToken::new();
 
         let task = spawn_broadcast_monitor(
             "test",
             rx,
             handler.clone(),
             shutdown.clone(),
+            on_failure.clone(),
             |h: &RecordingHandler, event: &SyncEvent| h.on_sync_event(event),
         );
 
+        // Drop sender without cancelling shutdown — this is unexpected
         drop(tx);
         task.await.unwrap();
+
+        assert_eq!(handler.error_count.load(Ordering::SeqCst), 1);
+        assert!(on_failure.is_cancelled());
     }
 
     #[tokio::test]
-    async fn broadcast_monitor_handles_lagged_receiver() {
+    async fn broadcast_monitor_exits_on_lagged_receiver() {
         let (tx, rx) = broadcast::channel(2);
         let handler = Arc::new(RecordingHandler::new());
         let shutdown = CancellationToken::new();
+        let on_failure = CancellationToken::new();
 
         // Send more messages than the buffer can hold before spawning the monitor
         tx.send(SyncEvent::BlockHeadersStored {
@@ -260,22 +293,17 @@ mod tests {
             rx,
             handler.clone(),
             shutdown.clone(),
+            on_failure.clone(),
             |h: &RecordingHandler, event: &SyncEvent| h.on_sync_event(event),
         );
 
-        // Send one more after the monitor starts
-        tx.send(SyncEvent::BlockHeadersStored {
-            tip_height: 4,
-        })
-        .unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        shutdown.cancel();
+        // The monitor should exit on its own due to the lagged error
         task.await.unwrap();
 
-        // The monitor should have received at least the last message (and possibly
-        // one from the lagged recovery). The key thing is it doesn't crash.
-        assert!(handler.sync_count.load(Ordering::SeqCst) >= 1);
+        // No sync events should have been dispatched, but on_error must have fired
+        assert_eq!(handler.sync_count.load(Ordering::SeqCst), 0);
+        assert_eq!(handler.error_count.load(Ordering::SeqCst), 1);
+        assert!(on_failure.is_cancelled());
     }
 
     #[tokio::test]
@@ -284,7 +312,8 @@ mod tests {
         let handler = Arc::new(RecordingHandler::new());
         let shutdown = CancellationToken::new();
 
-        let task = spawn_progress_monitor(rx, handler.clone(), shutdown.clone());
+        let task =
+            spawn_progress_monitor(rx, handler.clone(), shutdown.clone(), CancellationToken::new());
 
         // Give the task time to send initial progress
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -302,21 +331,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn progress_monitor_exits_on_sender_drop() {
+    async fn progress_monitor_fails_on_unexpected_sender_drop() {
         let (tx, rx) = watch::channel(SyncProgress::default());
         let handler = Arc::new(RecordingHandler::new());
         let shutdown = CancellationToken::new();
+        let on_failure = CancellationToken::new();
 
-        let task = spawn_progress_monitor(rx, handler.clone(), shutdown.clone());
+        let task =
+            spawn_progress_monitor(rx, handler.clone(), shutdown.clone(), on_failure.clone());
 
         // Give it time to send initial
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
+        // Drop sender without cancelling shutdown — this is unexpected
         drop(tx);
         task.await.unwrap();
 
-        // At least the initial progress was sent
+        // At least the initial progress was sent, plus on_error fired
         assert!(handler.progress_count.load(Ordering::SeqCst) >= 1);
+        assert_eq!(handler.error_count.load(Ordering::SeqCst), 1);
+        assert!(on_failure.is_cancelled());
     }
 
     #[tokio::test]
@@ -330,6 +364,7 @@ mod tests {
             rx,
             handler.clone(),
             shutdown.clone(),
+            CancellationToken::new(),
             |h: &RecordingHandler, event: &NetworkEvent| h.on_network_event(event),
         );
 

--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -39,6 +39,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
         tracing::info!("Starting continuous network monitoring...");
 
         let monitor_shutdown = CancellationToken::new();
+        let monitor_failure = CancellationToken::new();
 
         // Subscribe to channels
         let sync_event_rx = self.subscribe_sync_events().await;
@@ -52,6 +53,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
             sync_event_rx,
             handler.clone(),
             monitor_shutdown.clone(),
+            monitor_failure.clone(),
             |h, event| h.on_sync_event(event),
         );
 
@@ -60,6 +62,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
             network_event_rx,
             handler.clone(),
             monitor_shutdown.clone(),
+            monitor_failure.clone(),
             |h, event| h.on_network_event(event),
         );
 
@@ -68,11 +71,16 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
             wallet_event_rx,
             handler.clone(),
             monitor_shutdown.clone(),
+            monitor_failure.clone(),
             |h, event| h.on_wallet_event(event),
         );
 
-        let progress_task =
-            spawn_progress_monitor(progress_rx, handler.clone(), monitor_shutdown.clone());
+        let progress_task = spawn_progress_monitor(
+            progress_rx,
+            handler.clone(),
+            monitor_shutdown.clone(),
+            monitor_failure.clone(),
+        );
 
         // Run the sync loop
         let mut sync_coordinator_tick_interval = tokio::time::interval(SYNC_COORDINATOR_TICK_MS);
@@ -92,6 +100,12 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
                 _ = token.cancelled() => {
                     tracing::debug!("DashSpvClient run loop cancelled");
                     break None
+                }
+                _ = monitor_failure.cancelled() => {
+                    break Some(crate::SpvError::ChannelFailure(
+                        "event monitor".into(),
+                        "broadcast receiver lagged".into(),
+                    ))
                 }
             };
 

--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use super::event_handler::{spawn_broadcast_monitor, spawn_progress_monitor};
@@ -39,7 +40,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
         tracing::info!("Starting continuous network monitoring...");
 
         let monitor_shutdown = CancellationToken::new();
-        let monitor_failure = CancellationToken::new();
+        let (monitor_failure_tx, mut monitor_failure_rx) = mpsc::channel::<String>(1);
 
         // Subscribe to channels
         let sync_event_rx = self.subscribe_sync_events().await;
@@ -53,7 +54,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
             sync_event_rx,
             handler.clone(),
             monitor_shutdown.clone(),
-            monitor_failure.clone(),
+            monitor_failure_tx.clone(),
             |h, event| h.on_sync_event(event),
         );
 
@@ -62,7 +63,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
             network_event_rx,
             handler.clone(),
             monitor_shutdown.clone(),
-            monitor_failure.clone(),
+            monitor_failure_tx.clone(),
             |h, event| h.on_network_event(event),
         );
 
@@ -71,7 +72,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
             wallet_event_rx,
             handler.clone(),
             monitor_shutdown.clone(),
-            monitor_failure.clone(),
+            monitor_failure_tx.clone(),
             |h, event| h.on_wallet_event(event),
         );
 
@@ -79,7 +80,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
             progress_rx,
             handler.clone(),
             monitor_shutdown.clone(),
-            monitor_failure.clone(),
+            monitor_failure_tx,
         );
 
         // Run the sync loop
@@ -101,23 +102,26 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
                     tracing::debug!("DashSpvClient run loop cancelled");
                     break None
                 }
-                _ = monitor_failure.cancelled() => {
+                Some(msg) = monitor_failure_rx.recv() => {
                     break Some(crate::SpvError::ChannelFailure(
                         "event monitor".into(),
-                        "broadcast receiver lagged".into(),
+                        msg,
                     ))
                 }
             };
 
-            if let Some(ref e) = error {
-                handler.on_error(&e.to_string());
+            if error.is_some() {
                 break error;
             }
         };
 
-        // Cancel monitoring tasks and wait for them
+        // Signal monitors to shut down before channels close
         monitor_shutdown.cancel();
         let _ = tokio::join!(sync_task, network_task, wallet_task, progress_task);
+
+        if let Some(ref e) = error {
+            handler.on_error(&e.to_string());
+        }
 
         let stop_result = self.stop().await;
 


### PR DESCRIPTION
- Add `on_failure` cancellation token to `spawn_broadcast_monitor` and `spawn_progress_monitor` to signal the run loop on fatal monitor errors
- Treat Lagged broadcast errors as fatal, lost events are unrecoverable at the moment
- Distinguish expected vs unexpected channel close by checking the shutdown token
- Run loop watches `monitor_failure.cancelled()` and exits with `ChannelFailure` error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event monitors now report unexpected channel closures or lag, cancel monitoring, and cause the main run loop to exit instead of continuing silently.
  * Progress monitor now reports channel failures and stops promptly.

* **Tests**
  * Tests updated to assert a single failure message on unexpected channel drop/close/lag and that lagged broadcasts emit no sync/progress events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->