### PR TITLE
fix: replace `abort()` with cooperative wait in `wait_for_run_task`

### DIFF
--- a/dash-spv-ffi/src/client.rs
+++ b/dash-spv-ffi/src/client.rs
@@ -110,15 +110,27 @@ pub unsafe extern "C" fn dash_spv_ffi_client_new(
     }
 }
 
+/// Maximum time to wait for the run task to exit cooperatively before aborting.
+const RUN_TASK_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 impl FFIDashSpvClient {
-    /// Cancel the run task and wait for it to finish.
-    fn cancel_run_task(&self) {
+    /// Wait for the run task to finish cooperatively, aborting only on timeout.
+    ///
+    /// The caller must cancel `shutdown_token` before calling this so that
+    /// `DashSpvClient::run()` exits its loop and cleans up monitor tasks.
+    /// Only falls back to `abort()` if the task doesn't exit within the timeout.
+    fn wait_for_run_task(&self) {
         let task = self.run_task.lock().unwrap().take();
         if let Some(task) = task {
-            task.abort();
-            self.runtime.block_on(async {
-                let _ = task.await;
-            });
+            let finished = self
+                .runtime
+                .block_on(async { tokio::time::timeout(RUN_TASK_SHUTDOWN_TIMEOUT, task).await });
+            if finished.is_err() {
+                tracing::warn!(
+                    "Run task did not exit within {:?}, aborting",
+                    RUN_TASK_SHUTDOWN_TIMEOUT
+                );
+            }
         }
     }
 }
@@ -126,7 +138,7 @@ impl FFIDashSpvClient {
 fn stop_client_internal(client: &mut FFIDashSpvClient) -> Result<(), dash_spv::SpvError> {
     client.shutdown_token.cancel();
 
-    client.cancel_run_task();
+    client.wait_for_run_task();
 
     let result = client.runtime.block_on(async { client.inner.stop().await });
 
@@ -342,8 +354,8 @@ pub unsafe extern "C" fn dash_spv_ffi_client_destroy(client: *mut FFIDashSpvClie
             let _ = client.inner.stop().await;
         });
 
-        // Abort and await the run task
-        client.cancel_run_task();
+        // Wait for the run task to finish (cooperative, with timeout fallback)
+        client.wait_for_run_task();
 
         tracing::info!("FFI client destroyed and all tasks cleaned up");
     }

--- a/dash-spv-ffi/src/client.rs
+++ b/dash-spv-ffi/src/client.rs
@@ -352,16 +352,17 @@ pub unsafe extern "C" fn dash_spv_ffi_client_destroy(client: *mut FFIDashSpvClie
     if !client.is_null() {
         let client = Box::from_raw(client);
 
-        // Cancel shutdown token to stop all tasks
+        // Cancel shutdown token so run() exits its loop and cleans up
         client.shutdown_token.cancel();
-
-        // Stop the SPV client
-        client.runtime.block_on(async {
-            let _ = client.inner.stop().await;
-        });
 
         // Wait for the run task to finish (cooperative, with timeout fallback)
         client.wait_for_run_task();
+
+        // Stop the SPV client (run() calls stop() internally, but this
+        // handles the case where run() was never called or was aborted)
+        client.runtime.block_on(async {
+            let _ = client.inner.stop().await;
+        });
 
         tracing::info!("FFI client destroyed and all tasks cleaned up");
     }

--- a/dash-spv-ffi/src/client.rs
+++ b/dash-spv-ffi/src/client.rs
@@ -121,15 +121,21 @@ impl FFIDashSpvClient {
     /// Only falls back to `abort()` if the task doesn't exit within the timeout.
     fn wait_for_run_task(&self) {
         let task = self.run_task.lock().unwrap().take();
-        if let Some(task) = task {
-            let finished = self
-                .runtime
-                .block_on(async { tokio::time::timeout(RUN_TASK_SHUTDOWN_TIMEOUT, task).await });
-            if finished.is_err() {
-                tracing::warn!(
-                    "Run task did not exit within {:?}, aborting",
-                    RUN_TASK_SHUTDOWN_TIMEOUT
-                );
+        if let Some(mut task) = task {
+            let finished = self.runtime.block_on(async {
+                tokio::time::timeout(RUN_TASK_SHUTDOWN_TIMEOUT, &mut task).await
+            });
+            match finished {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::warn!("Run task exited with join error: {}", e),
+                Err(_) => {
+                    tracing::warn!(
+                        "Run task did not exit within {:?}, aborting",
+                        RUN_TASK_SHUTDOWN_TIMEOUT,
+                    );
+                    task.abort();
+                    let _ = self.runtime.block_on(task);
+                }
             }
         }
     }


### PR DESCRIPTION
`abort()` can interrupt the cleanup sequence in `DashSpvClient::run()` (the `monitor_shutdown.cancel()` + `tokio::join!`), leaving monitor tasks running after FFI callback pointers are freed. Use cooperative wait with a timeout fallback instead.

Based on:
- #572 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client shutdown: waits up to 5 seconds for background tasks to finish cooperatively, logs warnings on errors or timeouts, and falls back to forceful termination only after timeout — resulting in more stable shutdown and cleaner resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->