### PR TITLE
chore: add generated FFI header directories to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ coordination.md
 
 # Build artifacts
 **/*.rs.bk
+dash-spv-ffi/include/
+key-wallet-ffi/include/
 *.a
 *.so
 *.dylib


### PR DESCRIPTION
They show up after every build now after #579.