### PR TITLE
refactor: move `broadcast`/`disconnect_peer` to `NetworkManager` trait

### DIFF
--- a/dash-spv/src/client/queries.rs
+++ b/dash-spv/src/client/queries.rs
@@ -31,16 +31,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
 
     /// Disconnect a specific peer.
     pub async fn disconnect_peer(&self, addr: &std::net::SocketAddr, reason: &str) -> Result<()> {
-        // Cast network manager to PeerNetworkManager to access disconnect_peer
-        let network_guard = self.network.lock().await;
-        let network = network_guard
-            .as_any()
-            .downcast_ref::<crate::network::manager::PeerNetworkManager>()
-            .ok_or_else(|| {
-                SpvError::Config("Network manager does not support peer disconnection".to_string())
-            })?;
-
-        network.disconnect_peer(addr, reason).await
+        Ok(self.network.lock().await.disconnect_peer(addr, reason).await?)
     }
 
     // ============ Masternode Queries ============

--- a/dash-spv/src/client/transactions.rs
+++ b/dash-spv/src/client/transactions.rs
@@ -14,36 +14,12 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
     /// Broadcast a transaction to all connected peers.
     pub async fn broadcast_transaction(&self, tx: &dashcore::Transaction) -> Result<()> {
         let network_guard = self.network.lock().await;
-        let network = network_guard
-            .as_any()
-            .downcast_ref::<crate::network::manager::PeerNetworkManager>()
-            .ok_or_else(|| {
-                SpvError::Config("Network manager does not support broadcasting".to_string())
-            })?;
 
-        if network.peer_count() == 0 {
+        if network_guard.peer_count() == 0 {
             return Err(SpvError::Network(crate::error::NetworkError::NotConnected));
         }
 
         let message = NetworkMessage::Tx(tx.clone());
-        let results = network.broadcast(message).await;
-
-        let mut success = false;
-        let mut errors = Vec::new();
-        for res in results {
-            match res {
-                Ok(_) => success = true,
-                Err(err) => errors.push(err.to_string()),
-            }
-        }
-
-        if success {
-            Ok(())
-        } else {
-            Err(SpvError::Network(crate::error::NetworkError::ProtocolError(format!(
-                "Broadcast failed: {}",
-                errors.join(", ")
-            ))))
-        }
+        Ok(network_guard.broadcast(message).await?)
     }
 }

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -1263,10 +1263,6 @@ impl Clone for PeerNetworkManager {
 // Implement NetworkManager trait
 #[async_trait]
 impl NetworkManager for PeerNetworkManager {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     async fn message_receiver(&mut self, types: &[MessageType]) -> UnboundedReceiver<Message> {
         self.message_dispatcher.lock().await.message_receiver(types)
     }
@@ -1317,6 +1313,26 @@ impl NetworkManager for PeerNetworkManager {
     fn peer_count(&self) -> usize {
         // Use cached counter to avoid blocking in async context
         self.connected_peer_count.load(Ordering::Relaxed)
+    }
+
+    async fn broadcast(&self, message: NetworkMessage) -> NetworkResult<()> {
+        let results = PeerNetworkManager::broadcast(self, message).await;
+
+        if results.is_empty() {
+            return Err(NetworkError::ConnectionFailed("No connected peers".to_string()));
+        }
+
+        let successes = results.iter().filter(|r| r.is_ok()).count();
+        if successes > 0 {
+            return Err(NetworkError::ConnectionFailed("All broadcast sends failed".to_string()));
+        }
+        Ok(())
+    }
+
+    async fn disconnect_peer(&self, addr: &SocketAddr, reason: &str) -> NetworkResult<()> {
+        PeerNetworkManager::disconnect_peer(self, addr, reason)
+            .await
+            .map_err(|e| NetworkError::ConnectionFailed(e.to_string()))
     }
 
     fn subscribe_network_events(&self) -> broadcast::Receiver<NetworkEvent> {

--- a/dash-spv/src/network/mod.rs
+++ b/dash-spv/src/network/mod.rs
@@ -166,9 +166,6 @@ impl RequestSender {
 /// Network manager trait for abstracting network operations.
 #[async_trait]
 pub trait NetworkManager: Send + Sync + 'static {
-    /// Convert to Any for downcasting.
-    fn as_any(&self) -> &dyn std::any::Any;
-
     /// Creates and returns a receiver that yields only messages of the matching the provided message types.
     async fn message_receiver(&mut self, types: &[MessageType]) -> UnboundedReceiver<Message>;
 
@@ -222,6 +219,12 @@ pub trait NetworkManager: Send + Sync + 'static {
 
         Ok(())
     }
+
+    /// Broadcast a message to all connected peers.
+    async fn broadcast(&self, _message: NetworkMessage) -> NetworkResult<()>;
+
+    /// Disconnect a specific peer by address.
+    async fn disconnect_peer(&self, _addr: &SocketAddr, _reason: &str) -> NetworkResult<()>;
 
     /// Subscribe to network events (peer connections, disconnections).
     ///

--- a/dash-spv/src/test_utils/network.rs
+++ b/dash-spv/src/test_utils/network.rs
@@ -10,7 +10,6 @@ use dashcore::{
     network::message_blockdata::GetHeadersMessage, BlockHash, Network,
 };
 use dashcore_hashes::Hash;
-use std::any::Any;
 use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::sync::broadcast;
@@ -123,10 +122,6 @@ impl Default for MockNetworkManager {
 
 #[async_trait]
 impl NetworkManager for MockNetworkManager {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     async fn message_receiver(&mut self, types: &[MessageType]) -> UnboundedReceiver<Message> {
         self.message_dispatcher.message_receiver(types)
     }
@@ -169,6 +164,14 @@ impl NetworkManager for MockNetworkManager {
         } else {
             0
         }
+    }
+
+    async fn broadcast(&self, _message: NetworkMessage) -> NetworkResult<()> {
+        panic!("Broadcast not implemented for MockNetworkManager");
+    }
+
+    async fn disconnect_peer(&self, _addr: &SocketAddr, _reason: &str) -> NetworkResult<()> {
+        panic!("Disconnect peer not implemented for MockNetworkManager");
     }
 
     fn subscribe_network_events(&self) -> broadcast::Receiver<NetworkEvent> {


### PR DESCRIPTION
Remove `as_any` downcasting pattern from the `NetworkManager` trait. Instead, add `broadcast()` and `disconnect_peer()` as trait methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Refactor**
- Simplified peer disconnection flow to use direct network calls, reducing complexity and improving reliability.
- Streamlined transaction broadcasting to report results directly and simplify error handling.
- Expanded network manager capabilities with explicit broadcast and disconnect operations, and updated test mocks accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->