### PR TITLE
fix: fix setup-dashd.py script env var export

### DIFF
--- a/contrib/setup-dashd.py
+++ b/contrib/setup-dashd.py
@@ -159,9 +159,10 @@ def main():
 
     datadir = os.path.join(cache_dir, f"regtest-blockchain-{TEST_DATA_VERSION}")
 
-    # Output lines for GITHUB_ENV or shell eval
-    print(f"DASHD_PATH={dashd_path}")
-    print(f"DASHD_TEST_DATA={datadir}")
+    # GITHUB_ENV expects bare NAME=value; shell `eval` needs `export NAME=value`.
+    prefix = "" if os.environ.get("GITHUB_ACTIONS") == "true" else "export "
+    print(f"{prefix}DASHD_PATH={dashd_path}")
+    print(f"{prefix}DASHD_TEST_DATA={datadir}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I was wondering why this scrip was not working in my machine, it was missing to print export commands, I hope this doesn't brake how GitHub handles env vars