### PR TITLE
fix: apply BIP-69 sorting to asset lock credit outputs

### DIFF
--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -241,7 +241,8 @@ impl ManagedWalletInfo {
         let fee = tx_builder_with_inputs.calculate_fee();
         let fee_with_extra = tx_builder_with_inputs.calculate_fee_with_extra_output();
 
-        let transaction = tx_builder_with_inputs.build_asset_lock(credit_outputs)?;
+        let (transaction, sorted_indices) =
+            tx_builder_with_inputs.build_asset_lock(credit_outputs)?;
 
         let actual_fee = if transaction.output.len() > outputs_count_before {
             fee_with_extra
@@ -250,7 +251,9 @@ impl ManagedWalletInfo {
         };
 
         // Transaction built successfully — now derive keys.
-        let mut keys = Vec::with_capacity(credit_output_fundings.len());
+        // Keys are derived in the original funding order, then reordered
+        // to match the BIP-69 sorted credit output positions in the payload.
+        let mut original_keys = Vec::with_capacity(credit_output_fundings.len());
         for funding in &credit_output_fundings {
             let funding_key_account = resolve_funding_account(
                 &mut self.accounts,
@@ -260,7 +263,14 @@ impl ManagedWalletInfo {
             let key = funding_key_account
                 .next_private_key(root_xpriv, network)
                 .map_err(|e| AssetLockError::KeyDerivation(e.to_string()))?;
-            keys.push(key);
+            original_keys.push(key);
+        }
+
+        // Reorder keys to match sorted output positions:
+        // sorted_indices[i] = original index of the output now at position i
+        let mut keys = vec![[0u8; 32]; original_keys.len()];
+        for (sorted_pos, &orig_idx) in sorted_indices.iter().enumerate() {
+            keys[sorted_pos] = original_keys[orig_idx];
         }
 
         Ok(AssetLockResult {

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -629,13 +629,34 @@ impl TransactionBuilder {
 
     /// Build an Asset Lock Transaction
     ///
-    /// Used to lock Dash for use in Platform (creates Platform credits)
-    pub fn build_asset_lock(self, credit_outputs: Vec<TxOut>) -> Result<Transaction, BuilderError> {
+    /// Used to lock Dash for use in Platform (creates Platform credits).
+    /// Credit outputs in the payload are sorted by BIP-69 (amount ascending,
+    /// then scriptPubKey lexicographically) for deterministic ordering.
+    /// Returns `(Transaction, sorted_indices)` where `sorted_indices[i]` is
+    /// the original index of the credit output now at position `i` in the payload.
+    pub fn build_asset_lock(
+        self,
+        credit_outputs: Vec<TxOut>,
+    ) -> Result<(Transaction, Vec<usize>), BuilderError> {
+        // Track original indices so callers can re-map keys
+        let mut indexed: Vec<(usize, TxOut)> = credit_outputs.into_iter().enumerate().collect();
+
+        // BIP-69: sort by amount ascending, then scriptPubKey lexicographically
+        indexed.sort_by(|(_, a), (_, b)| match a.value.cmp(&b.value) {
+            std::cmp::Ordering::Equal => a.script_pubkey.as_bytes().cmp(b.script_pubkey.as_bytes()),
+            other => other,
+        });
+
+        let sorted_indices: Vec<usize> = indexed.iter().map(|(orig, _)| *orig).collect();
+        let sorted_outputs: Vec<TxOut> = indexed.into_iter().map(|(_, out)| out).collect();
+
         let payload = AssetLockPayload {
             version: 0,
-            credit_outputs,
+            credit_outputs: sorted_outputs,
         };
-        self.set_special_payload(TransactionPayload::AssetLockPayloadType(payload)).build()
+        let tx =
+            self.set_special_payload(TransactionPayload::AssetLockPayloadType(payload)).build()?;
+        Ok((tx, sorted_indices))
     }
 
     /// Estimate transaction size in bytes


### PR DESCRIPTION
## Summary

The asset lock payload's `credit_outputs` were not BIP-69 sorted, making the transaction output ordering non-deterministic and potentially fingerprintable.

## Changes

### `TransactionBuilder::build_asset_lock()`
- Now sorts credit outputs by BIP-69 before placing them in the payload (amount ascending, then scriptPubKey lexicographically)
- Returns `(Transaction, Vec<usize>)` where `sorted_indices[i]` = original index of the output now at sorted position `i`

### `ManagedWalletInfo::build_asset_lock()`
- Reorders derived private keys to match the sorted output positions
- `result.keys[i]` always corresponds to `payload.credit_outputs[i]`

## Why

BIP-69 mandates deterministic output ordering. The transaction's regular outputs were already sorted, but the payload's credit outputs were in caller-provided order. This inconsistency could fingerprint transactions built by this library.

## Test plan

- [x] All 11 asset lock tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction building logic to ensure proper key ordering alignment with output sorting requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->