### PR TITLE
docs: update stale `wallet_check_transaction` docs

### DIFF
--- a/key-wallet-ffi/FFI_API.md
+++ b/key-wallet-ffi/FFI_API.md
@@ -1321,10 +1321,10 @@ wallet_check_transaction(wallet: *mut FFIWallet, tx_bytes: *const u8, tx_len: us
 ```
 
 **Description:**
-Check if a transaction belongs to the wallet using ManagedWalletInfo  # Safety  - `wallet` must be a valid mutable pointer to an FFIWallet - `tx_bytes` must be a valid pointer to transaction bytes with at least `tx_len` bytes - `inputs_spent_out` must be a valid pointer to store the spent inputs count - `addresses_used_out` must be a valid pointer to store the used addresses count - `new_balance_out` must be a valid pointer to store the new balance - `new_address_out` must be a valid pointer to store the address array pointer - `new_address_count_out` must be a valid pointer to store the address count - `error` must be a valid pointer to an FFIError
+Check if a transaction belongs to the wallet using ManagedWalletInfo  # Safety  - `wallet` must be a valid mutable pointer to an FFIWallet - `tx_bytes` must be a valid pointer to transaction bytes with at least `tx_len` bytes - `result_out` must be a valid pointer to store the result - `error` must be a valid pointer to an FFIError
 
 **Safety:**
-- `wallet` must be a valid mutable pointer to an FFIWallet - `tx_bytes` must be a valid pointer to transaction bytes with at least `tx_len` bytes - `inputs_spent_out` must be a valid pointer to store the spent inputs count - `addresses_used_out` must be a valid pointer to store the used addresses count - `new_balance_out` must be a valid pointer to store the new balance - `new_address_out` must be a valid pointer to store the address array pointer - `new_address_count_out` must be a valid pointer to store the address count - `error` must be a valid pointer to an FFIError
+- `wallet` must be a valid mutable pointer to an FFIWallet - `tx_bytes` must be a valid pointer to transaction bytes with at least `tx_len` bytes - `result_out` must be a valid pointer to store the result - `error` must be a valid pointer to an FFIError
 
 **Module:** `transaction`
 

--- a/key-wallet-ffi/src/transaction.rs
+++ b/key-wallet-ffi/src/transaction.rs
@@ -382,11 +382,7 @@ pub struct FFITransactionCheckResult {
 ///
 /// - `wallet` must be a valid mutable pointer to an FFIWallet
 /// - `tx_bytes` must be a valid pointer to transaction bytes with at least `tx_len` bytes
-/// - `inputs_spent_out` must be a valid pointer to store the spent inputs count
-/// - `addresses_used_out` must be a valid pointer to store the used addresses count
-/// - `new_balance_out` must be a valid pointer to store the new balance
-/// - `new_address_out` must be a valid pointer to store the address array pointer
-/// - `new_address_count_out` must be a valid pointer to store the address count
+/// - `result_out` must be a valid pointer to store the result
 /// - `error` must be a valid pointer to an FFIError
 #[no_mangle]
 pub unsafe extern "C" fn wallet_check_transaction(


### PR DESCRIPTION
Remove references to old output params (`inputs_spent_out`, `addresses_used_out`, `new_balance_out`, `new_address_out`, `new_address_count_out`) that no longer exist in the signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated transaction verification API documentation with a simplified output format using a consolidated result parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->