### PR TITLE
refactor: use `String` for `TransactionRecord::label`

### DIFF
--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -730,8 +730,11 @@ impl FFIWalletEventCallbacks {
                         })
                         .collect();
 
-                    let c_label =
-                        record.label.as_ref().map(|l| CString::new(l.as_str()).unwrap_or_default());
+                    let c_label = if record.label.is_empty() {
+                        None
+                    } else {
+                        Some(CString::new(record.label.as_str()).unwrap_or_default())
+                    };
 
                     let ffi_record = FFITransactionRecord {
                         txid: record.txid.to_byte_array(),

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -730,10 +730,11 @@ impl FFIWalletEventCallbacks {
                         })
                         .collect();
 
-                    let c_label = if record.label.is_empty() {
-                        None
+                    let c_label = CString::new(record.label.as_str()).unwrap_or_default();
+                    let c_label_ptr = if record.label.is_empty() {
+                        std::ptr::null_mut()
                     } else {
-                        Some(CString::new(record.label.as_str()).unwrap_or_default())
+                        c_label.as_ptr() as *mut _
                     };
 
                     let ffi_record = FFITransactionRecord {
@@ -761,9 +762,7 @@ impl FFIWalletEventCallbacks {
                             tx_bytes.as_ptr() as *mut _
                         },
                         tx_len: tx_bytes.len(),
-                        label: c_label
-                            .as_ref()
-                            .map_or(std::ptr::null_mut(), |l| l.as_ptr() as *mut _),
+                        label: c_label_ptr,
                     };
 
                     cb(

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -778,9 +778,10 @@ pub unsafe extern "C" fn managed_core_account_get_transactions(
         };
 
         // Label
-        ffi_record.label = match &record.label {
-            Some(label) => std::ffi::CString::new(label.as_str()).unwrap_or_default().into_raw(),
-            None => std::ptr::null_mut(),
+        ffi_record.label = if record.label.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            std::ffi::CString::new(record.label.as_str()).unwrap_or_default().into_raw()
         };
 
         // Output details

--- a/key-wallet/src/managed_account/transaction_record.rs
+++ b/key-wallet/src/managed_account/transaction_record.rs
@@ -90,7 +90,7 @@ pub struct TransactionRecord {
     /// Fee paid (if we created it)
     pub fee: Option<u64>,
     /// Transaction label
-    pub label: Option<String>,
+    pub label: String,
 }
 
 impl TransactionRecord {
@@ -115,7 +115,7 @@ impl TransactionRecord {
             output_details,
             net_amount,
             fee: None,
-            label: None,
+            label: String::new(),
         }
     }
 
@@ -154,20 +154,15 @@ impl TransactionRecord {
 
     /// Set the label for this transaction.
     ///
-    /// Empty strings clear the label. Returns an error if the label
-    /// exceeds [`MAX_LABEL_LENGTH`] bytes.
+    /// Returns an error if the label exceeds [`MAX_LABEL_LENGTH`] bytes.
     pub fn set_label(&mut self, label: String) -> Result<(), Error> {
-        if label.is_empty() {
-            self.label = None;
-            return Ok(());
-        }
         if label.len() > MAX_LABEL_LENGTH {
             return Err(Error::InvalidParameter(format!(
                 "Label exceeds {} bytes",
                 MAX_LABEL_LENGTH
             )));
         }
-        self.label = Some(label);
+        self.label = label;
         Ok(())
     }
 
@@ -329,26 +324,26 @@ mod tests {
         let mut record = simple_record(tx, TransactionContext::Mempool, -50000);
 
         assert_eq!(record.fee, None);
-        assert_eq!(record.label, None);
+        assert!(record.label.is_empty());
 
         record.set_fee(226);
         record.set_label("Payment to Bob".to_string()).unwrap();
 
         assert_eq!(record.fee, Some(226));
-        assert_eq!(record.label, Some("Payment to Bob".to_string()));
+        assert_eq!(record.label, "Payment to Bob");
 
         // Empty string clears the label
         record.set_label(String::new()).unwrap();
-        assert_eq!(record.label, None);
+        assert!(record.label.is_empty());
 
         // Exceeding max length returns an error
         let long_label = "x".repeat(MAX_LABEL_LENGTH + 1);
         assert!(record.set_label(long_label).is_err());
-        assert_eq!(record.label, None); // unchanged
+        assert!(record.label.is_empty()); // unchanged
 
         // Exactly max length is fine
         let max_label = "x".repeat(MAX_LABEL_LENGTH);
         record.set_label(max_label.clone()).unwrap();
-        assert_eq!(record.label, Some(max_label));
+        assert_eq!(record.label, max_label);
     }
 }


### PR DESCRIPTION
Instead of `Option<String>`. Empty string represents "no label".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Transaction label handling made consistent across layers.
  * Clearing a label now results in an empty label (""), not an unset value; this affects how labels display and persist.
  * Empty labels are treated as absent when communicating with external interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->