### PR TITLE
feat(key-wallet): add async Signer trait and build_asset_lock_with_signer

### DIFF
--- a/key-wallet-ffi/src/transaction.rs
+++ b/key-wallet-ffi/src/transaction.rs
@@ -1146,8 +1146,21 @@ pub unsafe extern "C" fn wallet_build_and_sign_asset_lock_transaction(
             // Write outputs
             *fee_out = result.fee;
 
+            // `build_asset_lock` always returns private keys; the signer-variant
+            // path uses a different FFI entry point.
+            let private_keys = match &result.keys {
+                key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockCreditKeys::Private(k) => k,
+                key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockCreditKeys::Public(_) => {
+                    FFIError::set_error(
+                        error,
+                        FFIErrorCode::WalletError,
+                        "Unexpected public-key result from build_asset_lock".to_string(),
+                    );
+                    return false;
+                }
+            };
             let keys_out = slice::from_raw_parts_mut(private_keys_out, credit_outputs_count);
-            for (i, key) in result.keys.iter().enumerate() {
+            for (i, key) in private_keys.iter().enumerate() {
                 if i < keys_out.len() {
                     keys_out[i] = *key;
                 }

--- a/key-wallet/src/lib.rs
+++ b/key-wallet/src/lib.rs
@@ -62,7 +62,7 @@ pub use managed_account::managed_platform_account::ManagedPlatformAccount;
 pub use managed_account::platform_address::PlatformP2PKHAddress;
 pub use mnemonic::Mnemonic;
 pub use seed::Seed;
-pub use signer::Signer;
+pub use signer::{Signer, SignerMethod, TransactionCategory};
 pub use utxo::Utxo;
 pub use wallet::{balance::WalletCoreBalance, Wallet};
 

--- a/key-wallet/src/lib.rs
+++ b/key-wallet/src/lib.rs
@@ -38,6 +38,7 @@ pub mod managed_account;
 pub mod mnemonic;
 pub mod psbt;
 pub mod seed;
+pub mod signer;
 pub mod transaction_checking;
 pub(crate) mod utils;
 pub mod utxo;
@@ -61,6 +62,7 @@ pub use managed_account::managed_platform_account::ManagedPlatformAccount;
 pub use managed_account::platform_address::PlatformP2PKHAddress;
 pub use mnemonic::Mnemonic;
 pub use seed::Seed;
+pub use signer::Signer;
 pub use utxo::Utxo;
 pub use wallet::{balance::WalletCoreBalance, Wallet};
 

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -1079,15 +1079,18 @@ impl ManagedCoreAccount {
         Ok(private_key)
     }
 
-    /// Consume the next unused address and return only its derivation path.
+    /// Peek at the next unused address's path and index **without** marking
+    /// the index used.
     ///
-    /// Analogous to [`Self::next_private_key`] but does not require any
-    /// root extended private key: used when signing is delegated to an
-    /// external [`Signer`](crate::signer::Signer), which holds the keys
-    /// and only needs the path to produce signatures or public keys.
+    /// Intended for two-phase flows where path consumption must not commit
+    /// until an external operation (e.g. an async signer request) has
+    /// succeeded. Pair with [`Self::mark_first_pool_index_used`] to
+    /// commit, or drop the result to leave the pool untouched. Calling
+    /// `peek_next_path` twice without committing in between returns the
+    /// same `(path, index)`.
     ///
     /// Only works for single-pool account types (not Standard accounts).
-    pub fn next_path(&mut self) -> Result<crate::DerivationPath, &'static str> {
+    pub fn peek_next_path(&mut self) -> Result<(crate::DerivationPath, u32), &'static str> {
         if matches!(self.account_type, ManagedAccountType::Standard { .. }) {
             return Err("Standard accounts must use next_receive_address or next_change_address");
         }
@@ -1099,9 +1102,44 @@ impl ManagedCoreAccount {
             .next_unused_with_info(&address_pool::KeySource::NoKeySource, false)
             .map_err(|_| "No unused address available")?;
 
-        pool.mark_index_used(info.index);
+        Ok((info.path, info.index))
+    }
 
-        Ok(info.path)
+    /// Mark an index on the account's first address pool as used.
+    ///
+    /// Commits what [`Self::peek_next_path`] returned. Accepts any index —
+    /// callers are responsible for passing back the index they peeked, not
+    /// an arbitrary one.
+    ///
+    /// Only works for single-pool account types (not Standard accounts).
+    pub fn mark_first_pool_index_used(&mut self, index: u32) -> Result<(), &'static str> {
+        if matches!(self.account_type, ManagedAccountType::Standard { .. }) {
+            return Err("Standard accounts must use next_receive_address or next_change_address");
+        }
+
+        let mut pools = self.account_type.address_pools_mut();
+        let pool = pools.first_mut().ok_or("Account has no address pool")?;
+        pool.mark_index_used(index);
+        Ok(())
+    }
+
+    /// Consume the next unused address and return only its derivation path.
+    ///
+    /// Analogous to [`Self::next_private_key`] but does not require any
+    /// root extended private key: used when signing is delegated to an
+    /// external [`Signer`](crate::signer::Signer), which holds the keys
+    /// and only needs the path to produce signatures or public keys.
+    ///
+    /// Consumes the index immediately; callers that need to defer the
+    /// commit until after an external operation succeeds should use
+    /// [`Self::peek_next_path`] + [`Self::mark_first_pool_index_used`]
+    /// instead.
+    ///
+    /// Only works for single-pool account types (not Standard accounts).
+    pub fn next_path(&mut self) -> Result<crate::DerivationPath, &'static str> {
+        let (path, index) = self.peek_next_path()?;
+        self.mark_first_pool_index_used(index)?;
+        Ok(path)
     }
 
     /// Get the derivation path for an address if it belongs to this account

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -1079,6 +1079,31 @@ impl ManagedCoreAccount {
         Ok(private_key)
     }
 
+    /// Consume the next unused address and return only its derivation path.
+    ///
+    /// Analogous to [`Self::next_private_key`] but does not require any
+    /// root extended private key: used when signing is delegated to an
+    /// external [`Signer`](crate::signer::Signer), which holds the keys
+    /// and only needs the path to produce signatures or public keys.
+    ///
+    /// Only works for single-pool account types (not Standard accounts).
+    pub fn next_path(&mut self) -> Result<crate::DerivationPath, &'static str> {
+        if matches!(self.account_type, ManagedAccountType::Standard { .. }) {
+            return Err("Standard accounts must use next_receive_address or next_change_address");
+        }
+
+        let mut pools = self.account_type.address_pools_mut();
+        let pool = pools.first_mut().ok_or("Account has no address pool")?;
+
+        let info = pool
+            .next_unused_with_info(&address_pool::KeySource::NoKeySource, false)
+            .map_err(|_| "No unused address available")?;
+
+        pool.mark_index_used(info.index);
+
+        Ok(info.path)
+    }
+
     /// Get the derivation path for an address if it belongs to this account
     pub fn address_derivation_path(&self, address: &Address) -> Option<crate::DerivationPath> {
         self.account_type.get_address_derivation_path(address)

--- a/key-wallet/src/signer.rs
+++ b/key-wallet/src/signer.rs
@@ -71,8 +71,15 @@ pub enum TransactionCategory {
 }
 
 /// Sign on behalf of keys the host does not possess.
+///
+/// The `Send + Sync` supertrait bounds match how callers use a signer in
+/// practice: `build_asset_lock_with_signer` (and future signer-driven
+/// builders) call `&signer` methods across `.await` points, so any
+/// implementor that doesn't satisfy both bounds would fail to compile at
+/// the call site with a cryptic "future is not `Send`/`Sync`" message.
+/// Putting the bounds on the trait surfaces the requirement up front.
 #[async_trait]
-pub trait Signer {
+pub trait Signer: Send + Sync {
     /// Error produced by the underlying signing device or service.
     type Error: std::fmt::Display + Send + Sync + 'static;
 

--- a/key-wallet/src/signer.rs
+++ b/key-wallet/src/signer.rs
@@ -81,6 +81,14 @@ pub enum TransactionCategory {
 #[async_trait]
 pub trait Signer: Send + Sync {
     /// Error produced by the underlying signing device or service.
+    ///
+    /// The bound is intentionally loose — only `Display + Send + Sync +
+    /// 'static` — so bring-your-own error types (including `String`) work
+    /// out of the box. Implementors **should** prefer a type that also
+    /// implements `std::error::Error` (derived via `thiserror` or hand-
+    /// rolled) so callers can chain causes and inspect source errors;
+    /// this crate's call sites currently collapse the signer error to a
+    /// `String` via `Display`, which works for either shape.
     type Error: std::fmt::Display + Send + Sync + 'static;
 
     /// Signing methods this signer can perform. A caller that needs a

--- a/key-wallet/src/signer.rs
+++ b/key-wallet/src/signer.rs
@@ -1,0 +1,41 @@
+//! External signer abstraction.
+//!
+//! A [`Signer`] answers signing requests for private keys the host does not
+//! hold. It is the integration point for hardware wallets and remote signers
+//! used with [`WalletType::ExternalSignable`](crate::wallet::WalletType::ExternalSignable):
+//! the device owns every private key, and the host only sends derivation paths
+//! and pre-computed sighashes.
+//!
+//! The trait is async because hardware-wallet round-trips are inherently
+//! asynchronous (USB, BLE, network). Soft-wallet implementations can wrap a
+//! sync derive-and-sign in `async {}` without meaningful overhead.
+
+use async_trait::async_trait;
+use secp256k1::{ecdsa, PublicKey};
+
+use crate::bip32::DerivationPath;
+
+/// Sign on behalf of keys the host does not possess.
+#[async_trait]
+pub trait Signer {
+    /// Error produced by the underlying signing device or service.
+    type Error: std::fmt::Display + Send + Sync + 'static;
+
+    /// Produce an ECDSA signature over `sighash` for the key at `path`,
+    /// along with the compressed public key needed to assemble the scriptSig.
+    ///
+    /// `sighash` is the pre-computed 32-byte message digest (e.g. a legacy
+    /// P2PKH sighash). The signer must not re-derive or alter it.
+    async fn sign_ecdsa(
+        &self,
+        path: &DerivationPath,
+        sighash: [u8; 32],
+    ) -> Result<(ecdsa::Signature, PublicKey), Self::Error>;
+
+    /// Return the compressed public key at `path` without signing.
+    ///
+    /// Used to capture per-output public keys (e.g. asset-lock credit-output
+    /// keys) that the caller later references when signing Platform state
+    /// transitions.
+    async fn public_key(&self, path: &DerivationPath) -> Result<PublicKey, Self::Error>;
+}

--- a/key-wallet/src/signer.rs
+++ b/key-wallet/src/signer.rs
@@ -4,7 +4,8 @@
 //! hold. It is the integration point for hardware wallets and remote signers
 //! used with [`WalletType::ExternalSignable`](crate::wallet::WalletType::ExternalSignable):
 //! the device owns every private key, and the host only sends derivation paths
-//! and pre-computed sighashes.
+//! plus either pre-computed sighashes or full transactions — depending on what
+//! the device supports (see [`SignerMethod`]).
 //!
 //! The trait is async because hardware-wallet round-trips are inherently
 //! asynchronous (USB, BLE, network). Soft-wallet implementations can wrap a
@@ -15,17 +16,88 @@ use secp256k1::{ecdsa, PublicKey};
 
 use crate::bip32::DerivationPath;
 
+/// A signing method a [`Signer`] can perform.
+///
+/// Callers check which methods a signer supports via
+/// [`Signer::supported_methods`] and dispatch accordingly. A remote cloud
+/// signer or soft wallet typically supports [`SignerMethod::Digest`] (blind
+/// sighash signing). A hardware wallet protecting the user from a
+/// compromised host cannot safely sign blind digests — it needs the full
+/// transaction to re-hash and display — so it advertises
+/// [`SignerMethod::Transaction`] instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SignerMethod {
+    /// Sign a host-computed 32-byte digest. The device trusts that the
+    /// digest matches the intended transaction: fast, but offers no
+    /// on-device review of what's actually being signed. Suitable for
+    /// trusted remote signers and HSMs; **not** suitable for hardware
+    /// wallets that defend against a compromised host.
+    Digest,
+
+    /// Sign a full Dash transaction of a given [`TransactionCategory`].
+    /// The signer receives the unsigned transaction plus per-input
+    /// metadata, re-hashes it internally, and (for hardware wallets) may
+    /// present transaction details to the user for approval.
+    ///
+    /// A signer advertises one variant per category it can parse and
+    /// render — hardware-wallet firmware typically ships support for
+    /// categories rather than individual transaction types.
+    Transaction(TransactionCategory),
+}
+
+/// Category of Dash transaction, grouped by on-chain purpose.
+///
+/// Categories correspond to the transaction shapes a signer has to
+/// understand in order to safely display and sign them. Grouping by
+/// category (rather than by the raw DIP-2 type byte) matches how
+/// hardware-wallet firmware tends to gate feature support: a firmware
+/// release either understands "masternode lifecycle transactions" or it
+/// doesn't — not one specific sub-type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TransactionCategory {
+    /// Classical transaction — P2PKH / P2SH value transfer, no special
+    /// payload. DIP-2 type 0.
+    Classical,
+
+    /// Platform credit flow. Locks Dash on L1 to credit Platform, or
+    /// unlocks credits back to L1. DIP-2 types 8 (AssetLock) and 9
+    /// (AssetUnlock).
+    PlatformCredits,
+
+    /// DIP-3 masternode lifecycle. Register, update, or revoke a
+    /// masternode. DIP-2 types 3 (ProRegTx), 4 (ProUpServTx), 5
+    /// (ProUpRegTx), 6 (ProUpRevTx).
+    MasternodeLifecycle,
+}
+
 /// Sign on behalf of keys the host does not possess.
 #[async_trait]
 pub trait Signer {
     /// Error produced by the underlying signing device or service.
     type Error: std::fmt::Display + Send + Sync + 'static;
 
+    /// Signing methods this signer can perform. A caller that needs a
+    /// method the signer doesn't advertise should fail fast rather than
+    /// invoke a trait method it knows will be rejected.
+    ///
+    /// Returned as a borrowed slice so signers can back this with a
+    /// `&'static` constant when capabilities are fixed, or with a field
+    /// when they're resolved at runtime (e.g. after a firmware-version
+    /// handshake).
+    fn supported_methods(&self) -> &[SignerMethod];
+
+    /// Convenience: whether `method` appears in [`Self::supported_methods`].
+    fn supports(&self, method: SignerMethod) -> bool {
+        self.supported_methods().contains(&method)
+    }
+
     /// Produce an ECDSA signature over `sighash` for the key at `path`,
     /// along with the compressed public key needed to assemble the scriptSig.
     ///
     /// `sighash` is the pre-computed 32-byte message digest (e.g. a legacy
     /// P2PKH sighash). The signer must not re-derive or alter it.
+    ///
+    /// Only valid when the signer supports [`SignerMethod::Digest`].
     async fn sign_ecdsa(
         &self,
         path: &DerivationPath,

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -3,11 +3,16 @@
 //! Builds a Core special transaction (type 8) with `AssetLockPayload` that
 //! locks Dash for Platform credits.
 
+use dashcore::blockdata::script::{Builder, PushBytes};
+use dashcore::sighash::{EcdsaSighashType, SighashCache};
 use dashcore::{Address, ScriptBuf, Transaction, TxOut};
+use dashcore_hashes::Hash;
+use secp256k1::PublicKey;
 use std::collections::HashMap;
 use std::fmt;
 
 use crate::managed_account::ManagedCoreAccount;
+use crate::signer::Signer;
 use crate::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
 use crate::wallet::managed_wallet_info::fee::FeeRate;
 use crate::wallet::managed_wallet_info::transaction_builder::{BuilderError, TransactionBuilder};
@@ -43,17 +48,31 @@ pub struct CreditOutputFunding {
     pub identity_index: u32,
 }
 
+/// One-time credit-output keys carried back from an asset-lock build.
+///
+/// For each credit output (in payload order, unaffected by BIP-69 sorting of
+/// the transaction's output list), either the raw private key — when the host
+/// holds signing material — or the public key + derivation path, when signing
+/// was delegated to an external [`Signer`].
+pub enum AssetLockCreditKeys {
+    /// Raw private keys, one per credit output. Produced by
+    /// [`ManagedWalletInfo::build_asset_lock`] on soft wallets.
+    Private(Vec<[u8; 32]>),
+    /// Public key + derivation path per credit output. Produced by
+    /// [`ManagedWalletInfo::build_asset_lock_with_signer`] when the
+    /// private keys never leave the signing device.
+    Public(Vec<(PublicKey, DerivationPath)>),
+}
+
 /// Result of building an asset lock transaction.
 pub struct AssetLockResult {
     /// The signed transaction.
     pub transaction: Transaction,
     /// The fee paid in duffs.
     pub fee: u64,
-    /// One-time private keys, one per credit output (in order).
-    /// `keys[i]` corresponds to the credit output at index `i` in the
-    /// payload's `credit_outputs` vector (not affected by BIP-69 sorting
-    /// of the transaction's output list).
-    pub keys: Vec<[u8; 32]>,
+    /// Per-credit-output key material. See [`AssetLockCreditKeys`] for
+    /// ordering and variant semantics.
+    pub keys: AssetLockCreditKeys,
 }
 
 /// Errors specific to asset lock transaction building.
@@ -71,6 +90,10 @@ pub enum AssetLockError {
     NoAddressPool,
     /// Key derivation failed.
     KeyDerivation(String),
+    /// The external signer reported an error.
+    Signer(String),
+    /// Signing produced an unexpected state (e.g. input without a known path).
+    SigningFailed(String),
     /// The wallet does not have a private key (watch-only).
     WatchOnlyWallet,
     /// The specified BIP44 account was not found.
@@ -92,6 +115,8 @@ impl fmt::Display for AssetLockError {
             Self::NoAddressAvailable => write!(f, "No address available in funding account"),
             Self::NoAddressPool => write!(f, "Funding account has no address pool"),
             Self::KeyDerivation(msg) => write!(f, "Key derivation failed: {msg}"),
+            Self::Signer(msg) => write!(f, "Signer error: {msg}"),
+            Self::SigningFailed(msg) => write!(f, "Signing failed: {msg}"),
             Self::WatchOnlyWallet => write!(f, "Cannot sign with watch-only wallet"),
             Self::AccountNotFound(idx) => write!(f, "BIP44 account {} not found", idx),
             Self::NoChangeAddress => write!(f, "No change address available"),
@@ -280,7 +305,181 @@ impl ManagedWalletInfo {
         Ok(AssetLockResult {
             transaction,
             fee: actual_fee,
-            keys,
+            keys: AssetLockCreditKeys::Private(keys),
+        })
+    }
+
+    /// Build and sign an asset lock transaction via an external [`Signer`].
+    ///
+    /// Same shape and semantics as [`Self::build_asset_lock`], but every
+    /// signing operation — both the P2PKH input signatures and the public
+    /// keys recorded for credit outputs — is delegated to `signer`. The host
+    /// never sees the underlying private keys, so this is the entry point for
+    /// hardware wallets and remote signers backing a
+    /// [`WalletType::ExternalSignable`](crate::wallet::WalletType::ExternalSignable)
+    /// wallet.
+    ///
+    /// The returned [`AssetLockResult::keys`] is
+    /// [`AssetLockCreditKeys::Public`]: public keys plus derivation paths,
+    /// one per credit output in payload order. The caller uses the paths to
+    /// request signatures from the same signer when later consuming the
+    /// credits on Platform.
+    pub async fn build_asset_lock_with_signer<S: Signer>(
+        &mut self,
+        wallet: &Wallet,
+        account_index: u32,
+        credit_output_fundings: Vec<CreditOutputFunding>,
+        fee_per_kb: u64,
+        signer: &S,
+    ) -> Result<AssetLockResult, AssetLockError> {
+        if credit_output_fundings.is_empty() {
+            return Err(AssetLockError::NoCreditOutputs);
+        }
+
+        // UTXOs and address→path map from the funding account.
+        let funding_account = self
+            .accounts
+            .standard_bip44_accounts
+            .get(&account_index)
+            .ok_or(AssetLockError::AccountNotFound(account_index))?;
+
+        let utxos: Vec<Utxo> = funding_account.utxos.values().cloned().collect();
+        let mut address_to_path: HashMap<Address, DerivationPath> = HashMap::new();
+        for pool in funding_account.account_type.address_pools() {
+            for addr_info in pool.addresses.values() {
+                address_to_path.insert(addr_info.address.clone(), addr_info.path.clone());
+            }
+        }
+
+        // Next change address — derivable from the account xpub, no signing key needed.
+        let xpub = wallet.get_bip44_account(account_index).map(|a| a.account_xpub);
+        let change_address = self
+            .accounts
+            .standard_bip44_accounts
+            .get_mut(&account_index)
+            .and_then(|account| account.next_change_address(xpub.as_ref(), true).ok())
+            .ok_or(AssetLockError::NoChangeAddress)?;
+
+        let synced_height = self.synced_height();
+
+        let credit_outputs: Vec<TxOut> =
+            credit_output_fundings.iter().map(|f| f.output.clone()).collect();
+
+        // Same burn-output shape as the soft-wallet path: tx.output[0] is an
+        // OP_RETURN burn carrying the total locked amount, credit outputs
+        // live only in the payload. See build_asset_lock for details.
+        let total_credit: u64 = credit_outputs.iter().map(|o| o.value).sum();
+        let burn_output = TxOut {
+            value: total_credit,
+            script_pubkey: ScriptBuf::new_op_return(&[]),
+        };
+
+        // Build the transaction WITHOUT keys — TransactionBuilder's internal
+        // signer is skipped when every input's key is None, producing an
+        // unsigned tx we then sign ourselves via the Signer.
+        let tx_builder = TransactionBuilder::new()
+            .set_change_address(change_address)
+            .set_fee_rate(FeeRate::new(fee_per_kb))
+            .add_raw_output(burn_output);
+
+        let tx_builder_with_inputs = tx_builder.select_inputs(
+            &utxos,
+            SelectionStrategy::BranchAndBound,
+            synced_height,
+            |_utxo| None,
+        )?;
+
+        let outputs_count_before = tx_builder_with_inputs.outputs().len();
+        let fee = tx_builder_with_inputs.calculate_fee();
+        let fee_with_extra = tx_builder_with_inputs.calculate_fee_with_extra_output();
+
+        let mut transaction = tx_builder_with_inputs.build_asset_lock(credit_outputs)?;
+
+        let actual_fee = if transaction.output.len() > outputs_count_before {
+            fee_with_extra
+        } else {
+            fee
+        };
+
+        // Map each input back to its prev-txout via UTXO outpoint so we can
+        // compute the legacy P2PKH sighash and look up its derivation path.
+        let utxo_by_outpoint: HashMap<_, _> =
+            utxos.iter().map(|u| (u.outpoint, u.clone())).collect();
+
+        let mut scripts: Vec<ScriptBuf> = Vec::with_capacity(transaction.input.len());
+        {
+            let cache = SighashCache::new(&transaction);
+            for (index, txin) in transaction.input.iter().enumerate() {
+                let utxo = utxo_by_outpoint.get(&txin.previous_output).ok_or_else(|| {
+                    AssetLockError::SigningFailed(format!(
+                        "selected UTXO {:?} not found in funding account",
+                        txin.previous_output
+                    ))
+                })?;
+                let path = address_to_path.get(&utxo.address).ok_or_else(|| {
+                    AssetLockError::SigningFailed(format!(
+                        "no derivation path for input address {}",
+                        utxo.address
+                    ))
+                })?;
+
+                let sighash = cache
+                    .legacy_signature_hash(
+                        index,
+                        &utxo.txout.script_pubkey,
+                        EcdsaSighashType::All.to_u32(),
+                    )
+                    .map_err(|e| {
+                        AssetLockError::SigningFailed(format!(
+                            "failed to compute sighash for input {index}: {e}"
+                        ))
+                    })?;
+
+                let (sig, pubkey) = signer
+                    .sign_ecdsa(path, *sighash.as_byte_array())
+                    .await
+                    .map_err(|e| AssetLockError::Signer(e.to_string()))?;
+
+                let mut sig_bytes = sig.serialize_der().to_vec();
+                sig_bytes.push(EcdsaSighashType::All.to_u32() as u8);
+
+                let script_sig = Builder::new()
+                    .push_slice(<&PushBytes>::try_from(sig_bytes.as_slice()).map_err(|_| {
+                        AssetLockError::SigningFailed("invalid signature length".into())
+                    })?)
+                    .push_slice(pubkey.serialize())
+                    .into_script();
+
+                scripts.push(script_sig);
+            }
+        }
+        for (index, script_sig) in scripts.into_iter().enumerate() {
+            transaction.input[index].script_sig = script_sig;
+        }
+
+        // Credit-output bookkeeping: advance each funding account's pool to
+        // consume a fresh path, then ask the signer for the matching pubkey.
+        let mut credit_output_keys = Vec::with_capacity(credit_output_fundings.len());
+        for funding in &credit_output_fundings {
+            let funding_key_account = resolve_funding_account(
+                &mut self.accounts,
+                funding.funding_type,
+                funding.identity_index,
+            )?;
+            let path = funding_key_account
+                .next_path()
+                .map_err(|e| AssetLockError::KeyDerivation(e.to_string()))?;
+            let pubkey = signer
+                .public_key(&path)
+                .await
+                .map_err(|e| AssetLockError::Signer(e.to_string()))?;
+            credit_output_keys.push((pubkey, path));
+        }
+
+        Ok(AssetLockResult {
+            transaction,
+            fee: actual_fee,
+            keys: AssetLockCreditKeys::Public(credit_output_keys),
         })
     }
 }
@@ -361,6 +560,125 @@ mod tests {
         // Wallet has no UTXOs, so coin selection should fail
         let (wallet, mut info) = test_wallet_and_info();
         let result = info.build_asset_lock(&wallet, 0, test_credit_outputs(&[500_000]), 1000);
+        assert!(
+            matches!(result, Err(AssetLockError::Builder(_))),
+            "Expected Builder error for insufficient funds, got: {:?}",
+            result.err()
+        );
+    }
+
+    // -- Signer-variant tests --
+
+    /// Signer implementation backed by a real [`RootExtendedPrivKey`]. Models
+    /// the same derive-and-sign the soft-wallet path performs internally, so
+    /// `build_asset_lock_with_signer` can be exercised end-to-end without a
+    /// hardware device in the loop.
+    struct InMemorySigner {
+        root: crate::wallet::root_extended_keys::RootExtendedPrivKey,
+        network: Network,
+    }
+
+    #[async_trait::async_trait]
+    impl Signer for InMemorySigner {
+        type Error = String;
+
+        async fn sign_ecdsa(
+            &self,
+            path: &DerivationPath,
+            sighash: [u8; 32],
+        ) -> Result<(secp256k1::ecdsa::Signature, PublicKey), Self::Error> {
+            let secp = secp256k1::Secp256k1::new();
+            let xpriv = self
+                .root
+                .to_extended_priv_key(self.network)
+                .derive_priv(&secp, path)
+                .map_err(|e| e.to_string())?;
+            let msg = secp256k1::Message::from_digest(sighash);
+            let sig = secp.sign_ecdsa(&msg, &xpriv.private_key);
+            let pk = secp256k1::PublicKey::from_secret_key(&secp, &xpriv.private_key);
+            Ok((sig, pk))
+        }
+
+        async fn public_key(&self, path: &DerivationPath) -> Result<PublicKey, Self::Error> {
+            let secp = secp256k1::Secp256k1::new();
+            let xpriv = self
+                .root
+                .to_extended_priv_key(self.network)
+                .derive_priv(&secp, path)
+                .map_err(|e| e.to_string())?;
+            Ok(secp256k1::PublicKey::from_secret_key(&secp, &xpriv.private_key))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_signer_empty_credit_outputs_rejected() {
+        let (wallet, mut info) = test_wallet_and_info();
+        let root = match &wallet.wallet_type {
+            crate::wallet::WalletType::Mnemonic {
+                root_extended_private_key,
+                ..
+            } => root_extended_private_key.clone(),
+            _ => unreachable!("test_wallet_and_info produces a mnemonic wallet"),
+        };
+        let signer = InMemorySigner {
+            root,
+            network: Network::Testnet,
+        };
+        let result = info
+            .build_asset_lock_with_signer(&wallet, 0, vec![], 1000, &signer)
+            .await;
+        assert!(matches!(result, Err(AssetLockError::NoCreditOutputs)));
+    }
+
+    #[tokio::test]
+    async fn test_signer_invalid_account_index() {
+        let (wallet, mut info) = test_wallet_and_info();
+        let root = match &wallet.wallet_type {
+            crate::wallet::WalletType::Mnemonic {
+                root_extended_private_key,
+                ..
+            } => root_extended_private_key.clone(),
+            _ => unreachable!(),
+        };
+        let signer = InMemorySigner {
+            root,
+            network: Network::Testnet,
+        };
+        let result = info
+            .build_asset_lock_with_signer(
+                &wallet,
+                99,
+                test_credit_outputs(&[100_000]),
+                1000,
+                &signer,
+            )
+            .await;
+        assert!(matches!(result, Err(AssetLockError::AccountNotFound(99))));
+    }
+
+    #[tokio::test]
+    async fn test_signer_insufficient_funds() {
+        let (wallet, mut info) = test_wallet_and_info();
+        let root = match &wallet.wallet_type {
+            crate::wallet::WalletType::Mnemonic {
+                root_extended_private_key,
+                ..
+            } => root_extended_private_key.clone(),
+            _ => unreachable!(),
+        };
+        let signer = InMemorySigner {
+            root,
+            network: Network::Testnet,
+        };
+        let result = info
+            .build_asset_lock_with_signer(
+                &wallet,
+                0,
+                test_credit_outputs(&[500_000]),
+                1000,
+                &signer,
+            )
+            .await;
         assert!(
             matches!(result, Err(AssetLockError::Builder(_))),
             "Expected Builder error for insufficient funds, got: {:?}",

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 use crate::managed_account::ManagedCoreAccount;
-use crate::signer::Signer;
+use crate::signer::{Signer, SignerMethod};
 use crate::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
 use crate::wallet::managed_wallet_info::fee::FeeRate;
 use crate::wallet::managed_wallet_info::transaction_builder::{BuilderError, TransactionBuilder};
@@ -94,6 +94,8 @@ pub enum AssetLockError {
     Signer(String),
     /// Signing produced an unexpected state (e.g. input without a known path).
     SigningFailed(String),
+    /// The signer does not advertise a method required by this build path.
+    UnsupportedSignerMethod(SignerMethod),
     /// The wallet does not have a private key (watch-only).
     WatchOnlyWallet,
     /// The specified BIP44 account was not found.
@@ -117,6 +119,9 @@ impl fmt::Display for AssetLockError {
             Self::KeyDerivation(msg) => write!(f, "Key derivation failed: {msg}"),
             Self::Signer(msg) => write!(f, "Signer error: {msg}"),
             Self::SigningFailed(msg) => write!(f, "Signing failed: {msg}"),
+            Self::UnsupportedSignerMethod(m) => {
+                write!(f, "Signer does not support required method {m:?}")
+            }
             Self::WatchOnlyWallet => write!(f, "Cannot sign with watch-only wallet"),
             Self::AccountNotFound(idx) => write!(f, "BIP44 account {} not found", idx),
             Self::NoChangeAddress => write!(f, "No change address available"),
@@ -334,6 +339,14 @@ impl ManagedWalletInfo {
     ) -> Result<AssetLockResult, AssetLockError> {
         if credit_output_fundings.is_empty() {
             return Err(AssetLockError::NoCreditOutputs);
+        }
+
+        // This build path drives signing via pre-computed P2PKH sighashes,
+        // so the signer must support blind digest signing. Signers that
+        // only advertise transaction-level signing (typical of hardware
+        // wallets) need a future build path that hands them the full tx.
+        if !signer.supports(SignerMethod::Digest) {
+            return Err(AssetLockError::UnsupportedSignerMethod(SignerMethod::Digest));
         }
 
         // UTXOs and address→path map from the funding account.
@@ -578,9 +591,15 @@ mod tests {
         network: Network,
     }
 
+    const IN_MEMORY_METHODS: &[SignerMethod] = &[SignerMethod::Digest];
+
     #[async_trait::async_trait]
     impl Signer for InMemorySigner {
         type Error = String;
+
+        fn supported_methods(&self) -> &[SignerMethod] {
+            IN_MEMORY_METHODS
+        }
 
         async fn sign_ecdsa(
             &self,
@@ -654,6 +673,46 @@ mod tests {
             )
             .await;
         assert!(matches!(result, Err(AssetLockError::AccountNotFound(99))));
+    }
+
+    #[tokio::test]
+    async fn test_signer_without_digest_support_rejected() {
+        // A signer that advertises no methods (or only transaction-level
+        // signing) must be rejected by the digest-driven build path before
+        // any UTXO state is touched.
+        struct NoDigestSigner;
+        #[async_trait::async_trait]
+        impl Signer for NoDigestSigner {
+            type Error = String;
+            fn supported_methods(&self) -> &[SignerMethod] {
+                &[SignerMethod::Transaction(crate::signer::TransactionCategory::PlatformCredits)]
+            }
+            async fn sign_ecdsa(
+                &self,
+                _: &DerivationPath,
+                _: [u8; 32],
+            ) -> Result<(secp256k1::ecdsa::Signature, PublicKey), Self::Error> {
+                unreachable!("should be rejected before any signing is attempted")
+            }
+            async fn public_key(&self, _: &DerivationPath) -> Result<PublicKey, Self::Error> {
+                unreachable!()
+            }
+        }
+
+        let (wallet, mut info) = test_wallet_and_info();
+        let result = info
+            .build_asset_lock_with_signer(
+                &wallet,
+                0,
+                test_credit_outputs(&[100_000]),
+                1000,
+                &NoDigestSigner,
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(AssetLockError::UnsupportedSignerMethod(SignerMethod::Digest))
+        ));
     }
 
     #[tokio::test]

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -470,22 +470,50 @@ impl ManagedWalletInfo {
             transaction.input[index].script_sig = script_sig;
         }
 
-        // Credit-output bookkeeping: advance each funding account's pool to
-        // consume a fresh path, then ask the signer for the matching pubkey.
+        // Credit-output bookkeeping: for each funding, peek the next unused
+        // path on its account, ask the signer for the matching pubkey, and
+        // only mark the index used once the signer has succeeded.
+        //
+        // This protects against a signer failure mid-loop leaving earlier
+        // fundings' pool indices irreversibly consumed: if `public_key`
+        // errors, the current funding's index is still free, and no
+        // subsequent fundings have touched their pools yet.
         let mut credit_output_keys = Vec::with_capacity(credit_output_fundings.len());
         for funding in &credit_output_fundings {
-            let funding_key_account = resolve_funding_account(
-                &mut self.accounts,
-                funding.funding_type,
-                funding.identity_index,
-            )?;
-            let path = funding_key_account
-                .next_path()
-                .map_err(|e| AssetLockError::KeyDerivation(e.to_string()))?;
+            // Phase 1 (sync): peek without marking used. Borrow is scoped
+            // to the block so we can re-resolve the account after the
+            // signer await.
+            let (path, index) = {
+                let funding_key_account = resolve_funding_account(
+                    &mut self.accounts,
+                    funding.funding_type,
+                    funding.identity_index,
+                )?;
+                funding_key_account
+                    .peek_next_path()
+                    .map_err(|e| AssetLockError::KeyDerivation(e.to_string()))?
+            };
+
+            // Phase 2 (async): signer round-trip. If this errors, we return
+            // without ever calling mark_first_pool_index_used — index stays
+            // free for a retry.
             let pubkey = signer
                 .public_key(&path)
                 .await
                 .map_err(|e| AssetLockError::Signer(e.to_string()))?;
+
+            // Phase 3 (sync): signer succeeded, commit the index.
+            {
+                let funding_key_account = resolve_funding_account(
+                    &mut self.accounts,
+                    funding.funding_type,
+                    funding.identity_index,
+                )?;
+                funding_key_account
+                    .mark_first_pool_index_used(index)
+                    .map_err(|e| AssetLockError::KeyDerivation(e.to_string()))?;
+            }
+
             credit_output_keys.push((pubkey, path));
         }
 
@@ -643,9 +671,7 @@ mod tests {
             root,
             network: Network::Testnet,
         };
-        let result = info
-            .build_asset_lock_with_signer(&wallet, 0, vec![], 1000, &signer)
-            .await;
+        let result = info.build_asset_lock_with_signer(&wallet, 0, vec![], 1000, &signer).await;
         assert!(matches!(result, Err(AssetLockError::NoCreditOutputs)));
     }
 
@@ -713,6 +739,102 @@ mod tests {
             result,
             Err(AssetLockError::UnsupportedSignerMethod(SignerMethod::Digest))
         ));
+    }
+
+    #[tokio::test]
+    async fn test_signer_happy_path_end_to_end() {
+        use crate::Utxo;
+        use dashcore::{OutPoint, TxOut, Txid};
+
+        let (wallet, mut info) = test_wallet_and_info();
+        let root = match &wallet.wallet_type {
+            crate::wallet::WalletType::Mnemonic {
+                root_extended_private_key,
+                ..
+            } => root_extended_private_key.clone(),
+            _ => unreachable!(),
+        };
+
+        // Generate a receive address on account 0 and fund it with a
+        // real UTXO at that address — coin selection needs a confirmed,
+        // spendable output the signer can sign for.
+        let account_xpub = wallet.get_bip44_account(0).unwrap().account_xpub;
+        let funding_address = info
+            .accounts
+            .standard_bip44_accounts
+            .get_mut(&0)
+            .unwrap()
+            .next_receive_address(Some(&account_xpub), true)
+            .unwrap();
+
+        let utxo = Utxo {
+            outpoint: OutPoint {
+                txid: Txid::from_byte_array([0x11; 32]),
+                vout: 0,
+            },
+            txout: TxOut {
+                value: 1_000_000,
+                script_pubkey: funding_address.script_pubkey(),
+            },
+            address: funding_address,
+            height: 1000,
+            is_coinbase: false,
+            is_confirmed: true,
+            is_instantlocked: false,
+            is_locked: false,
+        };
+        info.accounts
+            .standard_bip44_accounts
+            .get_mut(&0)
+            .unwrap()
+            .utxos
+            .insert(utxo.outpoint, utxo);
+        info.update_synced_height(1100);
+
+        let signer = InMemorySigner {
+            root,
+            network: Network::Testnet,
+        };
+
+        let credit_amounts = [200_000u64, 300_000u64];
+        let fundings = test_credit_outputs(&credit_amounts);
+        let result = info
+            .build_asset_lock_with_signer(&wallet, 0, fundings, 1000, &signer)
+            .await
+            .expect("build_asset_lock_with_signer should succeed with funded wallet");
+
+        // Result shape: signer path returns public keys + paths, one per
+        // credit output, in payload order.
+        let pub_keys = match &result.keys {
+            AssetLockCreditKeys::Public(v) => v,
+            AssetLockCreditKeys::Private(_) => panic!("signer path must return Public keys"),
+        };
+        assert_eq!(pub_keys.len(), credit_amounts.len(), "one (pubkey, path) per credit output");
+
+        // DIP-00X: tx.output[0] is the OP_RETURN burn carrying the total
+        // locked amount. Credit outputs live only in the payload, not in
+        // tx.output.
+        let total_credit: u64 = credit_amounts.iter().sum();
+        let burn = &result.transaction.output[0];
+        assert_eq!(burn.value, total_credit, "burn output must carry total credit");
+        assert!(
+            burn.script_pubkey.is_op_return(),
+            "tx.output[0] must be OP_RETURN, got {:?}",
+            burn.script_pubkey
+        );
+
+        // Every input should have been signed — empty script_sig means
+        // the signer was never called for that input.
+        assert!(
+            !result.transaction.input.is_empty(),
+            "transaction should have at least one selected input"
+        );
+        for (i, txin) in result.transaction.input.iter().enumerate() {
+            assert!(
+                !txin.script_sig.is_empty(),
+                "input {i} has empty script_sig — signer did not produce a signature"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Adds an async `Signer` trait (`key-wallet/src/signer.rs`) for delegating ECDSA signing and public-key lookup to external devices — hardware wallets, remote signers, anything backing a `WalletType::ExternalSignable` wallet. Every call takes only a `DerivationPath` and pre-computed sighash; private keys never cross the host boundary.
- Adds `ManagedWalletInfo::build_asset_lock_with_signer<S: Signer>`, an async sibling of `build_asset_lock` that builds the unsigned tx via `TransactionBuilder`, computes per-input legacy P2PKH sighashes, delegates every signature to the `Signer`, and records credit-output bookkeeping as `(PublicKey, DerivationPath)` pairs pulled from the same signer.
- Reshapes `AssetLockResult.keys` into the new `AssetLockCreditKeys` enum (`Private(Vec<[u8;32]>)` for soft wallets, `Public(Vec<(PublicKey, DerivationPath)>)` for signer-backed wallets) so both paths share the same result type.
- Adds `ManagedCoreAccount::next_path()` — a key-free sibling of `next_private_key` that advances the funding-account pool and returns only the derivation path, used by the signer path for credit-output bookkeeping.
- Updates the one existing `AssetLockResult.keys` consumer in `key-wallet-ffi` to destructure the new enum (the soft-wallet FFI entry point only accepts the `Private` variant).

Non-goals: `TransactionBuilder` itself is not signer-aware yet; the signer path lives entirely in `build_asset_lock_with_signer`. `WalletType::ExternalSignable` doesn't yet carry the signer — callers supply it per-build.

## Test plan
- [x] `cargo test -p key-wallet --lib` — 457 existing tests pass plus 3 new async signer tests (empty outputs rejected, invalid account index, insufficient funds), using an in-memory `Signer` impl backed by a real root xpriv.
- [x] `cargo clippy -p key-wallet --all-targets -- -D warnings` — clean.
- [x] `cargo build -p key-wallet-ffi` — builds with the updated enum destructure.
- [ ] Exercise against a real hardware-wallet `Signer` impl (out of scope for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable external signer support with discoverable signing methods and transaction categories.
  * Asset-lock creation now supports both host-signing and external-signer flows, returning per-credit output key info and signer-aware signing.
  * Managed account APIs to peek, mark, and consume the next unused address derivation path for two-phase address consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->