### PR TITLE
refactor: unify logging on `tracing`

### DIFF
--- a/dash-spv/Cargo.toml
+++ b/dash-spv/Cargo.toml
@@ -52,9 +52,6 @@ dashcore-rpc = { path = "../rpc-client", optional = true }
 # DNS (trust-dns-resolver was renamed to hickory_resolver)
 hickory-resolver = "0.25"
 
-# Also add log to main dependencies for consistency
-log = "0.4"
-
 [dev-dependencies]
 dash-spv = { path = ".", features = ["test-utils"] }
 dashcore = { path = "../dash", features = ["test-utils"] }
@@ -63,7 +60,6 @@ key-wallet-manager = { path = "../key-wallet-manager", features = ["test-utils"]
 criterion = { version = "0.8.1", features = ["async_tokio"] }
 tempfile = "3.0"
 tokio-test = "0.4"
-env_logger = "0.10"
 hex = "0.4"
 test-case = "3.3"
 

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -204,7 +204,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
         // Shut down sync coordinator: signals cancellation and waits for manager
         // tasks to drain before we tear down the network and storage layers.
         if let Err(e) = self.sync_coordinator.lock().await.shutdown().await {
-            log::warn!("Error shutting down sync coordinator: {}", e);
+            tracing::warn!("Error shutting down sync coordinator: {}", e);
         }
 
         // Disconnect from network

--- a/dash-spv/src/network/addrv2.rs
+++ b/dash-spv/src/network/addrv2.rs
@@ -46,7 +46,7 @@ impl AddrV2Handler {
     /// Handle SendAddrV2 message indicating peer support
     pub async fn handle_sendaddrv2(&self, peer_addr: SocketAddr) {
         self.supports_addrv2.write().await.insert(peer_addr);
-        log::debug!("Peer {} supports AddrV2", peer_addr);
+        tracing::debug!("Peer {} supports AddrV2", peer_addr);
     }
 
     /// Handle incoming AddrV2 messages
@@ -55,7 +55,7 @@ impl AddrV2Handler {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_else(|e| {
-                log::error!("System time error in handle_addrv2: {}", e);
+                tracing::error!("System time error in handle_addrv2: {}", e);
                 Duration::from_secs(0)
             })
             .as_secs() as u32;
@@ -68,7 +68,7 @@ impl AddrV2Handler {
             // Accept addresses seen within the last week. Older addresses are likely stale.
             // Also, reject timestamps more than 10 minutes in the future which are invalid.
             if msg.time < now.saturating_sub(ONE_WEEK) || msg.time > now + TEN_MINUTES {
-                log::trace!("Ignoring AddrV2 with invalid timestamp: {}", msg.time);
+                tracing::trace!("Ignoring AddrV2 with invalid timestamp: {}", msg.time);
                 continue;
             }
 
@@ -87,7 +87,7 @@ impl AddrV2Handler {
 
         evict_if_needed(&mut known_peers);
 
-        log::info!(
+        tracing::info!(
             "Processed AddrV2 messages: received {}, added {}, updated {}, total known peers: {}",
             received,
             added,
@@ -129,7 +129,7 @@ impl AddrV2Handler {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_else(|e| {
-                log::error!("System time error in add_known_address: {}", e);
+                tracing::error!("System time error in add_known_address: {}", e);
                 Duration::from_secs(0)
             })
             .as_secs() as u32;

--- a/dash-spv/src/network/discovery.rs
+++ b/dash-spv/src/network/discovery.rs
@@ -35,7 +35,7 @@ impl DnsDiscovery {
             Network::Mainnet => (MAINNET_DNS_SEEDS, 9999),
             Network::Testnet => (TESTNET_DNS_SEEDS, 19999),
             _ => {
-                log::debug!("No DNS seeds for {:?} network", network);
+                tracing::debug!("No DNS seeds for {:?} network", network);
                 return vec![];
             }
         };
@@ -43,19 +43,19 @@ impl DnsDiscovery {
         let mut addresses = Vec::new();
 
         for seed in seeds {
-            log::debug!("Querying DNS seed: {}", seed);
+            tracing::debug!("Querying DNS seed: {}", seed);
 
             match self.resolver.lookup_ip(*seed).await {
                 Ok(lookup) => {
                     let ips: Vec<IpAddr> = lookup.iter().collect();
-                    log::info!("DNS seed {} returned {} addresses", seed, ips.len());
+                    tracing::info!("DNS seed {} returned {} addresses", seed, ips.len());
 
                     for ip in ips {
                         addresses.push(SocketAddr::new(ip, port));
                     }
                 }
                 Err(e) => {
-                    log::warn!("Failed to resolve DNS seed {}: {}", seed, e);
+                    tracing::warn!("Failed to resolve DNS seed {}: {}", seed, e);
                 }
             }
         }
@@ -64,7 +64,7 @@ impl DnsDiscovery {
         addresses.sort();
         addresses.dedup();
 
-        log::info!("Discovered {} unique peer addresses from DNS seeds", addresses.len());
+        tracing::info!("Discovered {} unique peer addresses from DNS seeds", addresses.len());
         addresses
     }
 

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -89,7 +89,7 @@ impl PeerNetworkManager {
         let reputation_manager = Arc::new(PeerReputationManager::new());
 
         if let Err(e) = reputation_manager.load_from_storage(&peer_store).await {
-            log::warn!("Failed to load peer reputation data: {}", e);
+            tracing::warn!("Failed to load peer reputation data: {}", e);
         }
 
         // Determine exclusive mode: either explicitly requested or peers were provided
@@ -141,7 +141,7 @@ impl PeerNetworkManager {
 
     /// Start the network manager
     pub async fn start(&self) -> Result<(), Error> {
-        log::info!("Starting peer network manager for {:?}", self.network);
+        tracing::info!("Starting peer network manager for {:?}", self.network);
 
         let mut peer_addresses: Vec<AddrV2Message> = self
             .initial_peers
@@ -150,7 +150,7 @@ impl PeerNetworkManager {
             .collect();
 
         if self.exclusive_mode {
-            log::info!(
+            tracing::info!(
                 "Exclusive peer mode: connecting ONLY to {} specified peer(s)",
                 self.initial_peers.len()
             );
@@ -164,7 +164,7 @@ impl PeerNetworkManager {
 
             // If we still have no peers, immediately discover via DNS
             if peer_addresses.is_empty() {
-                log::info!(
+                tracing::info!(
                     "No peers configured, performing immediate DNS discovery for {:?}",
                     self.network
                 );
@@ -176,13 +176,13 @@ impl PeerNetworkManager {
                         .take(TARGET_PEERS)
                         .map(|addr| AddrV2Message::new(addr, ServiceFlags::NETWORK)),
                 );
-                log::info!(
+                tracing::info!(
                     "DNS discovery found {} peers, using {} for startup",
                     dns_peers_found,
                     peer_addresses.len()
                 );
             } else {
-                log::info!(
+                tracing::info!(
                     "Starting with {} peers from disk (DNS discovery will be used later if needed)",
                     peer_addresses.len()
                 );
@@ -204,7 +204,7 @@ impl PeerNetworkManager {
     async fn connect_to_peer(&self, addr: SocketAddr) {
         // Check reputation first
         if !self.reputation_manager.should_connect_to_peer(&addr).await {
-            log::warn!("Not connecting to {} due to bad reputation", addr);
+            tracing::warn!("Not connecting to {} due to bad reputation", addr);
             return;
         }
 
@@ -241,12 +241,12 @@ impl PeerNetworkManager {
             }
         };
         tasks.spawn(async move {
-            log::debug!("Attempting to connect to {}", addr);
+            tracing::debug!("Attempting to connect to {}", addr);
 
             let connect_result = tokio::select! {
                 result = Peer::connect(addr, CONNECTION_TIMEOUT.as_secs(), network) => result,
                 _ = shutdown_token.cancelled() => {
-                    log::debug!("Connection to {} cancelled by shutdown", addr);
+                    tracing::debug!("Connection to {} cancelled by shutdown", addr);
                     pool.remove_peer(&addr).await;
                     return;
                 }
@@ -258,11 +258,11 @@ impl PeerNetworkManager {
                     let mut handshake_manager = HandshakeManager::new(network, user_agent);
                     match handshake_manager.perform_handshake(&mut peer).await {
                         Ok(_) => {
-                            log::info!("Successfully connected to {}", addr);
+                            tracing::info!("Successfully connected to {}", addr);
 
                             // Request addresses from the peer for discovery
                             if let Err(e) = peer.send_message(NetworkMessage::GetAddr).await {
-                                log::warn!("Failed to send GetAddr to {}: {}", addr, e);
+                                tracing::warn!("Failed to send GetAddr to {}: {}", addr, e);
                             }
 
                             // Record successful connection
@@ -270,7 +270,7 @@ impl PeerNetworkManager {
 
                             // Add to pool
                             if let Err(e) = pool.add_peer(addr, peer).await {
-                                log::error!("Failed to add peer to pool: {}", e);
+                                tracing::error!("Failed to add peer to pool: {}", e);
                                 return;
                             }
 
@@ -308,7 +308,7 @@ impl PeerNetworkManager {
                             .await;
                         }
                         Err(e) => {
-                            log::warn!("Handshake failed with {}: {}", addr, e);
+                            tracing::warn!("Handshake failed with {}: {}", addr, e);
                             // Only clears connecting set. Peer was never added, so no count/event needed.
                             pool.remove_peer(&addr).await;
                             // Update reputation for handshake failure
@@ -325,7 +325,7 @@ impl PeerNetworkManager {
                     }
                 }
                 Err(e) => {
-                    log::debug!("Failed to connect to {}: {}", addr, e);
+                    tracing::debug!("Failed to connect to {}: {}", addr, e);
                     // Only clears connecting set. Peer was never added, so no count/event needed.
                     pool.remove_peer(&addr).await;
                     // Minor reputation penalty for connection failure
@@ -352,7 +352,7 @@ impl PeerNetworkManager {
             connected_peer_count
                 .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| c.checked_sub(1));
         if sub_result.is_err() {
-            log::warn!("Peer count already zero when removing {}", addr);
+            tracing::warn!("Peer count already zero when removing {}", addr);
         }
         let count = connected_peer_count.load(Ordering::Relaxed);
         let addresses = pool.get_connected_addresses().await;
@@ -394,7 +394,7 @@ impl PeerNetworkManager {
         network_event_sender: broadcast::Sender<NetworkEvent>,
     ) {
         tokio::spawn(async move {
-            log::debug!("Starting peer reader loop for {}", addr);
+            tracing::debug!("Starting peer reader loop for {}", addr);
             let mut loop_iteration = 0;
             let mut headers2_state = CompressionState::default();
 
@@ -403,7 +403,7 @@ impl PeerNetworkManager {
 
                 // Check shutdown signal first with detailed logging
                 if shutdown_token.is_cancelled() {
-                    log::info!("Breaking peer reader loop for {} - shutdown signal received (iteration {})", addr, loop_iteration);
+                    tracing::info!("Breaking peer reader loop for {} - shutdown signal received (iteration {})", addr, loop_iteration);
                     break;
                 }
 
@@ -411,7 +411,7 @@ impl PeerNetworkManager {
                 let peer = match pool.get_peer(&addr).await {
                     Some(peer) => peer,
                     None => {
-                        log::warn!("Breaking peer reader loop for {} - peer no longer in pool (iteration {})", addr, loop_iteration);
+                        tracing::warn!("Breaking peer reader loop for {} - peer no longer in pool (iteration {})", addr, loop_iteration);
                         break;
                     }
                 };
@@ -421,7 +421,7 @@ impl PeerNetworkManager {
                     // Try to get a read lock first to check if peer is available
                     let peer_guard = peer.read().await;
                     if !peer_guard.is_connected() {
-                        log::warn!("Breaking peer reader loop for {} - peer no longer connected (iteration {})", addr, loop_iteration);
+                        tracing::warn!("Breaking peer reader loop for {} - peer no longer connected (iteration {})", addr, loop_iteration);
                         drop(peer_guard);
                         break;
                     }
@@ -437,7 +437,7 @@ impl PeerNetworkManager {
                             Ok(None)
                         },
                         _ = shutdown_token.cancelled() => {
-                            log::info!("Breaking peer reader loop for {} - shutdown signal received while reading (iteration {})", addr, loop_iteration);
+                            tracing::info!("Breaking peer reader loop for {} - shutdown signal received while reading (iteration {})", addr, loop_iteration);
                             break;
                         }
                     }
@@ -446,7 +446,7 @@ impl PeerNetworkManager {
                 match msg_result {
                     Ok(Some(msg)) => {
                         // Log all received messages at debug level to help troubleshoot
-                        log::debug!("Received {:?} from {}", msg.cmd(), addr);
+                        tracing::debug!("Received {:?} from {}", msg.cmd(), addr);
 
                         // Handle some messages directly
                         match &msg.inner() {
@@ -456,7 +456,7 @@ impl PeerNetworkManager {
                             }
                             NetworkMessage::SendHeaders2 => {
                                 // Peer is indicating they will send us compressed headers
-                                log::info!(
+                                tracing::info!(
                                     "Peer {} sent SendHeaders2 - they will send compressed headers",
                                     addr
                                 );
@@ -470,7 +470,7 @@ impl PeerNetworkManager {
                                 continue; // Don't forward to client
                             }
                             NetworkMessage::GetAddr => {
-                                log::trace!(
+                                tracing::trace!(
                                     "Received GetAddr from {}, sending known addresses",
                                     addr
                                 );
@@ -478,7 +478,11 @@ impl PeerNetworkManager {
                                 let response = addrv2_handler.build_addr_response().await;
                                 let mut peer_guard = peer.write().await;
                                 if let Err(e) = peer_guard.send_message(response).await {
-                                    log::error!("Failed to send addr response to {}: {}", addr, e);
+                                    tracing::error!(
+                                        "Failed to send addr response to {}: {}",
+                                        addr,
+                                        e
+                                    );
                                 }
                                 continue; // Don't forward GetAddr to client
                             }
@@ -486,10 +490,10 @@ impl PeerNetworkManager {
                                 // Handle ping directly
                                 let mut peer_guard = peer.write().await;
                                 if let Err(e) = peer_guard.handle_ping(*nonce).await {
-                                    log::error!("Failed to handle ping from {}: {}", addr, e);
+                                    tracing::error!("Failed to handle ping from {}: {}", addr, e);
                                     // If we can't send pong, connection is likely broken
                                     if matches!(e, NetworkError::ConnectionFailed(_)) {
-                                        log::warn!("Breaking peer reader loop for {} - failed to send pong response (iteration {})", addr, loop_iteration);
+                                        tracing::warn!("Breaking peer reader loop for {} - failed to send pong response (iteration {})", addr, loop_iteration);
                                         break;
                                     }
                                 }
@@ -499,13 +503,13 @@ impl PeerNetworkManager {
                                 // Handle pong directly
                                 let mut peer_guard = peer.write().await;
                                 if let Err(e) = peer_guard.handle_pong(*nonce) {
-                                    log::error!("Failed to handle pong from {}: {}", addr, e);
+                                    tracing::error!("Failed to handle pong from {}: {}", addr, e);
                                 }
                                 continue; // Don't forward pong to client
                             }
                             NetworkMessage::Version(_) | NetworkMessage::Verack => {
                                 // These are handled during handshake, ignore here
-                                log::trace!(
+                                tracing::trace!(
                                     "Ignoring handshake message {:?} from {}",
                                     msg.cmd(),
                                     addr
@@ -531,7 +535,7 @@ impl PeerNetworkManager {
                                     })
                                     .collect();
                                 if !converted.is_empty() {
-                                    log::debug!(
+                                    tracing::debug!(
                                         "Converted {} legacy addr entries from {}",
                                         converted.len(),
                                         addr
@@ -542,7 +546,7 @@ impl PeerNetworkManager {
                             }
                             NetworkMessage::Headers(headers) => {
                                 // Log headers messages specifically
-                                log::info!(
+                                tracing::info!(
                                     "📨 Received Headers message from {} with {} headers! (regular uncompressed)",
                                     addr,
                                     headers.len()
@@ -550,14 +554,14 @@ impl PeerNetworkManager {
                                 // Check if peer supports headers2
                                 let peer_guard = peer.read().await;
                                 if peer_guard.supports_headers2() {
-                                    log::warn!("⚠️  Peer {} supports headers2 but sent regular headers - possible protocol issue", addr);
+                                    tracing::warn!("⚠️  Peer {} supports headers2 but sent regular headers - possible protocol issue", addr);
                                 }
                                 drop(peer_guard);
                                 // Forward to client
                             }
                             NetworkMessage::Headers2(headers2) => {
                                 // Decompress headers in network layer and forward as regular Headers
-                                log::info!(
+                                tracing::info!(
                                     "Received Headers2 from {} with {} compressed headers - decompressing",
                                     addr,
                                     headers2.headers.len()
@@ -565,7 +569,7 @@ impl PeerNetworkManager {
 
                                 match headers2_state.process_headers(&headers2.headers) {
                                     Ok(headers) => {
-                                        log::info!(
+                                        tracing::info!(
                                             "Decompressed {} headers from {} - forwarding as regular Headers",
                                             headers.len(),
                                             addr
@@ -577,7 +581,7 @@ impl PeerNetworkManager {
                                         continue; // Already sent, don't forward the original Headers2
                                     }
                                     Err(e) => {
-                                        log::error!(
+                                        tracing::error!(
                                             "Headers2 decompression failed from {}: {} - disabling headers2",
                                             addr,
                                             e
@@ -597,7 +601,7 @@ impl PeerNetworkManager {
                             }
                             NetworkMessage::GetHeaders(_) => {
                                 // SPV clients don't serve headers to peers
-                                log::debug!(
+                                tracing::debug!(
                                     "Received GetHeaders from {} - ignoring (SPV client)",
                                     addr
                                 );
@@ -605,7 +609,7 @@ impl PeerNetworkManager {
                             }
                             NetworkMessage::GetHeaders2(_) => {
                                 // SPV clients don't serve compressed headers to peers
-                                log::debug!(
+                                tracing::debug!(
                                     "Received GetHeaders2 from {} - ignoring (SPV client)",
                                     addr
                                 );
@@ -616,13 +620,17 @@ impl PeerNetworkManager {
                                 payload,
                             } => {
                                 // Log unknown messages with more detail
-                                log::warn!("Received unknown message from {}: command='{}', payload_len={}",
+                                tracing::warn!("Received unknown message from {}: command='{}', payload_len={}",
                                          addr, command, payload.len());
                                 // Still forward to client
                             }
                             _ => {
                                 // Forward other messages to client
-                                log::trace!("Forwarding {:?} from {} to client", msg.cmd(), addr);
+                                tracing::trace!(
+                                    "Forwarding {:?} from {} to client",
+                                    msg.cmd(),
+                                    addr
+                                );
                             }
                         }
 
@@ -636,11 +644,11 @@ impl PeerNetworkManager {
                     Err(e) => {
                         match e {
                             NetworkError::PeerDisconnected => {
-                                log::info!("Peer {} disconnected", addr);
+                                tracing::info!("Peer {} disconnected", addr);
                                 break;
                             }
                             NetworkError::Timeout => {
-                                log::debug!("Timeout reading from {}, continuing...", addr);
+                                tracing::debug!("Timeout reading from {}, continuing...", addr);
                                 // Minor reputation penalty for timeout
                                 reputation_manager
                                     .update_reputation(
@@ -652,14 +660,14 @@ impl PeerNetworkManager {
                                 continue;
                             }
                             _ => {
-                                log::error!("Fatal error reading from {}: {}", addr, e);
+                                tracing::error!("Fatal error reading from {}: {}", addr, e);
 
                                 // Check if this is a serialization error that might have context
                                 if let NetworkError::Serialization(ref decode_error) = e {
                                     let error_msg = decode_error.to_string();
                                     if error_msg.contains("unknown special transaction type") {
-                                        log::warn!("Peer {} sent block with unsupported transaction type: {}", addr, decode_error);
-                                        log::error!(
+                                        tracing::warn!("Peer {} sent block with unsupported transaction type: {}", addr, decode_error);
+                                        tracing::error!(
                                             "BLOCK DECODE FAILURE - Error details: {}",
                                             error_msg
                                         );
@@ -675,7 +683,7 @@ impl PeerNetworkManager {
                                         .contains("Failed to decode transactions for block")
                                     {
                                         // The error now includes the block hash
-                                        log::error!("Peer {} sent block that failed transaction decoding: {}", addr, decode_error);
+                                        tracing::error!("Peer {} sent block that failed transaction decoding: {}", addr, decode_error);
                                         // Try to extract the block hash from the error message
                                         if let Some(hash_start) = error_msg.find("block ") {
                                             if let Some(hash_end) =
@@ -683,19 +691,22 @@ impl PeerNetworkManager {
                                             {
                                                 let block_hash = &error_msg
                                                     [hash_start + 6..hash_start + 6 + hash_end];
-                                                log::error!("FAILING BLOCK HASH: {}", block_hash);
+                                                tracing::error!(
+                                                    "FAILING BLOCK HASH: {}",
+                                                    block_hash
+                                                );
                                             }
                                         }
                                     } else if error_msg.contains("IO error") {
                                         // This might be our wrapped error - log it prominently
-                                        log::error!("BLOCK DECODE FAILURE - IO error (possibly unknown transaction type) from peer {}", addr);
-                                        log::error!(
+                                        tracing::error!("BLOCK DECODE FAILURE - IO error (possibly unknown transaction type) from peer {}", addr);
+                                        tracing::error!(
                                             "Serialization error from {}: {}",
                                             addr,
                                             decode_error
                                         );
                                     } else {
-                                        log::error!(
+                                        tracing::error!(
                                             "Serialization error from {}: {}",
                                             addr,
                                             decode_error
@@ -711,7 +722,7 @@ impl PeerNetworkManager {
             }
 
             // Remove from pool and notify consumers
-            log::warn!("Disconnecting from {} (peer reader loop ended)", addr);
+            tracing::warn!("Disconnecting from {} (peer reader loop ended)", addr);
             Self::remove_peer_and_notify(
                 &pool,
                 &addr,
@@ -742,7 +753,7 @@ impl PeerNetworkManager {
         };
 
         let Some(mut request_rx) = request_rx else {
-            log::warn!("Request processor already started or receiver unavailable");
+            tracing::warn!("Request processor already started or receiver unavailable");
             return;
         };
 
@@ -751,13 +762,13 @@ impl PeerNetworkManager {
 
         let mut tasks = self.tasks.lock().await;
         tasks.spawn(async move {
-            log::info!("Starting request processor task");
+            tracing::info!("Starting request processor task");
             loop {
                 tokio::select! {
                     request = request_rx.recv() => {
                         match request {
                             Some(NetworkRequest::SendMessage(msg)) => {
-                                log::debug!("Request processor: sending {}", msg.cmd());
+                                tracing::debug!("Request processor: sending {}", msg.cmd());
                                 // Spawn each send concurrently to allow parallel requests across peers.
                                 let this = this.clone();
                                 tokio::spawn(async move {
@@ -777,12 +788,12 @@ impl PeerNetworkManager {
                                         }
                                     };
                                     if let Err(e) = result {
-                                        log::error!("Request processor: failed to send message: {}", e);
+                                        tracing::error!("Request processor: failed to send message: {}", e);
                                     }
                                 });
                             }
                             Some(NetworkRequest::SendMessageToPeer(msg, peer_address)) => {
-                                log::debug!("Request processor: sending {} to peer {}", msg.cmd(), peer_address);
+                                tracing::debug!("Request processor: sending {} to peer {}", msg.cmd(), peer_address);
                                 let this = this.clone();
                                 tokio::spawn(async move {
                                     let fallback_msg = msg.clone();
@@ -790,7 +801,7 @@ impl PeerNetworkManager {
                                         Some(peer) => match this.send_message_to_peer(&peer_address, &peer, msg).await {
                                             Ok(()) => Ok(()),
                                             Err(err) => {
-                                                log::warn!(
+                                                tracing::warn!(
                                                     "Target peer {} send failed ({}), falling back to distributed send",
                                                     peer_address,
                                                     err
@@ -799,7 +810,7 @@ impl PeerNetworkManager {
                                             }
                                         },
                                         None => {
-                                            log::warn!(
+                                            tracing::warn!(
                                                 "Target peer {} disconnected, falling back to distributed send",
                                                 peer_address
                                             );
@@ -807,18 +818,18 @@ impl PeerNetworkManager {
                                         }
                                     };
                                     if let Err(e) = result {
-                                        log::error!("Request processor: failed to send message to peer {}: {}", peer_address, e);
+                                        tracing::error!("Request processor: failed to send message to peer {}: {}", peer_address, e);
                                     }
                                 });
                             }
                             None => {
-                                log::info!("Request processor: channel closed");
+                                tracing::info!("Request processor: channel closed");
                                 break;
                             }
                         }
                     }
                     _ = shutdown_token.cancelled() => {
-                        log::info!("Request processor: shutting down");
+                        tracing::info!("Request processor: shutting down");
                         break;
                     }
                 }
@@ -831,7 +842,7 @@ impl PeerNetworkManager {
         // This should not trigger under normal operation.
         let unhealthy = self.pool.remove_unhealthy().await;
         for addr in &unhealthy {
-            log::warn!("Maintenance removed stale peer {} - reader loop missed cleanup", addr);
+            tracing::warn!("Maintenance removed stale peer {} - reader loop missed cleanup", addr);
             Self::notify_peer_removed(
                 &self.pool,
                 addr,
@@ -842,14 +853,14 @@ impl PeerNetworkManager {
         }
 
         let count = self.pool.peer_count().await;
-        log::debug!("Connected peers: {}", count);
+        tracing::debug!("Connected peers: {}", count);
         // Keep the cached counter in sync with actual pool count
         self.connected_peer_count.store(count, Ordering::Relaxed);
         if self.exclusive_mode {
             // In exclusive mode, only reconnect to originally specified peers
             for addr in self.initial_peers.iter() {
                 if !self.pool.is_connected(addr).await && !self.pool.is_connecting(addr).await {
-                    log::info!("Reconnecting to exclusive peer: {}", addr);
+                    tracing::info!("Reconnecting to exclusive peer: {}", addr);
                     self.connect_to_peer(*addr).await;
                 }
             }
@@ -885,7 +896,7 @@ impl PeerNetworkManager {
             let mut peer_guard = peer.write().await;
             if peer_guard.should_ping() {
                 if let Err(e) = peer_guard.send_ping().await {
-                    log::error!("Failed to ping {}: {}", addr, e);
+                    tracing::error!("Failed to ping {}: {}", addr, e);
                     // Update reputation for ping failure
                     self.reputation_manager
                         .update_reputation(addr, misbehavior_scores::TIMEOUT, "Ping failed")
@@ -904,13 +915,13 @@ impl PeerNetworkManager {
             let addresses = self.addrv2_handler.get_known_addresses().await;
             if !addresses.is_empty() {
                 if let Err(e) = self.peer_store.save_peers(&addresses).await {
-                    log::warn!("Failed to save peers: {}", e);
+                    tracing::warn!("Failed to save peers: {}", e);
                 }
             }
 
             // Save reputation data periodically
             if let Err(e) = self.reputation_manager.save_to_storage(&*self.peer_store).await {
-                log::warn!("Failed to save reputation data: {}", e);
+                tracing::warn!("Failed to save reputation data: {}", e);
             }
         }
     }
@@ -923,12 +934,12 @@ impl PeerNetworkManager {
         let dns_peers = tokio::select! {
             peers = self.discovery.discover_peers(self.network) => peers,
             _ = self.shutdown_token.cancelled() => {
-                log::info!("Maintenance loop shutting down during DNS discovery");
+                tracing::info!("Maintenance loop shutting down during DNS discovery");
                 return
             }
         };
         let needed = TARGET_PEERS.saturating_sub(count);
-        log::debug!("DNS fallback tick found {} addresses. Needed {}", dns_peers.len(), needed);
+        tracing::debug!("DNS fallback tick found {} addresses. Needed {}", dns_peers.len(), needed);
         let mut dns_attempted = 0;
         for addr in dns_peers.iter() {
             if !self.pool.is_connected(addr).await && !self.pool.is_connecting(addr).await {
@@ -955,7 +966,7 @@ impl PeerNetworkManager {
             while !this.shutdown_token.is_cancelled() {
                 tokio::select! {
                     _ = maintenance_interval.tick() => {
-                        log::debug!("Maintenance interval elapsed");
+                        tracing::debug!("Maintenance interval elapsed");
                         this.maintenance_tick().await;
                     }
                     _ = dns_interval.tick(), if !this.exclusive_mode => {
@@ -964,7 +975,7 @@ impl PeerNetworkManager {
                     event = network_events.recv() => {
                         match event {
                             Ok(event) => {
-                                log::debug!("Network event in maintenance loop: {}", event.description());
+                                tracing::debug!("Network event in maintenance loop: {}", event.description());
                                 dns_interval.reset();
                                 this.maintenance_tick().await;
                             }
@@ -975,7 +986,7 @@ impl PeerNetworkManager {
                         }
                     }
                     _ = this.shutdown_token.cancelled() => {
-                        log::info!("Maintenance loop shutting down");
+                        tracing::info!("Maintenance loop shutting down");
                         break;
                     }
                 }
@@ -1007,11 +1018,16 @@ impl PeerNetworkManager {
         let (addr, peer) = if let Some((flags, required)) = preferred_service {
             match self.pool.peer_with_service(flags).await {
                 Some((address, peer)) => {
-                    log::debug!("Selected peer {} with {} for {}", address, flags, message.cmd());
+                    tracing::debug!(
+                        "Selected peer {} with {} for {}",
+                        address,
+                        flags,
+                        message.cmd()
+                    );
                     (address, peer)
                 }
                 None if required => {
-                    log::warn!("No peers support {}, cannot send {}", flags, message.cmd());
+                    tracing::warn!("No peers support {}, cannot send {}", flags, message.cmd());
                     return Err(NetworkError::ProtocolError(format!("No peers support {}", flags)));
                 }
                 None => self.next_peer(&peers),
@@ -1072,7 +1088,7 @@ impl PeerNetworkManager {
 
         let (addr, peer) = self.next_peer(&selected_peers);
 
-        log::debug!("Distributing {} request to peer {}", message.cmd(), addr);
+        tracing::debug!("Distributing {} request to peer {}", message.cmd(), addr);
 
         self.send_message_to_peer(&addr, &peer, message).await
     }
@@ -1098,7 +1114,7 @@ impl PeerNetworkManager {
             NetworkMessage::GetHeaders(get_headers) => {
                 let supports_headers2 = peer.read().await.can_request_headers2();
                 if supports_headers2 && !self.headers2_disabled.lock().await.contains(addr) {
-                    log::debug!("Upgrading GetHeaders to GetHeaders2 for peer {}", addr);
+                    tracing::debug!("Upgrading GetHeaders to GetHeaders2 for peer {}", addr);
                     NetworkMessage::GetHeaders2(get_headers)
                 } else {
                     NetworkMessage::GetHeaders(get_headers)
@@ -1124,10 +1140,10 @@ impl PeerNetworkManager {
             // Reduce verbosity for common sync messages
             match &message {
                 NetworkMessage::GetHeaders(_) | NetworkMessage::GetCFilters(_) => {
-                    log::debug!("Broadcasting {} to {}", message.cmd(), addr);
+                    tracing::debug!("Broadcasting {} to {}", message.cmd(), addr);
                 }
                 _ => {
-                    log::trace!("Broadcasting {:?} to {}", message.cmd(), addr);
+                    tracing::trace!("Broadcasting {:?} to {}", message.cmd(), addr);
                 }
             }
             let msg = message.clone();
@@ -1155,7 +1171,7 @@ impl PeerNetworkManager {
 
     /// Disconnect a specific peer
     pub async fn disconnect_peer(&self, addr: &SocketAddr, reason: &str) -> Result<(), Error> {
-        log::info!("Disconnecting peer {} - reason: {}", addr, reason);
+        tracing::info!("Disconnecting peer {} - reason: {}", addr, reason);
 
         Self::remove_peer_and_notify(
             &self.pool,
@@ -1176,7 +1192,7 @@ impl PeerNetworkManager {
 
     /// Ban a specific peer manually
     pub async fn ban_peer(&self, addr: &SocketAddr, reason: &str) -> Result<(), Error> {
-        log::info!("Manually banning peer {} - reason: {}", addr, reason);
+        tracing::info!("Manually banning peer {} - reason: {}", addr, reason);
 
         // Disconnect the peer first
         self.disconnect_peer(addr, reason).await?;
@@ -1200,20 +1216,20 @@ impl PeerNetworkManager {
 
     /// Shutdown the network manager
     pub async fn shutdown(&self) {
-        log::info!("Shutting down peer network manager");
+        tracing::info!("Shutting down peer network manager");
         self.shutdown_token.cancel();
 
         // Save known peers before shutdown
         let addresses = self.addrv2_handler.get_addresses_for_peer(MAX_ADDR_TO_STORE).await;
         if !addresses.is_empty() {
             if let Err(e) = self.peer_store.save_peers(&addresses).await {
-                log::warn!("Failed to save peers on shutdown: {}", e);
+                tracing::warn!("Failed to save peers on shutdown: {}", e);
             }
         }
 
         // Save reputation data before shutdown
         if let Err(e) = self.reputation_manager.save_to_storage(&*self.peer_store).await {
-            log::warn!("Failed to save reputation data on shutdown: {}", e);
+            tracing::warn!("Failed to save reputation data on shutdown: {}", e);
         }
 
         // Drain tasks while holding the lock.  connect_to_peer() already uses
@@ -1222,7 +1238,7 @@ impl PeerNetworkManager {
         let mut tasks = self.tasks.lock().await;
         while let Some(result) = tasks.join_next().await {
             if let Err(e) = result {
-                log::error!("Task join error: {}", e);
+                tracing::error!("Task join error: {}", e);
             }
         }
 

--- a/dash-spv/src/network/peer.rs
+++ b/dash-spv/src/network/peer.rs
@@ -287,7 +287,7 @@ impl Peer {
         );
 
         // Also log with standard logging for debugging
-        log::info!(
+        tracing::info!(
             "PEER_INFO_DEBUG: Updated peer {} with height={}, version={}",
             self.address,
             version_msg.start_height,

--- a/dash-spv/src/network/pool.rs
+++ b/dash-spv/src/network/pool.rs
@@ -58,7 +58,7 @@ impl PeerPool {
         }
 
         peers.insert(addr, Arc::new(RwLock::new(peer)));
-        log::info!("Added peer {}, total peers: {}", addr, peers.len());
+        tracing::info!("Added peer {}, total peers: {}", addr, peers.len());
         Ok(())
     }
 
@@ -67,7 +67,7 @@ impl PeerPool {
         self.connecting.write().await.remove(addr);
         let removed = self.peers.write().await.remove(addr);
         if removed.is_some() {
-            log::info!("Removed peer {}", addr);
+            tracing::info!("Removed peer {}", addr);
         }
         removed
     }
@@ -106,7 +106,7 @@ impl PeerPool {
         let peers = self.get_all_peers().await;
 
         if peers.is_empty() {
-            log::debug!("get_best_height: No peers available");
+            tracing::debug!("get_best_height: No peers available");
             return None;
         }
 
@@ -117,7 +117,7 @@ impl PeerPool {
             let peer_guard = peer.read().await;
             peer_count += 1;
 
-            log::debug!(
+            tracing::debug!(
                 "get_best_height: Peer {} - best_height: {:?}, version: {:?}, connected: {}",
                 addr,
                 peer_guard.best_height(),
@@ -128,7 +128,7 @@ impl PeerPool {
             if let Some(peer_height) = peer_guard.best_height() {
                 if peer_height > 0 {
                     best_height = best_height.max(peer_height);
-                    log::debug!(
+                    tracing::debug!(
                         "get_best_height: Updated best_height to {} from peer {}",
                         best_height,
                         addr
@@ -137,7 +137,11 @@ impl PeerPool {
             }
         }
 
-        log::debug!("get_best_height: Checked {} peers, best_height: {}", peer_count, best_height);
+        tracing::debug!(
+            "get_best_height: Checked {} peers, best_height: {}",
+            peer_count,
+            best_height
+        );
 
         if best_height > 0 {
             Some(best_height)

--- a/dash-spv/src/network/reputation.rs
+++ b/dash-spv/src/network/reputation.rs
@@ -94,10 +94,10 @@ where
     let mut v = i32::deserialize(deserializer)?;
 
     if v < MIN_MISBEHAVIOR_SCORE {
-        log::warn!("Peer has invalid score {v}, clamping to min {MIN_MISBEHAVIOR_SCORE}");
+        tracing::warn!("Peer has invalid score {v}, clamping to min {MIN_MISBEHAVIOR_SCORE}");
         v = MIN_MISBEHAVIOR_SCORE
     } else if v > MAX_MISBEHAVIOR_SCORE {
-        log::warn!("Peer has invalid score {v}, clamping to max {MAX_MISBEHAVIOR_SCORE}");
+        tracing::warn!("Peer has invalid score {v}, clamping to max {MAX_MISBEHAVIOR_SCORE}");
         v = MAX_MISBEHAVIOR_SCORE
     }
 
@@ -111,7 +111,7 @@ where
     let mut v = u32::deserialize(deserializer)?;
 
     if v > MAX_BAN_COUNT {
-        log::warn!("Peer has excessive ban count {v}, clamping to {MAX_BAN_COUNT}");
+        tracing::warn!("Peer has excessive ban count {v}, clamping to {MAX_BAN_COUNT}");
         v = MAX_BAN_COUNT
     }
 
@@ -290,7 +290,7 @@ impl PeerReputationManager {
         if should_ban {
             reputation.banned_until = Some(Instant::now() + BAN_DURATION);
             reputation.ban_count += 1;
-            log::warn!(
+            tracing::warn!(
                 "Peer {} banned for misbehavior (score: {}, ban #{}, reason: {})",
                 peer,
                 reputation.score,
@@ -301,7 +301,7 @@ impl PeerReputationManager {
 
         // Log significant changes
         if score_change.abs() >= 10 || should_ban {
-            log::info!(
+            tracing::info!(
                 "Peer {} reputation changed: {} -> {} (change: {}, reason: {})",
                 peer,
                 old_score,
@@ -368,7 +368,7 @@ impl PeerReputationManager {
         reputation.banned_until = Some(Instant::now() + duration);
         reputation.ban_count += 1;
 
-        log::warn!(
+        tracing::warn!(
             "Peer {} temporarily banned for {:?} (ban #{}, reason: {})",
             peer,
             duration,
@@ -415,7 +415,7 @@ impl PeerReputationManager {
         if let Some(reputation) = reputations.get_mut(peer) {
             reputation.banned_until = None;
             reputation.score = reputation.score.min(MAX_MISBEHAVIOR_SCORE - 10);
-            log::info!("Manually unbanned peer {}", peer);
+            tracing::info!("Manually unbanned peer {}", peer);
         }
     }
 
@@ -423,7 +423,7 @@ impl PeerReputationManager {
     pub async fn reset_reputation(&self, peer: &SocketAddr) {
         let mut reputations = self.reputations.write().await;
         reputations.remove(peer);
-        log::info!("Reset reputation for peer {}", peer);
+        tracing::info!("Reset reputation for peer {}", peer);
     }
 
     /// Get peers sorted by reputation (best first)
@@ -470,7 +470,7 @@ impl PeerReputationManager {
             if reputation.positive_actions > MAX_ACTION_COUNT
                 || reputation.negative_actions > MAX_ACTION_COUNT
             {
-                log::warn!("Skipping peer {} with potentially corrupted action counts", addr);
+                tracing::warn!("Skipping peer {} with potentially corrupted action counts", addr);
                 skipped_count += 1;
                 continue;
             }
@@ -484,7 +484,7 @@ impl PeerReputationManager {
             loaded_count += 1;
         }
 
-        log::info!(
+        tracing::info!(
             "Loaded reputation data for {} peers (skipped {} corrupted entries)",
             loaded_count,
             skipped_count
@@ -520,7 +520,7 @@ impl ReputationAware for PeerReputationManager {
 
         for peer in available_peers {
             let Ok(socket_addr) = peer.socket_addr() else {
-                log::warn!("Skip invalid peer address: {:?}", peer);
+                tracing::warn!("Skip invalid peer address: {:?}", peer);
                 continue;
             };
 

--- a/dash-spv/tests/peer_test.rs
+++ b/dash-spv/tests/peer_test.rs
@@ -15,6 +15,11 @@ use dash_spv::types::ValidationMode;
 use dashcore::Network;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet_manager::WalletManager;
+
+fn init_test_tracing() {
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+}
+
 /// Create a test configuration with the given network
 fn create_test_config(network: Network) -> ClientConfig {
     let mut config = ClientConfig::new(network);
@@ -32,7 +37,7 @@ fn create_test_config(network: Network) -> ClientConfig {
 #[tokio::test]
 #[ignore] // Requires network access
 async fn test_peer_connection() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    init_test_tracing();
 
     let config = create_test_config(Network::Testnet);
 
@@ -68,7 +73,7 @@ async fn test_peer_connection() {
 #[tokio::test]
 #[ignore] // Requires network access
 async fn test_peer_persistence() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    init_test_tracing();
 
     let config = create_test_config(Network::Testnet);
 
@@ -146,7 +151,7 @@ async fn test_peer_persistence() {
 
 #[tokio::test]
 async fn test_peer_disconnection() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    init_test_tracing();
 
     let mut config = create_test_config(Network::Regtest);
 

--- a/dash/Cargo.toml
+++ b/dash/Cargo.toml
@@ -59,7 +59,7 @@ ed25519-dalek = { version = "2.1", features = ["rand_core"], optional = true }
 blake3 = "1.8.1"
 thiserror = "2"
 bitvec = "1.0"
-log = "0.4"
+tracing = "0.1"
 
 [dev-dependencies]
 serde_json = "1.0.140"

--- a/dash/src/network/message.rs
+++ b/dash/src/network/message.rs
@@ -488,7 +488,7 @@ impl Decodable for RawNetworkMessage {
                 actual,
             }) => {
                 // Include message command and magic in logging to aid diagnostics
-                log::warn!(
+                tracing::warn!(
                     "Invalid payload checksum for network message '{}' (magic {:#x}): expected {:02x?}, actual {:02x?}",
                     cmd.0,
                     magic,

--- a/dash/src/sml/llmq_type/mod.rs
+++ b/dash/src/sml/llmq_type/mod.rs
@@ -525,7 +525,7 @@ impl LLMQType {
         let first_possible_cycle =
             ((start.saturating_sub(params.dkg_params.mining_window_end)) / interval) * interval;
 
-        log::trace!(
+        tracing::trace!(
             "get_dkg_windows_in_range for {:?}: start={}, end={}, interval={}, first_cycle={}",
             self,
             start,
@@ -542,7 +542,7 @@ impl LLMQType {
             // Include this window if its mining period overlaps with [start, end]
             if window.mining_end >= start && window.mining_start <= end {
                 windows.push(window.clone());
-                log::trace!(
+                tracing::trace!(
                     "  Added window: cycle={}, mining={}-{}",
                     window.cycle_start,
                     window.mining_start,
@@ -554,7 +554,7 @@ impl LLMQType {
             _cycles_checked += 1;
         }
 
-        log::trace!(
+        tracing::trace!(
             "get_dkg_windows_in_range for {:?}: checked {} cycles, found {} windows",
             self,
             _cycles_checked,

--- a/dash/src/sml/llmq_type/network.rs
+++ b/dash/src/sml/llmq_type/network.rs
@@ -83,7 +83,7 @@ impl NetworkLLMQExt for Network {
     fn get_all_dkg_windows(&self, start: u32, end: u32) -> BTreeMap<u32, Vec<DKGWindow>> {
         let mut windows_by_height: BTreeMap<u32, Vec<DKGWindow>> = BTreeMap::new();
 
-        log::debug!(
+        tracing::debug!(
             "get_all_dkg_windows: Calculating DKG windows for range {}-{} on network {:?}",
             start,
             end,
@@ -92,7 +92,7 @@ impl NetworkLLMQExt for Network {
 
         for llmq_type in self.enabled_llmq_types() {
             let type_windows = llmq_type.get_dkg_windows_in_range(start, end);
-            log::debug!(
+            tracing::debug!(
                 "LLMQ type {:?}: found {} DKG windows in range {}-{}",
                 llmq_type,
                 type_windows.len(),
@@ -103,7 +103,7 @@ impl NetworkLLMQExt for Network {
             for window in type_windows {
                 // Skip platform quorums before activation if needed
                 if self.should_skip_quorum_type(&llmq_type, window.mining_start) {
-                    log::trace!(
+                    tracing::trace!(
                         "Skipping {:?} for height {} (activation threshold not met)",
                         llmq_type,
                         window.mining_start
@@ -116,7 +116,7 @@ impl NetworkLLMQExt for Network {
             }
         }
 
-        log::info!(
+        tracing::info!(
             "get_all_dkg_windows: Total {} unique mining heights with DKG windows for range {}-{}",
             windows_by_height.len(),
             start,

--- a/dash/src/sml/masternode_list_engine/message_request_verification.rs
+++ b/dash/src/sml/masternode_list_engine/message_request_verification.rs
@@ -16,8 +16,8 @@ impl MasternodeListEngine {
         // Retrieve the cycle hash from the Instant Lock
         let cycle_hash = instant_lock.cyclehash;
 
-        log::debug!("IS lock verification - cyclehash from InstantLock: {}", cycle_hash);
-        log::debug!(
+        tracing::debug!("IS lock verification - cyclehash from InstantLock: {}", cycle_hash);
+        tracing::debug!(
             "Available cycle hashes in rotated_quorums_per_cycle: {:?}",
             self.rotated_quorums_per_cycle.keys().collect::<Vec<_>>()
         );
@@ -28,9 +28,9 @@ impl MasternodeListEngine {
             .get(&cycle_hash)
             .ok_or(MessageVerificationError::CycleHashNotPresent(cycle_hash))?;
 
-        log::debug!("Found {} quorums for cyclehash {}", quorums.len(), cycle_hash);
+        tracing::debug!("Found {} quorums for cyclehash {}", quorums.len(), cycle_hash);
         for q in quorums.iter() {
-            log::debug!(
+            tracing::debug!(
                 "  Quorum: hash={}, index={:?}, height at block_container={:?}",
                 q.quorum_entry.quorum_hash,
                 q.quorum_entry.quorum_index,
@@ -115,7 +115,7 @@ impl MasternodeListEngine {
         // Only God and maybe Odysseus knows why (64 - n - 1)
         let quorum_index = quorum_index_mask & (selection_hash_64 >> (64 - n - 1)) as usize;
 
-        log::debug!(
+        tracing::debug!(
             "IS lock quorum selection: txid={}, request_id={}, selection_hash_64={:#018x}, quorum_count={}, n={}, mask={:#x}, computed_index={}",
             instant_lock.txid,
             request_id,
@@ -137,7 +137,7 @@ impl MasternodeListEngine {
                 )
             })?;
 
-        log::debug!(
+        tracing::debug!(
             "IS lock selected quorum: hash={}, index={:?}, public_key={}, verified={:?}",
             quorum.quorum_entry.quorum_hash,
             quorum.quorum_entry.quorum_index,
@@ -195,7 +195,7 @@ impl MasternodeListEngine {
             )
             .map_err(|e| e.to_string())?;
 
-        log::debug!(
+        tracing::debug!(
             "IS lock verify: txid={}, cyclehash={}, quorum_index={}, quorum_hash={}, sign_id={}, public_key={}, signature={}",
             instant_lock.txid,
             instant_lock.cyclehash,
@@ -208,7 +208,7 @@ impl MasternodeListEngine {
 
         match quorum.verify_message_digest(sign_id.to_byte_array(), instant_lock.signature) {
             Ok(()) => {
-                log::info!(
+                tracing::info!(
                     "IS lock verified: txid={}, quorum_index={}, quorum_hash={}",
                     instant_lock.txid,
                     quorum_index,
@@ -217,7 +217,7 @@ impl MasternodeListEngine {
                 Ok(())
             }
             Err(e) => {
-                log::warn!(
+                tracing::warn!(
                     "IS lock verification failed: txid={}, quorum_index={}, quorum_hash={}, public_key={}, error={}",
                     instant_lock.txid,
                     quorum_index,

--- a/dash/src/sml/masternode_list_engine/mod.rs
+++ b/dash/src/sml/masternode_list_engine/mod.rs
@@ -693,7 +693,7 @@ impl MasternodeListEngine {
                 });
 
             for mut rotated_quorum in qualified_last_commitment_per_index {
-                log::debug!(
+                tracing::debug!(
                     "  Current cycle quorum: hash={}, index={:?}",
                     rotated_quorum.quorum_entry.quorum_hash,
                     rotated_quorum.quorum_entry.quorum_index

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/lib.rs"
 [dependencies]
 dashcore-rpc-json = { path = "../rpc-json" }
 
-log = "0.4.27"
 jsonrpc = "0.18.0"
+tracing = "0.1"
 
 # Used for deserialization of JSON.
 serde = { version = "1.0.219", features = ["derive"] }

--- a/rpc-client/examples/connect_to_masternode.rs
+++ b/rpc-client/examples/connect_to_masternode.rs
@@ -1,6 +1,5 @@
 extern crate dashcore_rpc;
 extern crate dashcore_rpc_json;
-extern crate log;
 
 use dashcore_rpc::{Auth, Client, RpcApi};
 use dashcore_rpc_json::{ProTxListType, QuorumType};

--- a/rpc-client/src/client.rs
+++ b/rpc-client/src/client.rs
@@ -33,7 +33,7 @@ use dashcore::{
 use dashcore_rpc_json::dashcore::bls_sig_utils::BLSSignature;
 use dashcore_rpc_json::dashcore::{BlockHash, ChainLock};
 use dashcore_rpc_json::{ProTxInfo, ProTxListType, QuorumType};
-use log::Level::{Debug, Trace, Warn};
+use tracing::Level;
 
 /// Crate-specific Result type, shorthand for `std::result::Result` with our
 /// crate-specific Error type;
@@ -1694,8 +1694,8 @@ impl RpcApi for Client {
         let raw_args_json = serde_json::to_string(args)?;
         let raw_args = Some(serde_json::value::RawValue::from_string(raw_args_json)?);
         let req = self.client.build_request(cmd, raw_args.as_deref());
-        if log_enabled!(Debug) {
-            debug!(target: "dashcore_rpc", "JSON-RPC request: {} {}", cmd, serde_json::Value::from(args));
+        if tracing::enabled!(target: "dashcore_rpc", Level::DEBUG) {
+            tracing::debug!(target: "dashcore_rpc", "JSON-RPC request: {} {}", cmd, serde_json::Value::from(args));
         }
 
         let resp = self.client.send_request(req).map_err(Error::from);
@@ -1705,26 +1705,29 @@ impl RpcApi for Client {
 }
 
 fn log_response(cmd: &str, resp: &Result<jsonrpc::Response>) {
-    if log_enabled!(Warn) || log_enabled!(Debug) || log_enabled!(Trace) {
+    if tracing::enabled!(target: "dashcore_rpc", Level::WARN)
+        || tracing::enabled!(target: "dashcore_rpc", Level::DEBUG)
+        || tracing::enabled!(target: "dashcore_rpc", Level::TRACE)
+    {
         match resp {
             Err(e) => {
-                if log_enabled!(Debug) {
-                    debug!(target: "dashcore_rpc", "JSON-RPC failed parsing reply of {}: {:?}", cmd, e);
+                if tracing::enabled!(target: "dashcore_rpc", Level::DEBUG) {
+                    tracing::debug!(target: "dashcore_rpc", "JSON-RPC failed parsing reply of {}: {:?}", cmd, e);
                 }
             }
             Ok(resp) => {
                 if let Some(e) = &resp.error {
-                    if log_enabled!(Debug) {
-                        debug!(target: "dashcore_rpc", "JSON-RPC error for {}: {:?}", cmd, e);
+                    if tracing::enabled!(target: "dashcore_rpc", Level::DEBUG) {
+                        tracing::debug!(target: "dashcore_rpc", "JSON-RPC error for {}: {:?}", cmd, e);
                     }
-                } else if log_enabled!(Trace) {
+                } else if tracing::enabled!(target: "dashcore_rpc", Level::TRACE) {
                     // we can't use to_raw_value here due to compat with Rust 1.29
                     let def = serde_json::value::RawValue::from_string(
                         serde_json::Value::Null.to_string(),
                     )
                     .unwrap();
                     let result = resp.result.as_ref().unwrap_or(&def);
-                    trace!(target: "dashcore_rpc", "JSON-RPC response for {}: {}", cmd, result);
+                    tracing::trace!(target: "dashcore_rpc", "JSON-RPC response for {}: {}", cmd, result);
                 }
             }
         }

--- a/rpc-client/src/lib.rs
+++ b/rpc-client/src/lib.rs
@@ -17,8 +17,6 @@
 #![crate_type = "rlib"]
 #![allow(unused)]
 
-#[macro_use]
-extern crate log;
 #[macro_use] // `macro_use` is needed for v1.24.0 compilation.
 extern crate serde;
 extern crate serde_json;

--- a/rpc-integration-test/Cargo.toml
+++ b/rpc-integration-test/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 [dependencies]
 dashcore-rpc = { path = "../rpc-client" }
 lazy_static = "1.4.0"
-log = "0.4"
 hex = "0.4.3"
 dotenvy = "0.15.7"
+tracing = "0.1"
+tracing-log = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/rpc-integration-test/src/main.rs
+++ b/rpc-integration-test/src/main.rs
@@ -10,11 +10,12 @@
 
 #[macro_use]
 extern crate lazy_static;
-extern crate log;
 
-use log::trace;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
+use tracing::trace;
+use tracing_log::LogTracer;
+use tracing_subscriber::EnvFilter;
 
 use dashcore_rpc::json;
 use dashcore_rpc::jsonrpc::error::Error as JsonRpcError;
@@ -54,26 +55,6 @@ lazy_static! {
     /// The default fee amount to use when needed.
     static ref FEE: Amount = Amount::from_btc(0.001).unwrap();
 }
-
-struct StdLogger;
-
-impl log::Log for StdLogger {
-    fn enabled(&self, metadata: &log::Metadata) -> bool {
-        metadata.target().contains("jsonrpc")
-            || metadata.target().contains("dashcore_rpc")
-            || metadata.target().contains("integration_test")
-    }
-
-    fn log(&self, record: &log::Record) {
-        if self.enabled(record.metadata()) {
-            println!("[{}][{}]: {}", record.level(), record.metadata().target(), record.args());
-        }
-    }
-
-    fn flush(&self) {}
-}
-
-static LOGGER: StdLogger = StdLogger;
 
 /// Assert that the call returns a "method not found" error.
 macro_rules! assert_not_found {
@@ -161,7 +142,9 @@ fn get_auth() -> (Auth, Auth) {
 }
 
 fn main() {
-    log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::max())).unwrap();
+    LogTracer::init().expect("failed to install log-to-tracing bridge");
+    let filter = EnvFilter::new("jsonrpc=trace,dashcore_rpc=trace,integration_test=trace");
+    tracing_subscriber::fmt().with_env_filter(filter).with_target(true).init();
     dotenvy::dotenv().ok();
 
     let (wallet_node_auth, evo_node_auth) = get_auth();


### PR DESCRIPTION
We currently use a mix of log and tracing. This PR unifies it to use tracing everywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated project-wide logging from the legacy logging facade to the tracing ecosystem, standardizing diagnostic output across networking, RPC, and core components.
* **Tests**
  * Updated test harnesses to initialize the new tracing-based logging so test output and diagnostics remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->