### PR TITLE
fix(rpc-json): disable key-wallet default features

### DIFF
--- a/rpc-json/Cargo.toml
+++ b/rpc-json/Cargo.toml
@@ -25,7 +25,7 @@ serde_with = "2.1.0"
 serde_repr = "0.1"
 hex = { version="0.4", features=["serde"]}
 
-key-wallet = { path = "../key-wallet", features=["serde"] }
+key-wallet = { path = "../key-wallet", default-features = false, features=["serde", "getrandom"] }
 dashcore = { path = "../dash", features=["secp-recovery", "rand-std", "signer", "serde"] }
 
 bincode = { version = "2.0.1", features = ["serde"] }


### PR DESCRIPTION
## Summary

Add `default-features = false` to key-wallet dep in rpc-json with explicit `getrandom` + `serde` features.

rpc-json only needs key-wallet for type definitions and serde — it doesn't use the wallet manager or SPV. Without this fix, any crate depending on dashcore-rpc transitively enables key-wallet's `manager` default feature which pulls in `tokio`, inflating WASM builds unnecessarily (e.g. platform's wasm-sdk).

## Changes

- `rpc-json/Cargo.toml`: `default-features = false, features=["serde", "getrandom"]`

## Testing

- `cargo check --workspace` passes
- `cargo test -p dashcore-rpc-json --all-features --no-run` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency configurations to optimize feature flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->