### PR TITLE
fix: ignore special transactions on block version 0 (pre DIP-0002)

### DIFF
--- a/dash/src/blockdata/transaction/mod.rs
+++ b/dash/src/blockdata/transaction/mod.rs
@@ -597,7 +597,6 @@ impl Decodable for Transaction {
     ) -> Result<Self, encode::Error> {
         let version = u16::consensus_decode_from_finite_reader(r)?;
         let special_transaction_type_u16 = u16::consensus_decode(r)?;
-        println!("bbbbbb");
         let special_transaction_type = if version != 0 {
             TransactionType::try_from(special_transaction_type_u16).map_err(|_| {
                 encode::Error::UnknownSpecialTransactionType(special_transaction_type_u16)

--- a/dash/src/blockdata/transaction/mod.rs
+++ b/dash/src/blockdata/transaction/mod.rs
@@ -597,10 +597,14 @@ impl Decodable for Transaction {
     ) -> Result<Self, encode::Error> {
         let version = u16::consensus_decode_from_finite_reader(r)?;
         let special_transaction_type_u16 = u16::consensus_decode(r)?;
-        let special_transaction_type = TransactionType::try_from(special_transaction_type_u16)
-            .map_err(|_| {
+        println!("bbbbbb");
+        let special_transaction_type = if version != 0 {
+            TransactionType::try_from(special_transaction_type_u16).map_err(|_| {
                 encode::Error::UnknownSpecialTransactionType(special_transaction_type_u16)
-            })?;
+            })?
+        } else {
+            TransactionType::Classic
+        };
         let input = Vec::<TxIn>::consensus_decode_from_finite_reader(r)?;
         // segwit
         let mut segwit = input.is_empty();


### PR DESCRIPTION
# Issue

There is one malformed block in mainnet network with special transaction type set to 8192 on pre DIP-0002 blocks. This is a block before special transaction were introduced in the network, and shouldn't even been set to 8192 (it should have been just 0), however Dash Core software tolerated this and as a result such block was included in the chain.

Rust dashcore, when tries to decode such block from hex, tries to decode the field but fails to match to any known special transaction type from the codebase eventually failing with:
```
Failed to decode transactions for block 000000000000000cdf5cc24c3beb0669b31e942d1301e07b53d6f0c7db10860d: unknown special transaction type: 8192
```

Here is the reference for that block
[842284](https://chainz.cryptoid.info/dash/block.dws?842284.htm)


# Proposed solution

Simply decode all transaction as `TransactionType::Classic` if the block version is 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction deserialization logic to correctly process transactions across different version encodings, ensuring accurate type field interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->