### PR TITLE
feat(ffi): add dash_spv_ffi_config_clear_peers

### DIFF
--- a/dash-spv-ffi/FFI_API.md
+++ b/dash-spv-ffi/FFI_API.md
@@ -4,7 +4,7 @@ This document provides a comprehensive reference for all FFI (Foreign Function I
 
 **Auto-generated**: This documentation is automatically generated from the source code. Do not edit manually.
 
-**Total Functions**: 40
+**Total Functions**: 41
 
 ## Table of Contents
 
@@ -31,12 +31,13 @@ Functions: 3
 
 ### Configuration
 
-Functions: 16
+Functions: 17
 
 | Function | Description | Module |
 |----------|-------------|--------|
 | `dash_spv_ffi_client_update_config` | Update the running client's configuration | client |
 | `dash_spv_ffi_config_add_peer` | Adds a peer address to the configuration  Accepts socket addresses with or... | config |
+| `dash_spv_ffi_config_clear_peers` | Removes all configured peers from the configuration  This is useful when the... | config |
 | `dash_spv_ffi_config_destroy` | Destroys an FFIClientConfig and frees its memory  # Safety - `config` must... | config |
 | `dash_spv_ffi_config_get_network` | Gets the network type from the configuration  # Safety - `config` must be a... | config |
 | `dash_spv_ffi_config_mainnet` | No description | config |
@@ -196,6 +197,22 @@ Adds a peer address to the configuration  Accepts socket addresses with or witho
 
 **Safety:**
 - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet - `addr` must be a valid null-terminated C string containing a socket address or IP-only string - The caller must ensure both pointers remain valid for the duration of this call
+
+**Module:** `config`
+
+---
+
+#### `dash_spv_ffi_config_clear_peers`
+
+```c
+dash_spv_ffi_config_clear_peers(config: *mut FFIClientConfig) -> i32
+```
+
+**Description:**
+Removes all configured peers from the configuration  This is useful when the caller wants to start with a clean slate before adding custom peers via `dash_spv_ffi_config_add_peer`.  # Safety - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet - The caller must ensure the config pointer remains valid for the duration of this call
+
+**Safety:**
+- `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet - The caller must ensure the config pointer remains valid for the duration of this call
 
 **Module:** `config`
 

--- a/dash-spv-ffi/src/config.rs
+++ b/dash-spv-ffi/src/config.rs
@@ -166,6 +166,25 @@ pub unsafe extern "C" fn dash_spv_ffi_config_add_peer(
     }
 }
 
+/// Removes all configured peers from the configuration
+///
+/// This is useful when the caller wants to start with a clean slate
+/// before adding custom peers via `dash_spv_ffi_config_add_peer`.
+///
+/// # Safety
+/// - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet
+/// - The caller must ensure the config pointer remains valid for the duration of this call
+#[no_mangle]
+pub unsafe extern "C" fn dash_spv_ffi_config_clear_peers(
+    config: *mut FFIClientConfig,
+) -> i32 {
+    null_check!(config);
+
+    let cfg = unsafe { &mut *((*config).inner as *mut ClientConfig) };
+    cfg.peers.clear();
+    FFIErrorCode::Success as i32
+}
+
 /// Sets the user agent string to advertise in the P2P handshake
 ///
 /// # Safety

--- a/dash-spv-ffi/src/config.rs
+++ b/dash-spv-ffi/src/config.rs
@@ -175,9 +175,7 @@ pub unsafe extern "C" fn dash_spv_ffi_config_add_peer(
 /// - `config` must be a valid pointer to an FFIClientConfig created by dash_spv_ffi_config_new/mainnet/testnet
 /// - The caller must ensure the config pointer remains valid for the duration of this call
 #[no_mangle]
-pub unsafe extern "C" fn dash_spv_ffi_config_clear_peers(
-    config: *mut FFIClientConfig,
-) -> i32 {
+pub unsafe extern "C" fn dash_spv_ffi_config_clear_peers(config: *mut FFIClientConfig) -> i32 {
     null_check!(config);
 
     let cfg = unsafe { &mut *((*config).inner as *mut ClientConfig) };

--- a/dash-spv-ffi/tests/test_config.rs
+++ b/dash-spv-ffi/tests/test_config.rs
@@ -96,6 +96,39 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_config_clear_peers() {
+        unsafe {
+            let config = dash_spv_ffi_config_new(FFINetwork::Testnet);
+
+            // Add peers
+            let peer1 = CString::new("127.0.0.1:9999").unwrap();
+            let peer2 = CString::new("127.0.0.2:9999").unwrap();
+            dash_spv_ffi_config_add_peer(config, peer1.as_ptr());
+            dash_spv_ffi_config_add_peer(config, peer2.as_ptr());
+
+            // Clear all peers
+            let result = dash_spv_ffi_config_clear_peers(config);
+            assert_eq!(result, FFIErrorCode::Success as i32);
+
+            // Clear on already-empty should still succeed
+            let result = dash_spv_ffi_config_clear_peers(config);
+            assert_eq!(result, FFIErrorCode::Success as i32);
+
+            dash_spv_ffi_config_destroy(config);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_clear_peers_null() {
+        unsafe {
+            let result = dash_spv_ffi_config_clear_peers(std::ptr::null_mut());
+            assert_eq!(result, FFIErrorCode::NullPointer as i32);
+        }
+    }
+
+    #[test]
+    #[serial]
     fn test_config_user_agent() {
         unsafe {
             let config = dash_spv_ffi_config_new(FFINetwork::Testnet);


### PR DESCRIPTION
## Summary

- Adds `dash_spv_ffi_config_clear_peers()` FFI function so iOS/Swift consumers can remove default peers before adding custom ones

## Problem

When creating an SPV config for regtest via `dash_spv_ffi_config_new(FFINetwork::Regtest)`, a default peer at `127.0.0.1:19899` is baked in. This doesn't match dashmate's Docker setup which maps Core P2P to port 20001. The iOS app calls `dash_spv_ffi_config_add_peer("127.0.0.1:20001")` but the dead 19899 peer remains, causing reconnect spam and intermittent QRInfo timeouts when requests get routed to it.

Rust consumers can already do `config.peers.clear()` since the field is `pub`, but FFI consumers had no way to clear defaults.

## Usage

```c
// Create config (regtest gets default 127.0.0.1:19899)
FFIClientConfig *config = dash_spv_ffi_config_new(FFINetwork_Regtest);

// Clear defaults, then add the actual peer
dash_spv_ffi_config_clear_peers(config);
dash_spv_ffi_config_add_peer(config, "127.0.0.1:20001");
```

## Test plan

- [x] Existing `dash-spv-ffi` config tests pass (9/9)
- [x] Existing `dash-spv` unit tests pass (243/243)
- [ ] Verify from Swift/iOS that `clear_peers` + `add_peer` results in only the intended peer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to clear peer connections from client configuration, allowing programs to reset configured peers programmatically.
* **Documentation**
  * Updated API docs to include the new configuration operation and its safety requirements for passing valid configuration handles during the call.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->