### PR TITLE
fix(key-wallet): correct AssetLockTx structure per DIP-00X

### DIFF
--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -3,7 +3,7 @@
 //! Builds a Core special transaction (type 8) with `AssetLockPayload` that
 //! locks Dash for Platform credits.
 
-use dashcore::{Address, Transaction, TxOut};
+use dashcore::{Address, ScriptBuf, Transaction, TxOut};
 use std::collections::HashMap;
 use std::fmt;
 
@@ -216,13 +216,27 @@ impl ManagedWalletInfo {
 
         // Build the transaction FIRST — before deriving keys.
         // This ensures no addresses are consumed if the build fails.
-        let mut tx_builder = TransactionBuilder::new()
-            .set_change_address(change_address)
-            .set_fee_rate(FeeRate::new(fee_per_kb));
+        //
+        // Per DIP-00X (AssetLockTx), `tx.output[0]` must be an OP_RETURN
+        // burn carrying the total amount being locked — this is what
+        // "destroys" the Dash coins on the L1 chain. The credit outputs
+        // themselves live only in the special transaction payload; they
+        // describe where the resulting Platform credits are delivered.
+        //
+        // The previous implementation added the credit outputs as raw
+        // `tx.output` entries (and duplicated them in the payload),
+        // producing a structurally-invalid asset lock transaction that
+        // masternodes refused to IS-lock.
+        let total_credit: u64 = credit_outputs.iter().map(|o| o.value).sum();
+        let burn_output = TxOut {
+            value: total_credit,
+            script_pubkey: ScriptBuf::new_op_return(&[]),
+        };
 
-        for credit_out in &credit_outputs {
-            tx_builder = tx_builder.add_raw_output(credit_out.clone());
-        }
+        let tx_builder = TransactionBuilder::new()
+            .set_change_address(change_address)
+            .set_fee_rate(FeeRate::new(fee_per_kb))
+            .add_raw_output(burn_output);
 
         let tx_builder_with_inputs = tx_builder.select_inputs(
             &utxos,

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -59,6 +59,11 @@ pub struct TransactionBuilder {
     version: u16,
     /// Special transaction payload for Dash-specific transactions
     special_payload: Option<TransactionPayload>,
+    /// When `true`, skip BIP-69 output sorting in [`Self::build`] so
+    /// callers that need position-dependent outputs (e.g. AssetLockTx,
+    /// whose payload validation requires `tx.output[0]` to be the
+    /// OP_RETURN burn) keep outputs in the order they were added.
+    skip_bip69_sort: bool,
 }
 
 impl Default for TransactionBuilder {
@@ -78,7 +83,17 @@ impl TransactionBuilder {
             lock_time: 0,
             version: 2, // Default to version 2 for Dash
             special_payload: None,
+            skip_bip69_sort: false,
         }
+    }
+
+    /// Disable BIP-69 output sorting. Required for transactions whose
+    /// payload validation depends on output position — e.g. AssetLockTx
+    /// requires `tx.output[0]` to be the OP_RETURN burn carrying the
+    /// total locked amount.
+    pub fn skip_bip69_sort(mut self) -> Self {
+        self.skip_bip69_sort = true;
+        self
     }
 
     pub fn outputs(&self) -> &Vec<TxOut> {
@@ -436,16 +451,22 @@ impl TransactionBuilder {
             }
         }
 
-        // BIP-69: Sort outputs by amount first, then by scriptPubKey lexicographically
-        tx_outputs.sort_by(|a, b| {
-            match a.value.cmp(&b.value) {
-                std::cmp::Ordering::Equal => {
-                    // If amounts match, compare scriptPubKeys lexicographically
-                    a.script_pubkey.as_bytes().cmp(b.script_pubkey.as_bytes())
+        // BIP-69: Sort outputs by amount first, then by scriptPubKey
+        // lexicographically. Opt-out via `skip_bip69_sort` for
+        // transactions whose payload validation requires
+        // position-dependent outputs (e.g. AssetLockTx, whose
+        // `tx.output[0]` must be the OP_RETURN burn).
+        if !self.skip_bip69_sort {
+            tx_outputs.sort_by(|a, b| {
+                match a.value.cmp(&b.value) {
+                    std::cmp::Ordering::Equal => {
+                        // If amounts match, compare scriptPubKeys lexicographically
+                        a.script_pubkey.as_bytes().cmp(b.script_pubkey.as_bytes())
+                    }
+                    other => other,
                 }
-                other => other,
-            }
-        });
+            });
+        }
 
         // Create unsigned transaction with optional special payload
         // Update sorted_inputs to maintain the key association after sorting
@@ -629,12 +650,23 @@ impl TransactionBuilder {
 
     /// Build an Asset Lock Transaction
     ///
-    /// Used to lock Dash for use in Platform (creates Platform credits)
-    pub fn build_asset_lock(self, credit_outputs: Vec<TxOut>) -> Result<Transaction, BuilderError> {
+    /// Used to lock Dash for use in Platform (creates Platform credits).
+    /// Per DIP-00X, the AssetLockPayload version is `1`, the credit
+    /// outputs live in the payload (not in `tx.output`), and the
+    /// Dash special transaction wire version is `3`. The caller must
+    /// have already added the OP_RETURN burn output to this builder
+    /// before calling `build_asset_lock`; BIP-69 output sorting is
+    /// disabled so the burn stays at `tx.output[0]`.
+    pub fn build_asset_lock(
+        mut self,
+        credit_outputs: Vec<TxOut>,
+    ) -> Result<Transaction, BuilderError> {
         let payload = AssetLockPayload {
-            version: 0,
+            version: 1,
             credit_outputs,
         };
+        self.version = 3;
+        self.skip_bip69_sort = true;
         self.set_special_payload(TransactionPayload::AssetLockPayloadType(payload)).build()
     }
 


### PR DESCRIPTION
## Summary

The asset-lock builder produced transactions that masternodes refused to IS-lock. Four related issues, all fixed in this PR:

1. **`AssetLockPayload.version` was `0`** — must be `1` per DIP-00X.
2. **`tx.output[0]` was the credit p2pkh output**, but per DIP-00X that position must hold an `OP_RETURN` burn carrying the total locked amount. Credit outputs live only in the special-transaction payload. Burn output construction is moved into `ManagedWalletInfo::build_asset_lock`.
3. **BIP-69 output sorting in `TransactionBuilder::build` moved the change output into position 0** (change is typically smaller than the burn), breaking the structural requirement from (2). Adds a `skip_bip69_sort` builder option and sets it in `build_asset_lock`.
4. **Tx wire version was the builder default (`2`)**; special-tx version must be `3`.

### Symptom

Self-broadcast asset-lock txs never received an `InstantLockReceived` event. Network-visible broadcasts succeeded, peers relayed them into mempool, but masternodes rejected them as invalid asset-lock transactions and never signed an IS-lock.

### Verification

Confirmed against `dash-evo-tool` e2e tests on testnet — `identity_create` and related tests go green after this fix.

## Extracted from

Cherry-picked from `feat/platform-wallet2` (draft PR #655) so it can land independently.

## Test plan

- [x] `cargo build -p key-wallet --all-features`
- [x] `cargo test -p key-wallet --all-features --lib` — 459 passed / 0 failed
- [x] `cargo test -p key-wallet --all-features --lib asset_lock` — 11 passed / 0 failed
- Two-file change (`key-wallet/src/wallet/managed_wallet_info/{asset_lock_builder, transaction_builder}.rs`, +65 / −19).

🤖 Extracted with [Claude Code](https://claude.com/claude-code)