### PR TITLE
fix(dash-spv): remove overly-strict is_synced gate from broadcast

### DIFF
--- a/dash-spv/src/client/transactions.rs
+++ b/dash-spv/src/client/transactions.rs
@@ -1,6 +1,6 @@
 //! Transaction-related client APIs (e.g., broadcasting)
 
-use crate::error::{NetworkError, Result, SpvError, SyncError};
+use crate::error::{NetworkError, Result, SpvError};
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
 use dashcore::network::message::NetworkMessage;
@@ -16,10 +16,6 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
     /// The transaction is also injected into the local message pipeline so that
     /// the mempool manager processes it immediately.
     pub async fn broadcast_transaction(&self, tx: &dashcore::Transaction) -> Result<()> {
-        if !self.sync_progress().await.is_synced() {
-            return Err(SpvError::Sync(SyncError::NotSynced));
-        }
-
         let network_guard = self.network.lock().await;
 
         if network_guard.peer_count() == 0 {


### PR DESCRIPTION
## Summary

The `dispatch_local` gate added in #626 rejected `broadcast_transaction` whenever `sync_progress().is_synced()` returned `false`. `is_synced()` is the aggregate of every sync manager (headers / filter_headers / filters / blocks / masternodes) — any single manager briefly transitioning to `WaitForEvents` (e.g. the blocks manager reacting to a new chain tip) flips the aggregate and blocks broadcasts.

In end-to-end tests this surfaced as intermittent `SpvBroadcastFailed { detail: "Client is not synced" }` errors well after initial sync had completed. The gate also doesn't protect anything the peer-level broadcast path doesn't already handle — peers reject unfit-for-propagation txs on their own. Drop it.

## Extracted from

This commit was cherry-picked from `feat/platform-wallet2` (the in-progress platform-wallet branch, draft PR #655). Pulling it into its own PR so it can land independently.

## Test plan

- [x] `cargo build -p dash-spv --all-features`
- [x] `cargo test -p dash-spv --all-features --lib` — 370 passed / 0 failed
- Single-file change (`dash-spv/src/client/transactions.rs`, −5 / +1).

🤖 Extracted with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Transactions can now be broadcast without requiring full client synchronization; only an active peer connection is needed to proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->