### PR TITLE
feat: support multiple spv event handlers

### DIFF
--- a/dash-spv-ffi/src/client.rs
+++ b/dash-spv-ffi/src/client.rs
@@ -20,7 +20,6 @@ type InnerClient = DashSpvClient<
     key_wallet_manager::WalletManager<key_wallet::wallet::managed_wallet_info::ManagedWalletInfo>,
     dash_spv::network::PeerNetworkManager,
     DiskStorageManager,
-    FFIEventCallbacks,
 >;
 
 pub struct FFIDashSpvClient {
@@ -94,8 +93,14 @@ pub unsafe extern "C" fn dash_spv_ffi_client_new(
 
         match (network, storage) {
             (Ok(network), Ok(storage)) => {
-                DashSpvClient::new(client_config, network, storage, wallet, Arc::new(callbacks))
-                    .await
+                DashSpvClient::new(
+                    client_config,
+                    network,
+                    storage,
+                    wallet,
+                    vec![Arc::new(callbacks)],
+                )
+                .await
             }
             (Err(e), _) => Err(e),
             (_, Err(e)) => Err(dash_spv::SpvError::Storage(e)),

--- a/dash-spv/examples/filter_sync.rs
+++ b/dash-spv/examples/filter_sync.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create the client
     let client =
-        DashSpvClient::new(config, network_manager, storage_manager, wallet, Arc::new(())).await?;
+        DashSpvClient::new(config, network_manager, storage_manager, wallet, vec![]).await?;
 
     println!("Starting synchronization with filter support...");
     println!("Watching address: {:?}", watch_address);

--- a/dash-spv/examples/simple_sync.rs
+++ b/dash-spv/examples/simple_sync.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create the client
     let client =
-        DashSpvClient::new(config, network_manager, storage_manager, wallet, Arc::new(())).await?;
+        DashSpvClient::new(config, network_manager, storage_manager, wallet, vec![]).await?;
 
     println!("Starting header synchronization...");
 

--- a/dash-spv/examples/spv_with_wallet.rs
+++ b/dash-spv/examples/spv_with_wallet.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create the SPV client with all components
     let client =
-        DashSpvClient::new(config, network_manager, storage_manager, wallet, Arc::new(())).await?;
+        DashSpvClient::new(config, network_manager, storage_manager, wallet, vec![]).await?;
 
     // The wallet will automatically be notified of:
     // - New blocks via process_block()

--- a/dash-spv/src/client/core.rs
+++ b/dash-spv/src/client/core.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 
 use super::ClientConfig;
-use crate::client::EventHandler;
 use crate::error::{Result, SpvError};
 use crate::network::NetworkManager;
 use crate::storage::{
@@ -73,7 +72,7 @@ pub(super) type PersistentSyncCoordinator<W> = SyncCoordinator<
 /// - `W: WalletInterface` - Handles UTXO tracking, address management, transaction processing
 /// - `N: NetworkManager` - Manages peer connections, message routing, network protocol
 /// - `S: StorageManager` - Persistent storage for headers, filters, chain state
-/// - `H: EventHandler` - Receives push-based event notifications (defaults to `()` no-op)
+/// - Event handlers are stored as `Vec<Arc<dyn EventHandler>>`
 ///
 /// ## Common Configurations
 ///
@@ -104,12 +103,7 @@ pub(super) type PersistentSyncCoordinator<W> = SyncCoordinator<
 /// - Not reduce binary size (production has one instantiation anyway)
 ///
 /// The generic design is an intentional, beneficial architectural choice for a library.
-pub struct DashSpvClient<
-    W: WalletInterface,
-    N: NetworkManager,
-    S: StorageManager,
-    H: EventHandler = (),
-> {
+pub struct DashSpvClient<W: WalletInterface, N: NetworkManager, S: StorageManager> {
     pub(super) config: Arc<RwLock<ClientConfig>>,
     pub(super) network: Arc<Mutex<N>>,
     pub(super) storage: Arc<Mutex<S>>,
@@ -118,12 +112,10 @@ pub struct DashSpvClient<
     pub(super) masternode_engine: Option<Arc<RwLock<MasternodeListEngine>>>,
     pub(super) sync_coordinator: Arc<Mutex<PersistentSyncCoordinator<W>>>,
     pub(super) running: Arc<RwLock<bool>>,
-    pub(super) event_handler: Arc<H>,
+    pub(super) event_handlers: Arc<Vec<Arc<dyn super::EventHandler>>>,
 }
 
-impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler> Clone
-    for DashSpvClient<W, N, S, H>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> Clone for DashSpvClient<W, N, S> {
     fn clone(&self) -> Self {
         Self {
             config: Arc::clone(&self.config),
@@ -133,14 +125,12 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler> 
             masternode_engine: self.masternode_engine.clone(),
             sync_coordinator: Arc::clone(&self.sync_coordinator),
             running: Arc::clone(&self.running),
-            event_handler: Arc::clone(&self.event_handler),
+            event_handlers: Arc::clone(&self.event_handlers),
         }
     }
 }
 
-impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
-    DashSpvClient<W, N, S, H>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     // ============ Simple Getters ============
 
     /// Get a reference to the wallet.

--- a/dash-spv/src/client/event_handler.rs
+++ b/dash-spv/src/client/event_handler.rs
@@ -38,18 +38,17 @@ impl EventHandler for () {}
 ///
 /// On failure, the error message is sent via `on_failure` so the coordinator can report
 /// it as the single source of error handling.
-pub(crate) fn spawn_broadcast_monitor<E, H, F>(
+pub(crate) fn spawn_broadcast_monitor<E, F>(
     name: &'static str,
     mut receiver: broadcast::Receiver<E>,
-    handler: Arc<H>,
+    handlers: Arc<Vec<Arc<dyn EventHandler>>>,
     shutdown: CancellationToken,
     on_failure: mpsc::Sender<String>,
     dispatch_fn: F,
 ) -> JoinHandle<()>
 where
     E: Clone + Send + 'static,
-    H: EventHandler,
-    F: Fn(&H, &E) + Send + 'static,
+    F: Fn(&dyn EventHandler, &E) + Send + 'static,
 {
     tokio::spawn(async move {
         tracing::debug!("{} monitoring task started", name);
@@ -57,7 +56,11 @@ where
             tokio::select! {
                 result = receiver.recv() => {
                     match result {
-                        Ok(event) => dispatch_fn(&handler, &event),
+                        Ok(event) => {
+                            for handler in handlers.iter() {
+                                dispatch_fn(handler.as_ref(), &event);
+                            }
+                        }
                         Err(broadcast::error::RecvError::Closed) if shutdown.is_cancelled() => break,
                         Err(broadcast::error::RecvError::Closed) => {
                             let msg = format!("{} monitor channel closed unexpectedly", name);
@@ -84,22 +87,28 @@ where
 /// Spawns a task that monitors a watch channel for progress updates.
 ///
 /// Sends the initial progress value, then monitors for changes.
-pub(crate) fn spawn_progress_monitor<H: EventHandler>(
+pub(crate) fn spawn_progress_monitor(
     mut receiver: watch::Receiver<SyncProgress>,
-    handler: Arc<H>,
+    handlers: Arc<Vec<Arc<dyn EventHandler>>>,
     shutdown: CancellationToken,
     on_failure: mpsc::Sender<String>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         tracing::debug!("Progress monitoring task started");
 
-        handler.on_progress(&receiver.borrow_and_update());
+        for handler in handlers.iter() {
+            handler.on_progress(&receiver.borrow_and_update());
+        }
 
         loop {
             tokio::select! {
                 result = receiver.changed() => {
                     match result {
-                        Ok(()) => handler.on_progress(&receiver.borrow_and_update()),
+                        Ok(()) => {
+                            for handler in handlers.iter() {
+                                handler.on_progress(&receiver.borrow_and_update());
+                            }
+                        }
                         Err(_) if shutdown.is_cancelled() => break,
                         Err(_) => {
                             let msg = "Progress monitor channel closed unexpectedly".to_string();
@@ -168,6 +177,12 @@ mod tests {
         }
     }
 
+    fn handlers(
+        entries: impl IntoIterator<Item = Arc<dyn EventHandler>>,
+    ) -> Arc<Vec<Arc<dyn EventHandler>>> {
+        Arc::new(entries.into_iter().collect())
+    }
+
     #[tokio::test]
     async fn noop_handler_does_not_panic() {
         let handler: () = ();
@@ -194,10 +209,10 @@ mod tests {
         let task = spawn_broadcast_monitor(
             "test",
             rx,
-            handler.clone(),
+            handlers([handler.clone() as Arc<dyn EventHandler>]),
             shutdown.clone(),
             failure_tx,
-            |h: &RecordingHandler, event: &SyncEvent| h.on_sync_event(event),
+            |h, event: &SyncEvent| h.on_sync_event(event),
         );
 
         tx.send(SyncEvent::BlockHeadersStored {
@@ -232,10 +247,10 @@ mod tests {
         let task = spawn_broadcast_monitor(
             "test",
             rx,
-            handler.clone(),
+            handlers([handler.clone() as Arc<dyn EventHandler>]),
             shutdown.clone(),
             failure_tx,
-            |h: &RecordingHandler, event: &SyncEvent| h.on_sync_event(event),
+            |h, event: &SyncEvent| h.on_sync_event(event),
         );
 
         shutdown.cancel();
@@ -254,10 +269,10 @@ mod tests {
         let task = spawn_broadcast_monitor(
             "test",
             rx,
-            handler.clone(),
+            handlers([handler.clone() as Arc<dyn EventHandler>]),
             shutdown.clone(),
             failure_tx,
-            |h: &RecordingHandler, event: &SyncEvent| h.on_sync_event(event),
+            |h, event: &SyncEvent| h.on_sync_event(event),
         );
 
         // Drop sender without cancelling shutdown — this is unexpected
@@ -293,10 +308,10 @@ mod tests {
         let task = spawn_broadcast_monitor(
             "test",
             rx,
-            handler.clone(),
+            handlers([handler.clone() as Arc<dyn EventHandler>]),
             shutdown.clone(),
             failure_tx,
-            |h: &RecordingHandler, event: &SyncEvent| h.on_sync_event(event),
+            |h, event: &SyncEvent| h.on_sync_event(event),
         );
 
         // The monitor should exit on its own due to the lagged error
@@ -316,7 +331,12 @@ mod tests {
         let shutdown = CancellationToken::new();
         let (failure_tx, _failure_rx) = mpsc::channel(1);
 
-        let task = spawn_progress_monitor(rx, handler.clone(), shutdown.clone(), failure_tx);
+        let task = spawn_progress_monitor(
+            rx,
+            handlers([handler.clone() as Arc<dyn EventHandler>]),
+            shutdown.clone(),
+            failure_tx,
+        );
 
         // Give the task time to send initial progress
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -340,7 +360,12 @@ mod tests {
         let shutdown = CancellationToken::new();
         let (failure_tx, mut failure_rx) = mpsc::channel(1);
 
-        let task = spawn_progress_monitor(rx, handler.clone(), shutdown.clone(), failure_tx);
+        let task = spawn_progress_monitor(
+            rx,
+            handlers([handler.clone() as Arc<dyn EventHandler>]),
+            shutdown.clone(),
+            failure_tx,
+        );
 
         // Give it time to send initial
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -366,10 +391,10 @@ mod tests {
         let task = spawn_broadcast_monitor(
             "network",
             rx,
-            handler.clone(),
+            handlers([handler.clone() as Arc<dyn EventHandler>]),
             shutdown.clone(),
             failure_tx,
-            |h: &RecordingHandler, event: &NetworkEvent| h.on_network_event(event),
+            |h, event: &NetworkEvent| h.on_network_event(event),
         );
 
         let addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
@@ -387,5 +412,67 @@ mod tests {
         task.await.unwrap();
 
         assert_eq!(handler.network_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn broadcast_monitor_dispatches_to_all_handlers() {
+        let (tx, rx) = broadcast::channel(16);
+        let first = Arc::new(RecordingHandler::new());
+        let second = Arc::new(RecordingHandler::new());
+        let shutdown = CancellationToken::new();
+        let (failure_tx, _failure_rx) = mpsc::channel(1);
+
+        let task = spawn_broadcast_monitor(
+            "test",
+            rx,
+            handlers([
+                first.clone() as Arc<dyn EventHandler>,
+                second.clone() as Arc<dyn EventHandler>,
+            ]),
+            shutdown.clone(),
+            failure_tx,
+            |h, event: &SyncEvent| h.on_sync_event(event),
+        );
+
+        tx.send(SyncEvent::BlockHeadersStored {
+            tip_height: 1,
+        })
+        .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        shutdown.cancel();
+        task.await.unwrap();
+
+        assert_eq!(first.sync_count.load(Ordering::SeqCst), 1);
+        assert_eq!(second.sync_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn progress_monitor_dispatches_to_all_handlers() {
+        let (tx, rx) = watch::channel(SyncProgress::default());
+        let first = Arc::new(RecordingHandler::new());
+        let second = Arc::new(RecordingHandler::new());
+        let shutdown = CancellationToken::new();
+        let (failure_tx, _failure_rx) = mpsc::channel(1);
+
+        let task = spawn_progress_monitor(
+            rx,
+            handlers([
+                first.clone() as Arc<dyn EventHandler>,
+                second.clone() as Arc<dyn EventHandler>,
+            ]),
+            shutdown.clone(),
+            failure_tx,
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tx.send_modify(|_| {});
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        shutdown.cancel();
+        task.await.unwrap();
+
+        assert!(first.progress_count.load(Ordering::SeqCst) >= 2);
+        assert!(second.progress_count.load(Ordering::SeqCst) >= 2);
     }
 }

--- a/dash-spv/src/client/events.rs
+++ b/dash-spv/src/client/events.rs
@@ -12,11 +12,9 @@ use crate::sync::{SyncEvent, SyncProgress};
 use key_wallet_manager::WalletInterface;
 use tokio::sync::broadcast;
 
-use super::{DashSpvClient, EventHandler};
+use super::DashSpvClient;
 
-impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
-    DashSpvClient<W, N, S, H>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     /// Subscribe to sync progress updates via watch channel.
     pub(crate) async fn subscribe_progress(&self) -> watch::Receiver<SyncProgress> {
         self.sync_coordinator.lock().await.subscribe_progress()

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -27,16 +27,14 @@ use dashcore::sml::masternode_list_engine::MasternodeListEngine;
 use dashcore_hashes::Hash;
 use key_wallet_manager::WalletInterface;
 
-impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
-    DashSpvClient<W, N, S, H>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     /// Create a new SPV client with the given configuration, network, storage, and wallet.
     pub async fn new(
         config: ClientConfig,
         network: N,
         mut storage: S,
         wallet: Arc<RwLock<W>>,
-        event_handler: Arc<H>,
+        event_handlers: Vec<Arc<dyn EventHandler>>,
     ) -> Result<Self> {
         // Validate configuration
         config.validate().map_err(SpvError::Config)?;
@@ -146,7 +144,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
             masternode_engine,
             sync_coordinator: Arc::new(Mutex::new(sync_coordinator)),
             running: Arc::new(RwLock::new(false)),
-            event_handler,
+            event_handlers: Arc::new(event_handlers),
         };
 
         // Load wallet data from storage
@@ -154,7 +152,9 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
 
         // Emit initial progress so callers get immediate feedback
         let initial_progress = client.sync_coordinator.lock().await.progress().clone();
-        client.event_handler.on_progress(&initial_progress);
+        for event_handler in client.event_handlers.iter() {
+            event_handler.on_progress(&initial_progress);
+        }
 
         Ok(client)
     }

--- a/dash-spv/src/client/mod.rs
+++ b/dash-spv/src/client/mod.rs
@@ -67,9 +67,10 @@ mod tests {
             DiskStorageManager::with_temp_dir().await.expect("Failed to create tmp storage");
         let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
-        let client = DashSpvClient::new(config, network_manager, storage, wallet, Arc::new(()))
-            .await
-            .expect("client construction must succeed");
+        let client =
+            DashSpvClient::new(config, network_manager, storage, wallet, vec![Arc::new(())])
+                .await
+                .expect("client construction must succeed");
 
         // Verify the wallet is accessible
         let wallet_ref = client.wallet();

--- a/dash-spv/src/client/queries.rs
+++ b/dash-spv/src/client/queries.rs
@@ -17,11 +17,9 @@ use key_wallet_manager::WalletInterface;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use super::{DashSpvClient, EventHandler};
+use super::DashSpvClient;
 
-impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
-    DashSpvClient<W, N, S, H>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     // ============ Peer Queries ============
 
     /// Get the number of connected peers.

--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use super::event_handler::{spawn_broadcast_monitor, spawn_progress_monitor};
-use super::{DashSpvClient, EventHandler};
+use super::DashSpvClient;
 use crate::error::Result;
 use crate::network::NetworkManager;
 use crate::storage::StorageManager;
@@ -16,9 +16,7 @@ use key_wallet_manager::WalletInterface;
 
 const SYNC_COORDINATOR_TICK_MS: Duration = Duration::from_millis(100);
 
-impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
-    DashSpvClient<W, N, S, H>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     /// Get current sync progress.
     pub async fn sync_progress(&self) -> SyncProgress {
         self.sync_coordinator.lock().await.progress().clone()
@@ -30,7 +28,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
     /// event handler provided at construction. Calls `start()` internally, runs
     /// continuous network monitoring, and calls `stop()` before returning.
     pub async fn run(&self, token: CancellationToken) -> Result<()> {
-        let handler = self.event_handler.clone();
+        let handlers = self.event_handlers.clone();
         let monitor_shutdown = CancellationToken::new();
         let (monitor_failure_tx, mut monitor_failure_rx) = mpsc::channel::<String>(1);
 
@@ -44,7 +42,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
         let sync_task = spawn_broadcast_monitor(
             "Sync event",
             sync_event_rx,
-            handler.clone(),
+            handlers.clone(),
             monitor_shutdown.clone(),
             monitor_failure_tx.clone(),
             |h, event| h.on_sync_event(event),
@@ -53,7 +51,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
         let network_task = spawn_broadcast_monitor(
             "Network event",
             network_event_rx,
-            handler.clone(),
+            handlers.clone(),
             monitor_shutdown.clone(),
             monitor_failure_tx.clone(),
             |h, event| h.on_network_event(event),
@@ -62,7 +60,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
         let wallet_task = spawn_broadcast_monitor(
             "Wallet event",
             wallet_event_rx,
-            handler.clone(),
+            handlers.clone(),
             monitor_shutdown.clone(),
             monitor_failure_tx.clone(),
             |h, event| h.on_wallet_event(event),
@@ -70,7 +68,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
 
         let progress_task = spawn_progress_monitor(
             progress_rx,
-            handler.clone(),
+            handlers.clone(),
             monitor_shutdown.clone(),
             monitor_failure_tx,
         );
@@ -78,7 +76,9 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
         if let Err(e) = self.start().await {
             monitor_shutdown.cancel();
             let _ = tokio::join!(sync_task, network_task, wallet_task, progress_task);
-            handler.on_error(&e.to_string());
+            for handler in handlers.iter() {
+                handler.on_error(&e.to_string());
+            }
             return Err(e);
         }
 
@@ -121,7 +121,9 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
         let _ = tokio::join!(sync_task, network_task, wallet_task, progress_task);
 
         if let Some(ref e) = error {
-            handler.on_error(&e.to_string());
+            for handler in handlers.iter() {
+                handler.on_error(&e.to_string());
+            }
         }
 
         let stop_result = self.stop().await;

--- a/dash-spv/src/client/transactions.rs
+++ b/dash-spv/src/client/transactions.rs
@@ -6,11 +6,9 @@ use crate::storage::StorageManager;
 use dashcore::network::message::NetworkMessage;
 use key_wallet_manager::WalletInterface;
 
-use super::{DashSpvClient, EventHandler};
+use super::DashSpvClient;
 
-impl<W: WalletInterface, N: NetworkManager, S: StorageManager, H: EventHandler>
-    DashSpvClient<W, N, S, H>
-{
+impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, N, S> {
     /// Broadcast a transaction to all connected peers.
     ///
     /// The transaction is also injected into the local message pipeline so that

--- a/dash-spv/src/lib.rs
+++ b/dash-spv/src/lib.rs
@@ -34,7 +34,13 @@
 //!     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 //!
 //!     // Create and run the client
-//!     let client = DashSpvClient::new(config.clone(), network, storage, wallet, Arc::new(())).await?;
+//!     let client = DashSpvClient::new(
+//!         config.clone(),
+//!         network,
+//!         storage,
+//!         wallet,
+//!         vec![Arc::new(())],
+//!     ).await?;
 //!     let shutdown_token = CancellationToken::new();
 //!
 //!     client.run(shutdown_token).await?;

--- a/dash-spv/src/main.rs
+++ b/dash-spv/src/main.rs
@@ -332,13 +332,12 @@ async fn run_client<S: dash_spv::storage::StorageManager>(
         WalletManager<ManagedWalletInfo>,
         dash_spv::network::manager::PeerNetworkManager,
         S,
-        LoggingEventHandler,
     >::new(
         config.clone(),
         network_manager,
         storage_manager,
         wallet.clone(),
-        Arc::new(LoggingEventHandler),
+        vec![Arc::new(LoggingEventHandler)],
     )
     .await
     {

--- a/dash-spv/tests/dashd_sync/setup.rs
+++ b/dash-spv/tests/dashd_sync/setup.rs
@@ -258,12 +258,8 @@ impl Drop for TestContext {
 }
 
 /// Type alias for the SPV client used in tests.
-pub(super) type TestClient = DashSpvClient<
-    WalletManager<ManagedWalletInfo>,
-    PeerNetworkManager,
-    DiskStorageManager,
-    TestEventHandler,
->;
+pub(super) type TestClient =
+    DashSpvClient<WalletManager<ManagedWalletInfo>, PeerNetworkManager, DiskStorageManager>;
 
 /// A `ClientHandle` is a utility structure that manages the state and handles for a `TestClient`
 /// required to interact with the synchronization process, various event channels, and cancellation capabilities.
@@ -331,7 +327,7 @@ pub(super) async fn create_and_start_client(
     let network_event_receiver = handler.subscribe_network_events();
 
     let client =
-        DashSpvClient::new(config.clone(), network_manager, storage_manager, wallet, handler)
+        DashSpvClient::new(config.clone(), network_manager, storage_manager, wallet, vec![handler])
             .await
             .expect("Failed to create client");
 

--- a/dash-spv/tests/peer_test.rs
+++ b/dash-spv/tests/peer_test.rs
@@ -50,9 +50,8 @@ async fn test_peer_connection() {
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
-    let client = DashSpvClient::new(config, network_manager, storage_manager, wallet, Arc::new(()))
-        .await
-        .unwrap();
+    let client =
+        DashSpvClient::new(config, network_manager, storage_manager, wallet, vec![]).await.unwrap();
 
     let token = CancellationToken::new();
     let cancel = token.clone();
@@ -88,15 +87,10 @@ async fn test_peer_persistence() {
         // Create wallet manager
         let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
-        let client = DashSpvClient::new(
-            config.clone(),
-            network_manager,
-            storage_manager,
-            wallet,
-            Arc::new(()),
-        )
-        .await
-        .unwrap();
+        let client =
+            DashSpvClient::new(config.clone(), network_manager, storage_manager, wallet, vec![])
+                .await
+                .unwrap();
 
         let token = CancellationToken::new();
         let cancel = token.clone();
@@ -123,10 +117,9 @@ async fn test_peer_persistence() {
         // Create wallet manager
         let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
-        let client =
-            DashSpvClient::new(config, network_manager, storage_manager, wallet, Arc::new(()))
-                .await
-                .unwrap();
+        let client = DashSpvClient::new(config, network_manager, storage_manager, wallet, vec![])
+            .await
+            .unwrap();
 
         // Should connect faster due to saved peers
         let token = CancellationToken::new();
@@ -167,9 +160,8 @@ async fn test_peer_disconnection() {
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
-    let client = DashSpvClient::new(config, network_manager, storage_manager, wallet, Arc::new(()))
-        .await
-        .unwrap();
+    let client =
+        DashSpvClient::new(config, network_manager, storage_manager, wallet, vec![]).await.unwrap();
 
     // Note: This test would require actual regtest nodes running
     // For now, we just test that the API works

--- a/dash-spv/tests/wallet_integration_test.rs
+++ b/dash-spv/tests/wallet_integration_test.rs
@@ -33,9 +33,7 @@ async fn create_test_client(
     // Create wallet manager
     let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
 
-    DashSpvClient::new(config, network_manager, storage_manager, wallet, Arc::new(()))
-        .await
-        .unwrap()
+    DashSpvClient::new(config, network_manager, storage_manager, wallet, vec![]).await.unwrap()
 }
 
 #[tokio::test]


### PR DESCRIPTION
Just allows multiple handlers to get called back on events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated DashSpvClient constructor to accept multiple event handlers as a collection rather than a single handler. The client now stores and dispatches events to all registered handlers. All examples, tests, and documentation have been updated to reflect this change in the constructor signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->