### PR TITLE
fix: detect coinbase by input pattern in `classify_transaction`

### DIFF
--- a/key-wallet/src/transaction_checking/transaction_router/mod.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/mod.rs
@@ -61,6 +61,8 @@ impl TransactionRouter {
                 TransactionPayload::QuorumCommitmentPayloadType(_) => TransactionType::Ignored,
                 TransactionPayload::MnhfSignalPayloadType(_) => TransactionType::Ignored,
             }
+        } else if tx.is_coin_base() {
+            TransactionType::Coinbase
         } else if Self::is_coinjoin_transaction(tx) {
             TransactionType::CoinJoin
         } else {

--- a/key-wallet/src/transaction_checking/transaction_router/tests/classification.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/classification.rs
@@ -187,6 +187,10 @@ fn test_classify_coinbase_transaction() {
     tx.special_transaction_payload = Some(TransactionPayload::CoinbasePayloadType(payload));
 
     assert_eq!(TransactionRouter::classify_transaction(&tx), TransactionType::Coinbase);
+
+    // Also detected by coinbase input pattern (null txid + 0xffffffff vout) without payload
+    let coinbase_tx = Transaction::dummy_coinbase(&addr, 100_000_000);
+    assert_eq!(TransactionRouter::classify_transaction(&coinbase_tx), TransactionType::Coinbase);
 }
 
 #[test]


### PR DESCRIPTION
`classify_transaction` only detected coinbase via `CoinbasePayloadType` payload, missing coinbase transactions without the special payload. Now also checks `tx.is_coin_base()` (null txid + 0xffffffff vout).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed transaction classification logic to correctly identify and classify coinbase transactions during the transaction routing process, preventing them from being misclassified as standard or other transaction types and ensuring accurate transaction categorization.

* **Tests**
  * Added comprehensive test cases to verify that coinbase transactions are properly identified and classified in all transaction processing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->