### PR TITLE
fix: replace hickory-resolver with tokio::net::lookup_host

### DIFF
--- a/dash-network/src/lib.rs
+++ b/dash-network/src/lib.rs
@@ -119,11 +119,13 @@ impl Network {
         }
     }
 
+    /// DNS seed hostnames for this network. Empty for networks without
+    /// public DNS seeds (Devnet, Regtest).
     pub const fn dns_seeds(self) -> &'static [&'static str] {
         match self {
             Network::Mainnet => &["dnsseed.dash.org"],
             Network::Testnet => &["testnet-seed.dashdot.io"],
-            Network::Devnet | Network::Regtest => &[""],
+            Network::Devnet | Network::Regtest => &[],
         }
     }
 }

--- a/dash-spv/Cargo.toml
+++ b/dash-spv/Cargo.toml
@@ -50,9 +50,6 @@ rayon = "1.11"
 tempfile = { version = "3.0", optional = true }
 dashcore-rpc = { path = "../rpc-client", optional = true }
 
-# DNS (trust-dns-resolver was renamed to hickory_resolver)
-hickory-resolver = "0.25"
-
 [dev-dependencies]
 dash-spv = { path = ".", features = ["test-utils"] }
 dashcore = { path = "../dash", features = ["test-utils"] }

--- a/dash-spv/src/network/discovery.rs
+++ b/dash-spv/src/network/discovery.rs
@@ -12,35 +12,20 @@
 //! Results from both sources are merged and deduplicated.
 
 use dashcore::Network;
-use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-use hickory_resolver::name_server::TokioConnectionProvider;
-use hickory_resolver::TokioResolver;
-use std::net::{IpAddr, SocketAddr};
-
-use crate::error::SpvError as Error;
+use std::net::SocketAddr;
 
 /// DNS discovery for finding initial peers.
 ///
 /// Despite the name (kept for backwards compatibility), this type also returns
 /// hardcoded masternode seeds embedded at compile time; DNS is used as a
 /// fallback.
-pub struct DnsDiscovery {
-    resolver: TokioResolver,
-}
+#[derive(Default)]
+pub struct DnsDiscovery {}
 
 impl DnsDiscovery {
     /// Create a new DNS discovery instance
-    pub async fn new() -> Result<Self, Error> {
-        let resolver = hickory_resolver::Resolver::builder_with_config(
-            ResolverConfig::default(),
-            TokioConnectionProvider::default(),
-        )
-        .with_options(ResolverOpts::default())
-        .build();
-
-        Ok(Self {
-            resolver,
-        })
+    pub fn new() -> Self {
+        Self {}
     }
 
     /// Discover peers for the given network.
@@ -60,14 +45,11 @@ impl DnsDiscovery {
         for seed in seeds {
             tracing::debug!("Querying DNS seed: {}", seed);
 
-            match self.resolver.lookup_ip(*seed).await {
-                Ok(lookup) => {
-                    let ips: Vec<IpAddr> = lookup.iter().collect();
-                    tracing::info!("DNS seed {} returned {} addresses", seed, ips.len());
-
-                    for ip in ips {
-                        addresses.push(SocketAddr::new(ip, port));
-                    }
+            match tokio::net::lookup_host((*seed, port)).await {
+                Ok(iter) => {
+                    let resolved: Vec<SocketAddr> = iter.collect();
+                    tracing::info!("DNS seed {} returned {} addresses", seed, resolved.len());
+                    addresses.extend(resolved);
                 }
                 Err(e) => {
                     // DNS is a best-effort backup; do not propagate the error.
@@ -103,7 +85,7 @@ mod tests {
     #[tokio::test]
     #[ignore] // Requires network access
     async fn test_dns_discovery_mainnet() {
-        let discovery = DnsDiscovery::new().await.expect("Failed to create DNS discovery for test");
+        let discovery = DnsDiscovery::new();
         let peers = discovery.discover_peers(Network::Mainnet).await;
 
         // Print discovered peers for debugging
@@ -122,7 +104,7 @@ mod tests {
     async fn test_dns_discovery_testnet_returns_embedded_when_dns_fails() {
         // This test does not require network access: even if DNS resolution
         // fails, the embedded seed file must yield peers.
-        let discovery = DnsDiscovery::new().await.expect("Failed to create DNS discovery for test");
+        let discovery = DnsDiscovery::new();
         let peers = discovery.discover_peers(Network::Testnet).await;
 
         assert!(
@@ -137,7 +119,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_dns_discovery_regtest() {
-        let discovery = DnsDiscovery::new().await.expect("Failed to create DNS discovery for test");
+        let discovery = DnsDiscovery::new();
         let peers = discovery.discover_peers(Network::Regtest).await;
 
         // Should return empty for regtest (no DNS seeds and no embedded list)

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -99,7 +99,7 @@ fn required_services_from_config(config: &ClientConfig, exclusive_mode: bool) ->
 impl PeerNetworkManager {
     /// Create a new peer network manager
     pub async fn new(config: &ClientConfig) -> Result<Self, Error> {
-        let discovery = DnsDiscovery::new().await?;
+        let discovery = DnsDiscovery::new();
         let data_dir = config.storage_path.clone();
 
         let peer_store = PersistentPeerStorage::open(data_dir.clone()).await?;
@@ -1515,7 +1515,7 @@ impl PeerNetworkManager {
         let test_dir = tempfile::tempdir().expect("test dir creation failed").keep();
         let peer_store =
             PersistentPeerStorage::open(&test_dir).await.expect("test peer store init failed");
-        let discovery = DnsDiscovery::new().await.expect("test DNS discovery init failed");
+        let discovery = DnsDiscovery::new();
         let (request_tx, request_rx) = unbounded_channel();
         Self {
             pool: Arc::new(PeerPool::new()),

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -41,7 +41,6 @@ mod pool_tests {
         assert_eq!(pool.peer_count().await, 0);
     }
 
-    // Cases are sequential in one test to avoid concurrent DnsDiscovery drops (TSAN race in hickory-resolver).
     #[tokio::test]
     async fn test_capability_policy_for_handshake_and_eviction() {
         let cf = ServiceFlags::COMPACT_FILTERS;

--- a/dash-spv/tests/peer_test.rs
+++ b/dash-spv/tests/peer_test.rs
@@ -221,7 +221,7 @@ mod unit_tests {
     #[tokio::test]
     #[ignore] // Requires network access
     async fn test_dns_discovery() {
-        let discovery = DnsDiscovery::new().await.unwrap();
+        let discovery = DnsDiscovery::new();
 
         // Test mainnet discovery
         let peers = discovery.discover_peers(Network::Mainnet).await;

--- a/masternode-seeds-fetcher/Cargo.toml
+++ b/masternode-seeds-fetcher/Cargo.toml
@@ -18,7 +18,6 @@ dash-spv = { path = "../dash-spv" }
 dash-network-seeds = { path = "../dash-network-seeds" }
 
 tokio = { version = "1.0", features = ["full"] }
-hickory-resolver = "0.25"
 
 clap = { version = "4.0", features = ["derive", "env"] }
 anyhow = "1.0"

--- a/masternode-seeds-fetcher/src/main.rs
+++ b/masternode-seeds-fetcher/src/main.rs
@@ -49,8 +49,6 @@ use dashcore::network::message_sml::{GetMnListDiff, MnListDiff};
 use dashcore::sml::masternode_list_entry::EntryMasternodeType;
 use dashcore::{BlockHash, Network};
 use futures::stream::{FuturesUnordered, StreamExt};
-use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-use hickory_resolver::name_server::TokioConnectionProvider;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use tokio::time::Instant;
@@ -222,18 +220,11 @@ async fn gather_candidate_peers(
     }
 
     // DNS seeds.
-    if let Ok(resolver) = build_resolver() {
-        for seed in network.dns_seeds() {
-            match resolver.lookup_ip(*seed).await {
-                Ok(lookup) => {
-                    for ip in lookup.iter() {
-                        out.insert(SocketAddr::new(ip, network.default_p2p_port()));
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!("DNS seed {} failed: {}", seed, e);
-                }
-            }
+    let port = network.default_p2p_port();
+    for seed in network.dns_seeds() {
+        match tokio::net::lookup_host((*seed, port)).await {
+            Ok(iter) => out.extend(iter),
+            Err(e) => tracing::warn!("DNS seed {} failed: {}", seed, e),
         }
     }
 
@@ -243,16 +234,6 @@ async fn gather_candidate_peers(
     list.shuffle(&mut rand::thread_rng());
     list.truncate(max.saturating_mul(4).max(max));
     list
-}
-
-fn build_resolver() -> Result<hickory_resolver::TokioResolver> {
-    let resolver = hickory_resolver::Resolver::builder_with_config(
-        ResolverConfig::default(),
-        TokioConnectionProvider::default(),
-    )
-    .with_options(ResolverOpts::default())
-    .build();
-    Ok(resolver)
 }
 
 // ---------- per-peer P2P flow ----------


### PR DESCRIPTION
In this PR I'm replacing hickory-resolver with tokio::net::lookup_host. We were honestly overkilling for DNS discovery, it caused intermittent CI failures (PR #687) and added 50 indirect dependencies to dash-spv (down from 331 to 281). No visible performance regressions given our usage of DNS discovery.

Fixes #687

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined DNS peer discovery mechanism across services using native network resolution for improved performance and reliability.
  * Simplified peer network manager initialization by removing unnecessary resolver configuration.
  * Optimized address resolution in peer discovery operations for better efficiency.

* **Chores**
  * Removed unused external dependencies to reduce application footprint and simplify deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->