### PR TITLE
fix: register error callback in FFI CLI binary

### DIFF
--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -252,6 +252,22 @@ extern "C" fn on_progress_update(progress: *const FFISyncProgress, _user_data: *
     println!();
 }
 
+// ============================================================================
+// Error Callback
+// ============================================================================
+
+extern "C" fn on_error(error: *const c_char, _user_data: *mut c_void) {
+    let msg = if error.is_null() {
+        "unknown error".to_string()
+    } else {
+        unsafe { std::ffi::CStr::from_ptr(error) }
+            .to_str()
+            .unwrap_or("invalid error string")
+            .to_string()
+    };
+    eprintln!("[FATAL] {}", msg);
+}
+
 fn main() {
     let matches = Command::new("dash-spv-ffi")
         .about("Run SPV sync via FFI using event callbacks")
@@ -418,7 +434,7 @@ fn main() {
                 user_data: ptr::null_mut(),
             },
             error: FFIClientErrorCallback {
-                on_error: None,
+                on_error: Some(on_error),
                 user_data: ptr::null_mut(),
             },
         };

--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -266,6 +266,7 @@ extern "C" fn on_error(error: *const c_char, _user_data: *mut c_void) {
             .to_string()
     };
     eprintln!("[FATAL] {}", msg);
+    std::process::exit(1);
 }
 
 fn main() {


### PR DESCRIPTION
Without `on_error`, fatal errors from the background sync task were silently swallowed and the CLI would hang waiting for Ctrl+C.

Based on: 
- #572 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages are now written to standard error and prefixed with "[FATAL]" for clear visibility.
  * Client-side error events now trigger the configured error handler so failures are reported consistently.
  * On critical errors, the application terminates immediately to prevent continuing in an invalid state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->