### PR TITLE
chore: update manki action to manki-review org

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: xdustinface/manki@v4
+      - uses: manki-review/manki@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -1,0 +1,29 @@
+name: Manki Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+concurrency:
+  group: manki-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: xdustinface/manki@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.manki.yml
+++ b/.manki.yml
@@ -1,0 +1,18 @@
+# Manki — AI Code Review Configuration
+# https://github.com/xdustinface/manki
+
+auto_review: true
+auto_approve: true
+
+exclude_paths:
+  - "*.lock"
+  - "fuzz/**"
+
+instructions: |
+  This is a Rust implementation of the Dash cryptocurrency protocol.
+  Pay special attention to:
+  - Consensus-critical code paths — changes here can cause chain splits
+  - FFI safety for C/Swift bindings in dash-spv-* crates
+  - Proper error handling — prefer Result over unwrap/expect in library code
+  - DIP (Dash Improvement Proposal) compliance for protocol changes
+  - Memory safety in hash/crypto implementations

--- a/.manki.yml
+++ b/.manki.yml
@@ -1,5 +1,5 @@
 # Manki — AI Code Review Configuration
-# https://github.com/xdustinface/manki
+# https://github.com/manki-review/manki
 
 auto_review: true
 auto_approve: true


### PR DESCRIPTION
## Summary
- Update GitHub Actions reference from `xdustinface/manki@v4` to `manki-review/manki@v4`
- Update comment URL in `.manki.yml` to point to new org

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD infrastructure and code review automation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->