### PR TITLE
chore(key-wallet-ffi): enable and update key-wallet-ffi unit tests defined out of scope

### DIFF
--- a/key-wallet-ffi/src/account_derivation.rs
+++ b/key-wallet-ffi/src/account_derivation.rs
@@ -699,3 +699,7 @@ pub unsafe extern "C" fn account_derive_private_key_from_mnemonic(
         }
     }
 }
+
+#[cfg(test)]
+#[path = "account_derivation_tests.rs"]
+mod account_derivation_tests;

--- a/key-wallet-ffi/src/account_derivation_tests.rs
+++ b/key-wallet-ffi/src/account_derivation_tests.rs
@@ -9,8 +9,7 @@ mod tests {
     use crate::keys::{extended_private_key_free, private_key_free};
     use crate::types::FFIAccountType;
     use crate::wallet;
-    use std::ffi::CString;
-    use std::os::raw::c_char;
+    use crate::FFINetwork;
 
     const MNEMONIC: &str =
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
@@ -19,15 +18,24 @@ mod tests {
     fn test_account_derive_private_key_at_receive_index() {
         let mut error = FFIError::success();
 
+        let mnemonic = std::ffi::CString::new(MNEMONIC).unwrap();
+        let passphrase = std::ffi::CString::new("").unwrap();
+
         // Create wallet on testnet with default accounts
-        let wallet = unsafe { wallet::wallet_create_from_mnemonic(c_str(MNEMONIC), c_str(""), FFINetwork::Testnet, &mut error) };
+        let wallet = unsafe {
+            wallet::wallet_create_from_mnemonic(
+                mnemonic.as_ptr(),
+                passphrase.as_ptr(),
+                FFINetwork::Testnet,
+                &mut error,
+            )
+        };
         assert!(!wallet.is_null());
-        assert_eq!(unsafe { (*(&mut error)).code }, FFIErrorCode::Success);
+        assert_eq!(error.code, FFIErrorCode::Success);
 
         // Get account 0 (BIP44)
         let account = unsafe {
-            crate::account::wallet_get_account(wallet, crate::FFINetwork::Testnet, 0, FFIAccountType::StandardBIP44)
-                .account
+            crate::account::wallet_get_account(wallet, 0, FFIAccountType::StandardBIP44).account
         };
         assert!(!account.is_null());
 
@@ -35,22 +43,37 @@ mod tests {
         let mut seed = [0u8; 64];
         // Deterministic seed from mnemonic helper
         let ok = unsafe {
-            crate::mnemonic::mnemonic_to_seed(c_str(MNEMONIC), c_str(""), seed.as_mut_ptr(), &mut (seed.len()), &mut error)
+            crate::mnemonic::mnemonic_to_seed(
+                mnemonic.as_ptr(),
+                passphrase.as_ptr(),
+                seed.as_mut_ptr(),
+                &mut (seed.len()),
+                &mut error,
+            )
         };
         assert!(ok);
 
-        let master_xpriv = unsafe { derivation_new_master_key(seed.as_ptr(), seed.len(), crate::FFINetwork::Testnet, &mut error) };
+        let master_xpriv = unsafe {
+            derivation_new_master_key(
+                seed.as_ptr(),
+                seed.len(),
+                crate::FFINetwork::Testnet,
+                &mut error,
+            )
+        };
         assert!(!master_xpriv.is_null());
 
         // For standard accounts with internal/external, this helper should fail
-        let priv_key = unsafe { account_derive_private_key_at(account, master_xpriv, 0, &mut error) };
+        let priv_key =
+            unsafe { account_derive_private_key_at(account, master_xpriv, 0, &mut error) };
         assert!(priv_key.is_null());
-        assert_eq!(unsafe { (*(&mut error)).code }, FFIErrorCode::WalletError);
+        assert_eq!(error.code, FFIErrorCode::WalletError);
 
         // Derive WIF should also fail for such accounts
-        let wif = unsafe { account_derive_private_key_as_wif_at(account, master_xpriv, 0, &mut error) };
+        let wif =
+            unsafe { account_derive_private_key_as_wif_at(account, master_xpriv, 0, &mut error) };
         assert!(wif.is_null());
-        assert_eq!(unsafe { (*(&mut error)).code }, FFIErrorCode::WalletError);
+        assert_eq!(error.code, FFIErrorCode::WalletError);
 
         // Cleanup
         unsafe {
@@ -70,32 +93,28 @@ mod tests {
         // BLS nulls
         #[cfg(feature = "bls")]
         unsafe {
-            assert!(
-                super::super::account_derivation::bls_account_derive_private_key_from_seed(
-                    std::ptr::null(),
-                    std::ptr::null(),
-                    0,
-                    0,
-                    &mut error,
-                )
-                .is_null()
-            );
+            assert!(super::super::bls_account_derive_private_key_from_seed(
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                0,
+                &mut error,
+            )
+            .is_null());
             assert_eq!(error.code, FFIErrorCode::InvalidInput);
         }
 
         // EdDSA nulls
         #[cfg(feature = "eddsa")]
         unsafe {
-            assert!(
-                super::super::account_derivation::eddsa_account_derive_private_key_from_seed(
-                    std::ptr::null(),
-                    std::ptr::null(),
-                    0,
-                    0,
-                    &mut error,
-                )
-                .is_null()
-            );
+            assert!(super::super::eddsa_account_derive_private_key_from_seed(
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                0,
+                &mut error,
+            )
+            .is_null());
             assert_eq!(error.code, FFIErrorCode::InvalidInput);
         }
 
@@ -106,31 +125,53 @@ mod tests {
     fn test_account_derive_extended_private_key_at_change_index() {
         let mut error = FFIError::success();
 
+        let mnemonic = std::ffi::CString::new(MNEMONIC).unwrap();
+        let passphrase = std::ffi::CString::new("").unwrap();
+
         // Create wallet on testnet with default accounts
-        let wallet = unsafe { wallet::wallet_create_from_mnemonic(c_str(MNEMONIC), c_str(""), FFINetwork::Testnet, &mut error) };
+        let wallet = unsafe {
+            wallet::wallet_create_from_mnemonic(
+                mnemonic.as_ptr(),
+                passphrase.as_ptr(),
+                FFINetwork::Testnet,
+                &mut error,
+            )
+        };
         assert!(!wallet.is_null());
 
         // Get account 0 (BIP44)
         let account = unsafe {
-            crate::account::wallet_get_account(wallet, crate::FFINetwork::Testnet, 0, FFIAccountType::StandardBIP44)
-                .account
+            crate::account::wallet_get_account(wallet, 0, FFIAccountType::StandardBIP44).account
         };
         assert!(!account.is_null());
 
         // Seed and master xpriv
         let mut seed = [0u8; 64];
         let ok = unsafe {
-            crate::mnemonic::mnemonic_to_seed(c_str(MNEMONIC), c_str(""), seed.as_mut_ptr(), &mut (seed.len()), &mut error)
+            crate::mnemonic::mnemonic_to_seed(
+                mnemonic.as_ptr(),
+                passphrase.as_ptr(),
+                seed.as_mut_ptr(),
+                &mut (seed.len()),
+                &mut error,
+            )
         };
         assert!(ok);
-        let master_xpriv = unsafe { derivation_new_master_key(seed.as_ptr(), seed.len(), crate::FFINetwork::Testnet, &mut error) };
+        let master_xpriv = unsafe {
+            derivation_new_master_key(
+                seed.as_ptr(),
+                seed.len(),
+                crate::FFINetwork::Testnet,
+                &mut error,
+            )
+        };
         assert!(!master_xpriv.is_null());
 
         // Extended xpriv helper should also fail for standard accounts
         let xpriv =
             unsafe { account_derive_extended_private_key_at(account, master_xpriv, 5, &mut error) };
         assert!(xpriv.is_null());
-        assert_eq!(unsafe { (*(&mut error)).code }, FFIErrorCode::WalletError);
+        assert_eq!(error.code, FFIErrorCode::WalletError);
 
         // Cleanup
         unsafe {
@@ -145,26 +186,41 @@ mod tests {
     fn test_account_derive_from_seed_and_mnemonic_helpers_fail_for_standard() {
         let mut error = FFIError::success();
 
+        let mnemonic = std::ffi::CString::new(MNEMONIC).unwrap();
+        let passphrase = std::ffi::CString::new("").unwrap();
+
         // Create wallet and get account 0
-        let wallet = unsafe { wallet::wallet_create_from_mnemonic(c_str(MNEMONIC), c_str(""), FFINetwork::Testnet, &mut error) };
+        let wallet = unsafe {
+            wallet::wallet_create_from_mnemonic(
+                mnemonic.as_ptr(),
+                passphrase.as_ptr(),
+                FFINetwork::Testnet,
+                &mut error,
+            )
+        };
         assert!(!wallet.is_null());
         let account = unsafe {
-            crate::account::wallet_get_account(wallet, crate::FFINetwork::Testnet, 0, FFIAccountType::StandardBIP44)
-                .account
+            crate::account::wallet_get_account(wallet, 0, FFIAccountType::StandardBIP44).account
         };
         assert!(!account.is_null());
 
         // Prepare seed
-        let mnemonic = std::ffi::CString::new(MNEMONIC).unwrap();
-        let pass = std::ffi::CString::new("").unwrap();
         let mut seed = [0u8; 64];
         let mut seed_len = seed.len();
-        let ok = unsafe { crate::mnemonic::mnemonic_to_seed(mnemonic.as_ptr(), pass.as_ptr(), seed.as_mut_ptr(), &mut seed_len, &mut error) };
+        let ok = unsafe {
+            crate::mnemonic::mnemonic_to_seed(
+                mnemonic.as_ptr(),
+                passphrase.as_ptr(),
+                seed.as_mut_ptr(),
+                &mut seed_len,
+                &mut error,
+            )
+        };
         assert!(ok);
 
         // account_derive_extended_private_key_from_seed should fail for standard accounts
         let xpriv_seed = unsafe {
-            super::super::account_derivation::account_derive_extended_private_key_from_seed(
+            super::super::account_derive_extended_private_key_from_seed(
                 account,
                 seed.as_ptr(),
                 seed_len,
@@ -173,11 +229,11 @@ mod tests {
             )
         };
         assert!(xpriv_seed.is_null());
-        assert_eq!(unsafe { (*(&mut error)).code }, FFIErrorCode::WalletError);
+        assert_eq!(error.code, FFIErrorCode::WalletError);
 
         // account_derive_private_key_from_seed should fail
         let priv_seed = unsafe {
-            super::super::account_derivation::account_derive_private_key_from_seed(
+            super::super::account_derive_private_key_from_seed(
                 account,
                 seed.as_ptr(),
                 seed_len,
@@ -186,43 +242,38 @@ mod tests {
             )
         };
         assert!(priv_seed.is_null());
-        assert_eq!(unsafe { (*(&mut error)).code }, FFIErrorCode::WalletError);
+        assert_eq!(error.code, FFIErrorCode::WalletError);
 
         // account_derive_extended_private_key_from_mnemonic should fail
         let xpriv_mn = unsafe {
-            super::super::account_derivation::account_derive_extended_private_key_from_mnemonic(
+            super::super::account_derive_extended_private_key_from_mnemonic(
                 account,
                 mnemonic.as_ptr(),
-                pass.as_ptr(),
+                passphrase.as_ptr(),
                 0,
                 &mut error,
             )
         };
         assert!(xpriv_mn.is_null());
-        assert_eq!(unsafe { (*(&mut error)).code }, FFIErrorCode::WalletError);
+        assert_eq!(error.code, FFIErrorCode::WalletError);
 
         // account_derive_private_key_from_mnemonic should fail
         let priv_mn = unsafe {
-            super::super::account_derivation::account_derive_private_key_from_mnemonic(
+            super::super::account_derive_private_key_from_mnemonic(
                 account,
                 mnemonic.as_ptr(),
-                pass.as_ptr(),
+                passphrase.as_ptr(),
                 0,
                 &mut error,
             )
         };
         assert!(priv_mn.is_null());
-        assert_eq!(unsafe { (*(&mut error)).code }, FFIErrorCode::WalletError);
+        assert_eq!(error.code, FFIErrorCode::WalletError);
 
         unsafe {
             account_free(account);
             wallet::wallet_free(wallet);
             error.free_message();
         }
-    }
-
-    // Helper to make C string pointers
-    fn c_str(s: &str) -> *const c_char {
-        std::ffi::CString::new(s).unwrap().as_ptr()
     }
 }

--- a/key-wallet-ffi/src/managed_wallet.rs
+++ b/key-wallet-ffi/src/managed_wallet.rs
@@ -1164,3 +1164,7 @@ mod tests {
         unsafe { error.free_message() };
     }
 }
+
+#[cfg(test)]
+#[path = "managed_wallet_tests.rs"]
+mod managed_wallet_tests;

--- a/key-wallet-ffi/src/managed_wallet_tests.rs
+++ b/key-wallet-ffi/src/managed_wallet_tests.rs
@@ -2,56 +2,109 @@
 
 #[cfg(test)]
 mod tests {
+    use crate::address_pool::managed_wallet_mark_address_used;
     use crate::error::{FFIError, FFIErrorCode};
     use crate::managed_wallet::*;
-    use crate::types::FFINetwork;
+    use crate::types::{FFINetwork, FFIWallet};
     use crate::wallet;
+    use crate::wallet_manager::FFIWalletManager;
+    use crate::wallet_manager::{
+        wallet_manager_add_wallet_from_mnemonic, wallet_manager_create, wallet_manager_free,
+        wallet_manager_free_wallet_ids, wallet_manager_get_managed_wallet_info,
+        wallet_manager_get_wallet, wallet_manager_get_wallet_ids,
+    };
     use std::ffi::CString;
     use std::ptr;
 
     const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
-    #[test]
-    fn test_managed_wallet_create_success() {
-        let mut error = FFIError::success();
+    /// Helper: build a manager populated with a single wallet derived from TEST_MNEMONIC
+    /// and return the manager, the retrieved wallet, the managed wallet info, the raw
+    /// wallet-id buffer owned by the manager, and the wallet-id length. The caller is
+    /// responsible for calling `cleanup_fixture` once done.
+    unsafe fn setup_fixture(
+        error: &mut FFIError,
+    ) -> (*mut FFIWalletManager, *const FFIWallet, *mut FFIManagedWalletInfo, *mut u8, usize) {
+        let manager = wallet_manager_create(FFINetwork::Testnet, error);
+        assert!(!manager.is_null());
 
-        // Create a wallet first
         let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
         let passphrase = CString::new("").unwrap();
 
-        let wallet = unsafe {
-            wallet::wallet_create_from_mnemonic(
-                mnemonic.as_ptr(),
-                passphrase.as_ptr(),
-                FFINetwork::Testnet,
-                &mut error,
-            )
-        };
+        let added = wallet_manager_add_wallet_from_mnemonic(
+            manager,
+            mnemonic.as_ptr(),
+            passphrase.as_ptr(),
+            error,
+        );
+        assert!(added);
+        assert_eq!(error.code, FFIErrorCode::Success);
+
+        let mut wallet_ids: *mut u8 = ptr::null_mut();
+        let mut id_count: usize = 0;
+        let got_ids = wallet_manager_get_wallet_ids(
+            manager,
+            &mut wallet_ids as *mut *mut u8,
+            &mut id_count as *mut usize,
+            error,
+        );
+        assert!(got_ids);
+        assert_eq!(id_count, 1);
+        assert!(!wallet_ids.is_null());
+
+        let wallet = wallet_manager_get_wallet(manager, wallet_ids, error);
         assert!(!wallet.is_null());
 
-        // Create managed wallet
-        let managed_wallet = unsafe {
-            managed_wallet_create(wallet, &mut error)
-        };
+        let managed_wallet = wallet_manager_get_managed_wallet_info(manager, wallet_ids, error);
+        assert!(!managed_wallet.is_null());
 
-        // Should succeed
+        (manager, wallet, managed_wallet, wallet_ids, id_count)
+    }
+
+    unsafe fn cleanup_fixture(
+        manager: *mut FFIWalletManager,
+        wallet: *const FFIWallet,
+        managed_wallet: *mut FFIManagedWalletInfo,
+        wallet_ids: *mut u8,
+        id_count: usize,
+        error: &mut FFIError,
+    ) {
+        if !managed_wallet.is_null() {
+            managed_wallet_info_free(managed_wallet);
+        }
+        if !wallet.is_null() {
+            wallet::wallet_free_const(wallet);
+        }
+        if !wallet_ids.is_null() {
+            wallet_manager_free_wallet_ids(wallet_ids, id_count);
+        }
+        if !manager.is_null() {
+            wallet_manager_free(manager);
+        }
+        error.free_message();
+    }
+
+    #[test]
+    fn test_managed_wallet_info_from_manager_success() {
+        let mut error = FFIError::success();
+        let (manager, wallet, managed_wallet, wallet_ids, id_count) =
+            unsafe { setup_fixture(&mut error) };
+
         assert!(!managed_wallet.is_null());
         assert_eq!(error.code, FFIErrorCode::Success);
 
-        // Clean up
         unsafe {
-            managed_wallet_free(managed_wallet);
-            wallet::wallet_free(wallet);
-            error.free_message();
+            cleanup_fixture(manager, wallet, managed_wallet, wallet_ids, id_count, &mut error);
         }
     }
 
     #[test]
-    fn test_managed_wallet_create_null_wallet() {
+    fn test_managed_wallet_info_from_manager_null_manager() {
         let mut error = FFIError::success();
+        let wallet_id = [0u8; 32];
 
         let managed_wallet = unsafe {
-            managed_wallet_create(ptr::null(), &mut error)
+            wallet_manager_get_managed_wallet_info(ptr::null(), wallet_id.as_ptr(), &mut error)
         };
 
         assert!(managed_wallet.is_null());
@@ -61,35 +114,36 @@ mod tests {
     }
 
     #[test]
+    fn test_managed_wallet_info_from_manager_unknown_wallet_id() {
+        let mut error = FFIError::success();
+        let manager = wallet_manager_create(FFINetwork::Testnet, &mut error);
+        assert!(!manager.is_null());
+
+        let bogus_wallet_id = [0u8; 32];
+        let managed_wallet = unsafe {
+            wallet_manager_get_managed_wallet_info(manager, bogus_wallet_id.as_ptr(), &mut error)
+        };
+
+        assert!(managed_wallet.is_null());
+        assert_eq!(error.code, FFIErrorCode::NotFound);
+
+        unsafe {
+            wallet_manager_free(manager);
+            error.free_message();
+        }
+    }
+
+    #[test]
     fn test_managed_wallet_mark_address_used_valid() {
         let mut error = FFIError::success();
+        let (manager, wallet, managed_wallet, wallet_ids, id_count) =
+            unsafe { setup_fixture(&mut error) };
 
-        // Create managed wallet
-        let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
-        let passphrase = CString::new("").unwrap();
-
-        let wallet = unsafe {
-            wallet::wallet_create_from_mnemonic(
-                mnemonic.as_ptr(),
-                passphrase.as_ptr(),
-                FFINetwork::Testnet,
-                &mut error,
-            )
-        };
-
-        let managed_wallet = unsafe {
-            managed_wallet_create(wallet, &mut error)
-        };
-
-        // Test with a valid testnet address
+        // Well-formed testnet address. It may or may not belong to any pool of this
+        // wallet, but the function must at minimum parse it without panicking.
         let address = CString::new("yXdxAYfK7KGx7gNpVHUfRsQMNpMj5cAadG").unwrap();
         let success = unsafe {
-            managed_wallet_mark_address_used(
-                managed_wallet,
-                FFINetwork::Testnet,
-                address.as_ptr(),
-                &mut error,
-            )
+            managed_wallet_mark_address_used(managed_wallet, address.as_ptr(), &mut error)
         };
 
         // Should succeed or fail gracefully depending on address validation
@@ -98,72 +152,39 @@ mod tests {
             assert_eq!(error.code, FFIErrorCode::Success);
         } else {
             // Address validation might fail due to library version differences
-            assert!(error.code == FFIErrorCode::InvalidAddress);
+            assert!(error.code == FFIErrorCode::InvalidInput);
         }
 
-        // Clean up
         unsafe {
-            managed_wallet_free(managed_wallet);
-            wallet::wallet_free(wallet);
-            error.free_message();
+            cleanup_fixture(manager, wallet, managed_wallet, wallet_ids, id_count, &mut error);
         }
     }
 
     #[test]
     fn test_managed_wallet_mark_address_used_invalid() {
         let mut error = FFIError::success();
+        let (manager, wallet, managed_wallet, wallet_ids, id_count) =
+            unsafe { setup_fixture(&mut error) };
 
-        // Create managed wallet
-        let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
-        let passphrase = CString::new("").unwrap();
-
-        let wallet = unsafe {
-            wallet::wallet_create_from_mnemonic(
-                mnemonic.as_ptr(),
-                passphrase.as_ptr(),
-                FFINetwork::Testnet,
-                &mut error,
-            )
-        };
-
-        let managed_wallet = unsafe {
-            managed_wallet_create(wallet, &mut error)
-        };
-
-        // Test with invalid address
         let address = CString::new("invalid_address").unwrap();
         let success = unsafe {
-            managed_wallet_mark_address_used(
-                managed_wallet,
-                FFINetwork::Testnet,
-                address.as_ptr(),
-                &mut error,
-            )
+            managed_wallet_mark_address_used(managed_wallet, address.as_ptr(), &mut error)
         };
 
         assert!(!success);
-        assert_eq!(error.code, FFIErrorCode::InvalidAddress);
+        assert_eq!(error.code, FFIErrorCode::InvalidInput);
 
-        // Clean up
         unsafe {
-            managed_wallet_free(managed_wallet);
-            wallet::wallet_free(wallet);
-            error.free_message();
+            cleanup_fixture(manager, wallet, managed_wallet, wallet_ids, id_count, &mut error);
         }
     }
 
     #[test]
-    fn test_managed_wallet_mark_address_used_null_address() {
+    fn test_managed_wallet_mark_address_used_null_inputs() {
         let mut error = FFIError::success();
 
-        let success = unsafe {
-            managed_wallet_mark_address_used(
-                ptr::null_mut(),
-                FFINetwork::Testnet,
-                ptr::null(),
-                &mut error,
-            )
-        };
+        let success =
+            unsafe { managed_wallet_mark_address_used(ptr::null_mut(), ptr::null(), &mut error) };
 
         assert!(!success);
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
@@ -172,103 +193,38 @@ mod tests {
     }
 
     #[test]
-    fn test_managed_wallet_get_next_receive_address_not_implemented() {
+    fn test_managed_wallet_get_next_bip44_receive_address_null_inputs() {
         let mut error = FFIError::success();
 
         let address = unsafe {
-            managed_wallet_get_next_receive_address(
+            managed_wallet_get_next_bip44_receive_address(
                 ptr::null_mut(),
                 ptr::null(),
-                FFINetwork::Testnet,
                 0,
                 &mut error,
             )
         };
 
         assert!(address.is_null());
-        assert_eq!(error.code, FFIErrorCode::WalletError);
-
-        unsafe { error.free_message() };
-    }
-
-    #[test]
-    fn test_managed_wallet_get_next_change_address_not_implemented() {
-        let mut error = FFIError::success();
-
-        let address = unsafe {
-            managed_wallet_get_next_change_address(
-                ptr::null_mut(),
-                ptr::null(),
-                FFINetwork::Testnet,
-                0,
-                &mut error,
-            )
-        };
-
-        assert!(address.is_null());
-        assert_eq!(error.code, FFIErrorCode::WalletError);
-
-        unsafe { error.free_message() };
-    }
-
-    #[test]
-    fn test_managed_wallet_get_all_addresses_success() {
-        let mut error = FFIError::success();
-        let mut addresses_out: *mut *mut std::os::raw::c_char = ptr::null_mut();
-        let mut count_out: usize = 0;
-
-        let success = unsafe {
-            managed_wallet_get_all_addresses(
-                ptr::null(),
-                FFINetwork::Testnet,
-                0,
-                &mut addresses_out,
-                &mut count_out,
-                &mut error,
-            )
-        };
-
-        assert!(success);
-        assert_eq!(count_out, 0);
-        assert!(addresses_out.is_null());
-        assert_eq!(error.code, FFIErrorCode::Success);
-
-        unsafe { error.free_message() };
-    }
-
-    #[test]
-    fn test_managed_wallet_get_all_addresses_null_outputs() {
-        let mut error = FFIError::success();
-
-        // Test with null addresses_out
-        let success = unsafe {
-            managed_wallet_get_all_addresses(
-                ptr::null(),
-                FFINetwork::Testnet,
-                0,
-                ptr::null_mut(),
-                &mut 0,
-                &mut error,
-            )
-        };
-
-        assert!(!success);
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
 
-        // Test with null count_out
-        let mut addresses_out: *mut *mut std::os::raw::c_char = ptr::null_mut();
-        let success = unsafe {
-            managed_wallet_get_all_addresses(
-                ptr::null(),
-                FFINetwork::Testnet,
-                0,
-                &mut addresses_out,
+        unsafe { error.free_message() };
+    }
+
+    #[test]
+    fn test_managed_wallet_get_next_bip44_change_address_null_inputs() {
+        let mut error = FFIError::success();
+
+        let address = unsafe {
+            managed_wallet_get_next_bip44_change_address(
                 ptr::null_mut(),
+                ptr::null(),
+                0,
                 &mut error,
             )
         };
 
-        assert!(!success);
+        assert!(address.is_null());
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
 
         unsafe { error.free_message() };
@@ -279,66 +235,34 @@ mod tests {
         // Should handle null gracefully
         unsafe {
             managed_wallet_free(ptr::null_mut());
+            managed_wallet_info_free(ptr::null_mut());
         }
     }
 
     #[test]
-    fn test_managed_wallet_free_valid() {
+    fn test_managed_wallet_info_free_valid() {
         let mut error = FFIError::success();
-
-        // Create managed wallet
-        let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
-        let passphrase = CString::new("").unwrap();
-
-        let wallet = unsafe {
-            wallet::wallet_create_from_mnemonic(
-                mnemonic.as_ptr(),
-                passphrase.as_ptr(),
-                FFINetwork::Testnet,
-                &mut error,
-            )
-        };
-
-        let managed_wallet = unsafe {
-            managed_wallet_create(wallet, &mut error)
-        };
+        let (manager, wallet, managed_wallet, wallet_ids, id_count) =
+            unsafe { setup_fixture(&mut error) };
         assert!(!managed_wallet.is_null());
 
-        // Free managed wallet - should not crash
-        unsafe {
-            managed_wallet_free(managed_wallet);
-        }
+        // Free the managed wallet info independently — should not crash.
+        unsafe { managed_wallet_info_free(managed_wallet) };
 
-        // Clean up wallet
+        // Pass null to cleanup_fixture so it doesn't double-free managed_wallet.
         unsafe {
-            wallet::wallet_free(wallet);
-            error.free_message();
+            cleanup_fixture(manager, wallet, ptr::null_mut(), wallet_ids, id_count, &mut error);
         }
     }
 
     #[test]
     fn test_ffi_managed_wallet_info_methods() {
         let mut error = FFIError::success();
-
-        // Create managed wallet
-        let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
-        let passphrase = CString::new("").unwrap();
-
-        let wallet = unsafe {
-            wallet::wallet_create_from_mnemonic(
-                mnemonic.as_ptr(),
-                passphrase.as_ptr(),
-                FFINetwork::Testnet,
-                &mut error,
-            )
-        };
-
-        let managed_wallet = unsafe {
-            managed_wallet_create(wallet, &mut error)
-        };
+        let (manager, wallet, managed_wallet, wallet_ids, id_count) =
+            unsafe { setup_fixture(&mut error) };
         assert!(!managed_wallet.is_null());
 
-        // Test that we can access the inner methods
+        // Verify we can access the inner methods on FFIManagedWalletInfo.
         unsafe {
             let managed_ref = &*managed_wallet;
             let _inner = managed_ref.inner();
@@ -347,41 +271,22 @@ mod tests {
             let _inner_mut = managed_mut.inner_mut();
         }
 
-        // Clean up
         unsafe {
-            managed_wallet_free(managed_wallet);
-            wallet::wallet_free(wallet);
-            error.free_message();
+            cleanup_fixture(manager, wallet, managed_wallet, wallet_ids, id_count, &mut error);
         }
     }
 
     #[test]
     fn test_managed_wallet_mark_address_used_utf8_error() {
         let mut error = FFIError::success();
+        let (manager, wallet, managed_wallet, wallet_ids, id_count) =
+            unsafe { setup_fixture(&mut error) };
 
-        // Create managed wallet
-        let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
-        let passphrase = CString::new("").unwrap();
-
-        let wallet = unsafe {
-            wallet::wallet_create_from_mnemonic(
-                mnemonic.as_ptr(),
-                passphrase.as_ptr(),
-                FFINetwork::Testnet,
-                &mut error,
-            )
-        };
-
-        let managed_wallet = unsafe {
-            managed_wallet_create(wallet, &mut error)
-        };
-
-        // Create invalid UTF-8 string
-        let invalid_utf8 = [0xFF, 0xFE, 0xFD, 0x00]; // Invalid UTF-8 bytes with null terminator
+        // Invalid UTF-8 bytes with null terminator.
+        let invalid_utf8 = [0xFFu8, 0xFE, 0xFD, 0x00];
         let success = unsafe {
             managed_wallet_mark_address_used(
                 managed_wallet,
-                FFINetwork::Testnet,
                 invalid_utf8.as_ptr() as *const std::os::raw::c_char,
                 &mut error,
             )
@@ -390,69 +295,42 @@ mod tests {
         assert!(!success);
         assert_eq!(error.code, FFIErrorCode::InvalidInput);
 
-        // Clean up
         unsafe {
-            managed_wallet_free(managed_wallet);
-            wallet::wallet_free(wallet);
-            error.free_message();
+            cleanup_fixture(manager, wallet, managed_wallet, wallet_ids, id_count, &mut error);
         }
     }
 
     #[test]
     fn test_managed_wallet_address_operations_with_real_wallet() {
         let mut error = FFIError::success();
-
-        // Create managed wallet
-        let mnemonic = CString::new(TEST_MNEMONIC).unwrap();
-        let passphrase = CString::new("").unwrap();
-
-        let wallet = unsafe {
-            wallet::wallet_create_from_mnemonic(
-                mnemonic.as_ptr(),
-                passphrase.as_ptr(),
-                FFINetwork::Testnet,
-                &mut error,
-            )
-        };
-
-        let managed_wallet = unsafe {
-            managed_wallet_create(wallet, &mut error)
-        };
+        let (manager, wallet, managed_wallet, wallet_ids, id_count) =
+            unsafe { setup_fixture(&mut error) };
         assert!(!managed_wallet.is_null());
 
-        // Test get_next_receive_address with real wallet (should still fail as not implemented)
-        let address = unsafe {
-            managed_wallet_get_next_receive_address(
-                managed_wallet,
-                wallet,
-                FFINetwork::Testnet,
-                0,
-                &mut error,
-            )
+        // Get the next receive address for BIP44 account 0 — with a fully populated
+        // managed wallet this should succeed.
+        let address_ptr = unsafe {
+            managed_wallet_get_next_bip44_receive_address(managed_wallet, wallet, 0, &mut error)
         };
-
-        assert!(address.is_null());
-        assert_eq!(error.code, FFIErrorCode::WalletError);
-
-        // Test get_next_change_address with real wallet (should still fail as not implemented)
-        let address = unsafe {
-            managed_wallet_get_next_change_address(
-                managed_wallet,
-                wallet,
-                FFINetwork::Testnet,
-                0,
-                &mut error,
-            )
-        };
-
-        assert!(address.is_null());
-        assert_eq!(error.code, FFIErrorCode::WalletError);
-
-        // Clean up
+        assert!(!address_ptr.is_null(), "expected a receive address, error: {:?}", error.code);
+        assert_eq!(error.code, FFIErrorCode::Success);
         unsafe {
-            managed_wallet_free(managed_wallet);
-            wallet::wallet_free(wallet);
-            error.free_message();
+            // Reclaim the C string allocated by the FFI function.
+            let _ = CString::from_raw(address_ptr);
+        }
+
+        // Same for the next change address.
+        let address_ptr = unsafe {
+            managed_wallet_get_next_bip44_change_address(managed_wallet, wallet, 0, &mut error)
+        };
+        assert!(!address_ptr.is_null(), "expected a change address, error: {:?}", error.code);
+        assert_eq!(error.code, FFIErrorCode::Success);
+        unsafe {
+            let _ = CString::from_raw(address_ptr);
+        }
+
+        unsafe {
+            cleanup_fixture(manager, wallet, managed_wallet, wallet_ids, id_count, &mut error);
         }
     }
 }


### PR DESCRIPTION
Getting back this tests into scope, I don't know when they went out of it. One of the files was really out of date and I tried my best to get it back after API changes. I basically want this in because I am doing refactoring related to the FFINetwork enum and, since it is being used here, I would like to bring them back now and avoid creating more future issues if someone tries to update them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reorganized and expanded test suites for account derivation and wallet management to improve structure and coverage.
  * Switched tests to use fixtures and inline string handling, added more null/input-edge cases, and improved cleanup to avoid double-free scenarios.
  * No changes to public APIs or runtime/FFI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->