### PR TITLE
feat: track input/output details and direction in `TransactionRecord`

### DIFF
--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -670,8 +670,6 @@ pub struct FFITransactionRecord {
     pub context: FFITransactionContextDetails,
     /// Fee if known, 0 if unknown
     pub fee: u64,
-    /// Whether this is our transaction
-    pub is_ours: bool,
 }
 
 /// Get all transactions from a managed account
@@ -730,9 +728,6 @@ pub unsafe extern "C" fn managed_core_account_get_transactions(
 
         // Copy fee (0 if unknown)
         ffi_record.fee = record.fee.unwrap_or(0);
-
-        // Copy is_ours flag
-        ffi_record.is_ours = record.is_ours;
     }
 
     *transactions_out = ptr;

--- a/key-wallet/src/account/mod.rs
+++ b/key-wallet/src/account/mod.rs
@@ -35,7 +35,9 @@ pub use crate::managed_account::managed_account_collection::ManagedAccountCollec
 pub use crate::managed_account::managed_account_trait::ManagedAccountTrait;
 pub use crate::managed_account::managed_account_type::ManagedAccountType;
 pub use crate::managed_account::metadata::AccountMetadata;
-pub use crate::managed_account::transaction_record::TransactionRecord;
+pub use crate::managed_account::transaction_record::{
+    InputDetail, OutputDetail, OutputRole, TransactionDirection, TransactionRecord,
+};
 pub use crate::managed_account::ManagedCoreAccount;
 pub use account_collection::AccountCollection;
 pub use account_trait::AccountTrait;

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -14,6 +14,10 @@ use crate::account::TransactionRecord;
 use crate::derivation_bls_bip32::ExtendedBLSPubKey;
 #[cfg(any(feature = "bls", feature = "eddsa"))]
 use crate::managed_account::address_pool::PublicKeyType;
+use crate::managed_account::transaction_record::{
+    InputDetail, OutputDetail, OutputRole, TransactionDirection,
+};
+use crate::transaction_checking::transaction_router::TransactionType;
 use crate::transaction_checking::{AccountMatch, TransactionContext};
 use crate::utxo::Utxo;
 use crate::wallet::balance::WalletCoreBalance;
@@ -401,14 +405,21 @@ impl ManagedCoreAccount {
         tx: &Transaction,
         account_match: &AccountMatch,
         context: TransactionContext,
+        transaction_type: TransactionType,
     ) -> bool {
         if !self.transactions.contains_key(&tx.txid()) {
-            self.record_transaction(tx, account_match, context);
+            self.record_transaction(tx, account_match, context, transaction_type);
             return true;
         }
 
         let mut changed = false;
         if let Some(tx_record) = self.transactions.get_mut(&tx.txid()) {
+            debug_assert_eq!(
+                tx_record.transaction_type,
+                transaction_type,
+                "transaction_type changed between recordings for {}",
+                tx.txid()
+            );
             if tx_record.context != context {
                 let was_confirmed = tx_record.context.confirmed();
                 tx_record.update_context(context);
@@ -429,9 +440,97 @@ impl ManagedCoreAccount {
         tx: &Transaction,
         account_match: &AccountMatch,
         context: TransactionContext,
+        transaction_type: TransactionType,
     ) {
         let net_amount = account_match.received as i64 - account_match.sent as i64;
-        let tx_record = TransactionRecord::new(tx.clone(), context, net_amount, net_amount < 0);
+
+        let receive_addrs: HashSet<_> = account_match
+            .account_type_match
+            .involved_receive_addresses()
+            .iter()
+            .map(|info| &info.address)
+            .collect();
+        let change_addrs: HashSet<_> = account_match
+            .account_type_match
+            .involved_change_addresses()
+            .iter()
+            .map(|info| &info.address)
+            .collect();
+
+        // Input details must be built before `update_utxos` removes spent UTXOs
+        let mut input_details = Vec::new();
+        if !tx.is_coin_base() {
+            for (idx, input) in tx.input.iter().enumerate() {
+                if let Some(utxo) = self.utxos.get(&input.previous_output) {
+                    input_details.push(InputDetail {
+                        index: idx as u32,
+                        value: utxo.txout.value,
+                        address: utxo.address.clone(),
+                    });
+                }
+            }
+        }
+
+        // Use both UTXO-based input details and `account_match.sent` as signals
+        // that we created this transaction. The UTXO set may be incomplete
+        // (e.g., partial rescan) so `account_match.sent > 0` catches cases where
+        // the transaction still spent our funds even without matching UTXOs.
+        let has_inputs = !input_details.is_empty() || account_match.sent > 0;
+
+        let resolved_outputs: Vec<Option<Address>> = tx
+            .output
+            .iter()
+            .map(|output| Address::from_script(&output.script_pubkey, self.network).ok())
+            .collect();
+
+        // Build output details — annotate every output with its role
+        let mut output_details = Vec::new();
+        for (idx, output) in tx.output.iter().enumerate() {
+            let role = match &resolved_outputs[idx] {
+                Some(addr) if receive_addrs.contains(addr) => OutputRole::Received,
+                Some(addr) if change_addrs.contains(addr) => OutputRole::Change,
+                Some(_) if has_inputs => OutputRole::Sent,
+                Some(_) => continue,
+                None => {
+                    if output.script_pubkey.is_provably_unspendable() {
+                        OutputRole::Unspendable
+                    } else if has_inputs {
+                        OutputRole::Sent
+                    } else {
+                        continue;
+                    }
+                }
+            };
+            output_details.push(OutputDetail {
+                index: idx as u32,
+                role,
+            });
+        }
+
+        // Determine direction
+        let has_sent = output_details.iter().any(|d| d.role == OutputRole::Sent);
+        let has_our_outputs = output_details
+            .iter()
+            .any(|d| d.role == OutputRole::Received || d.role == OutputRole::Change);
+        let direction = if transaction_type == TransactionType::CoinJoin {
+            TransactionDirection::CoinJoin
+        } else if !has_sent && has_inputs && has_our_outputs {
+            TransactionDirection::Internal
+        } else if has_inputs {
+            TransactionDirection::Outgoing
+        } else {
+            TransactionDirection::Incoming
+        };
+
+        let tx_record = TransactionRecord::new(
+            tx.clone(),
+            context,
+            transaction_type,
+            direction,
+            input_details,
+            output_details,
+            net_amount,
+        );
 
         self.transactions.insert(tx.txid(), tx_record);
 

--- a/key-wallet/src/managed_account/transaction_record.rs
+++ b/key-wallet/src/managed_account/transaction_record.rs
@@ -3,11 +3,65 @@
 //! This module contains the transaction record structure used to track
 //! transactions associated with accounts.
 
+use crate::transaction_checking::transaction_router::TransactionType;
 use crate::transaction_checking::{BlockInfo, TransactionContext};
+use crate::Address;
 use dashcore::blockdata::transaction::Transaction;
 use dashcore::Txid;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+/// Wallet-context metadata for a transaction input.
+/// The index references `transaction.input[index]`.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct InputDetail {
+    /// Index into the transaction's input array
+    pub index: u32,
+    /// Value of the UTXO being spent
+    pub value: u64,
+    /// Address that owned the spent UTXO
+    pub address: Address,
+}
+
+/// Wallet-context metadata for a transaction output.
+/// The index references `transaction.output[index]`.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct OutputDetail {
+    /// Index into the transaction's output array
+    pub index: u32,
+    /// Role of this output from the wallet's perspective
+    pub role: OutputRole,
+}
+
+/// Role of a transaction output from the wallet's perspective
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum OutputRole {
+    /// Output to our external/receive address
+    Received,
+    /// Output to our internal/change address
+    Change,
+    /// Output to counterparty address
+    Sent,
+    /// Unspendable output (OP_RETURN, non-standard, bare multisig)
+    Unspendable,
+}
+
+/// Direction of a transaction from the wallet's perspective
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum TransactionDirection {
+    /// Received funds from external source
+    Incoming,
+    /// Sent funds to external address
+    Outgoing,
+    /// Self-transfer or consolidation (no outputs to external addresses; may include unspendable data outputs)
+    Internal,
+    /// CoinJoin mixing transaction
+    CoinJoin,
+}
 
 /// Transaction record with full details
 #[derive(Debug, Clone)]
@@ -19,14 +73,20 @@ pub struct TransactionRecord {
     pub txid: Txid,
     /// The context in which this transaction was last seen
     pub context: TransactionContext,
+    /// Classification of the transaction type
+    pub transaction_type: TransactionType,
+    /// Direction of the transaction from the wallet's perspective
+    pub direction: TransactionDirection,
+    /// Wallet-relevant input details
+    pub input_details: Vec<InputDetail>,
+    /// Wallet-relevant output details
+    pub output_details: Vec<OutputDetail>,
     /// Net amount for this account
     pub net_amount: i64,
     /// Fee paid (if we created it)
     pub fee: Option<u64>,
     /// Transaction label
     pub label: Option<String>,
-    /// Whether this is our transaction
-    pub is_ours: bool,
 }
 
 impl TransactionRecord {
@@ -34,18 +94,24 @@ impl TransactionRecord {
     pub fn new(
         transaction: Transaction,
         context: TransactionContext,
+        transaction_type: TransactionType,
+        direction: TransactionDirection,
+        input_details: Vec<InputDetail>,
+        output_details: Vec<OutputDetail>,
         net_amount: i64,
-        is_ours: bool,
     ) -> Self {
         let txid = transaction.txid();
         Self {
-            transaction,
             txid,
+            transaction,
             context,
+            transaction_type,
+            direction,
+            input_details,
+            output_details,
             net_amount,
             fee: None,
             label: None,
-            is_ours,
         }
     }
 
@@ -92,14 +158,14 @@ impl TransactionRecord {
         self.context = context;
     }
 
-    /// Check if this is an incoming transaction (positive net amount)
+    /// Check if this is an incoming transaction
     pub fn is_incoming(&self) -> bool {
-        self.net_amount > 0
+        self.direction == TransactionDirection::Incoming
     }
 
-    /// Check if this is an outgoing transaction (negative net amount)
+    /// Check if this is an outgoing transaction
     pub fn is_outgoing(&self) -> bool {
-        self.net_amount < 0
+        self.direction == TransactionDirection::Outgoing
     }
 
     /// Get the absolute value of the net amount
@@ -118,21 +184,37 @@ mod tests {
         TransactionContext::InBlock(BlockInfo::new(height, BlockHash::all_zeros(), 1234567890))
     }
 
+    fn simple_record(
+        tx: Transaction,
+        context: TransactionContext,
+        net_amount: i64,
+    ) -> TransactionRecord {
+        TransactionRecord::new(
+            tx,
+            context,
+            TransactionType::Standard,
+            TransactionDirection::Incoming,
+            Vec::new(),
+            Vec::new(),
+            net_amount,
+        )
+    }
+
     #[test]
     fn test_transaction_record_creation() {
         let tx = Transaction::dummy_empty();
-        let record = TransactionRecord::new(tx.clone(), TransactionContext::Mempool, 50000, true);
+        let record = simple_record(tx.clone(), TransactionContext::Mempool, 50000);
 
         assert_eq!(record.txid, tx.txid());
         assert_eq!(record.net_amount, 50000);
-        assert!(record.is_ours);
+        assert_eq!(record.direction, TransactionDirection::Incoming);
         assert!(!record.is_confirmed());
     }
 
     #[test]
     fn test_confirmations_calculation() {
         let tx = Transaction::dummy_empty();
-        let mut record = TransactionRecord::new(tx, TransactionContext::Mempool, 50000, true);
+        let mut record = simple_record(tx, TransactionContext::Mempool, 50000);
 
         // Unconfirmed transaction
         assert_eq!(record.confirmations(100), 0);
@@ -158,23 +240,53 @@ mod tests {
     fn test_incoming_outgoing() {
         let tx = Transaction::dummy_empty();
 
-        let incoming =
-            TransactionRecord::new(tx.clone(), TransactionContext::Mempool, 50000, false);
+        let incoming = simple_record(tx.clone(), TransactionContext::Mempool, 50000);
         assert!(incoming.is_incoming());
         assert!(!incoming.is_outgoing());
         assert_eq!(incoming.amount(), 50000);
 
-        let outgoing =
-            TransactionRecord::new(tx.clone(), TransactionContext::Mempool, -50000, true);
+        let outgoing = TransactionRecord::new(
+            tx.clone(),
+            TransactionContext::Mempool,
+            TransactionType::Standard,
+            TransactionDirection::Outgoing,
+            Vec::new(),
+            Vec::new(),
+            -50000,
+        );
         assert!(!outgoing.is_incoming());
         assert!(outgoing.is_outgoing());
         assert_eq!(outgoing.amount(), 50000);
+
+        let internal = TransactionRecord::new(
+            tx.clone(),
+            TransactionContext::Mempool,
+            TransactionType::Standard,
+            TransactionDirection::Internal,
+            Vec::new(),
+            Vec::new(),
+            0,
+        );
+        assert!(!internal.is_incoming());
+        assert!(!internal.is_outgoing());
+
+        let coinjoin = TransactionRecord::new(
+            tx,
+            TransactionContext::Mempool,
+            TransactionType::CoinJoin,
+            TransactionDirection::CoinJoin,
+            Vec::new(),
+            Vec::new(),
+            0,
+        );
+        assert!(!coinjoin.is_incoming());
+        assert!(!coinjoin.is_outgoing());
     }
 
     #[test]
     fn test_confirmed_transaction_creation() {
         let tx = Transaction::dummy_empty();
-        let record = TransactionRecord::new(tx.clone(), test_block_context(100), 50000, true);
+        let record = simple_record(tx.clone(), test_block_context(100), 50000);
 
         assert_eq!(record.height(), Some(100));
         assert!(record.is_confirmed());
@@ -183,7 +295,7 @@ mod tests {
     #[test]
     fn test_update_context_reorg() {
         let tx = Transaction::dummy_empty();
-        let mut record = TransactionRecord::new(tx, test_block_context(100), 50000, true);
+        let mut record = simple_record(tx, test_block_context(100), 50000);
 
         assert!(record.is_confirmed());
 
@@ -196,7 +308,7 @@ mod tests {
     #[test]
     fn test_labels_and_fees() {
         let tx = Transaction::dummy_empty();
-        let mut record = TransactionRecord::new(tx, TransactionContext::Mempool, -50000, true);
+        let mut record = simple_record(tx, TransactionContext::Mempool, -50000);
 
         assert_eq!(record.fee, None);
         assert_eq!(record.label, None);

--- a/key-wallet/src/tests/spent_outpoints_tests.rs
+++ b/key-wallet/src/tests/spent_outpoints_tests.rs
@@ -4,8 +4,9 @@ use dashcore::blockdata::transaction::{OutPoint, Transaction};
 use dashcore::{TxIn, Txid};
 
 use crate::account::TransactionRecord;
+use crate::managed_account::transaction_record::TransactionDirection;
 use crate::managed_account::ManagedCoreAccount;
-use crate::transaction_checking::TransactionContext;
+use crate::transaction_checking::{TransactionContext, TransactionType};
 
 /// Create a transaction that spends the given outpoints.
 fn spending_tx(spent: &[OutPoint]) -> Transaction {
@@ -36,7 +37,15 @@ fn receive_only_tx() -> Transaction {
 }
 
 fn record_from_tx(tx: &Transaction) -> TransactionRecord {
-    TransactionRecord::new(tx.clone(), TransactionContext::Mempool, 0, false)
+    TransactionRecord::new(
+        tx.clone(),
+        TransactionContext::Mempool,
+        TransactionType::Standard,
+        TransactionDirection::Incoming,
+        Vec::new(),
+        Vec::new(),
+        0,
+    )
 }
 
 #[test]

--- a/key-wallet/src/transaction_checking/account_checker.rs
+++ b/key-wallet/src/transaction_checking/account_checker.rs
@@ -124,6 +124,79 @@ pub enum CoreAccountTypeMatch {
 }
 
 impl CoreAccountTypeMatch {
+    /// Get involved receive (external) addresses
+    pub fn involved_receive_addresses(&self) -> &[AddressInfo] {
+        match self {
+            CoreAccountTypeMatch::StandardBIP44 {
+                involved_receive_addresses,
+                ..
+            }
+            | CoreAccountTypeMatch::StandardBIP32 {
+                involved_receive_addresses,
+                ..
+            } => involved_receive_addresses,
+            CoreAccountTypeMatch::CoinJoin {
+                involved_addresses,
+                ..
+            }
+            | CoreAccountTypeMatch::IdentityRegistration {
+                involved_addresses,
+            }
+            | CoreAccountTypeMatch::IdentityTopUp {
+                involved_addresses,
+                ..
+            }
+            | CoreAccountTypeMatch::IdentityTopUpNotBound {
+                involved_addresses,
+            }
+            | CoreAccountTypeMatch::IdentityInvitation {
+                involved_addresses,
+            }
+            | CoreAccountTypeMatch::AssetLockAddressTopUp {
+                involved_addresses,
+            }
+            | CoreAccountTypeMatch::AssetLockShieldedAddressTopUp {
+                involved_addresses,
+            }
+            | CoreAccountTypeMatch::ProviderVotingKeys {
+                involved_addresses,
+            }
+            | CoreAccountTypeMatch::ProviderOwnerKeys {
+                involved_addresses,
+            }
+            | CoreAccountTypeMatch::ProviderOperatorKeys {
+                involved_addresses,
+            }
+            | CoreAccountTypeMatch::ProviderPlatformKeys {
+                involved_addresses,
+            }
+            | CoreAccountTypeMatch::DashpayReceivingFunds {
+                involved_addresses,
+                ..
+            }
+            | CoreAccountTypeMatch::DashpayExternalAccount {
+                involved_addresses,
+                ..
+            } => involved_addresses,
+        }
+    }
+
+    /// Get involved change (internal) addresses
+    pub fn involved_change_addresses(&self) -> &[AddressInfo] {
+        match self {
+            CoreAccountTypeMatch::StandardBIP44 {
+                involved_change_addresses,
+                ..
+            }
+            | CoreAccountTypeMatch::StandardBIP32 {
+                involved_change_addresses,
+                ..
+            } => involved_change_addresses,
+            // Non-standard account types don't have change addresses
+            _ => &[],
+        }
+    }
+
     /// Get all involved addresses (both receive and change combined)
     pub fn all_involved_addresses(&self) -> Vec<AddressInfo> {
         match self {

--- a/key-wallet/src/transaction_checking/transaction_router/mod.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/mod.rs
@@ -10,7 +10,8 @@ use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
 use dashcore::blockdata::transaction::Transaction;
 
 /// Classification of transaction types for routing
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TransactionType {
     /// Standard payment transaction
     Standard,

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -124,9 +124,9 @@ impl WalletTransactionChecker for ManagedWalletInfo {
             };
 
             if is_new {
-                account.record_transaction(tx, &account_match, context);
+                account.record_transaction(tx, &account_match, context, tx_type);
                 result.state_modified = true;
-            } else if account.confirm_transaction(tx, &account_match, context) {
+            } else if account.confirm_transaction(tx, &account_match, context, tx_type) {
                 result.state_modified = true;
             }
 
@@ -190,8 +190,10 @@ impl WalletTransactionChecker for ManagedWalletInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::managed_account::transaction_record::{OutputRole, TransactionDirection};
     use crate::test_utils::TestWalletContext;
     use crate::transaction_checking::BlockInfo;
+    use crate::transaction_checking::TransactionType;
     use crate::wallet::initialization::WalletAccountCreationOptions;
     use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
     use crate::wallet::{ManagedWalletInfo, Wallet};
@@ -1012,7 +1014,8 @@ mod tests {
         let block_hash = BlockHash::from_slice(&[9u8; 32]).expect("hash");
         let block_context =
             TransactionContext::InBlock(BlockInfo::new(600, block_hash, 1700000000));
-        let changed = account.confirm_transaction(&tx, &account_match, block_context);
+        let tx_type = TransactionRouter::classify_transaction(&tx);
+        let changed = account.confirm_transaction(&tx, &account_match, block_context, tx_type);
         assert!(changed, "Should return true when backfilling a missing record");
 
         // Verify the transaction was recorded with block context
@@ -1062,12 +1065,476 @@ mod tests {
             .managed_wallet
             .first_bip44_managed_account_mut()
             .expect("Should have BIP44 account");
-        let changed = account.confirm_transaction(&tx, &account_match, block_context);
+        let tx_type = TransactionRouter::classify_transaction(&tx);
+        let changed = account.confirm_transaction(&tx, &account_match, block_context, tx_type);
         assert!(changed, "Should return true when confirming unconfirmed tx");
 
         let record = account.transactions.get(&txid).expect("Should have record");
         assert!(record.is_confirmed());
         assert_eq!(record.height(), Some(700));
         assert_eq!(record.block_info().unwrap().block_hash, block_hash);
+    }
+
+    // ── Record-detail tests ─────────────────────────────────────────────
+
+    /// Exercises record details across all standard transaction shapes:
+    /// incoming, multi-output incoming, outgoing with change, internal
+    /// (self-transfer), sweep (no change), OP_RETURN + change, OP_RETURN
+    /// only (all-burn), coinbase, and confirmation preserving details.
+    #[tokio::test]
+    async fn test_record_details_across_transaction_types() {
+        let mut ctx = TestWalletContext::new_random();
+        let external_address = Address::p2pkh(
+            &dashcore::PublicKey::from_slice(&[0x02; 33]).expect("pubkey"),
+            Network::Testnet,
+        );
+        let mut block_height = 10u32;
+
+        let block_ctx = |height: &mut u32| {
+            let ctx = TransactionContext::InBlock(BlockInfo::new(
+                *height,
+                BlockHash::from_slice(&[*height as u8; 32]).expect("hash"),
+                1_700_000_000 + *height,
+            ));
+            *height += 1;
+            ctx
+        };
+
+        // ── Incoming ────────────────────────────────────────────────────
+        let incoming_amount = 500_000u64;
+        let incoming_tx = Transaction::dummy(&ctx.receive_address, 0..1, &[incoming_amount]);
+        let result = ctx.check_transaction(&incoming_tx, block_ctx(&mut block_height)).await;
+        assert!(result.is_relevant);
+
+        let record = ctx.transaction(&incoming_tx.txid());
+        assert_eq!(record.direction, TransactionDirection::Incoming);
+        assert_eq!(record.transaction_type, TransactionType::Standard);
+        assert_eq!(record.net_amount, incoming_amount as i64);
+        assert!(record.input_details.is_empty());
+        assert_eq!(record.output_details.len(), 1);
+        assert_eq!(record.output_details[0].index, 0);
+        assert_eq!(record.output_details[0].role, OutputRole::Received);
+        assert!(!record.output_details.iter().any(|d| d.role == OutputRole::Sent));
+
+        // ── Multi-output incoming ───────────────────────────────────────
+        let amount_1 = 300_000u64;
+        let amount_2 = 200_000u64;
+        let second_address = ctx
+            .managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("account")
+            .next_receive_address(Some(&ctx.xpub), true)
+            .expect("second receive address");
+
+        let multi_tx = Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: OutPoint::new(Txid::from([50u8; 32]), 0),
+                script_sig: ScriptBuf::new(),
+                sequence: 0xffffffff,
+                witness: dashcore::Witness::new(),
+            }],
+            output: vec![
+                TxOut {
+                    value: amount_1,
+                    script_pubkey: ctx.receive_address.script_pubkey(),
+                },
+                TxOut {
+                    value: amount_2,
+                    script_pubkey: second_address.script_pubkey(),
+                },
+            ],
+            special_transaction_payload: None,
+        };
+
+        let result = ctx.check_transaction(&multi_tx, block_ctx(&mut block_height)).await;
+        assert!(result.is_relevant);
+
+        let record = ctx.transaction(&multi_tx.txid());
+        assert_eq!(record.direction, TransactionDirection::Incoming);
+        assert_eq!(record.output_details.len(), 2);
+        assert!(record.output_details.iter().all(|d| d.role == OutputRole::Received));
+        assert_eq!(record.output_details[0].index, 0);
+        assert_eq!(record.output_details[1].index, 1);
+        assert_eq!(record.net_amount, (amount_1 + amount_2) as i64);
+
+        // ── Outgoing with change ────────────────────────────────────────
+        // Fund with a fresh UTXO so the spend has a known input.
+        // Each funding tx uses a different input range to produce unique txids.
+        let funding_value = 1_000_000u64;
+        let funding_tx = Transaction::dummy(&ctx.receive_address, 10..11, &[funding_value]);
+        ctx.check_transaction(&funding_tx, block_ctx(&mut block_height)).await;
+
+        let change_address = ctx
+            .managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("account")
+            .next_change_address(Some(&ctx.xpub), true)
+            .expect("change address");
+
+        let send_amount = 600_000u64;
+        let change_amount = funding_value - send_amount - 1_000;
+        let spend_tx = Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: funding_tx.txid(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: 0xffffffff,
+                witness: dashcore::Witness::new(),
+            }],
+            output: vec![
+                TxOut {
+                    value: send_amount,
+                    script_pubkey: external_address.script_pubkey(),
+                },
+                TxOut {
+                    value: change_amount,
+                    script_pubkey: change_address.script_pubkey(),
+                },
+            ],
+            special_transaction_payload: None,
+        };
+
+        let result = ctx.check_transaction(&spend_tx, block_ctx(&mut block_height)).await;
+        assert!(result.is_relevant);
+
+        let record = ctx.transaction(&spend_tx.txid());
+        assert_eq!(record.direction, TransactionDirection::Outgoing);
+        assert_eq!(record.transaction_type, TransactionType::Standard);
+        assert_eq!(record.input_details.len(), 1);
+        assert_eq!(record.input_details[0].index, 0);
+        assert_eq!(record.input_details[0].value, funding_value);
+        assert_eq!(record.input_details[0].address, ctx.receive_address);
+        assert_eq!(record.output_details.len(), 2);
+        let sent = record.output_details.iter().find(|d| d.role == OutputRole::Sent);
+        let change = record.output_details.iter().find(|d| d.role == OutputRole::Change);
+        assert!(sent.is_some() && change.is_some());
+        assert_eq!(sent.unwrap().index, 0);
+        assert_eq!(change.unwrap().index, 1);
+        assert_eq!(record.net_amount, change_amount as i64 - funding_value as i64);
+
+        // ── Internal (self-transfer) ────────────────────────────────────
+        let funding_tx = Transaction::dummy(&ctx.receive_address, 20..21, &[funding_value]);
+        ctx.check_transaction(&funding_tx, block_ctx(&mut block_height)).await;
+
+        let self_address = ctx
+            .managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("account")
+            .next_receive_address(Some(&ctx.xpub), true)
+            .expect("self address");
+        let change_address = ctx
+            .managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("account")
+            .next_change_address(Some(&ctx.xpub), true)
+            .expect("change address");
+
+        let self_amount = 800_000u64;
+        let change_amount = funding_value - self_amount - 1_000;
+        let internal_tx = Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: funding_tx.txid(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: 0xffffffff,
+                witness: dashcore::Witness::new(),
+            }],
+            output: vec![
+                TxOut {
+                    value: self_amount,
+                    script_pubkey: self_address.script_pubkey(),
+                },
+                TxOut {
+                    value: change_amount,
+                    script_pubkey: change_address.script_pubkey(),
+                },
+            ],
+            special_transaction_payload: None,
+        };
+
+        let result = ctx.check_transaction(&internal_tx, block_ctx(&mut block_height)).await;
+        assert!(result.is_relevant);
+
+        let record = ctx.transaction(&internal_tx.txid());
+        assert_eq!(record.direction, TransactionDirection::Internal);
+        assert_eq!(record.transaction_type, TransactionType::Standard);
+        assert_eq!(record.input_details.len(), 1);
+        assert_eq!(record.input_details[0].value, funding_value);
+        assert!(!record.output_details.iter().any(|d| d.role == OutputRole::Sent));
+        assert!(record.output_details.iter().any(|d| d.role == OutputRole::Received));
+        assert!(record.output_details.iter().any(|d| d.role == OutputRole::Change));
+        assert_eq!(record.output_details.len(), 2);
+        assert_eq!(record.net_amount, (self_amount + change_amount) as i64 - funding_value as i64);
+
+        // ── Sweep (outgoing, no change) ─────────────────────────────────
+        let funding_tx = Transaction::dummy(&ctx.receive_address, 30..31, &[funding_value]);
+        ctx.check_transaction(&funding_tx, block_ctx(&mut block_height)).await;
+
+        let sweep_tx = Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: funding_tx.txid(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: 0xffffffff,
+                witness: dashcore::Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: funding_value - 1_000,
+                script_pubkey: external_address.script_pubkey(),
+            }],
+            special_transaction_payload: None,
+        };
+
+        let result = ctx.check_transaction(&sweep_tx, block_ctx(&mut block_height)).await;
+        assert!(result.is_relevant);
+
+        let record = ctx.transaction(&sweep_tx.txid());
+        assert_eq!(record.direction, TransactionDirection::Outgoing);
+        assert_eq!(record.input_details.len(), 1);
+        assert_eq!(record.input_details[0].value, funding_value);
+        assert_eq!(record.output_details.len(), 1);
+        assert_eq!(record.output_details[0].role, OutputRole::Sent);
+        assert!(!record.output_details.iter().any(|d| d.role == OutputRole::Change));
+        assert_eq!(record.net_amount, -(funding_value as i64));
+
+        // ── OP_RETURN with change ───────────────────────────────────────
+        let funding_tx = Transaction::dummy(&ctx.receive_address, 40..41, &[funding_value]);
+        ctx.check_transaction(&funding_tx, block_ctx(&mut block_height)).await;
+
+        let change_address = ctx
+            .managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("account")
+            .next_change_address(Some(&ctx.xpub), true)
+            .expect("change address");
+
+        let send_amount = 400_000u64;
+        let change_amount = funding_value - send_amount - 1_000;
+        let op_return_tx = Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: funding_tx.txid(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: 0xffffffff,
+                witness: dashcore::Witness::new(),
+            }],
+            output: vec![
+                TxOut {
+                    value: send_amount,
+                    script_pubkey: external_address.script_pubkey(),
+                },
+                TxOut {
+                    value: 0,
+                    script_pubkey: ScriptBuf::new_op_return(&[0x01, 0x02, 0x03]),
+                },
+                TxOut {
+                    value: change_amount,
+                    script_pubkey: change_address.script_pubkey(),
+                },
+            ],
+            special_transaction_payload: None,
+        };
+
+        let result = ctx.check_transaction(&op_return_tx, block_ctx(&mut block_height)).await;
+        assert!(result.is_relevant);
+
+        let record = ctx.transaction(&op_return_tx.txid());
+        assert_eq!(record.direction, TransactionDirection::Outgoing);
+        assert_eq!(record.output_details.len(), 3);
+        let sent = record.output_details.iter().find(|d| d.role == OutputRole::Sent);
+        let unspendable = record.output_details.iter().find(|d| d.role == OutputRole::Unspendable);
+        let change = record.output_details.iter().find(|d| d.role == OutputRole::Change);
+        assert!(sent.is_some());
+        assert_eq!(sent.unwrap().index, 0);
+        assert!(unspendable.is_some());
+        assert_eq!(unspendable.unwrap().index, 1);
+        assert!(change.is_some());
+        assert_eq!(change.unwrap().index, 2);
+
+        // ── OP_RETURN only (all-burn) ───────────────────────────────────
+        let funding_tx = Transaction::dummy(&ctx.receive_address, 50..51, &[funding_value]);
+        ctx.check_transaction(&funding_tx, block_ctx(&mut block_height)).await;
+
+        let burn_tx = Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: funding_tx.txid(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: 0xffffffff,
+                witness: dashcore::Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: 0,
+                script_pubkey: ScriptBuf::new_op_return(&[0x01]),
+            }],
+            special_transaction_payload: None,
+        };
+
+        let result = ctx.check_transaction(&burn_tx, block_ctx(&mut block_height)).await;
+        assert!(result.is_relevant);
+
+        let record = ctx.transaction(&burn_tx.txid());
+        assert_eq!(record.direction, TransactionDirection::Outgoing);
+        assert_eq!(record.input_details.len(), 1);
+        assert_eq!(record.output_details.len(), 1);
+        assert_eq!(record.output_details[0].role, OutputRole::Unspendable);
+        assert_eq!(record.net_amount, -(funding_value as i64));
+
+        // ── Coinbase ────────────────────────────────────────────────────
+        let reward = 5_000_000_000u64;
+        let coinbase_tx = Transaction::dummy_coinbase(&ctx.receive_address, reward);
+        let result = ctx.check_transaction(&coinbase_tx, block_ctx(&mut block_height)).await;
+        assert!(result.is_relevant);
+
+        let record = ctx.transaction(&coinbase_tx.txid());
+        assert_eq!(record.direction, TransactionDirection::Incoming);
+        assert_eq!(record.transaction_type, TransactionType::Coinbase);
+        assert!(record.input_details.is_empty());
+        assert_eq!(record.output_details.len(), 1);
+        assert_eq!(record.output_details[0].role, OutputRole::Received);
+        assert_eq!(record.output_details[0].index, 0);
+
+        // ── Confirmation preserves details ──────────────────────────────
+        let amount = 750_000u64;
+        let mempool_tx = Transaction::dummy(&ctx.receive_address, 60..61, &[amount]);
+        let mempool_txid = mempool_tx.txid();
+        ctx.check_transaction(&mempool_tx, TransactionContext::Mempool).await;
+
+        let record_before = ctx.transaction(&mempool_txid);
+        assert!(!record_before.is_confirmed());
+        assert_eq!(record_before.direction, TransactionDirection::Incoming);
+        assert_eq!(record_before.output_details.len(), 1);
+        assert_eq!(record_before.output_details[0].role, OutputRole::Received);
+        assert!(record_before.input_details.is_empty());
+
+        ctx.check_transaction(&mempool_tx, block_ctx(&mut block_height)).await;
+
+        let record_after = ctx.transaction(&mempool_txid);
+        assert!(record_after.is_confirmed());
+        assert_eq!(record_after.direction, TransactionDirection::Incoming);
+        assert_eq!(record_after.input_details.len(), 0);
+        assert_eq!(record_after.output_details.len(), 1);
+        assert_eq!(record_after.output_details[0].role, OutputRole::Received);
+    }
+
+    /// CoinJoin transaction: direction should be `CoinJoin` regardless of output roles.
+    #[tokio::test]
+    async fn test_record_details_coinjoin_transaction() {
+        use crate::account::AccountType;
+        use crate::managed_account::managed_account_type::ManagedAccountType;
+
+        // Create a wallet with a CoinJoin account
+        let mut wallet = Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::None)
+            .expect("wallet");
+        wallet
+            .add_account(
+                AccountType::CoinJoin {
+                    index: 0,
+                },
+                None,
+            )
+            .expect("add coinjoin");
+
+        let mut managed_wallet =
+            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
+
+        let xpub =
+            wallet.accounts.coinjoin_accounts.get(&0).expect("coinjoin account").account_xpub;
+
+        let managed_account =
+            managed_wallet.first_coinjoin_managed_account_mut().expect("managed coinjoin");
+
+        // Get an address from the CoinJoin pool
+        let coinjoin_address = if let ManagedAccountType::CoinJoin {
+            addresses,
+            ..
+        } = &mut managed_account.account_type
+        {
+            addresses.next_unused(&KeySource::Public(xpub), true).expect("coinjoin address")
+        } else {
+            panic!("Expected CoinJoin account type");
+        };
+
+        // Build a CoinJoin-like tx: 3+ inputs, 3+ outputs with denomination amounts
+        let denomination = 100_000u64; // 0.001 DASH
+        let external_addr = Address::dummy(Network::Testnet, 99);
+        let tx = Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![
+                TxIn {
+                    previous_output: OutPoint::new(Txid::from([1u8; 32]), 0),
+                    script_sig: ScriptBuf::new(),
+                    sequence: 0xffffffff,
+                    witness: dashcore::Witness::new(),
+                },
+                TxIn {
+                    previous_output: OutPoint::new(Txid::from([2u8; 32]), 0),
+                    script_sig: ScriptBuf::new(),
+                    sequence: 0xffffffff,
+                    witness: dashcore::Witness::new(),
+                },
+                TxIn {
+                    previous_output: OutPoint::new(Txid::from([3u8; 32]), 0),
+                    script_sig: ScriptBuf::new(),
+                    sequence: 0xffffffff,
+                    witness: dashcore::Witness::new(),
+                },
+            ],
+            output: vec![
+                TxOut {
+                    value: denomination,
+                    script_pubkey: coinjoin_address.script_pubkey(),
+                },
+                TxOut {
+                    value: denomination,
+                    script_pubkey: external_addr.script_pubkey(),
+                },
+                TxOut {
+                    value: denomination,
+                    script_pubkey: Address::dummy(Network::Testnet, 100).script_pubkey(),
+                },
+            ],
+            special_transaction_payload: None,
+        };
+
+        let context = TransactionContext::InBlock(BlockInfo::new(
+            50,
+            BlockHash::from_slice(&[5u8; 32]).expect("hash"),
+            1_700_000_000,
+        ));
+        let result =
+            managed_wallet.check_core_transaction(&tx, context, &mut wallet, true, true).await;
+        assert!(result.is_relevant, "CoinJoin tx should be relevant");
+
+        let account = managed_wallet.first_coinjoin_managed_account().expect("coinjoin account");
+        let record = account.transactions.get(&tx.txid()).expect("should have record");
+        assert_eq!(record.direction, TransactionDirection::CoinJoin);
+        assert_eq!(record.transaction_type, TransactionType::CoinJoin);
+        assert!(record.input_details.is_empty(), "CoinJoin test has no funded UTXOs");
+        assert_eq!(record.output_details.len(), 1, "One output to our CoinJoin address");
+        assert_eq!(record.output_details[0].role, OutputRole::Received);
     }
 }


### PR DESCRIPTION
Add `InputDetail`, `OutputDetail`, `OutputRole`, and `TransactionDirection` to capture which inputs/outputs are wallet-relevant and classify the transaction direction at recording time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Transaction records now include richer metadata: explicit transaction-type tagging, direction classification (incoming/outgoing/internal/coinjoin), per-input details, and per-output roles (received/change/sent/unspendable) with associated addresses.
* **Tests**
  - Expanded test coverage validating direction, transaction-type, net amounts and per-input/output role/index/address behaviors across many transaction shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->