### PR TITLE
refactor(key-wallet-ffi): remove and replaced FFIExtendedPrivateKey with FFIExtendedPrivKey

### DIFF
--- a/key-wallet-ffi/FFI_API.md
+++ b/key-wallet-ffi/FFI_API.md
@@ -1445,11 +1445,11 @@ Create a new random wallet with options  # Safety  - `account_options` must be a
 #### `wallet_derive_extended_private_key`
 
 ```c
-wallet_derive_extended_private_key(wallet: *const FFIWallet, derivation_path: *const c_char, error: *mut FFIError,) -> *mut FFIExtendedPrivateKey
+wallet_derive_extended_private_key(wallet: *const FFIWallet, derivation_path: *const c_char, error: *mut FFIError,) -> *mut FFIExtendedPrivKey
 ```
 
 **Description:**
-Derive extended private key at a specific path Returns an opaque FFIExtendedPrivateKey pointer that must be freed with extended_private_key_free  # Safety  - `wallet` must be a valid pointer to an FFIWallet - `derivation_path` must be a valid null-terminated C string - `error` must be a valid pointer to an FFIError - The returned pointer must be freed with `extended_private_key_free`
+Derive extended private key at a specific path Returns an opaque FFIExtendedPrivKey pointer that must be freed with extended_private_key_free  # Safety  - `wallet` must be a valid pointer to an FFIWallet - `derivation_path` must be a valid null-terminated C string - `error` must be a valid pointer to an FFIError - The returned pointer must be freed with `extended_private_key_free`
 
 **Safety:**
 - `wallet` must be a valid pointer to an FFIWallet - `derivation_path` must be a valid null-terminated C string - `error` must be a valid pointer to an FFIError - The returned pointer must be freed with `extended_private_key_free`
@@ -2183,11 +2183,11 @@ Free an account collection summary and all its allocated memory  # Safety  - `su
 #### `account_derive_extended_private_key_at`
 
 ```c
-account_derive_extended_private_key_at(account: *const FFIAccount, master_xpriv: *const FFIExtendedPrivateKey, index: c_uint, error: *mut FFIError,) -> *mut FFIExtendedPrivateKey
+account_derive_extended_private_key_at(account: *const FFIAccount, master_xpriv: *const FFIExtendedPrivKey, index: c_uint, error: *mut FFIError,) -> *mut FFIExtendedPrivKey
 ```
 
 **Description:**
-Derive an extended private key from an account at a given index, using the provided master xpriv.  Returns an opaque FFIExtendedPrivateKey pointer that must be freed with `extended_private_key_free`.  Notes: - This is chain-agnostic. For accounts with internal/external chains, this returns an error. - For hardened-only account types (e.g., EdDSA), a hardened index is used.  # Safety - `account` and `master_xpriv` must be valid, non-null pointers allocated by this library. - `error` must be a valid pointer to an FFIError or null. - The caller must free the returned pointer with `extended_private_key_free`.
+Derive an extended private key from an account at a given index, using the provided master xpriv.  Returns an opaque FFIExtendedPrivKey pointer that must be freed with `extended_private_key_free`.  Notes: - This is chain-agnostic. For accounts with internal/external chains, this returns an error. - For hardened-only account types (e.g., EdDSA), a hardened index is used.  # Safety - `account` and `master_xpriv` must be valid, non-null pointers allocated by this library. - `error` must be a valid pointer to an FFIError or null. - The caller must free the returned pointer with `extended_private_key_free`.
 
 **Safety:**
 - `account` and `master_xpriv` must be valid, non-null pointers allocated by this library. - `error` must be a valid pointer to an FFIError or null. - The caller must free the returned pointer with `extended_private_key_free`.
@@ -2199,11 +2199,11 @@ Derive an extended private key from an account at a given index, using the provi
 #### `account_derive_extended_private_key_from_mnemonic`
 
 ```c
-account_derive_extended_private_key_from_mnemonic(account: *const FFIAccount, mnemonic: *const c_char, passphrase: *const c_char, index: c_uint, error: *mut FFIError,) -> *mut FFIExtendedPrivateKey
+account_derive_extended_private_key_from_mnemonic(account: *const FFIAccount, mnemonic: *const c_char, passphrase: *const c_char, index: c_uint, error: *mut FFIError,) -> *mut FFIExtendedPrivKey
 ```
 
 **Description:**
-Derive an extended private key from a mnemonic + optional passphrase at the given index. Returns an opaque FFIExtendedPrivateKey pointer that must be freed with `extended_private_key_free`.  # Safety - `account` must be a valid pointer to an FFIAccount - `mnemonic` must be a valid, null-terminated C string - `passphrase` may be null; if not null, must be a valid C string - `error` must be a valid pointer to an FFIError or null
+Derive an extended private key from a mnemonic + optional passphrase at the given index. Returns an opaque FFIExtendedPrivKey pointer that must be freed with `extended_private_key_free`.  # Safety - `account` must be a valid pointer to an FFIAccount - `mnemonic` must be a valid, null-terminated C string - `passphrase` may be null; if not null, must be a valid C string - `error` must be a valid pointer to an FFIError or null
 
 **Safety:**
 - `account` must be a valid pointer to an FFIAccount - `mnemonic` must be a valid, null-terminated C string - `passphrase` may be null; if not null, must be a valid C string - `error` must be a valid pointer to an FFIError or null
@@ -2215,11 +2215,11 @@ Derive an extended private key from a mnemonic + optional passphrase at the give
 #### `account_derive_extended_private_key_from_seed`
 
 ```c
-account_derive_extended_private_key_from_seed(account: *const FFIAccount, seed: *const u8, seed_len: usize, index: c_uint, error: *mut FFIError,) -> *mut FFIExtendedPrivateKey
+account_derive_extended_private_key_from_seed(account: *const FFIAccount, seed: *const u8, seed_len: usize, index: c_uint, error: *mut FFIError,) -> *mut FFIExtendedPrivKey
 ```
 
 **Description:**
-Derive an extended private key from a raw seed buffer at the given index. Returns an opaque FFIExtendedPrivateKey pointer that must be freed with `extended_private_key_free`.  # Safety - `account` must be a valid pointer to an FFIAccount - `seed` must point to a valid buffer of length `seed_len` - `error` must be a valid pointer to an FFIError or null
+Derive an extended private key from a raw seed buffer at the given index. Returns an opaque FFIExtendedPrivKey pointer that must be freed with `extended_private_key_free`.  # Safety - `account` must be a valid pointer to an FFIAccount - `seed` must point to a valid buffer of length `seed_len` - `error` must be a valid pointer to an FFIError or null
 
 **Safety:**
 - `account` must be a valid pointer to an FFIAccount - `seed` must point to a valid buffer of length `seed_len` - `error` must be a valid pointer to an FFIError or null
@@ -2231,7 +2231,7 @@ Derive an extended private key from a raw seed buffer at the given index. Return
 #### `account_derive_private_key_as_wif_at`
 
 ```c
-account_derive_private_key_as_wif_at(account: *const FFIAccount, master_xpriv: *const FFIExtendedPrivateKey, index: c_uint, error: *mut FFIError,) -> *mut c_char
+account_derive_private_key_as_wif_at(account: *const FFIAccount, master_xpriv: *const FFIExtendedPrivKey, index: c_uint, error: *mut FFIError,) -> *mut c_char
 ```
 
 **Description:**
@@ -2247,7 +2247,7 @@ Derive a private key from an account at a given chain/index and return as WIF st
 #### `account_derive_private_key_at`
 
 ```c
-account_derive_private_key_at(account: *const FFIAccount, master_xpriv: *const FFIExtendedPrivateKey, index: c_uint, error: *mut FFIError,) -> *mut FFIPrivateKey
+account_derive_private_key_at(account: *const FFIAccount, master_xpriv: *const FFIExtendedPrivKey, index: c_uint, error: *mut FFIError,) -> *mut FFIPrivateKey
 ```
 
 **Description:**
@@ -3859,7 +3859,7 @@ Create a new master extended private key from seed  # Safety  - `seed` must be a
 #### `extended_private_key_free`
 
 ```c
-extended_private_key_free(key: *mut FFIExtendedPrivateKey) -> ()
+extended_private_key_free(key: *mut FFIExtendedPrivKey) -> ()
 ```
 
 **Description:**
@@ -3875,14 +3875,14 @@ Free an extended private key  # Safety  - `key` must be a valid pointer created 
 #### `extended_private_key_get_private_key`
 
 ```c
-extended_private_key_get_private_key(extended_key: *const FFIExtendedPrivateKey, error: *mut FFIError,) -> *mut FFIPrivateKey
+extended_private_key_get_private_key(extended_key: *const FFIExtendedPrivKey, error: *mut FFIError,) -> *mut FFIPrivateKey
 ```
 
 **Description:**
-Get the private key from an extended private key  Extracts the non-extended private key from an extended private key.  # Safety  - `extended_key` must be a valid pointer to an FFIExtendedPrivateKey - `error` must be a valid pointer to an FFIError - The returned FFIPrivateKey must be freed with `private_key_free`
+Get the private key from an extended private key  Extracts the non-extended private key from an extended private key.  # Safety  - `extended_key` must be a valid pointer to an FFIExtendedPrivKey - `error` must be a valid pointer to an FFIError - The returned FFIPrivateKey must be freed with `private_key_free`
 
 **Safety:**
-- `extended_key` must be a valid pointer to an FFIExtendedPrivateKey - `error` must be a valid pointer to an FFIError - The returned FFIPrivateKey must be freed with `private_key_free`
+- `extended_key` must be a valid pointer to an FFIExtendedPrivKey - `error` must be a valid pointer to an FFIError - The returned FFIPrivateKey must be freed with `private_key_free`
 
 **Module:** `keys`
 
@@ -3891,14 +3891,14 @@ Get the private key from an extended private key  Extracts the non-extended priv
 #### `extended_private_key_to_string`
 
 ```c
-extended_private_key_to_string(key: *const FFIExtendedPrivateKey, network: FFINetwork, error: *mut FFIError,) -> *mut c_char
+extended_private_key_to_string(key: *const FFIExtendedPrivKey, network: FFINetwork, error: *mut FFIError,) -> *mut c_char
 ```
 
 **Description:**
-Get extended private key as string (xprv format)  Returns the extended private key in base58 format (xprv... for mainnet, tprv... for testnet)  # Safety  - `key` must be a valid pointer to an FFIExtendedPrivateKey - `network` is ignored; the network is encoded in the extended key - `error` must be a valid pointer to an FFIError - The returned string must be freed with `string_free`
+Get extended private key as string (xprv format)  Returns the extended private key in base58 format (xprv... for mainnet, tprv... for testnet)  # Safety  - `key` must be a valid pointer to an FFIExtendedPrivKey - `network` is ignored; the network is encoded in the extended key - `error` must be a valid pointer to an FFIError - The returned string must be freed with `string_free`
 
 **Safety:**
-- `key` must be a valid pointer to an FFIExtendedPrivateKey - `network` is ignored; the network is encoded in the extended key - `error` must be a valid pointer to an FFIError - The returned string must be freed with `string_free`
+- `key` must be a valid pointer to an FFIExtendedPrivKey - `network` is ignored; the network is encoded in the extended key - `error` must be a valid pointer to an FFIError - The returned string must be freed with `string_free`
 
 **Module:** `keys`
 

--- a/key-wallet-ffi/src/account_derivation.rs
+++ b/key-wallet-ffi/src/account_derivation.rs
@@ -6,7 +6,7 @@ use crate::account::FFIBLSAccount;
 #[cfg(feature = "eddsa")]
 use crate::account::FFIEdDSAAccount;
 use crate::error::{FFIError, FFIErrorCode};
-use crate::keys::{FFIExtendedPrivateKey, FFIPrivateKey};
+use crate::keys::{FFIExtendedPrivKey, FFIPrivateKey};
 use key_wallet::account::derivation::AccountDerivation;
 use key_wallet::account::AccountTrait;
 use std::ffi::CString;
@@ -17,7 +17,7 @@ use std::ptr;
 
 /// Derive an extended private key from an account at a given index, using the provided master xpriv.
 ///
-/// Returns an opaque FFIExtendedPrivateKey pointer that must be freed with `extended_private_key_free`.
+/// Returns an opaque FFIExtendedPrivKey pointer that must be freed with `extended_private_key_free`.
 ///
 /// Notes:
 /// - This is chain-agnostic. For accounts with internal/external chains, this returns an error.
@@ -30,10 +30,10 @@ use std::ptr;
 #[no_mangle]
 pub unsafe extern "C" fn account_derive_extended_private_key_at(
     account: *const FFIAccount,
-    master_xpriv: *const FFIExtendedPrivateKey,
+    master_xpriv: *const FFIExtendedPrivKey,
     index: c_uint,
     error: *mut FFIError,
-) -> *mut FFIExtendedPrivateKey {
+) -> *mut FFIExtendedPrivKey {
     if account.is_null() || master_xpriv.is_null() {
         FFIError::set_error(error, FFIErrorCode::InvalidInput, "Null pointer provided".to_string());
         return ptr::null_mut();
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn account_derive_extended_private_key_at(
     match account.inner().derive_from_master_xpriv_extended_xpriv_at(master_xpriv.inner(), index) {
         Ok(derived) => {
             FFIError::set_success(error);
-            Box::into_raw(Box::new(FFIExtendedPrivateKey::from_inner(derived)))
+            Box::into_raw(Box::new(FFIExtendedPrivKey::from_inner(derived)))
         }
         Err(e) => {
             FFIError::set_error(
@@ -381,7 +381,7 @@ pub unsafe extern "C" fn eddsa_account_derive_private_key_from_mnemonic(
 #[no_mangle]
 pub unsafe extern "C" fn account_derive_private_key_at(
     account: *const FFIAccount,
-    master_xpriv: *const FFIExtendedPrivateKey,
+    master_xpriv: *const FFIExtendedPrivKey,
     index: c_uint,
     error: *mut FFIError,
 ) -> *mut FFIPrivateKey {
@@ -427,7 +427,7 @@ pub unsafe extern "C" fn account_derive_private_key_at(
 #[no_mangle]
 pub unsafe extern "C" fn account_derive_private_key_as_wif_at(
     account: *const FFIAccount,
-    master_xpriv: *const FFIExtendedPrivateKey,
+    master_xpriv: *const FFIExtendedPrivKey,
     index: c_uint,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -483,7 +483,7 @@ pub unsafe extern "C" fn account_derive_private_key_as_wif_at(
 }
 
 /// Derive an extended private key from a raw seed buffer at the given index.
-/// Returns an opaque FFIExtendedPrivateKey pointer that must be freed with `extended_private_key_free`.
+/// Returns an opaque FFIExtendedPrivKey pointer that must be freed with `extended_private_key_free`.
 ///
 /// # Safety
 /// - `account` must be a valid pointer to an FFIAccount
@@ -496,7 +496,7 @@ pub unsafe extern "C" fn account_derive_extended_private_key_from_seed(
     seed_len: usize,
     index: c_uint,
     error: *mut FFIError,
-) -> *mut FFIExtendedPrivateKey {
+) -> *mut FFIExtendedPrivKey {
     if account.is_null() || seed.is_null() {
         FFIError::set_error(error, FFIErrorCode::InvalidInput, "Null pointer provided".to_string());
         return ptr::null_mut();
@@ -508,7 +508,7 @@ pub unsafe extern "C" fn account_derive_extended_private_key_from_seed(
     match account.inner().derive_from_seed_extended_xpriv_at(seed_slice, index) {
         Ok(derived) => {
             FFIError::set_success(error);
-            Box::into_raw(Box::new(FFIExtendedPrivateKey::from_inner(derived)))
+            Box::into_raw(Box::new(FFIExtendedPrivKey::from_inner(derived)))
         }
         Err(e) => {
             FFIError::set_error(
@@ -561,7 +561,7 @@ pub unsafe extern "C" fn account_derive_private_key_from_seed(
 }
 
 /// Derive an extended private key from a mnemonic + optional passphrase at the given index.
-/// Returns an opaque FFIExtendedPrivateKey pointer that must be freed with `extended_private_key_free`.
+/// Returns an opaque FFIExtendedPrivKey pointer that must be freed with `extended_private_key_free`.
 ///
 /// # Safety
 /// - `account` must be a valid pointer to an FFIAccount
@@ -575,7 +575,7 @@ pub unsafe extern "C" fn account_derive_extended_private_key_from_mnemonic(
     passphrase: *const c_char,
     index: c_uint,
     error: *mut FFIError,
-) -> *mut FFIExtendedPrivateKey {
+) -> *mut FFIExtendedPrivKey {
     if account.is_null() || mnemonic.is_null() {
         FFIError::set_error(error, FFIErrorCode::InvalidInput, "Null pointer provided".to_string());
         return ptr::null_mut();
@@ -617,7 +617,7 @@ pub unsafe extern "C" fn account_derive_extended_private_key_from_mnemonic(
     ) {
         Ok(derived) => {
             FFIError::set_success(error);
-            Box::into_raw(Box::new(FFIExtendedPrivateKey::from_inner(derived)))
+            Box::into_raw(Box::new(FFIExtendedPrivKey::from_inner(derived)))
         }
         Err(e) => {
             FFIError::set_error(

--- a/key-wallet-ffi/src/derivation.rs
+++ b/key-wallet-ffi/src/derivation.rs
@@ -1,6 +1,7 @@
 //! BIP32 and DIP9 derivation path functions
 
 use crate::error::{FFIError, FFIErrorCode};
+use crate::keys::FFIExtendedPrivKey;
 use crate::types::FFINetwork;
 use dashcore::Network;
 use key_wallet::{ExtendedPrivKey, ExtendedPubKey};
@@ -33,11 +34,6 @@ pub enum FFIDerivationPathType {
     PathRoot = 255,
 }
 
-/// Extended private key structure
-pub struct FFIExtendedPrivKey {
-    inner: key_wallet::bip32::ExtendedPrivKey,
-}
-
 /// Extended public key structure
 pub struct FFIExtendedPubKey {
     inner: key_wallet::bip32::ExtendedPubKey,
@@ -68,9 +64,7 @@ pub unsafe extern "C" fn derivation_new_master_key(
     match key_wallet::bip32::ExtendedPrivKey::new_master(network_rust, seed_slice) {
         Ok(xpriv) => {
             FFIError::set_success(error);
-            Box::into_raw(Box::new(FFIExtendedPrivKey {
-                inner: xpriv,
-            }))
+            Box::into_raw(Box::new(FFIExtendedPrivKey::from_inner(xpriv)))
         }
         Err(e) => {
             FFIError::set_error(
@@ -492,9 +486,7 @@ pub unsafe extern "C" fn derivation_derive_private_key_from_seed(
     match master.derive_priv(&secp, &derivation_path) {
         Ok(xpriv) => {
             FFIError::set_success(error);
-            Box::into_raw(Box::new(FFIExtendedPrivKey {
-                inner: xpriv,
-            }))
+            Box::into_raw(Box::new(FFIExtendedPrivKey::from_inner(xpriv)))
         }
         Err(e) => {
             FFIError::set_error(
@@ -534,7 +526,7 @@ pub unsafe extern "C" fn derivation_xpriv_to_xpub(
         use secp256k1::Secp256k1;
 
         let secp = Secp256k1::new();
-        let xpub = ExtendedPubKey::from_priv(&secp, &xpriv.inner);
+        let xpub = ExtendedPubKey::from_priv(&secp, xpriv.inner());
 
         FFIError::set_success(error);
         Box::into_raw(Box::new(FFIExtendedPubKey {
@@ -566,7 +558,7 @@ pub unsafe extern "C" fn derivation_xpriv_to_string(
 
     unsafe {
         let xpriv = &*xpriv;
-        let xpriv_str = xpriv.inner.to_string();
+        let xpriv_str = xpriv.inner().to_string();
 
         match CString::new(xpriv_str) {
             Ok(c_str) => {

--- a/key-wallet-ffi/src/keys.rs
+++ b/key-wallet-ffi/src/keys.rs
@@ -12,7 +12,7 @@ pub struct FFIPrivateKey {
 }
 
 /// Opaque type for an extended private key
-pub struct FFIExtendedPrivateKey {
+pub struct FFIExtendedPrivKey {
     inner: key_wallet::bip32::ExtendedPrivKey,
 }
 
@@ -26,7 +26,7 @@ pub struct FFIExtendedPublicKey {
     inner: key_wallet::bip32::ExtendedPubKey,
 }
 
-impl FFIExtendedPrivateKey {
+impl FFIExtendedPrivKey {
     #[inline]
     pub(crate) fn inner(&self) -> &key_wallet::bip32::ExtendedPrivKey {
         &self.inner
@@ -34,7 +34,7 @@ impl FFIExtendedPrivateKey {
 
     #[inline]
     pub(crate) fn from_inner(inner: key_wallet::bip32::ExtendedPrivKey) -> Self {
-        FFIExtendedPrivateKey {
+        FFIExtendedPrivKey {
             inner,
         }
     }
@@ -209,7 +209,7 @@ pub unsafe extern "C" fn wallet_derive_private_key(
 }
 
 /// Derive extended private key at a specific path
-/// Returns an opaque FFIExtendedPrivateKey pointer that must be freed with extended_private_key_free
+/// Returns an opaque FFIExtendedPrivKey pointer that must be freed with extended_private_key_free
 ///
 /// # Safety
 ///
@@ -222,7 +222,7 @@ pub unsafe extern "C" fn wallet_derive_extended_private_key(
     wallet: *const FFIWallet,
     derivation_path: *const c_char,
     error: *mut FFIError,
-) -> *mut FFIExtendedPrivateKey {
+) -> *mut FFIExtendedPrivKey {
     if wallet.is_null() || derivation_path.is_null() {
         FFIError::set_error(error, FFIErrorCode::InvalidInput, "Null pointer provided".to_string());
         return ptr::null_mut();
@@ -261,7 +261,7 @@ pub unsafe extern "C" fn wallet_derive_extended_private_key(
     match wallet.inner().derive_extended_private_key(&path) {
         Ok(extended_private_key) => {
             FFIError::set_success(error);
-            Box::into_raw(Box::new(FFIExtendedPrivateKey {
+            Box::into_raw(Box::new(FFIExtendedPrivKey {
                 inner: extended_private_key,
             }))
         }
@@ -371,7 +371,7 @@ pub unsafe extern "C" fn private_key_free(key: *mut FFIPrivateKey) {
 /// - `key` must be a valid pointer created by extended private key functions or null
 /// - After calling this function, the pointer becomes invalid
 #[no_mangle]
-pub unsafe extern "C" fn extended_private_key_free(key: *mut FFIExtendedPrivateKey) {
+pub unsafe extern "C" fn extended_private_key_free(key: *mut FFIExtendedPrivKey) {
     if !key.is_null() {
         let _ = unsafe { Box::from_raw(key) };
     }
@@ -383,13 +383,13 @@ pub unsafe extern "C" fn extended_private_key_free(key: *mut FFIExtendedPrivateK
 ///
 /// # Safety
 ///
-/// - `key` must be a valid pointer to an FFIExtendedPrivateKey
+/// - `key` must be a valid pointer to an FFIExtendedPrivKey
 /// - `network` is ignored; the network is encoded in the extended key
 /// - `error` must be a valid pointer to an FFIError
 /// - The returned string must be freed with `string_free`
 #[no_mangle]
 pub unsafe extern "C" fn extended_private_key_to_string(
-    key: *const FFIExtendedPrivateKey,
+    key: *const FFIExtendedPrivKey,
     network: FFINetwork,
     error: *mut FFIError,
 ) -> *mut c_char {
@@ -428,12 +428,12 @@ pub unsafe extern "C" fn extended_private_key_to_string(
 ///
 /// # Safety
 ///
-/// - `extended_key` must be a valid pointer to an FFIExtendedPrivateKey
+/// - `extended_key` must be a valid pointer to an FFIExtendedPrivKey
 /// - `error` must be a valid pointer to an FFIError
 /// - The returned FFIPrivateKey must be freed with `private_key_free`
 #[no_mangle]
 pub unsafe extern "C" fn extended_private_key_get_private_key(
-    extended_key: *const FFIExtendedPrivateKey,
+    extended_key: *const FFIExtendedPrivKey,
     error: *mut FFIError,
 ) -> *mut FFIPrivateKey {
     if extended_key.is_null() {


### PR DESCRIPTION
so, for some reason, we have twice the same structure but with slightly different name and this was causing issues when trying to recover some old tests that are out of scope right now