### PR TITLE
chore: bump pinned Rust toolchain to `1.94.1`

### DIFF
--- a/dash/src/lib.rs
+++ b/dash/src/lib.rs
@@ -116,6 +116,7 @@ pub mod string;
 pub mod taproot;
 pub mod util;
 
+#[cfg(feature = "serde")]
 use std::error::Error as StdError;
 
 pub use std::io;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.94.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
`1.94.1` is the latest stable release.

The stricter unused-import detection in `1.94.1` flags `use std::error::Error as StdError;` in `dash/src/lib.rs` as unused under default features, since its only consumers in `dash::consensus::serde` are gated on `#[cfg(feature = "serde")]`.