### PR TITLE
chore: bump pinned Rust toolchain to 1.95.0

### DIFF
--- a/dash-spv/src/chain/chain_tip.rs
+++ b/dash-spv/src/chain/chain_tip.rs
@@ -121,7 +121,7 @@ impl ChainTipManager {
     /// Get all tips sorted by chain work (descending)
     pub fn get_all_tips(&self) -> Vec<&ChainTip> {
         let mut tips: Vec<_> = self.tips.values().collect();
-        tips.sort_by(|a, b| b.chain_work.cmp(&a.chain_work));
+        tips.sort_by_key(|t| std::cmp::Reverse(t.chain_work));
         tips
     }
 

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -440,12 +440,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
     async fn try_commit_batches(&mut self) -> SyncResult<Vec<SyncEvent>> {
         let mut events = Vec::new();
 
-        loop {
-            // Get the lowest batch
-            let Some((&batch_start, batch)) = self.active_batches.first_key_value() else {
-                break;
-            };
-
+        while let Some((&batch_start, batch)) = self.active_batches.first_key_value() {
             // Check if batch was scanned - can't commit until scanned
             if !batch.scanned() {
                 break;

--- a/dash/src/bip158.rs
+++ b/dash/src/bip158.rs
@@ -646,7 +646,7 @@ mod test {
                 filter
                     .match_all(
                         block_hash,
-                        &mut txmap.iter().filter_map(|(_, s)| if !s.is_empty() {
+                        &mut txmap.values().filter_map(|s| if !s.is_empty() {
                             Some(s.as_bytes())
                         } else {
                             None

--- a/dash/src/sml/masternode_list/merkle_roots.rs
+++ b/dash/src/sml/masternode_list/merkle_roots.rs
@@ -158,7 +158,7 @@ impl MasternodeList {
     pub fn hashes_for_merkle_root(&self, block_height: u32) -> Option<Vec<sha256d::Hash>> {
         (block_height != u32::MAX).then_some({
             let mut pro_tx_hashes = self.reversed_pro_reg_tx_hashes();
-            pro_tx_hashes.sort_by(|&s1, &s2| s1.reverse().cmp(&s2.reverse()));
+            pro_tx_hashes.sort_by_key(|&s| s.reverse());
             pro_tx_hashes
                 .into_iter()
                 .map(|hash| self.masternodes[hash].entry_hash)

--- a/dash/src/sml/masternode_list_engine/mod.rs
+++ b/dash/src/sml/masternode_list_engine/mod.rs
@@ -600,8 +600,7 @@ impl MasternodeListEngine {
         } = qr_info;
 
         // Apply quorum snapshots and masternode list diffs
-        for (snapshot, diff) in quorum_snapshot_list.into_iter().zip(mn_list_diff_list.into_iter())
-        {
+        for (snapshot, diff) in quorum_snapshot_list.into_iter().zip(mn_list_diff_list) {
             self.known_snapshots.insert(diff.block_hash, snapshot);
             self.apply_diff(diff, None, false, None)?;
         }

--- a/key-wallet/src/psbt/mod.rs
+++ b/key-wallet/src/psbt/mod.rs
@@ -139,7 +139,7 @@ impl PartiallySignedTransaction {
     pub fn extract_tx(self) -> Transaction {
         let mut tx: Transaction = self.unsigned_tx;
 
-        for (vin, psbtin) in tx.input.iter_mut().zip(self.inputs.into_iter()) {
+        for (vin, psbtin) in tx.input.iter_mut().zip(self.inputs) {
             vin.script_sig = psbtin.final_script_sig.unwrap_or_default();
             vin.witness = psbtin.final_script_witness.unwrap_or_default();
         }
@@ -202,11 +202,11 @@ impl PartiallySignedTransaction {
         self.proprietary.extend(other.proprietary);
         self.unknown.extend(other.unknown);
 
-        for (self_input, other_input) in self.inputs.iter_mut().zip(other.inputs.into_iter()) {
+        for (self_input, other_input) in self.inputs.iter_mut().zip(other.inputs) {
             self_input.combine(other_input);
         }
 
-        for (self_output, other_output) in self.outputs.iter_mut().zip(other.outputs.into_iter()) {
+        for (self_output, other_output) in self.outputs.iter_mut().zip(other.outputs) {
             self_output.combine(other_output);
         }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- \`constant_time_eq@0.4.3\` was published requiring rustc 1.95.0. Because \`Cargo.lock\` isn't tracked, every CI run resolves dependencies fresh and picks up 0.4.3, failing against the current 1.94.1 pin. All open PR CI is currently red for this reason.
- Bumps \`rust-toolchain.toml\` to 1.95.0 — the floor the newer transitive dep needs.
- Fixes the handful of new clippy lints this unlocks so \`-D warnings\` stays clean:
  - \`useless_conversion\`: drop redundant \`.into_iter()\` on \`zip()\`'s second operand (key-wallet psbt, sml engine)
  - \`sort_by_key\`: \`sort_by(cmp)\` → \`sort_by_key\` for simple keyers (sml merkle roots, chain_tip)
  - \`iter_on_hashmap_values\`: \`map.iter().filter_map(|(_, s)| …)\` → \`map.values().filter_map(|s| …)\` (bip158)
  - \`while_let_loop\`: collapse \`loop { let Some(..) = .. else break; .. }\` into \`while let Some(..) = .. { .. }\` (filters manager)

MSRV (1.89) is unchanged — the toolchain pin is the dev toolchain, not the library MSRV. The MSRV job in \`.github/workflows/rust.yml\` still claims to check 1.89; whether it actually does (given rust-toolchain.toml overrides \`dtolnay/rust-toolchain@1.89\`) is a separate pre-existing question and out of scope here.

## Test plan
- [x] \`cargo check --workspace --all-features\` with 1.95.0 locally
- [x] \`cargo clippy --workspace --all-features --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI green on this PR (the point of the bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)