### PR TITLE
refactor: remove `default_peers_for_network` from `ClientConfig`

### DIFF
--- a/dash-spv/src/client/config.rs
+++ b/dash-spv/src/client/config.rs
@@ -103,7 +103,6 @@ impl ClientConfig {
     pub fn new(network: Network) -> Self {
         Self {
             network,
-            peers: Self::default_peers_for_network(network),
             restrict_to_configured_peers: false,
             ..Self::default()
         }
@@ -215,26 +214,5 @@ impl ClientConfig {
         })?;
 
         Ok(())
-    }
-
-    /// Get default peers for a network.
-    /// Returns empty vector to enable immediate DNS discovery on startup.
-    /// Explicit peers can still be added via add_peer() or configuration.
-    fn default_peers_for_network(network: Network) -> Vec<SocketAddr> {
-        match network {
-            Network::Mainnet | Network::Testnet => {
-                // Return empty to trigger immediate DNS discovery
-                // DNS seeds will be used: dnsseed.dash.org (mainnet), testnet-seed.dashdot.io (testnet)
-                vec![]
-            }
-            Network::Regtest => {
-                // Regtest typically uses local peers
-                vec!["127.0.0.1:19899".parse::<SocketAddr>()]
-                    .into_iter()
-                    .filter_map(Result::ok)
-                    .collect()
-            }
-            _ => vec![],
-        }
     }
 }

--- a/dash-spv/src/client/config_test.rs
+++ b/dash-spv/src/client/config_test.rs
@@ -39,8 +39,7 @@ mod tests {
 
         let regtest = ClientConfig::regtest();
         assert_eq!(regtest.network, Network::Regtest);
-        assert_eq!(regtest.peers.len(), 1);
-        assert_eq!(regtest.peers[0].to_string(), "127.0.0.1:19899");
+        assert!(regtest.peers.is_empty());
     }
 
     #[test]

--- a/dash-spv/tests/dashd_sync/setup.rs
+++ b/dash-spv/tests/dashd_sync/setup.rs
@@ -383,7 +383,6 @@ pub(super) fn create_test_wallet(
 /// Create test client config pointing to a specific peer (exclusive mode).
 fn create_test_config(storage_path: PathBuf, peer_addr: std::net::SocketAddr) -> ClientConfig {
     let mut config = ClientConfig::regtest().with_storage_path(storage_path).without_masternodes();
-    config.peers.clear();
     config.add_peer(peer_addr);
     config
 }
@@ -396,9 +395,7 @@ pub(super) async fn create_non_exclusive_test_config(
     storage_path: PathBuf,
     peer_addr: std::net::SocketAddr,
 ) -> ClientConfig {
-    let mut config = ClientConfig::regtest().with_storage_path(storage_path).without_masternodes();
-    // Clear default regtest peers so the manager enters non-exclusive mode
-    config.peers.clear();
+    let config = ClientConfig::regtest().with_storage_path(storage_path).without_masternodes();
     // Seed the peer store so the client can discover our dashd node
     let peer_store = PersistentPeerStorage::open(config.storage_path.clone())
         .await


### PR DESCRIPTION
The function returned empty peers for mainnet/testnet (already the `Default` behavior) and a hardcoded `127.0.0.1:19899` for regtest that no caller actually relied on — dashd tests always clear and add their own peer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed automatic peer initialization based on network configuration. Clients now require explicit peer configuration instead of relying on network-specific defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->