### PR TITLE
feat: add address and value fields to FFIOutputDetail

### DIFF
--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -731,6 +731,13 @@ impl FFIWalletEventCallbacks {
                         .map(|d| FFIOutputDetail {
                             index: d.index,
                             role: FFIOutputRole::from(d.role),
+                            value: d.value,
+                            address: match &d.address {
+                                Some(addr) => {
+                                    CString::new(addr.to_string()).unwrap_or_default().into_raw()
+                                }
+                                None => std::ptr::null_mut(),
+                            },
                         })
                         .collect();
 
@@ -778,6 +785,14 @@ impl FFIWalletEventCallbacks {
 
                     // Free the CString addresses from input details
                     for detail in input_details {
+                        if !detail.address.is_null() {
+                            unsafe {
+                                drop(CString::from_raw(detail.address));
+                            }
+                        }
+                    }
+                    // Free the CString addresses from output details
+                    for detail in output_details {
                         if !detail.address.is_null() {
                             unsafe {
                                 drop(CString::from_raw(detail.address));

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -791,6 +791,13 @@ pub unsafe extern "C" fn managed_core_account_get_transactions(
             .map(|d| FFIOutputDetail {
                 index: d.index,
                 role: FFIOutputRole::from(d.role),
+                value: d.value,
+                address: match &d.address {
+                    Some(addr) => {
+                        std::ffi::CString::new(addr.to_string()).unwrap_or_default().into_raw()
+                    }
+                    None => std::ptr::null_mut(),
+                },
             })
             .collect::<Vec<_>>()
             .into_boxed_slice();
@@ -841,12 +848,16 @@ pub unsafe extern "C" fn managed_core_account_free_transactions(
             drop(Box::from_raw(slice as *mut [FFIInputDetail]));
         }
 
-        // Free output details
+        // Free output detail addresses first, then the array
         if !record.output_details.is_null() && record.output_details_count > 0 {
-            drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
-                record.output_details,
-                record.output_details_count,
-            )));
+            let slice =
+                std::slice::from_raw_parts_mut(record.output_details, record.output_details_count);
+            for detail in slice.iter() {
+                if !detail.address.is_null() {
+                    drop(std::ffi::CString::from_raw(detail.address));
+                }
+            }
+            drop(Box::from_raw(slice as *mut [FFIOutputDetail]));
         }
 
         // Free tx data
@@ -2027,7 +2038,7 @@ mod tests {
             let addr = std::ffi::CString::new("XtestAddress123").unwrap();
             let input_slice = vec![FFIInputDetail {
                 index: 0,
-                value: 100000,
+                value: 0,
                 address: addr.into_raw(),
             }]
             .into_boxed_slice();
@@ -2038,6 +2049,8 @@ mod tests {
             let output_slice = vec![FFIOutputDetail {
                 index: 0,
                 role: FFIOutputRole::Received,
+                value: 0,
+                address: std::ptr::null_mut(),
             }]
             .into_boxed_slice();
             r0.output_details_count = output_slice.len();

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -931,7 +931,7 @@ pub struct FFIOutputDetail {
     pub index: u32,
     pub role: FFIOutputRole,
     pub value: u64,
-    pub address: *mut std::os::raw::c_char,
+    pub address: *mut c_char,
 }
 
 #[cfg(test)]

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -930,6 +930,8 @@ pub struct FFIInputDetail {
 pub struct FFIOutputDetail {
     pub index: u32,
     pub role: FFIOutputRole,
+    pub value: u64,
+    pub address: *mut std::os::raw::c_char,
 }
 
 #[cfg(test)]

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -504,6 +504,8 @@ impl ManagedCoreAccount {
             output_details.push(OutputDetail {
                 index: idx as u32,
                 role,
+                address: resolved_outputs[idx].clone(),
+                value: output.value,
             });
         }
 

--- a/key-wallet/src/managed_account/transaction_record.rs
+++ b/key-wallet/src/managed_account/transaction_record.rs
@@ -38,10 +38,8 @@ pub struct OutputDetail {
     /// Role of this output from the wallet's perspective
     pub role: OutputRole,
     /// Decoded address (None for non-standard scripts)
-    #[cfg_attr(feature = "serde", serde(default))]
     pub address: Option<Address>,
     /// Value in satoshis
-    #[cfg_attr(feature = "serde", serde(default))]
     pub value: u64,
 }
 

--- a/key-wallet/src/managed_account/transaction_record.rs
+++ b/key-wallet/src/managed_account/transaction_record.rs
@@ -37,6 +37,12 @@ pub struct OutputDetail {
     pub index: u32,
     /// Role of this output from the wallet's perspective
     pub role: OutputRole,
+    /// Decoded address (None for non-standard scripts)
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub address: Option<Address>,
+    /// Value in satoshis
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub value: u64,
 }
 
 /// Role of a transaction output from the wallet's perspective


### PR DESCRIPTION
## Summary
- Adds `address: Option<Address>` and `value: u64` to `OutputDetail` (key-wallet crate)
- Adds `address: *mut c_char` and `value: u64` to `FFIOutputDetail` (key-wallet-ffi + dash-spv-ffi)
- Purely additive — existing consumers reading `index` and `role` are unaffected

## Motivation
The tx detail screen in dashwallet-ios needs output addresses to display "Received at" / "Sent to" sections. The wallet crate already resolves output addresses via `Address::from_script` during transaction processing but wasn't storing them in `OutputDetail`. This change surfaces what's already computed.

## Test plan
- [x] `cargo fmt` passes
- [ ] `cargo test -p key-wallet-ffi` passes
- [ ] `cargo test -p key-wallet` passes
- [ ] Downstream: rebuild xcframework, verify addresses appear in dashwallet-ios tx detail screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Convert raw script bytes into human-readable addresses for supported networks.
  * Inspect transaction outputs from raw transaction bytes to return an output’s script and value, plus a matching way to free returned script memory.
  * Wallet event callbacks now include per-output values and derived addresses (network-aware).

* **Documentation**
  * API reference updated to document the new address & transaction output APIs and memory ownership rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->