### PR TITLE
fix: make `broadcast` not return an error on success

### DIFF
--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -1323,7 +1323,7 @@ impl NetworkManager for PeerNetworkManager {
         }
 
         let successes = results.iter().filter(|r| r.is_ok()).count();
-        if successes > 0 {
+        if successes == 0 {
             return Err(NetworkError::ConnectionFailed("All broadcast sends failed".to_string()));
         }
         Ok(())


### PR DESCRIPTION
I thought I was clever and could simplify the condition in #623 but instead I introduced this issue :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed network broadcast error handling to accurately report failures only when all broadcast attempts fail, resolving incorrect error reporting for successful broadcasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->