### PR TITLE
fix: drop `max_retries` from `DownloadCoordinator` to prevent sync stall

### DIFF
--- a/dash-spv/src/sync/block_headers/segment_state.rs
+++ b/dash-spv/src/sync/block_headers/segment_state.rs
@@ -50,8 +50,7 @@ impl SegmentState {
             coordinator: DownloadCoordinator::new(
                 DownloadConfig::default()
                     .with_max_concurrent(1) // Only 1 request at a time (sequential getheaders)
-                    .with_timeout(HEADERS_TIMEOUT)
-                    .with_max_retries(3),
+                    .with_timeout(HEADERS_TIMEOUT),
             ),
             buffered_headers: Vec::new(),
             complete: false,

--- a/dash-spv/src/sync/blocks/pipeline.rs
+++ b/dash-spv/src/sync/blocks/pipeline.rs
@@ -169,16 +169,8 @@ impl BlocksPipeline {
     }
 
     /// Check for timed out downloads and re-queue them.
-    ///
-    /// Returns the list of timed out block hashes.
-    pub(super) fn handle_timeouts(&mut self) -> Vec<BlockHash> {
-        let timed_out = self.coordinator.check_and_retry_timeouts();
-
-        if !timed_out.is_empty() {
-            tracing::debug!("Re-queued {} timed out block downloads", timed_out.len());
-        }
-
-        timed_out
+    pub(super) fn handle_timeouts(&mut self) {
+        self.coordinator.check_and_retry_timeouts();
     }
 }
 
@@ -320,10 +312,8 @@ mod tests {
         // Wait for timeout
         std::thread::sleep(Duration::from_millis(20));
 
-        let timed_out = pipeline.handle_timeouts();
+        pipeline.handle_timeouts();
 
-        assert_eq!(timed_out.len(), 1);
-        assert_eq!(timed_out[0], hash);
         assert_eq!(pipeline.coordinator.active_count(), 0);
         assert_eq!(pipeline.coordinator.pending_count(), 1);
     }

--- a/dash-spv/src/sync/blocks/pipeline.rs
+++ b/dash-spv/src/sync/blocks/pipeline.rs
@@ -19,9 +19,6 @@ const MAX_CONCURRENT_BLOCK_DOWNLOADS: usize = 20;
 /// Timeout for block downloads before retry.
 const BLOCK_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Maximum number of retries for block downloads.
-const BLOCK_MAX_RETRIES: u32 = 3;
-
 /// Maximum blocks per GetData request, kept a bit lower for better download distribution to multiple peers
 const BLOCKS_PER_REQUEST: usize = 8;
 
@@ -64,8 +61,7 @@ impl BlocksPipeline {
             coordinator: DownloadCoordinator::new(
                 DownloadConfig::default()
                     .with_max_concurrent(MAX_CONCURRENT_BLOCK_DOWNLOADS)
-                    .with_timeout(BLOCK_TIMEOUT)
-                    .with_max_retries(BLOCK_MAX_RETRIES),
+                    .with_timeout(BLOCK_TIMEOUT),
             ),
             pending_heights: BTreeSet::new(),
             downloaded: BTreeMap::new(),
@@ -428,53 +424,6 @@ mod tests {
 
         pipeline.pending_heights.remove(&100);
         assert!(pipeline.is_complete());
-    }
-
-    #[test]
-    fn test_handle_timeouts_with_multiple_retries() {
-        let mut pipeline = BlocksPipeline {
-            coordinator: DownloadCoordinator::new(
-                DownloadConfig::default()
-                    .with_max_concurrent(MAX_CONCURRENT_BLOCK_DOWNLOADS)
-                    .with_timeout(Duration::from_millis(1))
-                    .with_max_retries(2),
-            ),
-            pending_heights: BTreeSet::new(),
-            downloaded: BTreeMap::new(),
-            hash_to_height: HashMap::new(),
-        };
-
-        // Use coordinator to set up in-flight state
-        let hash = test_hash(1);
-        pipeline.coordinator.enqueue([hash]);
-        let hashes = pipeline.coordinator.take_pending(1);
-        pipeline.coordinator.mark_sent(&hashes);
-
-        // First timeout - returns item (it's re-queued)
-        std::thread::sleep(Duration::from_millis(5));
-        let timed_out = pipeline.handle_timeouts();
-        assert_eq!(timed_out.len(), 1);
-        assert_eq!(pipeline.coordinator.pending_count(), 1);
-
-        // Re-send the retry
-        let items = pipeline.coordinator.take_pending(1);
-        pipeline.coordinator.mark_sent(&items);
-
-        // Second timeout - still re-queued
-        std::thread::sleep(Duration::from_millis(5));
-        let timed_out = pipeline.handle_timeouts();
-        assert_eq!(timed_out.len(), 1);
-        assert_eq!(pipeline.coordinator.pending_count(), 1);
-
-        // Re-send
-        let items = pipeline.coordinator.take_pending(1);
-        pipeline.coordinator.mark_sent(&items);
-
-        // Third timeout - exceeds max retries, NOT re-queued
-        std::thread::sleep(Duration::from_millis(5));
-        let timed_out = pipeline.handle_timeouts();
-        assert_eq!(timed_out.len(), 0);
-        assert_eq!(pipeline.coordinator.pending_count(), 0);
     }
 
     #[test]

--- a/dash-spv/src/sync/blocks/sync_manager.rs
+++ b/dash-spv/src/sync/blocks/sync_manager.rs
@@ -183,10 +183,7 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface + 'static> SyncM
 
     async fn tick(&mut self, requests: &RequestSender) -> SyncResult<Vec<SyncEvent>> {
         // Handle timeouts
-        let timed_out = self.pipeline.handle_timeouts();
-        if !timed_out.is_empty() {
-            tracing::debug!("Re-queued {} timed out block downloads", timed_out.len());
-        }
+        self.pipeline.handle_timeouts();
 
         self.send_pending(requests).await?;
 

--- a/dash-spv/src/sync/download_coordinator.rs
+++ b/dash-spv/src/sync/download_coordinator.rs
@@ -140,6 +140,7 @@ impl<K: Hash + Eq + Clone> DownloadCoordinator<K> {
     /// Returns true if the item was being tracked, false if unexpected.
     pub(crate) fn receive(&mut self, key: &K) -> bool {
         if self.in_flight.remove(key).is_some() {
+            self.retry_counts.remove(key);
             self.last_progress = Instant::now();
             true
         } else {

--- a/dash-spv/src/sync/download_coordinator.rs
+++ b/dash-spv/src/sync/download_coordinator.rs
@@ -17,8 +17,6 @@ pub struct DownloadConfig {
     max_concurrent: usize,
     /// Timeout duration for requests.
     timeout: Duration,
-    /// Maximum retry attempts before giving up.
-    max_retries: u32,
 }
 
 impl Default for DownloadConfig {
@@ -26,7 +24,6 @@ impl Default for DownloadConfig {
         Self {
             max_concurrent: 10,
             timeout: Duration::from_secs(30),
-            max_retries: 3,
         }
     }
 }
@@ -41,12 +38,6 @@ impl DownloadConfig {
     /// Create config with custom timeout.
     pub(crate) fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
-        self
-    }
-
-    /// Create config with custom max retries.
-    pub(crate) fn with_max_retries(mut self, max: u32) -> Self {
-        self.max_retries = max;
         self
     }
 }
@@ -109,17 +100,11 @@ impl<K: Hash + Eq + Clone> DownloadCoordinator<K> {
     }
 
     /// Queue an item for retry (goes to front of queue).
-    ///
-    /// Returns false if max retries exceeded.
-    pub(crate) fn enqueue_retry(&mut self, item: K) -> bool {
+    pub(crate) fn enqueue_retry(&mut self, item: K) {
         let count = self.retry_counts.entry(item.clone()).or_insert(0);
-        if *count >= self.config.max_retries {
-            tracing::warn!("Max retries ({}) exceeded, giving up", self.config.max_retries);
-            return false;
-        }
         *count += 1;
+        tracing::warn!("Retrying item (attempt {})", count);
         self.pending.push_front(item);
-        true
     }
 
     /// Get the number of items available to send (respecting concurrency limit).
@@ -194,11 +179,13 @@ impl<K: Hash + Eq + Clone> DownloadCoordinator<K> {
     /// Check for timed-out items and re-enqueue them for retry.
     ///
     /// Combines `check_timeouts()` and `enqueue_retry()` in one call.
-    /// Returns only items that were successfully re-queued. Items that
-    /// exceeded their max retry count are excluded from the result.
+    /// Returns all timed-out items that were re-queued.
     pub(crate) fn check_and_retry_timeouts(&mut self) -> Vec<K> {
         let timed_out = self.check_timeouts();
-        timed_out.into_iter().filter(|item| self.enqueue_retry(item.clone())).collect()
+        for item in &timed_out {
+            self.enqueue_retry(item.clone());
+        }
+        timed_out
     }
 
     /// Check if the coordinator has no work (empty pending and in-flight).
@@ -250,16 +237,6 @@ mod tests {
 
         let items = coord.take_pending(3);
         assert_eq!(items, vec![99, 1, 2]);
-    }
-
-    #[test]
-    fn test_max_retries() {
-        let mut coord: DownloadCoordinator<u32> =
-            DownloadCoordinator::new(DownloadConfig::default().with_max_retries(2));
-
-        assert!(coord.enqueue_retry(1));
-        assert!(coord.enqueue_retry(1));
-        assert!(!coord.enqueue_retry(1)); // Exceeds max
     }
 
     #[test]
@@ -363,42 +340,11 @@ mod tests {
 
     #[test]
     fn test_config_builders() {
-        let config = DownloadConfig::default()
-            .with_max_concurrent(20)
-            .with_timeout(Duration::from_secs(60))
-            .with_max_retries(5);
+        let config =
+            DownloadConfig::default().with_max_concurrent(20).with_timeout(Duration::from_secs(60));
 
         assert_eq!(config.max_concurrent, 20);
         assert_eq!(config.timeout, Duration::from_secs(60));
-        assert_eq!(config.max_retries, 5);
-    }
-
-    #[test]
-    fn test_check_and_retry_timeouts_excludes_exceeded_retries() {
-        let mut coord: DownloadCoordinator<u32> = DownloadCoordinator::new(
-            DownloadConfig::default().with_timeout(Duration::from_millis(10)).with_max_retries(1),
-        );
-
-        // Send two items and let them time out
-        coord.mark_sent(&[1, 2]);
-        std::thread::sleep(Duration::from_millis(20));
-
-        // First round: both should be re-queued successfully
-        let requeued = coord.check_and_retry_timeouts();
-        assert_eq!(requeued.len(), 2);
-        assert!(requeued.contains(&1));
-        assert!(requeued.contains(&2));
-
-        // Drain pending and send again so they can time out a second time
-        let items = coord.take_pending(2);
-        coord.mark_sent(&items);
-        std::thread::sleep(Duration::from_millis(20));
-
-        // Second round: both have exceeded max_retries (1), so neither should be returned
-        let requeued = coord.check_and_retry_timeouts();
-        assert!(requeued.is_empty());
-        // Items should not have been re-added to pending
-        assert_eq!(coord.pending_count(), 0);
     }
 
     #[test]

--- a/dash-spv/src/sync/filter_headers/pipeline.rs
+++ b/dash-spv/src/sync/filter_headers/pipeline.rs
@@ -24,9 +24,6 @@ const MAX_CONCURRENT_CFHEADERS_REQUESTS: usize = 10;
 /// Timeout for CFHeaders requests. Single response but allow time for network latency.
 const FILTER_HEADERS_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Maximum number of retries for CFHeaders requests.
-const FILTER_HEADERS_MAX_RETRIES: u32 = 3;
-
 /// Pipeline for downloading compact block filter headers.
 ///
 /// Uses DownloadCoordinator<BlockHash> for batch-level tracking (keyed by stop_hash),
@@ -58,8 +55,7 @@ impl FilterHeadersPipeline {
             coordinator: DownloadCoordinator::new(
                 DownloadConfig::default()
                     .with_max_concurrent(MAX_CONCURRENT_CFHEADERS_REQUESTS)
-                    .with_timeout(FILTER_HEADERS_TIMEOUT)
-                    .with_max_retries(FILTER_HEADERS_MAX_RETRIES),
+                    .with_timeout(FILTER_HEADERS_TIMEOUT),
             ),
             batch_starts: HashMap::new(),
             buffered: HashMap::new(),
@@ -265,22 +261,10 @@ impl FilterHeadersPipeline {
     }
 
     /// Re-enqueue timed out requests for retry.
-    ///
-    /// Returns heights that exceeded max retries and were permanently dropped.
-    pub(super) fn handle_timeouts(&mut self) -> Vec<u32> {
-        let mut failed = Vec::new();
+    pub(super) fn handle_timeouts(&mut self) {
         for stop_hash in self.coordinator.check_timeouts() {
-            if !self.coordinator.enqueue_retry(stop_hash) {
-                if let Some(start_height) = self.batch_starts.remove(&stop_hash) {
-                    tracing::warn!(
-                        "CFHeaders batch at height {} exceeded max retries, dropping",
-                        start_height
-                    );
-                    failed.push(start_height);
-                }
-            }
+            self.coordinator.enqueue_retry(stop_hash);
         }
-        failed
     }
 }
 
@@ -402,9 +386,7 @@ mod tests {
 
         let mut pipeline = FilterHeadersPipeline {
             coordinator: DownloadCoordinator::new(
-                DownloadConfig::default()
-                    .with_timeout(Duration::from_millis(1))
-                    .with_max_retries(3),
+                DownloadConfig::default().with_timeout(Duration::from_millis(1)),
             ),
             batch_starts: HashMap::new(),
             buffered: HashMap::new(),
@@ -418,44 +400,8 @@ mod tests {
 
         std::thread::sleep(Duration::from_millis(5));
 
-        let failed = pipeline.handle_timeouts();
-        assert!(failed.is_empty()); // First retry succeeds
+        pipeline.handle_timeouts();
         assert_eq!(pipeline.coordinator.pending_count(), 1);
-    }
-
-    #[test]
-    fn test_handle_timeouts_max_retries_exceeded() {
-        use std::time::Duration;
-
-        let mut pipeline = FilterHeadersPipeline {
-            coordinator: DownloadCoordinator::new(
-                DownloadConfig::default()
-                    .with_timeout(Duration::from_millis(1))
-                    .with_max_retries(1),
-            ),
-            batch_starts: HashMap::new(),
-            buffered: HashMap::new(),
-            next_expected: 100,
-            target_height: 2000,
-        };
-
-        let stop_hash = BlockHash::from_byte_array([0x01; 32]);
-        pipeline.batch_starts.insert(stop_hash, 100);
-
-        // First timeout + retry
-        pipeline.coordinator.mark_sent(&[stop_hash]);
-        std::thread::sleep(Duration::from_millis(5));
-        let failed = pipeline.handle_timeouts();
-        assert!(failed.is_empty());
-
-        // Re-send retry
-        let items = pipeline.coordinator.take_pending(1);
-        pipeline.coordinator.mark_sent(&items);
-
-        // Second timeout exceeds max
-        std::thread::sleep(Duration::from_millis(5));
-        let failed = pipeline.handle_timeouts();
-        assert_eq!(failed, vec![100]);
     }
 
     #[test]
@@ -482,9 +428,7 @@ mod tests {
 
         let mut pipeline = FilterHeadersPipeline {
             coordinator: DownloadCoordinator::new(
-                DownloadConfig::default()
-                    .with_timeout(Duration::from_millis(1))
-                    .with_max_retries(0),
+                DownloadConfig::default().with_timeout(Duration::from_millis(1)),
             ),
             batch_starts: HashMap::new(),
             buffered: HashMap::new(),
@@ -501,10 +445,10 @@ mod tests {
 
         std::thread::sleep(Duration::from_millis(5));
 
-        let mut failed = pipeline.handle_timeouts();
-        failed.sort();
-        assert_eq!(failed.len(), 2);
-        assert!(failed.contains(&1));
-        assert!(failed.contains(&2001));
+        pipeline.handle_timeouts();
+        // Both batches re-queued
+        assert_eq!(pipeline.coordinator.pending_count(), 2);
+        assert!(pipeline.batch_starts.contains_key(&hash1));
+        assert!(pipeline.batch_starts.contains_key(&hash2));
     }
 }

--- a/dash-spv/src/sync/filter_headers/sync_manager.rs
+++ b/dash-spv/src/sync/filter_headers/sync_manager.rs
@@ -146,14 +146,8 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage> SyncManager for FilterHeade
     }
 
     async fn tick(&mut self, requests: &RequestSender) -> SyncResult<Vec<SyncEvent>> {
-        // Handle timed out requests
-        let failed = self.pipeline.handle_timeouts();
-        if !failed.is_empty() {
-            return Err(SyncError::Timeout(format!(
-                "CFHeaders batches exceeded max retries at heights: {:?}",
-                failed
-            )));
-        }
+        // Handle timed out requests (re-queues them for retry)
+        self.pipeline.handle_timeouts();
 
         // Send pending requests (including retries)
         self.pipeline.send_pending(requests)?;

--- a/dash-spv/src/sync/filters/pipeline.rs
+++ b/dash-spv/src/sync/filters/pipeline.rs
@@ -29,9 +29,6 @@ const MAX_CONCURRENT_FILTER_BATCHES: usize = 20;
 /// Each batch requires 1000 individual filter messages, so allow plenty of time.
 const FILTER_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Maximum number of retries for CFilter requests.
-const FILTERS_MAX_RETRIES: u32 = 3;
-
 /// Pipeline for downloading compact block filters.
 ///
 /// Uses DownloadCoordinator<u32> for batch-level download mechanics,
@@ -69,8 +66,7 @@ impl FiltersPipeline {
             coordinator: DownloadCoordinator::new(
                 DownloadConfig::default()
                     .with_max_concurrent(MAX_CONCURRENT_FILTER_BATCHES)
-                    .with_timeout(FILTER_TIMEOUT)
-                    .with_max_retries(FILTERS_MAX_RETRIES),
+                    .with_timeout(FILTER_TIMEOUT),
             ),
             batch_trackers: HashMap::new(),
             completed_batches: BTreeSet::new(),
@@ -250,20 +246,14 @@ impl FiltersPipeline {
     /// Check for timed out batches and handle retries.
     ///
     /// Returns batch starts that timed out and were re-queued.
-    /// Uses coordinator's retry mechanism to avoid duplicate requests.
-    /// Note: Does not remove batch trackers - keeps them to receive any late-arriving filters.
+    /// Note: Does not remove batch trackers — keeps them to receive any late-arriving filters.
     pub(super) fn handle_timeouts(&mut self) -> Vec<u32> {
         let mut timed_out_starts = Vec::new();
 
         for start in self.coordinator.check_timeouts() {
-            if self.coordinator.enqueue_retry(start) {
-                tracing::warn!("Filter batch at {} timed out, queued for retry", start);
-                timed_out_starts.push(start);
-            } else {
-                // Max retries exceeded - remove tracker, log error
-                tracing::error!("Filter batch at {} exceeded max retries, giving up", start);
-                self.batch_trackers.remove(&start);
-            }
+            self.coordinator.enqueue_retry(start);
+            tracing::warn!("Filter batch at {} timed out, queued for retry", start);
+            timed_out_starts.push(start);
         }
 
         timed_out_starts
@@ -291,9 +281,7 @@ mod tests {
     fn create_pipeline_with_short_timeout() -> FiltersPipeline {
         FiltersPipeline {
             coordinator: DownloadCoordinator::new(
-                DownloadConfig::default()
-                    .with_timeout(Duration::from_millis(1))
-                    .with_max_retries(3),
+                DownloadConfig::default().with_timeout(Duration::from_millis(1)),
             ),
             batch_trackers: HashMap::new(),
             completed_batches: BTreeSet::new(),
@@ -307,10 +295,7 @@ mod tests {
     fn create_pipeline_with_low_concurrency() -> FiltersPipeline {
         FiltersPipeline {
             coordinator: DownloadCoordinator::new(
-                DownloadConfig::default()
-                    .with_max_concurrent(2)
-                    .with_timeout(FILTER_TIMEOUT)
-                    .with_max_retries(FILTERS_MAX_RETRIES),
+                DownloadConfig::default().with_max_concurrent(2).with_timeout(FILTER_TIMEOUT),
             ),
             batch_trackers: HashMap::new(),
             completed_batches: BTreeSet::new(),
@@ -721,7 +706,6 @@ mod tests {
             coordinator: DownloadCoordinator::new(
                 DownloadConfig::default()
                     .with_timeout(Duration::from_millis(1))
-                    .with_max_retries(3)
                     .with_max_concurrent(10),
             ),
             batch_trackers: HashMap::new(),

--- a/dash-spv/src/sync/filters/pipeline.rs
+++ b/dash-spv/src/sync/filters/pipeline.rs
@@ -245,18 +245,11 @@ impl FiltersPipeline {
 
     /// Check for timed out batches and handle retries.
     ///
-    /// Returns batch starts that timed out and were re-queued.
-    /// Note: Does not remove batch trackers — keeps them to receive any late-arriving filters.
-    pub(super) fn handle_timeouts(&mut self) -> Vec<u32> {
-        let mut timed_out_starts = Vec::new();
-
+    /// Does not remove batch trackers — keeps them to receive any late-arriving filters.
+    pub(super) fn handle_timeouts(&mut self) {
         for start in self.coordinator.check_timeouts() {
             self.coordinator.enqueue_retry(start);
-            tracing::warn!("Filter batch at {} timed out, queued for retry", start);
-            timed_out_starts.push(start);
         }
-
-        timed_out_starts
     }
 }
 
@@ -650,8 +643,7 @@ mod tests {
     #[test]
     fn test_handle_timeouts_no_batches() {
         let mut pipeline = FiltersPipeline::new();
-        let timed_out = pipeline.handle_timeouts();
-        assert!(timed_out.is_empty());
+        pipeline.handle_timeouts();
     }
 
     #[test]
@@ -666,9 +658,8 @@ mod tests {
         // Wait for timeout
         std::thread::sleep(Duration::from_millis(5));
 
-        let timed_out = pipeline.handle_timeouts();
+        pipeline.handle_timeouts();
 
-        assert_eq!(timed_out, vec![0]);
         // Batch should be re-queued in coordinator's pending queue
         assert_eq!(pipeline.coordinator.pending_count(), 1);
         assert_eq!(pipeline.coordinator.active_count(), 0);
@@ -690,10 +681,9 @@ mod tests {
 
         std::thread::sleep(Duration::from_millis(5));
 
-        let timed_out = pipeline.handle_timeouts();
+        pipeline.handle_timeouts();
 
         // Should timeout but tracker is preserved for late arrivals
-        assert_eq!(timed_out, vec![0]);
         assert!(pipeline.batch_trackers.contains_key(&0));
         assert_eq!(pipeline.batch_trackers.get(&0).unwrap().received(), 10);
     }
@@ -728,8 +718,7 @@ mod tests {
         std::thread::sleep(Duration::from_millis(5));
 
         // Handle timeouts - all 3 should timeout and be re-queued
-        let timed_out = pipeline.handle_timeouts();
-        assert_eq!(timed_out.len(), 3);
+        pipeline.handle_timeouts();
 
         // All 3 batches should be in the pending queue, not duplicated
         assert_eq!(pipeline.coordinator.pending_count(), 3);
@@ -929,8 +918,7 @@ mod tests {
         std::thread::sleep(Duration::from_millis(5));
 
         // Handle timeout - should re-queue the batch via coordinator
-        let timed_out = pipeline.handle_timeouts();
-        assert_eq!(timed_out.len(), 1);
+        pipeline.handle_timeouts();
         assert_eq!(pipeline.coordinator.pending_count(), 1);
         assert_eq!(pipeline.coordinator.active_count(), 0);
 

--- a/dash-spv/src/sync/filters/sync_manager.rs
+++ b/dash-spv/src/sync/filters/sync_manager.rs
@@ -207,10 +207,7 @@ impl<
         }
 
         // Handle timeouts
-        let timed_out = self.filter_pipeline.handle_timeouts();
-        if !timed_out.is_empty() {
-            tracing::debug!("Re-queued {} timed out filter batches", timed_out.len());
-        }
+        self.filter_pipeline.handle_timeouts();
 
         // Send pending requests (decoupled from processing)
         let header_storage = self.header_storage.read().await;

--- a/dash-spv/src/sync/masternodes/pipeline.rs
+++ b/dash-spv/src/sync/masternodes/pipeline.rs
@@ -18,9 +18,6 @@ const MAX_CONCURRENT_MNLISTDIFF: usize = 20;
 /// Timeout for MnListDiff requests.
 const MNLISTDIFF_TIMEOUT: Duration = Duration::from_secs(15);
 
-/// Maximum number of retries for MnListDiff requests.
-const MNLISTDIFF_MAX_RETRIES: u32 = 3;
-
 /// Pipeline for downloading MnListDiff messages for quorum validation.
 ///
 /// Uses `DownloadCoordinator<BlockHash>` for request tracking (keyed by target block_hash),
@@ -46,8 +43,7 @@ impl MnListDiffPipeline {
             coordinator: DownloadCoordinator::new(
                 DownloadConfig::default()
                     .with_max_concurrent(MAX_CONCURRENT_MNLISTDIFF)
-                    .with_timeout(MNLISTDIFF_TIMEOUT)
-                    .with_max_retries(MNLISTDIFF_MAX_RETRIES),
+                    .with_timeout(MNLISTDIFF_TIMEOUT),
             ),
             base_hashes: HashMap::new(),
         }
@@ -134,37 +130,22 @@ impl MnListDiffPipeline {
     /// Requeue a received MnListDiff for retry.
     ///
     /// Removes from in-flight tracking and pushes back to the front of the
-    /// pending queue. Returns `true` if successfully requeued, `false` if
-    /// max retries were exceeded (in which case the request is dropped).
-    pub(super) fn requeue(&mut self, diff: &MnListDiff) -> bool {
+    /// pending queue.
+    pub(super) fn requeue(&mut self, diff: &MnListDiff) {
         let target_hash = diff.block_hash;
 
         // Remove from in-flight
         self.coordinator.receive(&target_hash);
 
         // Re-enqueue for retry
-        if self.coordinator.enqueue_retry(target_hash) {
-            tracing::debug!("Requeued MnListDiff for {} for retry", diff.block_hash);
-            true
-        } else {
-            tracing::warn!("MnListDiff for {} exceeded max retries, dropping", diff.block_hash);
-            self.base_hashes.remove(&target_hash);
-            false
-        }
+        self.coordinator.enqueue_retry(target_hash);
+        tracing::debug!("Requeued MnListDiff for {} for retry", diff.block_hash);
     }
 
-    /// Handle timeouts, re-queuing failed requests.
-    ///
-    /// Returns hashes that exceeded max retries and were dropped.
+    /// Handle timeouts, re-queuing timed out requests.
     pub(super) fn handle_timeouts(&mut self) {
         for target_hash in self.coordinator.check_timeouts() {
-            if !self.coordinator.enqueue_retry(target_hash) {
-                tracing::warn!(
-                    "MnListDiff request for {} exceeded max retries, dropping",
-                    target_hash
-                );
-                self.base_hashes.remove(&target_hash);
-            }
+            self.coordinator.enqueue_retry(target_hash);
         }
     }
 
@@ -321,9 +302,7 @@ mod tests {
 
         let mut pipeline = MnListDiffPipeline {
             coordinator: DownloadCoordinator::new(
-                DownloadConfig::default()
-                    .with_timeout(Duration::from_millis(1))
-                    .with_max_retries(0),
+                DownloadConfig::default().with_timeout(Duration::from_millis(1)),
             ),
             base_hashes: HashMap::new(),
         };
@@ -336,32 +315,7 @@ mod tests {
 
         std::thread::sleep(Duration::from_millis(5));
 
-        pipeline.handle_timeouts();
-        assert!(pipeline.base_hashes.is_empty());
-    }
-
-    #[test]
-    fn test_handle_timeouts_with_retry() {
-        use std::time::Duration;
-
-        let mut pipeline = MnListDiffPipeline {
-            coordinator: DownloadCoordinator::new(
-                DownloadConfig::default()
-                    .with_timeout(Duration::from_millis(1))
-                    .with_max_retries(3),
-            ),
-            base_hashes: HashMap::new(),
-        };
-
-        let base = BlockHash::from_byte_array([0x01; 32]);
-        let target = BlockHash::from_byte_array([0x02; 32]);
-
-        pipeline.base_hashes.insert(target, base);
-        pipeline.coordinator.mark_sent(&[target]);
-
-        std::thread::sleep(Duration::from_millis(5));
-
-        // First timeout should retry, not fail
+        // Timeout re-queues the request, base_hashes preserved
         pipeline.handle_timeouts();
         assert_eq!(pipeline.coordinator.pending_count(), 1);
         assert!(pipeline.base_hashes.contains_key(&target));
@@ -385,7 +339,7 @@ mod tests {
         let diff = create_test_diff(base, target);
 
         // Requeue should move from in-flight back to pending
-        assert!(pipeline.requeue(&diff));
+        pipeline.requeue(&diff);
         assert_eq!(pipeline.active_count(), 0);
         assert_eq!(pipeline.coordinator.pending_count(), 1);
         // base_hash mapping should be preserved for the retry
@@ -395,11 +349,8 @@ mod tests {
     }
 
     #[test]
-    fn test_requeue_drops_after_max_retries() {
-        let mut pipeline = MnListDiffPipeline {
-            coordinator: DownloadCoordinator::new(DownloadConfig::default().with_max_retries(0)),
-            base_hashes: HashMap::new(),
-        };
+    fn test_requeue_always_succeeds() {
+        let mut pipeline = MnListDiffPipeline::new();
 
         let base = BlockHash::from_byte_array([0x01; 32]);
         let target = BlockHash::from_byte_array([0x02; 32]);
@@ -409,9 +360,9 @@ mod tests {
 
         let diff = create_test_diff(base, target);
 
-        // With max_retries=0, requeue should fail and clean up
-        assert!(!pipeline.requeue(&diff));
-        assert!(!pipeline.base_hashes.contains_key(&target));
-        assert_eq!(pipeline.coordinator.pending_count(), 0);
+        // Requeue always succeeds
+        pipeline.requeue(&diff);
+        assert!(pipeline.base_hashes.contains_key(&target));
+        assert_eq!(pipeline.coordinator.pending_count(), 1);
     }
 }


### PR DESCRIPTION
When a entry exceeded max retries it was permanently dropped from the pipeline which lead to stalling sync. All pipeline retries now continue indefinitely avoid giving up on required sync data. Retry counts are kept for logging visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Retry behavior changed: timed-out downloads are always re-queued instead of being dropped after a fixed retry limit; timeout handling simplified across headers, blocks, filters, and masternode sync.
  * Logging and failure tracking for exceeded retries removed to favor persistent re-queuing.

* **Tests**
  * Removed and updated tests that validated maximum-retry cutoffs and related drop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->