### PR TITLE
fix(rpc-json): disable key-wallet default features

### DIFF
--- a/key-wallet/Cargo.toml
+++ b/key-wallet/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "CC0-1.0"
 
 [features]
-default = ["secp256k1/std", "bip39/std", "getrandom", "rand", "manager"]
+default = ["secp256k1/std", "bip39/std", "getrandom", "rand"]
 manager = ["dep:tokio"]
 parallel-filters = ["manager", "dep:rayon"]
 serde = ["dep:serde", "dep:serde_json", "dashcore_hashes/serde", "secp256k1/serde", "dashcore/serde"]


### PR DESCRIPTION
## Summary

Add `default-features = false` to key-wallet dep in rpc-json.

rpc-json only needs key-wallet for type definitions and serde serialization — it doesn't use the wallet manager, SPV, or parallel filter functionality.

Without this fix, any crate depending on dashcore-rpc transitively enables key-wallet's default features (`manager`, `std`) which pulls in `tokio` and `rayon`. This inflates WASM builds unnecessarily (e.g. platform's wasm-sdk).

## Changes

- `rpc-json/Cargo.toml`: add `default-features = false` on key-wallet dep

## Testing

- `cargo check --workspace` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default build configuration to exclude the `manager` feature, reducing default dependencies and build size. Users can still enable this feature explicitly if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->