### PR TITLE
fix(dash): use platform LLMQ type for regtest in `platform_type()`

### DIFF
--- a/dash/src/sml/llmq_type/network.rs
+++ b/dash/src/sml/llmq_type/network.rs
@@ -46,7 +46,7 @@ impl NetworkLLMQExt for Network {
             Network::Mainnet => LLMQType::Llmqtype100_67,
             Network::Testnet => LLMQType::Llmqtype25_67,
             Network::Devnet => LLMQType::LlmqtypeDevnet,
-            Network::Regtest => LLMQType::LlmqtypeTest,
+            Network::Regtest => LLMQType::LlmqtypeTestnetPlatform,
         }
     }
 


### PR DESCRIPTION
`Network::Regtest.platform_type()` returned `LlmqtypeTest` (100) instead of the value Dash Core sets for regtest: `LLMQ_TEST_PLATFORM` (106).

https://github.com/dashpay/dash/blob/0b7f5bec8d401d5d08214e5071f96816f2254bcb/src/chainparams.cpp#L914