### PR TITLE
feat(dash-spv): enforce required peer capabilities

### DIFF
--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -1337,8 +1337,10 @@ impl PeerNetworkManager {
 
     async fn is_capability_rejected(&self, addr: &SocketAddr) -> bool {
         let mut rejected = self.capability_rejected.write().await;
-        let cutoff = Instant::now() - CAPABILITY_REJECTED_TTL;
-        rejected.retain(|_, rejected_at| *rejected_at > cutoff);
+        let now = Instant::now();
+        rejected.retain(|_, rejected_at| {
+            now.saturating_duration_since(*rejected_at) < CAPABILITY_REJECTED_TTL
+        });
         rejected.contains_key(addr)
     }
 }
@@ -1506,14 +1508,6 @@ impl PeerNetworkManager {
 
     pub(crate) async fn insert_test_capability_rejected(&self, addr: SocketAddr) {
         self.record_capability_rejection(addr).await;
-    }
-
-    pub(crate) async fn insert_test_capability_rejected_at(
-        &self,
-        addr: SocketAddr,
-        rejected_at: Instant,
-    ) {
-        self.capability_rejected.write().await.insert(addr, rejected_at);
     }
 
     pub(crate) async fn test_capability_rejected_count(&self) -> usize {

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -248,6 +248,8 @@ impl PeerNetworkManager {
         let shutdown_token = self.shutdown_token.clone();
         let reputation_manager = self.reputation_manager.clone();
         let user_agent = self.user_agent.clone();
+        let required_services = self.required_services;
+        let capability_rejected = self.capability_rejected.clone();
         let connected_peer_count = self.connected_peer_count.clone();
         let headers2_disabled = self.headers2_disabled.clone();
         let message_dispatcher = self.message_dispatcher.clone();
@@ -279,6 +281,26 @@ impl PeerNetworkManager {
                     let mut handshake_manager = HandshakeManager::new(network, user_agent);
                     match handshake_manager.perform_handshake(&mut peer).await {
                         Ok(_) => {
+                            if PeerNetworkManager::should_reject_after_handshake(
+                                &pool,
+                                &peer,
+                                required_services,
+                            )
+                            .await
+                            {
+                                tracing::info!(
+                                    "Rejecting peer {} during handshake - missing required services ({}) while a capable peer is connected",
+                                    addr,
+                                    required_services
+                                );
+                                PeerNetworkManager::record_capability_rejection_in(
+                                    &capability_rejected,
+                                    addr,
+                                )
+                                .await;
+                                pool.remove_peer(&addr).await;
+                                return;
+                            }
                             tracing::info!("Successfully connected to {}", addr);
 
                             // Request addresses from the peer for discovery
@@ -882,17 +904,27 @@ impl PeerNetworkManager {
         if connected_count <= 1 {
             return;
         }
+        let mut matched_count = 0;
         let mut mismatched = Vec::new();
         for (addr, peer) in &all_peers {
             let peer_guard = peer.read().await;
-            if peer_guard.services_known() && !peer_guard.has_service(self.required_services) {
+            if peer_guard.services_known() && peer_guard.has_service(self.required_services) {
+                matched_count += 1;
+            } else if peer_guard.services_known() {
                 mismatched.push(*addr);
             }
         }
         if mismatched.is_empty() {
             return;
         }
-        let drop_count = mismatched.len().min(connected_count - 1);
+        let drop_count = if matched_count > 0 {
+            mismatched.len()
+        } else {
+            mismatched.len().min(connected_count - 1)
+        };
+        if drop_count == 0 {
+            return;
+        }
         tracing::info!(
             "Capability churn: dropping {} of {} peers lacking required services",
             drop_count,
@@ -1331,8 +1363,7 @@ impl PeerNetworkManager {
     }
 
     async fn record_capability_rejection(&self, addr: SocketAddr) {
-        let mut rejected = self.capability_rejected.write().await;
-        rejected.insert(addr, Instant::now());
+        Self::record_capability_rejection_in(&self.capability_rejected, addr).await;
     }
 
     async fn is_capability_rejected(&self, addr: &SocketAddr) -> bool {
@@ -1342,6 +1373,24 @@ impl PeerNetworkManager {
             now.saturating_duration_since(*rejected_at) < CAPABILITY_REJECTED_TTL
         });
         rejected.contains_key(addr)
+    }
+
+    async fn record_capability_rejection_in(
+        capability_rejected: &RwLock<HashMap<SocketAddr, Instant>>,
+        addr: SocketAddr,
+    ) {
+        capability_rejected.write().await.insert(addr, Instant::now());
+    }
+
+    async fn should_reject_after_handshake(
+        pool: &PeerPool,
+        peer: &Peer,
+        required_services: ServiceFlags,
+    ) -> bool {
+        required_services != ServiceFlags::NONE
+            && pool.has_peers_with_service(required_services).await
+            && peer.services_known()
+            && !peer.has_service(required_services)
     }
 }
 
@@ -1516,5 +1565,14 @@ impl PeerNetworkManager {
 
     pub(crate) async fn test_is_capability_rejected(&self, addr: &SocketAddr) -> bool {
         self.is_capability_rejected(addr).await
+    }
+
+    pub(crate) async fn test_has_capable_peer(&self) -> bool {
+        self.required_services != ServiceFlags::NONE
+            && self.pool.has_peers_with_service(self.required_services).await
+    }
+
+    pub(crate) async fn test_should_reject_after_handshake(&self, peer: &Peer) -> bool {
+        Self::should_reject_after_handshake(&self.pool, peer, self.required_services).await
     }
 }

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -62,6 +62,11 @@ pub struct PeerNetworkManager {
     user_agent: Option<String>,
     /// Exclusive mode: restrict to configured peers only (no DNS or peer store)
     exclusive_mode: bool,
+    /// Service flags connected peers must advertise. NONE disables capability churn.
+    required_services: ServiceFlags,
+    /// Addresses evicted for lacking required services. Excluded from top-up candidates.
+    /// TODO: remove once peer session outcomes track why sessions ended and drive reconnect policy.
+    capability_rejected: Arc<RwLock<HashSet<SocketAddr>>>,
     /// Cached count of currently connected peers for fast, non-blocking queries
     connected_peer_count: Arc<AtomicUsize>,
     /// Disable headers2 after decompression failure
@@ -76,6 +81,17 @@ pub struct PeerNetworkManager {
     round_robin_counter: Arc<AtomicUsize>,
     /// Network event bus for notifying about network/peer related changes.
     network_event_sender: broadcast::Sender<NetworkEvent>,
+}
+
+fn required_services_from_config(config: &ClientConfig, exclusive_mode: bool) -> ServiceFlags {
+    if exclusive_mode {
+        return ServiceFlags::NONE;
+    }
+    let mut flags = ServiceFlags::NONE;
+    if config.enable_filters {
+        flags |= ServiceFlags::COMPACT_FILTERS;
+    }
+    flags
 }
 
 impl PeerNetworkManager {
@@ -94,6 +110,7 @@ impl PeerNetworkManager {
 
         // Determine exclusive mode: either explicitly requested or peers were provided
         let exclusive_mode = config.restrict_to_configured_peers || !config.peers.is_empty();
+        let required_services = required_services_from_config(config, exclusive_mode);
 
         // Create request queue for outgoing messages
         let (request_tx, request_rx) = unbounded_channel();
@@ -111,6 +128,8 @@ impl PeerNetworkManager {
             data_dir,
             user_agent: config.user_agent.clone(),
             exclusive_mode,
+            required_services,
+            capability_rejected: Arc::new(RwLock::new(HashSet::new())),
             connected_peer_count: Arc::new(AtomicUsize::new(0)),
             headers2_disabled: Arc::new(Mutex::new(HashSet::new())),
             message_dispatcher: Arc::new(Mutex::new(MessageDispatcher::default())),
@@ -852,6 +871,43 @@ impl PeerNetworkManager {
         });
     }
 
+    pub(crate) async fn evict_mismatched_peers(&self) {
+        if self.required_services == ServiceFlags::NONE {
+            return;
+        }
+        let all_peers = self.pool.get_all_peers().await;
+        let connected_count = all_peers.len();
+        if connected_count <= 1 {
+            return;
+        }
+        let mut mismatched = Vec::new();
+        for (addr, peer) in &all_peers {
+            let peer_guard = peer.read().await;
+            if peer_guard.services_known() && !peer_guard.has_service(self.required_services) {
+                mismatched.push(*addr);
+            }
+        }
+        if mismatched.is_empty() {
+            return;
+        }
+        let drop_count = mismatched.len().min(connected_count - 1);
+        tracing::info!(
+            "Capability churn: dropping {} of {} peers lacking required services",
+            drop_count,
+            connected_count,
+        );
+        let mut rejected = self.capability_rejected.write().await;
+        for addr in mismatched.into_iter().take(drop_count) {
+            rejected.insert(addr);
+            let _ = self
+                .disconnect_peer(
+                    &addr,
+                    &format!("missing required services ({:?})", self.required_services),
+                )
+                .await;
+        }
+    }
+
     async fn maintenance_tick(&self) {
         // Remove peers that the reader loop failed to clean up.
         // This should not trigger under normal operation.
@@ -880,16 +936,24 @@ impl PeerNetworkManager {
                 }
             }
         } else {
-            // Normal mode: try to maintain minimum peer count with discovery
+            // Evict peers that lack required services before top-up so replacements
+            // can be pulled in during the same tick.
+            self.evict_mismatched_peers().await;
+            // Re-read count after potential churn so top-up sees the current pool size.
+            let count = self.pool.peer_count().await;
             if count < TARGET_PEERS {
                 // Try known addresses first, sorted by reputation
                 let known = self.addrv2_handler.get_known_addresses().await;
                 let needed = TARGET_PEERS.saturating_sub(count);
                 // Select best peers based on reputation
                 let best_peers = self.reputation_manager.select_best_peers(known, needed * 2).await;
+                let rejected = self.capability_rejected.read().await;
                 let mut attempted = 0;
 
                 for addr in best_peers {
+                    if rejected.contains(&addr) {
+                        continue;
+                    }
                     if !self.pool.is_connected(&addr).await && !self.pool.is_connecting(&addr).await
                     {
                         self.connect_to_peer(addr).await;
@@ -955,8 +1019,12 @@ impl PeerNetworkManager {
         };
         let needed = TARGET_PEERS.saturating_sub(count);
         tracing::debug!("DNS fallback tick found {} addresses. Needed {}", dns_peers.len(), needed);
+        let rejected = self.capability_rejected.read().await;
         let mut dns_attempted = 0;
         for addr in dns_peers.iter() {
+            if rejected.contains(addr) {
+                continue;
+            }
             if !self.pool.is_connected(addr).await && !self.pool.is_connecting(addr).await {
                 self.connect_to_peer(*addr).await;
                 dns_attempted += 1;
@@ -1280,6 +1348,8 @@ impl Clone for PeerNetworkManager {
             data_dir: self.data_dir.clone(),
             user_agent: self.user_agent.clone(),
             exclusive_mode: self.exclusive_mode,
+            required_services: self.required_services,
+            capability_rejected: self.capability_rejected.clone(),
             connected_peer_count: self.connected_peer_count.clone(),
             headers2_disabled: self.headers2_disabled.clone(),
             message_dispatcher: self.message_dispatcher.clone(),
@@ -1374,5 +1444,52 @@ impl NetworkManager for PeerNetworkManager {
 
     fn subscribe_network_events(&self) -> broadcast::Receiver<NetworkEvent> {
         self.network_event_sender.subscribe()
+    }
+}
+
+#[cfg(test)]
+impl PeerNetworkManager {
+    pub(crate) async fn new_for_test(required_services: ServiceFlags) -> Self {
+        let test_dir = tempfile::tempdir().expect("test dir creation failed").keep();
+        let peer_store =
+            PersistentPeerStorage::open(&test_dir).await.expect("test peer store init failed");
+        let discovery = DnsDiscovery::new().await.expect("test DNS discovery init failed");
+        let (request_tx, request_rx) = unbounded_channel();
+        Self {
+            pool: Arc::new(PeerPool::new()),
+            discovery: Arc::new(discovery),
+            addrv2_handler: Arc::new(AddrV2Handler::new()),
+            peer_store: Arc::new(peer_store),
+            reputation_manager: Arc::new(PeerReputationManager::new()),
+            network: Network::Testnet,
+            shutdown_token: CancellationToken::new(),
+            tasks: Arc::new(Mutex::new(JoinSet::new())),
+            initial_peers: vec![],
+            data_dir: test_dir,
+            user_agent: None,
+            exclusive_mode: false,
+            required_services,
+            capability_rejected: Arc::new(RwLock::new(HashSet::new())),
+            connected_peer_count: Arc::new(AtomicUsize::new(0)),
+            headers2_disabled: Arc::new(Mutex::new(HashSet::new())),
+            message_dispatcher: Arc::new(Mutex::new(MessageDispatcher::default())),
+            request_tx,
+            request_rx: Arc::new(Mutex::new(Some(request_rx))),
+            round_robin_counter: Arc::new(AtomicUsize::new(0)),
+            network_event_sender: broadcast::Sender::new(DEFAULT_NETWORK_EVENT_CAPACITY),
+        }
+    }
+
+    pub(crate) async fn insert_test_peer(&self, addr: SocketAddr, flags: ServiceFlags) {
+        self.pool.insert_peer_with_services(addr, flags).await;
+        self.connected_peer_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) async fn test_peer_count(&self) -> usize {
+        self.pool.peer_count().await
+    }
+
+    pub(crate) async fn test_is_connected(&self, addr: &SocketAddr) -> bool {
+        self.pool.is_connected(addr).await
     }
 }

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -66,7 +66,7 @@ pub struct PeerNetworkManager {
     required_services: ServiceFlags,
     /// Addresses evicted for lacking required services. Excluded from top-up candidates.
     /// TODO: remove once peer session outcomes track why sessions ended and drive reconnect policy.
-    capability_rejected: Arc<RwLock<HashSet<SocketAddr>>>,
+    capability_rejected: Arc<RwLock<HashMap<SocketAddr, Instant>>>,
     /// Cached count of currently connected peers for fast, non-blocking queries
     connected_peer_count: Arc<AtomicUsize>,
     /// Disable headers2 after decompression failure
@@ -82,6 +82,8 @@ pub struct PeerNetworkManager {
     /// Network event bus for notifying about network/peer related changes.
     network_event_sender: broadcast::Sender<NetworkEvent>,
 }
+
+const CAPABILITY_REJECTED_TTL: Duration = Duration::from_secs(30 * 60);
 
 fn required_services_from_config(config: &ClientConfig, exclusive_mode: bool) -> ServiceFlags {
     if exclusive_mode {
@@ -129,7 +131,7 @@ impl PeerNetworkManager {
             user_agent: config.user_agent.clone(),
             exclusive_mode,
             required_services,
-            capability_rejected: Arc::new(RwLock::new(HashSet::new())),
+            capability_rejected: Arc::new(RwLock::new(HashMap::new())),
             connected_peer_count: Arc::new(AtomicUsize::new(0)),
             headers2_disabled: Arc::new(Mutex::new(HashSet::new())),
             message_dispatcher: Arc::new(Mutex::new(MessageDispatcher::default())),
@@ -896,13 +898,12 @@ impl PeerNetworkManager {
             drop_count,
             connected_count,
         );
-        let mut rejected = self.capability_rejected.write().await;
         for addr in mismatched.into_iter().take(drop_count) {
-            rejected.insert(addr);
+            self.record_capability_rejection(addr).await;
             let _ = self
                 .disconnect_peer(
                     &addr,
-                    &format!("missing required services ({:?})", self.required_services),
+                    &format!("missing required services ({})", self.required_services),
                 )
                 .await;
         }
@@ -947,11 +948,10 @@ impl PeerNetworkManager {
                 let needed = TARGET_PEERS.saturating_sub(count);
                 // Select best peers based on reputation
                 let best_peers = self.reputation_manager.select_best_peers(known, needed * 2).await;
-                let rejected = self.capability_rejected.read().await;
                 let mut attempted = 0;
 
                 for addr in best_peers {
-                    if rejected.contains(&addr) {
+                    if self.is_capability_rejected(&addr).await {
                         continue;
                     }
                     if !self.pool.is_connected(&addr).await && !self.pool.is_connecting(&addr).await
@@ -1019,10 +1019,9 @@ impl PeerNetworkManager {
         };
         let needed = TARGET_PEERS.saturating_sub(count);
         tracing::debug!("DNS fallback tick found {} addresses. Needed {}", dns_peers.len(), needed);
-        let rejected = self.capability_rejected.read().await;
         let mut dns_attempted = 0;
         for addr in dns_peers.iter() {
-            if rejected.contains(addr) {
+            if self.is_capability_rejected(addr).await {
                 continue;
             }
             if !self.pool.is_connected(addr).await && !self.pool.is_connecting(addr).await {
@@ -1330,6 +1329,18 @@ impl PeerNetworkManager {
             self.pool.remove_peer(&addr).await;
         }
     }
+
+    async fn record_capability_rejection(&self, addr: SocketAddr) {
+        let mut rejected = self.capability_rejected.write().await;
+        rejected.insert(addr, Instant::now());
+    }
+
+    async fn is_capability_rejected(&self, addr: &SocketAddr) -> bool {
+        let mut rejected = self.capability_rejected.write().await;
+        let cutoff = Instant::now() - CAPABILITY_REJECTED_TTL;
+        rejected.retain(|_, rejected_at| *rejected_at > cutoff);
+        rejected.contains_key(addr)
+    }
 }
 
 // Implement Clone for use in async closures
@@ -1469,7 +1480,7 @@ impl PeerNetworkManager {
             user_agent: None,
             exclusive_mode: false,
             required_services,
-            capability_rejected: Arc::new(RwLock::new(HashSet::new())),
+            capability_rejected: Arc::new(RwLock::new(HashMap::new())),
             connected_peer_count: Arc::new(AtomicUsize::new(0)),
             headers2_disabled: Arc::new(Mutex::new(HashSet::new())),
             message_dispatcher: Arc::new(Mutex::new(MessageDispatcher::default())),
@@ -1491,5 +1502,25 @@ impl PeerNetworkManager {
 
     pub(crate) async fn test_is_connected(&self, addr: &SocketAddr) -> bool {
         self.pool.is_connected(addr).await
+    }
+
+    pub(crate) async fn insert_test_capability_rejected(&self, addr: SocketAddr) {
+        self.record_capability_rejection(addr).await;
+    }
+
+    pub(crate) async fn insert_test_capability_rejected_at(
+        &self,
+        addr: SocketAddr,
+        rejected_at: Instant,
+    ) {
+        self.capability_rejected.write().await.insert(addr, rejected_at);
+    }
+
+    pub(crate) async fn test_capability_rejected_count(&self) -> usize {
+        self.capability_rejected.read().await.len()
+    }
+
+    pub(crate) async fn test_is_capability_rejected(&self, addr: &SocketAddr) -> bool {
+        self.is_capability_rejected(addr).await
     }
 }

--- a/dash-spv/src/network/peer.rs
+++ b/dash-spv/src/network/peer.rs
@@ -147,6 +147,10 @@ impl Peer {
         self.services.map(|s| ServiceFlags::from(s).has(flags)).unwrap_or(false)
     }
 
+    pub(crate) fn services_known(&self) -> bool {
+        self.services.is_some()
+    }
+
     /// Connect to the peer (instance method for compatibility).
     pub async fn connect_instance(&mut self) -> NetworkResult<()> {
         let stream = tokio::time::timeout(self.timeout, TcpStream::connect(self.address))

--- a/dash-spv/src/network/pool.rs
+++ b/dash-spv/src/network/pool.rs
@@ -179,6 +179,17 @@ impl PeerPool {
         result
     }
 
+    /// Check whether any connected peer advertises the given service flags.
+    pub(crate) async fn has_peers_with_service(&self, flags: ServiceFlags) -> bool {
+        let peers = self.peers.read().await;
+        for peer in peers.values() {
+            if peer.read().await.has_service(flags) {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Check if we need more peers
     pub async fn needs_more_peers(&self) -> bool {
         self.peer_count().await < TARGET_PEERS

--- a/dash-spv/src/network/pool.rs
+++ b/dash-spv/src/network/pool.rs
@@ -225,7 +225,7 @@ impl Default for PeerPool {
 
 #[cfg(test)]
 impl PeerPool {
-    async fn insert_peer_with_services(&self, addr: SocketAddr, flags: ServiceFlags) {
+    pub(crate) async fn insert_peer_with_services(&self, addr: SocketAddr, flags: ServiceFlags) {
         let mut peer = Peer::dummy(addr);
         peer.set_services(flags);
         self.peers.write().await.insert(addr, Arc::new(RwLock::new(peer)));

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -19,7 +19,10 @@ mod peer_tests {
 
 #[cfg(test)]
 mod pool_tests {
+    use crate::network::manager::PeerNetworkManager;
     use crate::network::pool::PeerPool;
+    use crate::test_utils::test_socket_address;
+    use dashcore::network::constants::ServiceFlags;
 
     #[tokio::test]
     async fn test_pool_limits() {
@@ -33,7 +36,52 @@ mod pool_tests {
 
         // Test peer count
         assert_eq!(pool.peer_count().await, 0);
+    }
 
-        // Verify pool limits indirectly through methods; avoid constant assertions
+    // Cases are sequential in one test to avoid concurrent DnsDiscovery drops (TSAN race in hickory-resolver).
+    #[tokio::test]
+    async fn test_evict_mismatched_peers() {
+        let cf = ServiceFlags::COMPACT_FILTERS;
+
+        // Healthy pool: all peers match, nothing evicted
+        let manager = PeerNetworkManager::new_for_test(cf).await;
+        manager.insert_test_peer(test_socket_address(1), cf).await;
+        manager.insert_test_peer(test_socket_address(2), cf).await;
+        manager.insert_test_peer(test_socket_address(3), cf).await;
+        manager.evict_mismatched_peers().await;
+        assert_eq!(manager.test_peer_count().await, 3);
+
+        // Lone mismatched peer is preserved (never drop to zero)
+        let manager = PeerNetworkManager::new_for_test(cf).await;
+        manager.insert_test_peer(test_socket_address(1), ServiceFlags::NETWORK).await;
+        manager.evict_mismatched_peers().await;
+        assert_eq!(manager.test_peer_count().await, 1);
+
+        // All peers lack service: tick 1 drops all but 1, tick 2 preserves the lone peer
+        let manager = PeerNetworkManager::new_for_test(cf).await;
+        manager.insert_test_peer(test_socket_address(1), ServiceFlags::NETWORK).await;
+        manager.insert_test_peer(test_socket_address(2), ServiceFlags::NETWORK).await;
+        manager.insert_test_peer(test_socket_address(3), ServiceFlags::NETWORK).await;
+        manager.evict_mismatched_peers().await;
+        assert_eq!(manager.test_peer_count().await, 1);
+        manager.evict_mismatched_peers().await;
+        assert_eq!(manager.test_peer_count().await, 1);
+
+        // Mixed pool: only mismatched peers are dropped, matching peers survive
+        let manager = PeerNetworkManager::new_for_test(cf).await;
+        let p1 = test_socket_address(1);
+        let p2 = test_socket_address(2);
+        let p3 = test_socket_address(3);
+        let p4 = test_socket_address(4);
+        manager.insert_test_peer(p1, cf).await;
+        manager.insert_test_peer(p2, cf).await;
+        manager.insert_test_peer(p3, ServiceFlags::NETWORK).await;
+        manager.insert_test_peer(p4, ServiceFlags::NETWORK).await;
+        manager.evict_mismatched_peers().await;
+        assert_eq!(manager.test_peer_count().await, 2);
+        assert!(manager.test_is_connected(&p1).await);
+        assert!(manager.test_is_connected(&p2).await);
+        assert!(!manager.test_is_connected(&p3).await);
+        assert!(!manager.test_is_connected(&p4).await);
     }
 }

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -23,6 +23,7 @@ mod pool_tests {
     use crate::network::pool::PeerPool;
     use crate::test_utils::test_socket_address;
     use dashcore::network::constants::ServiceFlags;
+    use tokio::time::{Duration, Instant};
 
     #[tokio::test]
     async fn test_pool_limits() {
@@ -83,5 +84,25 @@ mod pool_tests {
         assert!(manager.test_is_connected(&p2).await);
         assert!(!manager.test_is_connected(&p3).await);
         assert!(!manager.test_is_connected(&p4).await);
+    }
+
+    #[tokio::test]
+    async fn test_capability_rejection_cache_expires() {
+        let manager = PeerNetworkManager::new_for_test(ServiceFlags::COMPACT_FILTERS).await;
+        let fresh = test_socket_address(42);
+        let expired = test_socket_address(43);
+
+        manager.insert_test_capability_rejected(fresh).await;
+        manager
+            .insert_test_capability_rejected_at(
+                expired,
+                Instant::now() - Duration::from_secs(31 * 60),
+            )
+            .await;
+
+        assert!(manager.test_is_capability_rejected(&fresh).await);
+        assert!(!manager.test_is_capability_rejected(&expired).await);
+
+        assert_eq!(manager.test_capability_rejected_count().await, 1);
     }
 }

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -20,9 +20,11 @@ mod peer_tests {
 #[cfg(test)]
 mod pool_tests {
     use crate::network::manager::PeerNetworkManager;
+    use crate::network::peer::Peer;
     use crate::network::pool::PeerPool;
     use crate::test_utils::test_socket_address;
     use dashcore::network::constants::ServiceFlags;
+    use dashcore::Network;
     use tokio::time::Duration;
 
     #[tokio::test]
@@ -41,8 +43,22 @@ mod pool_tests {
 
     // Cases are sequential in one test to avoid concurrent DnsDiscovery drops (TSAN race in hickory-resolver).
     #[tokio::test]
-    async fn test_evict_mismatched_peers() {
+    async fn test_capability_policy_for_handshake_and_eviction() {
         let cf = ServiceFlags::COMPACT_FILTERS;
+        let mut incapable =
+            Peer::new(test_socket_address(9), Duration::from_secs(10), Network::Testnet);
+        incapable.set_services(ServiceFlags::NETWORK);
+
+        // Handshake admission: keep fallback when no capable peer exists yet.
+        let manager = PeerNetworkManager::new_for_test(cf).await;
+        assert!(!manager.test_has_capable_peer().await);
+        assert!(!manager.test_should_reject_after_handshake(&incapable).await);
+
+        // Handshake admission: reject incapable peers once a capable peer exists.
+        let manager = PeerNetworkManager::new_for_test(cf).await;
+        manager.insert_test_peer(test_socket_address(1), cf).await;
+        assert!(manager.test_has_capable_peer().await);
+        assert!(manager.test_should_reject_after_handshake(&incapable).await);
 
         // Healthy pool: all peers match, nothing evicted
         let manager = PeerNetworkManager::new_for_test(cf).await;

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -23,7 +23,7 @@ mod pool_tests {
     use crate::network::pool::PeerPool;
     use crate::test_utils::test_socket_address;
     use dashcore::network::constants::ServiceFlags;
-    use tokio::time::{Duration, Instant};
+    use tokio::time::Duration;
 
     #[tokio::test]
     async fn test_pool_limits() {
@@ -86,19 +86,15 @@ mod pool_tests {
         assert!(!manager.test_is_connected(&p4).await);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_capability_rejection_cache_expires() {
         let manager = PeerNetworkManager::new_for_test(ServiceFlags::COMPACT_FILTERS).await;
         let fresh = test_socket_address(42);
         let expired = test_socket_address(43);
 
+        manager.insert_test_capability_rejected(expired).await;
+        tokio::time::advance(Duration::from_secs(31 * 60)).await;
         manager.insert_test_capability_rejected(fresh).await;
-        manager
-            .insert_test_capability_rejected_at(
-                expired,
-                Instant::now() - Duration::from_secs(31 * 60),
-            )
-            .await;
 
         assert!(manager.test_is_capability_rejected(&fresh).await);
         assert!(!manager.test_is_capability_rejected(&expired).await);


### PR DESCRIPTION
This branch changes peer management in the network layer to actively enforces peers that advertise the required services.

- incapable peers are rejected earlier, at handshake time, once at least one capable peer is already connected
- if no capable peer exists yet, one fallback incapable peer may still be kept so discovery can continue
- once a capable peer exists, maintenance drops connected peers that do not meet the required services instead of keeping them around unnecessarily
- temporarily rejected peers are remembered with a TTL, which avoids immediate reconnect loops without blacklisting them forever
- capability checks are centralized around pool-level service queries, and the related tests were updated to cover the new admission, churn, and expiry behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peers advertising insufficient capabilities are detected and disconnected; normal and DNS fallback peer discovery skip recently rejected addresses.
* **Tests**
  * Added tests for capability-based handshake rejection and eviction, rejection-cache TTL behavior, and connection-state verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->