### PR TITLE
chore(key-wallet): loosen wallet recovery perf threshold to 70ms

### DIFF
--- a/key-wallet/src/tests/performance_tests.rs
+++ b/key-wallet/src/tests/performance_tests.rs
@@ -149,13 +149,16 @@ fn test_wallet_recovery_performance() {
     println!("Total time for {} iterations: {:?}", iterations, metrics.total_time);
     println!("Operations per second: {:.2}", metrics.ops_per_second);
     println!("Min/Max times: {:?} / {:?}", metrics.min_time, metrics.max_time);
-    println!("Expected: < 50ms per recovery");
+    println!("Expected: < 70ms per recovery");
     println!("===================================\n");
 
-    // Assert performance requirements
+    // Assert performance requirements. Threshold sized for the slowest
+    // CI runners (shared GitHub-hosted Ubuntu), where observed averages
+    // land in the 50-60ms range. 70ms gives headroom without hiding real
+    // regressions.
     assert!(
-        metrics.avg_time < Duration::from_millis(50),
-        "Wallet recovery too slow: avg {:?}, expected < 50ms",
+        metrics.avg_time < Duration::from_millis(70),
+        "Wallet recovery too slow: avg {:?}, expected < 70ms",
         metrics.avg_time
     );
 }


### PR DESCRIPTION
## Summary
- \`test_wallet_recovery_performance\` asserts a <50ms average over 10 iterations. On shared GitHub-hosted Ubuntu runners, the observed averages land in the 50-60ms range, with max samples up to ~70ms (see [PR #662 CI run](https://github.com/dashpay/rust-dashcore/actions/runs/24639212165/job/72040056386) — "Average time: 54.977162ms", max 70.018ms). The test is gating on runner speed rather than code performance — flakes with no regression to investigate.
- Bumps the avg threshold to 70ms and updates the accompanying \`println!\` + assert message.

Not a code-perf change, just a CI-stability fix. If real regressions land, the test will still catch them (a regression that pushed averages above 70ms on the same hardware would be significant).

## Test plan
- [x] Existing observed averages (50-60ms) comfortably below new 70ms threshold
- [ ] Ubuntu CI runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted wallet recovery performance test thresholds to improve test reliability across different CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->