### PR TITLE
feat: make wallet events atomic

### DIFF
--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -5,8 +5,7 @@ use std::ptr;
 use clap::{Arg, ArgAction, Command};
 use dash_network::ffi::FFINetwork;
 use dash_spv_ffi::*;
-use key_wallet_ffi::managed_account::FFITransactionRecord;
-use key_wallet_ffi::types::FFITransactionContext;
+use key_wallet_ffi::types::FFIBalance;
 use key_wallet_ffi::wallet_manager::wallet_manager_add_wallet_from_mnemonic;
 use key_wallet_ffi::FFIError;
 
@@ -156,61 +155,105 @@ extern "C" fn on_peers_updated(connected_count: u32, best_height: u32, _user_dat
 // Wallet Event Callbacks
 // ============================================================================
 
+fn short_wallet(wallet_id: *const c_char) -> String {
+    let s = ffi_string_to_rust(wallet_id);
+    if s.len() > 8 {
+        s[..8].to_string()
+    } else {
+        s
+    }
+}
+
+fn read_balance(balance: *const FFIBalance) -> FFIBalance {
+    if balance.is_null() {
+        tracing::warn!("read_balance: null pointer, returning zero balance");
+        return FFIBalance::default();
+    }
+    unsafe { *balance }
+}
+
 extern "C" fn on_transaction_received(
     wallet_id: *const c_char,
-    account_index: u32,
     record: *const FFITransactionRecord,
+    balance: *const FFIBalance,
     _user_data: *mut c_void,
 ) {
-    let wallet_str = ffi_string_to_rust(wallet_id);
-    let wallet_short = if wallet_str.len() > 8 {
-        &wallet_str[..8]
-    } else {
-        &wallet_str
-    };
+    let wallet_short = short_wallet(wallet_id);
     if record.is_null() {
-        println!(
-            "[Wallet] TX received: wallet={}..., account={}, record=null",
-            wallet_short, account_index
-        );
+        println!("[Wallet] TX received: wallet={}..., record=null", wallet_short);
         return;
     }
     let r = unsafe { &*record };
+    let b = read_balance(balance);
     let txid_hex = hex::encode(r.txid);
     println!(
-        "[Wallet] TX received: wallet={}..., txid={}, account={}, amount={} duffs, tx_size={}",
-        wallet_short, txid_hex, account_index, r.net_amount, r.tx_len
+        "[Wallet] TX received: wallet={}..., txid={}, account_kind={:?}, account_index={}, amount={} duffs, balance[confirmed={}, unconfirmed={}]",
+        wallet_short,
+        txid_hex,
+        r.account_type.kind,
+        r.account_type.index,
+        r.net_amount,
+        b.confirmed,
+        b.unconfirmed
     );
 }
 
 extern "C" fn on_transaction_status_changed(
-    _wallet_id: *const c_char,
+    wallet_id: *const c_char,
     txid: *const [u8; 32],
-    status: FFITransactionContext,
+    _context: key_wallet_ffi::types::FFITransactionContext,
+    balance: *const FFIBalance,
     _user_data: *mut c_void,
 ) {
-    let txid_hex = unsafe { hex::encode(*txid) };
-    println!("[Wallet] TX status changed: txid={}, status={:?}", txid_hex, status);
+    let wallet_short = short_wallet(wallet_id);
+    if txid.is_null() {
+        println!("[Wallet] TX status changed: wallet={}..., txid=null", wallet_short);
+        return;
+    }
+    let txid_bytes = unsafe { &*txid };
+    let b = read_balance(balance);
+    let txid_hex = hex::encode(txid_bytes);
+    println!(
+        "[Wallet] TX status changed: wallet={}..., txid={}, balance[confirmed={}, unconfirmed={}]",
+        wallet_short, txid_hex, b.confirmed, b.unconfirmed
+    );
 }
 
-extern "C" fn on_balance_updated(
+extern "C" fn on_block_update(
     wallet_id: *const c_char,
-    spendable: u64,
-    unconfirmed: u64,
-    immature: u64,
-    locked: u64,
+    height: u32,
+    _inserted: *const FFITransactionRecord,
+    inserted_count: u32,
+    _updated: *const FFITransactionRecord,
+    updated_count: u32,
+    _matured: *const FFITransactionRecord,
+    matured_count: u32,
+    balance: *const FFIBalance,
     _user_data: *mut c_void,
 ) {
-    let wallet_str = ffi_string_to_rust(wallet_id);
-    let wallet_short = if wallet_str.len() > 8 {
-        &wallet_str[..8]
-    } else {
-        &wallet_str
-    };
+    let wallet_short = short_wallet(wallet_id);
+    let b = read_balance(balance);
     println!(
-        "[Wallet] Balance updated: wallet={}..., spendable={}, unconfirmed={}, immature={}, locked={}",
-        wallet_short, spendable, unconfirmed, immature, locked
+        "[Wallet] Block update: wallet={}..., height={}, inserted={}, updated={}, matured={}, balance[confirmed={}, unconfirmed={}, immature={}, locked={}]",
+        wallet_short,
+        height,
+        inserted_count,
+        updated_count,
+        matured_count,
+        b.confirmed,
+        b.unconfirmed,
+        b.immature,
+        b.locked
     );
+}
+
+extern "C" fn on_sync_height_update(
+    wallet_id: *const c_char,
+    height: u32,
+    _user_data: *mut c_void,
+) {
+    let wallet_short = short_wallet(wallet_id);
+    println!("[Wallet] Sync height update: wallet={}..., height={}", wallet_short, height);
 }
 
 // ============================================================================
@@ -436,7 +479,8 @@ fn main() {
             wallet: FFIWalletEventCallbacks {
                 on_transaction_received: Some(on_transaction_received),
                 on_transaction_status_changed: Some(on_transaction_status_changed),
-                on_balance_updated: Some(on_balance_updated),
+                on_block_update: Some(on_block_update),
+                on_sync_height_update: Some(on_sync_height_update),
                 user_data: ptr::null_mut(),
             },
             error: FFIClientErrorCallback {

--- a/dash-spv-ffi/src/bin/ffi_cli.rs
+++ b/dash-spv-ffi/src/bin/ffi_cli.rs
@@ -172,7 +172,7 @@ fn read_balance(balance: *const FFIBalance) -> FFIBalance {
     unsafe { *balance }
 }
 
-extern "C" fn on_transaction_received(
+extern "C" fn on_transaction_detected(
     wallet_id: *const c_char,
     record: *const FFITransactionRecord,
     balance: *const FFIBalance,
@@ -180,14 +180,14 @@ extern "C" fn on_transaction_received(
 ) {
     let wallet_short = short_wallet(wallet_id);
     if record.is_null() {
-        println!("[Wallet] TX received: wallet={}..., record=null", wallet_short);
+        println!("[Wallet] TX detected: wallet={}..., record=null", wallet_short);
         return;
     }
     let r = unsafe { &*record };
     let b = read_balance(balance);
     let txid_hex = hex::encode(r.txid);
     println!(
-        "[Wallet] TX received: wallet={}..., txid={}, account_kind={:?}, account_index={}, amount={} duffs, balance[confirmed={}, unconfirmed={}]",
+        "[Wallet] TX detected: wallet={}..., txid={}, account_kind={:?}, account_index={}, amount={} duffs, balance[confirmed={}, unconfirmed={}]",
         wallet_short,
         txid_hex,
         r.account_type.kind,
@@ -198,28 +198,29 @@ extern "C" fn on_transaction_received(
     );
 }
 
-extern "C" fn on_transaction_status_changed(
+extern "C" fn on_transaction_instant_locked(
     wallet_id: *const c_char,
     txid: *const [u8; 32],
-    _context: key_wallet_ffi::types::FFITransactionContext,
+    _islock_data: *const u8,
+    islock_len: usize,
     balance: *const FFIBalance,
     _user_data: *mut c_void,
 ) {
     let wallet_short = short_wallet(wallet_id);
     if txid.is_null() {
-        println!("[Wallet] TX status changed: wallet={}..., txid=null", wallet_short);
+        println!("[Wallet] TX instant-locked: wallet={}..., txid=null", wallet_short);
         return;
     }
     let txid_bytes = unsafe { &*txid };
     let b = read_balance(balance);
     let txid_hex = hex::encode(txid_bytes);
     println!(
-        "[Wallet] TX status changed: wallet={}..., txid={}, balance[confirmed={}, unconfirmed={}]",
-        wallet_short, txid_hex, b.confirmed, b.unconfirmed
+        "[Wallet] TX instant-locked: wallet={}..., txid={}, islock_len={}, balance[confirmed={}, unconfirmed={}]",
+        wallet_short, txid_hex, islock_len, b.confirmed, b.unconfirmed
     );
 }
 
-extern "C" fn on_block_update(
+extern "C" fn on_wallet_block_processed(
     wallet_id: *const c_char,
     height: u32,
     _inserted: *const FFITransactionRecord,
@@ -234,7 +235,7 @@ extern "C" fn on_block_update(
     let wallet_short = short_wallet(wallet_id);
     let b = read_balance(balance);
     println!(
-        "[Wallet] Block update: wallet={}..., height={}, inserted={}, updated={}, matured={}, balance[confirmed={}, unconfirmed={}, immature={}, locked={}]",
+        "[Wallet] Block processed: wallet={}..., height={}, inserted={}, updated={}, matured={}, balance[confirmed={}, unconfirmed={}, immature={}, locked={}]",
         wallet_short,
         height,
         inserted_count,
@@ -247,13 +248,13 @@ extern "C" fn on_block_update(
     );
 }
 
-extern "C" fn on_sync_height_update(
+extern "C" fn on_sync_height_advanced(
     wallet_id: *const c_char,
     height: u32,
     _user_data: *mut c_void,
 ) {
     let wallet_short = short_wallet(wallet_id);
-    println!("[Wallet] Sync height update: wallet={}..., height={}", wallet_short, height);
+    println!("[Wallet] Sync height advanced: wallet={}..., height={}", wallet_short, height);
 }
 
 // ============================================================================
@@ -477,10 +478,10 @@ fn main() {
                 user_data: ptr::null_mut(),
             },
             wallet: FFIWalletEventCallbacks {
-                on_transaction_received: Some(on_transaction_received),
-                on_transaction_status_changed: Some(on_transaction_status_changed),
-                on_block_update: Some(on_block_update),
-                on_sync_height_update: Some(on_sync_height_update),
+                on_transaction_detected: Some(on_transaction_detected),
+                on_transaction_instant_locked: Some(on_transaction_instant_locked),
+                on_block_processed: Some(on_wallet_block_processed),
+                on_sync_height_advanced: Some(on_sync_height_advanced),
                 user_data: ptr::null_mut(),
             },
             error: FFIClientErrorCallback {

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -12,7 +12,7 @@ use dash_spv::sync::{SyncEvent, SyncProgress};
 use dash_spv::EventHandler;
 use dashcore::hashes::Hash;
 use key_wallet_ffi::managed_account::FFITransactionRecord;
-use key_wallet_ffi::types::{FFIBalance, FFITransactionContext};
+use key_wallet_ffi::types::FFIBalance;
 use key_wallet_manager::WalletEvent;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
@@ -530,7 +530,7 @@ impl FFINetworkEventCallbacks {
 // FFIWalletEventCallbacks - One callback per WalletEvent variant
 // ============================================================================
 
-/// Callback for `WalletEvent::TransactionReceived`.
+/// Callback for `WalletEvent::TransactionDetected`.
 ///
 /// Fires when a wallet-relevant transaction is first seen off-chain — either
 /// in the mempool, or directly via an InstantSend lock (in that case the
@@ -539,7 +539,7 @@ impl FFINetworkEventCallbacks {
 /// All pointer parameters are borrowed and only valid for the duration of the
 /// callback. `balance` is the wallet's balance *after* the transaction was
 /// recorded.
-pub type OnTransactionReceivedCallback = Option<
+pub type OnTransactionDetectedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
         record: *const FFITransactionRecord,
@@ -548,27 +548,27 @@ pub type OnTransactionReceivedCallback = Option<
     ),
 >;
 
-/// Callback for `WalletEvent::TransactionStatusChanged`.
+/// Callback for `WalletEvent::TransactionInstantLocked`.
 ///
-/// Fires when a previously-seen off-chain wallet-relevant transaction had
-/// its state change off-chain (currently only InstantSend locks applied to
-/// a known mempool tx). Consumers already hold the full record from the
-/// prior `TransactionReceived`; only the txid, the new context, and the
-/// post-change balance are delivered.
+/// Fires when an InstantSend lock is applied to a previously-seen off-chain
+/// wallet-relevant transaction. Consumers already hold the full record from
+/// the prior `TransactionDetected`; only the txid, the consensus-serialized
+/// `InstantLock` bytes, and the post-change balance are delivered.
 ///
 /// All pointer parameters are borrowed and only valid for the duration of
 /// the callback. `balance` is the wallet's balance *after* the change.
-pub type OnTransactionStatusChangedCallback = Option<
+pub type OnTransactionInstantLockedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
         txid: *const [u8; 32],
-        context: FFITransactionContext,
+        islock_data: *const u8,
+        islock_len: usize,
         balance: *const FFIBalance,
         user_data: *mut c_void,
     ),
 >;
 
-/// Callback for `WalletEvent::BlockUpdate`.
+/// Callback for `WalletEvent::BlockProcessed`.
 ///
 /// Fires once per wallet affected by a processed block. The three record
 /// arrays bucket what happened in this block: `inserted` is records first
@@ -579,7 +579,7 @@ pub type OnTransactionStatusChangedCallback = Option<
 ///
 /// All array pointers and their contents are borrowed and only valid for the
 /// duration of the callback.
-pub type OnBlockUpdateCallback = Option<
+pub type OnWalletBlockProcessedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
         height: u32,
@@ -594,13 +594,13 @@ pub type OnBlockUpdateCallback = Option<
     ),
 >;
 
-/// Callback for `WalletEvent::SyncHeightUpdate`.
+/// Callback for `WalletEvent::SyncHeightAdvanced`.
 ///
 /// Fires once per wallet when the filter pipeline commits a batch — the
 /// wallet has been scanned up to `height`. Consumers can persist this as a
 /// checkpoint atomically with any records/balance already persisted from
-/// prior `BlockUpdate` events inside the batch.
-pub type OnSyncHeightUpdateCallback =
+/// prior `BlockProcessed` events inside the batch.
+pub type OnSyncHeightAdvancedCallback =
     Option<extern "C" fn(wallet_id: *const c_char, height: u32, user_data: *mut c_void)>;
 
 /// Wallet event callbacks - one callback per WalletEvent variant.
@@ -613,10 +613,10 @@ pub type OnSyncHeightUpdateCallback =
 #[repr(C)]
 #[derive(Clone)]
 pub struct FFIWalletEventCallbacks {
-    pub on_transaction_received: OnTransactionReceivedCallback,
-    pub on_transaction_status_changed: OnTransactionStatusChangedCallback,
-    pub on_block_update: OnBlockUpdateCallback,
-    pub on_sync_height_update: OnSyncHeightUpdateCallback,
+    pub on_transaction_detected: OnTransactionDetectedCallback,
+    pub on_transaction_instant_locked: OnTransactionInstantLockedCallback,
+    pub on_block_processed: OnWalletBlockProcessedCallback,
+    pub on_sync_height_advanced: OnSyncHeightAdvancedCallback,
     pub user_data: *mut c_void,
 }
 
@@ -627,10 +627,10 @@ unsafe impl Sync for FFIWalletEventCallbacks {}
 impl Default for FFIWalletEventCallbacks {
     fn default() -> Self {
         Self {
-            on_transaction_received: None,
-            on_transaction_status_changed: None,
-            on_block_update: None,
-            on_sync_height_update: None,
+            on_transaction_detected: None,
+            on_transaction_instant_locked: None,
+            on_block_processed: None,
+            on_sync_height_advanced: None,
             user_data: std::ptr::null_mut(),
         }
     }
@@ -725,12 +725,12 @@ impl FFIWalletEventCallbacks {
     /// Dispatch a WalletEvent to the appropriate callback.
     pub fn dispatch(&self, event: &WalletEvent) {
         match event {
-            WalletEvent::TransactionReceived {
+            WalletEvent::TransactionDetected {
                 wallet_id,
                 record,
                 balance,
             } => {
-                if let Some(cb) = self.on_transaction_received {
+                if let Some(cb) = self.on_transaction_detected {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
                     let ffi_record = FFITransactionRecord::from(record.as_ref());
@@ -744,29 +744,30 @@ impl FFIWalletEventCallbacks {
                     );
                 }
             }
-            WalletEvent::TransactionStatusChanged {
+            WalletEvent::TransactionInstantLocked {
                 wallet_id,
                 txid,
-                status,
+                instant_lock,
                 balance,
             } => {
-                if let Some(cb) = self.on_transaction_status_changed {
+                if let Some(cb) = self.on_transaction_instant_locked {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
                     let txid_bytes = *txid.as_byte_array();
-                    let ffi_context = FFITransactionContext::from(status.clone());
+                    let islock_bytes = dashcore::consensus::serialize(instant_lock);
                     let ffi_balance = FFIBalance::from(*balance);
 
                     cb(
                         c_wallet_id.as_ptr(),
                         &txid_bytes as *const [u8; 32],
-                        ffi_context,
+                        islock_bytes.as_ptr(),
+                        islock_bytes.len(),
                         &ffi_balance as *const FFIBalance,
                         self.user_data,
                     );
                 }
             }
-            WalletEvent::BlockUpdate {
+            WalletEvent::BlockProcessed {
                 wallet_id,
                 height,
                 inserted,
@@ -774,7 +775,7 @@ impl FFIWalletEventCallbacks {
                 matured,
                 balance,
             } => {
-                if let Some(cb) = self.on_block_update {
+                if let Some(cb) = self.on_block_processed {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
                     let ffi_inserted: Vec<FFITransactionRecord> =
@@ -822,11 +823,11 @@ impl FFIWalletEventCallbacks {
                     drop(ffi_matured);
                 }
             }
-            WalletEvent::SyncHeightUpdate {
+            WalletEvent::SyncHeightAdvanced {
                 wallet_id,
                 height,
             } => {
-                if let Some(cb) = self.on_sync_height_update {
+                if let Some(cb) = self.on_sync_height_advanced {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
                     cb(c_wallet_id.as_ptr(), *height, self.user_data);

--- a/dash-spv-ffi/src/callbacks.rs
+++ b/dash-spv-ffi/src/callbacks.rs
@@ -12,11 +12,11 @@ use dash_spv::sync::{SyncEvent, SyncProgress};
 use dash_spv::EventHandler;
 use dashcore::hashes::Hash;
 use key_wallet_ffi::managed_account::FFITransactionRecord;
-use key_wallet_ffi::types::FFITransactionContext;
+use key_wallet_ffi::types::{FFIBalance, FFITransactionContext};
 use key_wallet_manager::WalletEvent;
 use std::ffi::CString;
-use std::ops::Deref;
 use std::os::raw::{c_char, c_void};
+use std::ptr;
 
 // ============================================================================
 // Sync Event Types (for FFISyncEventCallbacks)
@@ -530,63 +530,93 @@ impl FFINetworkEventCallbacks {
 // FFIWalletEventCallbacks - One callback per WalletEvent variant
 // ============================================================================
 
-/// Callback for WalletEvent::TransactionReceived
+/// Callback for `WalletEvent::TransactionReceived`.
 ///
-/// The `record` pointer is borrowed and only valid for the duration of the
-/// callback. Callers must copy any data they need to retain after the callback
-/// returns. The record contains all transaction details including serialized
-/// transaction bytes, input/output details, and classification metadata.
+/// Fires when a wallet-relevant transaction is first seen off-chain — either
+/// in the mempool, or directly via an InstantSend lock (in that case the
+/// record's `context` is `InstantSend(..)`).
+///
+/// All pointer parameters are borrowed and only valid for the duration of the
+/// callback. `balance` is the wallet's balance *after* the transaction was
+/// recorded.
 pub type OnTransactionReceivedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
-        account_index: u32,
         record: *const FFITransactionRecord,
+        balance: *const FFIBalance,
         user_data: *mut c_void,
     ),
 >;
 
-/// Callback for WalletEvent::TransactionStatusChanged
+/// Callback for `WalletEvent::TransactionStatusChanged`.
 ///
-/// The `wallet_id` string pointer and `txid` hash pointer are borrowed and only
-/// valid for the duration of the callback.
+/// Fires when a previously-seen off-chain wallet-relevant transaction had
+/// its state change off-chain (currently only InstantSend locks applied to
+/// a known mempool tx). Consumers already hold the full record from the
+/// prior `TransactionReceived`; only the txid, the new context, and the
+/// post-change balance are delivered.
+///
+/// All pointer parameters are borrowed and only valid for the duration of
+/// the callback. `balance` is the wallet's balance *after* the change.
 pub type OnTransactionStatusChangedCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
         txid: *const [u8; 32],
-        status: FFITransactionContext,
+        context: FFITransactionContext,
+        balance: *const FFIBalance,
         user_data: *mut c_void,
     ),
 >;
 
-/// Callback for WalletEvent::BalanceUpdated
+/// Callback for `WalletEvent::BlockUpdate`.
 ///
-/// The `wallet_id` string pointer is borrowed and only valid for the duration
-/// of the callback. Callers must copy the string if they need to retain it
-/// after the callback returns.
-pub type OnBalanceUpdatedCallback = Option<
+/// Fires once per wallet affected by a processed block. The three record
+/// arrays bucket what happened in this block: `inserted` is records first
+/// stored, `updated` is previously-known records confirmed, `matured` is
+/// older coinbase records whose maturity threshold was just crossed. Empty
+/// arrays are passed as null with a zero count. `balance` is the wallet's
+/// balance *after* the block was processed.
+///
+/// All array pointers and their contents are borrowed and only valid for the
+/// duration of the callback.
+pub type OnBlockUpdateCallback = Option<
     extern "C" fn(
         wallet_id: *const c_char,
-        confirmed: u64,
-        unconfirmed: u64,
-        immature: u64,
-        locked: u64,
+        height: u32,
+        inserted: *const FFITransactionRecord,
+        inserted_count: u32,
+        updated: *const FFITransactionRecord,
+        updated_count: u32,
+        matured: *const FFITransactionRecord,
+        matured_count: u32,
+        balance: *const FFIBalance,
         user_data: *mut c_void,
     ),
 >;
+
+/// Callback for `WalletEvent::SyncHeightUpdate`.
+///
+/// Fires once per wallet when the filter pipeline commits a batch — the
+/// wallet has been scanned up to `height`. Consumers can persist this as a
+/// checkpoint atomically with any records/balance already persisted from
+/// prior `BlockUpdate` events inside the batch.
+pub type OnSyncHeightUpdateCallback =
+    Option<extern "C" fn(wallet_id: *const c_char, height: u32, user_data: *mut c_void)>;
 
 /// Wallet event callbacks - one callback per WalletEvent variant.
 ///
 /// Set only the callbacks you're interested in; unset callbacks will be ignored.
 ///
-/// All pointer parameters passed to callbacks (wallet IDs, txids, addresses)
-/// are borrowed and only valid for the duration of the callback invocation.
-/// Callers must copy any data they need to retain.
+/// All pointer parameters passed to callbacks (wallet IDs, txids, records,
+/// balances) are borrowed and only valid for the duration of the callback
+/// invocation. Callers must copy any data they need to retain.
 #[repr(C)]
 #[derive(Clone)]
 pub struct FFIWalletEventCallbacks {
     pub on_transaction_received: OnTransactionReceivedCallback,
     pub on_transaction_status_changed: OnTransactionStatusChangedCallback,
-    pub on_balance_updated: OnBalanceUpdatedCallback,
+    pub on_block_update: OnBlockUpdateCallback,
+    pub on_sync_height_update: OnSyncHeightUpdateCallback,
     pub user_data: *mut c_void,
 }
 
@@ -599,7 +629,8 @@ impl Default for FFIWalletEventCallbacks {
         Self {
             on_transaction_received: None,
             on_transaction_status_changed: None,
-            on_balance_updated: None,
+            on_block_update: None,
+            on_sync_height_update: None,
             user_data: std::ptr::null_mut(),
         }
     }
@@ -696,19 +727,19 @@ impl FFIWalletEventCallbacks {
         match event {
             WalletEvent::TransactionReceived {
                 wallet_id,
-                account_index,
                 record,
+                balance,
             } => {
                 if let Some(cb) = self.on_transaction_received {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
-
-                    let ffi_record = FFITransactionRecord::from(record.deref());
+                    let ffi_record = FFITransactionRecord::from(record.as_ref());
+                    let ffi_balance = FFIBalance::from(*balance);
 
                     cb(
                         c_wallet_id.as_ptr(),
-                        *account_index,
                         &ffi_record as *const FFITransactionRecord,
+                        &ffi_balance as *const FFIBalance,
                         self.user_data,
                     );
                 }
@@ -717,39 +748,88 @@ impl FFIWalletEventCallbacks {
                 wallet_id,
                 txid,
                 status,
+                balance,
             } => {
                 if let Some(cb) = self.on_transaction_status_changed {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
-                    let txid_bytes = txid.as_byte_array();
-                    let ffi_ctx = FFITransactionContext::from(status.clone());
+                    let txid_bytes = *txid.as_byte_array();
+                    let ffi_context = FFITransactionContext::from(status.clone());
+                    let ffi_balance = FFIBalance::from(*balance);
 
                     cb(
                         c_wallet_id.as_ptr(),
-                        txid_bytes as *const [u8; 32],
-                        ffi_ctx,
+                        &txid_bytes as *const [u8; 32],
+                        ffi_context,
+                        &ffi_balance as *const FFIBalance,
                         self.user_data,
                     );
                 }
             }
-            WalletEvent::BalanceUpdated {
+            WalletEvent::BlockUpdate {
                 wallet_id,
-                confirmed,
-                unconfirmed,
-                immature,
-                locked,
+                height,
+                inserted,
+                updated,
+                matured,
+                balance,
             } => {
-                if let Some(cb) = self.on_balance_updated {
+                if let Some(cb) = self.on_block_update {
                     let wallet_id_hex = hex::encode(wallet_id);
                     let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
+                    let ffi_inserted: Vec<FFITransactionRecord> =
+                        inserted.iter().map(FFITransactionRecord::from).collect();
+                    let ffi_updated: Vec<FFITransactionRecord> =
+                        updated.iter().map(FFITransactionRecord::from).collect();
+                    let ffi_matured: Vec<FFITransactionRecord> =
+                        matured.iter().map(FFITransactionRecord::from).collect();
+                    let ffi_balance = FFIBalance::from(*balance);
+
+                    // Pass a null pointer when an array is empty so C/Swift
+                    // consumers that null-check before reading don't see a
+                    // non-null dangling pointer paired with a zero count.
+                    let inserted_ptr = if ffi_inserted.is_empty() {
+                        ptr::null()
+                    } else {
+                        ffi_inserted.as_ptr()
+                    };
+                    let updated_ptr = if ffi_updated.is_empty() {
+                        ptr::null()
+                    } else {
+                        ffi_updated.as_ptr()
+                    };
+                    let matured_ptr = if ffi_matured.is_empty() {
+                        ptr::null()
+                    } else {
+                        ffi_matured.as_ptr()
+                    };
+
                     cb(
                         c_wallet_id.as_ptr(),
-                        *confirmed,
-                        *unconfirmed,
-                        *immature,
-                        *locked,
+                        *height,
+                        inserted_ptr,
+                        ffi_inserted.len() as u32,
+                        updated_ptr,
+                        ffi_updated.len() as u32,
+                        matured_ptr,
+                        ffi_matured.len() as u32,
+                        &ffi_balance as *const FFIBalance,
                         self.user_data,
                     );
+
+                    drop(ffi_inserted);
+                    drop(ffi_updated);
+                    drop(ffi_matured);
+                }
+            }
+            WalletEvent::SyncHeightUpdate {
+                wallet_id,
+                height,
+            } => {
+                if let Some(cb) = self.on_sync_height_update {
+                    let wallet_id_hex = hex::encode(wallet_id);
+                    let c_wallet_id = CString::new(wallet_id_hex).unwrap_or_default();
+                    cb(c_wallet_id.as_ptr(), *height, self.user_data);
                 }
             }
         }

--- a/dash-spv-ffi/src/lib.rs
+++ b/dash-spv-ffi/src/lib.rs
@@ -14,6 +14,12 @@ pub use platform_integration::*;
 pub use types::*;
 pub use utils::*;
 
+// Re-export wallet-FFI types used by `FFIWalletEventCallbacks` so consumers
+// can refer to them via `dash_spv_ffi::*` without importing `key_wallet_ffi`
+// directly.
+pub use key_wallet_ffi::managed_account::{FFIAccountType, FFITransactionRecord};
+pub use key_wallet_ffi::types::FFIAccountKind;
+
 // FFINetwork is now defined in types.rs for cbindgen compatibility
 // It must match the definition in key_wallet_ffi
 

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -2,13 +2,13 @@
 
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
+use std::slice;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use dash_spv_ffi::*;
-use key_wallet_ffi::managed_account::FFITransactionRecord;
-use key_wallet_ffi::types::FFITransactionContext;
+use key_wallet_ffi::types::FFIBalance;
 
 /// Tracks callback invocations for verification.
 ///
@@ -38,8 +38,12 @@ pub(super) struct CallbackTracker {
 
     // Wallet event tracking
     pub(super) transaction_received_count: AtomicU32,
-    pub(super) transaction_status_changed_count: AtomicU32,
-    pub(super) balance_updated_count: AtomicU32,
+    pub(super) transaction_instant_send_locked_count: AtomicU32,
+    pub(super) block_processed_wallet_count: AtomicU32,
+    pub(super) block_processed_wallet_record_count: AtomicU32,
+    pub(super) synced_height_updated_count: AtomicU32,
+    /// Highest synced-height value observed from any `SyncedHeightUpdated`.
+    pub(super) last_synced_height: AtomicU32,
 
     // Data from callbacks
     pub(super) last_header_tip: AtomicU32,
@@ -49,12 +53,37 @@ pub(super) struct CallbackTracker {
     pub(super) connected_peers: Mutex<Vec<String>>,
     pub(super) errors: Mutex<Vec<String>>,
 
-    // Transaction data from on_transaction_received (txid, net_amount)
+    // Per-record (txid, net_amount) seen via the off-chain wallet callback.
     pub(super) received_transactions: Mutex<Vec<([u8; 32], i64)>>,
+    // Per-record (txid, net_amount) seen via the block-processed callback.
+    pub(super) block_received_transactions: Mutex<Vec<([u8; 32], i64)>>,
 
-    // Balance data from on_balance_updated
-    pub(super) last_spendable: AtomicU64,
+    // `FFIAccountKind` discriminants captured from wallet callbacks. Lets
+    // tests assert that account-type delivery is well-formed and matches the
+    // expected account.
+    pub(super) received_account_types: Mutex<Vec<FFIAccountKind>>,
+    pub(super) block_account_types: Mutex<Vec<FFIAccountKind>>,
+
+    // `account_index` values captured alongside `FFIAccountKind`, paired
+    // positionally with the corresponding `*_account_types` entries.
+    pub(super) received_account_indices: Mutex<Vec<u32>>,
+    pub(super) block_account_indices: Mutex<Vec<u32>>,
+
+    // Per-record bucketing observed on `BlockUpdate` changes, in delivery
+    // order. Each entry is `true` when the record was delivered via the
+    // `inserted` array, `false` when delivered via `updated`. Lets tests
+    // assert that confirmation of a previously-known mempool transaction
+    // lands in `updated` rather than `inserted`.
+    pub(super) block_record_inserted: Mutex<Vec<bool>>,
+
+    // Balance data from the most recent wallet event.
+    pub(super) last_confirmed: AtomicU64,
     pub(super) last_unconfirmed: AtomicU64,
+
+    // Raw IS lock bytes captured from the most recent
+    // `on_transaction_instant_send_locked` callback. Lets tests verify the
+    // payload is non-empty and round-trips through `InstantLock` deserialisation.
+    pub(super) last_islock_bytes: Mutex<Option<Vec<u8>>>,
 
     // Lifecycle ordering via global sequence counter
     pub(super) sequence_counter: AtomicU32,
@@ -341,15 +370,25 @@ extern "C" fn on_peers_updated(connected_count: u32, best_height: u32, user_data
     tracing::debug!("on_peers_updated: connected={}, best_height={}", connected_count, best_height);
 }
 
+fn record_balance(tracker: &CallbackTracker, balance: *const FFIBalance) {
+    if balance.is_null() {
+        return;
+    }
+    let b = unsafe { *balance };
+    tracker.last_confirmed.store(b.confirmed, Ordering::SeqCst);
+    tracker.last_unconfirmed.store(b.unconfirmed, Ordering::SeqCst);
+}
+
 extern "C" fn on_transaction_received(
     wallet_id: *const c_char,
-    account_index: u32,
     record: *const FFITransactionRecord,
+    balance: *const FFIBalance,
     user_data: *mut c_void,
 ) {
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
+    let mut account_log = None;
     if !record.is_null() {
         let r = unsafe { &*record };
         tracker
@@ -357,48 +396,126 @@ extern "C" fn on_transaction_received(
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .push((r.txid, r.net_amount));
+        tracker
+            .received_account_types
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(r.account_type.kind);
+        tracker
+            .received_account_indices
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(r.account_type.index);
+        account_log = Some((r.account_type.kind, r.account_type.index));
     }
+    // Store the balance before bumping the counter so a test that waits on the
+    // counter and then reads `last_unconfirmed` is guaranteed to observe the
+    // balance for the same callback invocation.
+    record_balance(tracker, balance);
     tracker.transaction_received_count.fetch_add(1, Ordering::SeqCst);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
-    tracing::info!("on_transaction_received: wallet={}, account={}", wallet_str, account_index,);
+    tracing::info!("on_transaction_received: wallet={}, account={:?}", wallet_str, account_log);
 }
 
 extern "C" fn on_transaction_status_changed(
     _wallet_id: *const c_char,
     _txid: *const [u8; 32],
-    status: FFITransactionContext,
+    context: key_wallet_ffi::types::FFITransactionContext,
+    balance: *const FFIBalance,
     user_data: *mut c_void,
 ) {
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
-    tracker.transaction_status_changed_count.fetch_add(1, Ordering::SeqCst);
-    tracing::debug!("on_transaction_status_changed: status={:?}", status);
+    if let key_wallet_ffi::types::FFITransactionContextType::InstantSend = context.context_type {
+        if !context.islock_data.is_null() && context.islock_len > 0 {
+            let bytes =
+                unsafe { slice::from_raw_parts(context.islock_data, context.islock_len) }.to_vec();
+            *tracker.last_islock_bytes.lock().unwrap_or_else(|e| e.into_inner()) = Some(bytes);
+        }
+    }
+    tracker.transaction_instant_send_locked_count.fetch_add(1, Ordering::SeqCst);
+    record_balance(tracker, balance);
+    tracing::debug!("on_transaction_status_changed");
 }
 
-extern "C" fn on_balance_updated(
+#[allow(clippy::too_many_arguments)]
+extern "C" fn on_block_update(
     wallet_id: *const c_char,
-    spendable: u64,
-    unconfirmed: u64,
-    immature: u64,
-    locked: u64,
+    height: u32,
+    inserted: *const FFITransactionRecord,
+    inserted_count: u32,
+    updated: *const FFITransactionRecord,
+    updated_count: u32,
+    _matured: *const FFITransactionRecord,
+    matured_count: u32,
+    balance: *const FFIBalance,
     user_data: *mut c_void,
 ) {
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
-    tracker.last_spendable.store(spendable, Ordering::SeqCst);
-    tracker.last_unconfirmed.store(unconfirmed, Ordering::SeqCst);
-    tracker.balance_updated_count.fetch_add(1, Ordering::SeqCst);
+    // Append all per-record state before bumping either counter so that a
+    // test waiting on `block_processed_wallet_count` (the per-callback counter)
+    // is guaranteed to also observe the matching `block_processed_wallet_record_count`
+    // and the underlying vectors. Tests should always wait on
+    // `block_processed_wallet_count` and read the record counter afterwards.
+    let mut sink = tracker.block_received_transactions.lock().unwrap_or_else(|e| e.into_inner());
+    let mut types = tracker.block_account_types.lock().unwrap_or_else(|e| e.into_inner());
+    let mut indices = tracker.block_account_indices.lock().unwrap_or_else(|e| e.into_inner());
+    let mut bucket = tracker.block_record_inserted.lock().unwrap_or_else(|e| e.into_inner());
+    let mut records_added = 0u32;
+    if !inserted.is_null() && inserted_count > 0 {
+        let slice = unsafe { slice::from_raw_parts(inserted, inserted_count as usize) };
+        for r in slice {
+            sink.push((r.txid, r.net_amount));
+            types.push(r.account_type.kind);
+            indices.push(r.account_type.index);
+            bucket.push(true);
+            records_added += 1;
+        }
+    }
+    if !updated.is_null() && updated_count > 0 {
+        let slice = unsafe { slice::from_raw_parts(updated, updated_count as usize) };
+        for r in slice {
+            sink.push((r.txid, r.net_amount));
+            types.push(r.account_type.kind);
+            indices.push(r.account_type.index);
+            bucket.push(false);
+            records_added += 1;
+        }
+    }
+    drop(sink);
+    drop(types);
+    drop(indices);
+    drop(bucket);
+    if records_added > 0 {
+        tracker.block_processed_wallet_record_count.fetch_add(records_added, Ordering::SeqCst);
+    }
+    tracker.block_processed_wallet_count.fetch_add(1, Ordering::SeqCst);
+    record_balance(tracker, balance);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
     tracing::info!(
-        "on_balance_updated: wallet={}, spendable={}, unconfirmed={}, immature={}, locked={}",
+        "on_block_update: wallet={}, height={}, inserted={}, updated={}, matured={}",
         wallet_str,
-        spendable,
-        unconfirmed,
-        immature,
-        locked,
+        height,
+        inserted_count,
+        updated_count,
+        matured_count
     );
+}
+
+extern "C" fn on_sync_height_update(wallet_id: *const c_char, height: u32, user_data: *mut c_void) {
+    let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
+        return;
+    };
+    // Store the height before bumping the counter so a test that waits on the
+    // counter and then reads `last_synced_height` is guaranteed to observe the
+    // height for the same callback invocation.
+    tracker.last_synced_height.store(height, Ordering::SeqCst);
+    tracker.synced_height_updated_count.fetch_add(1, Ordering::SeqCst);
+    let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
+    tracing::info!("on_sync_height_update: wallet={}, height={}", wallet_str, height);
 }
 
 /// Create sync callbacks with all event handlers wired to the tracker.
@@ -446,7 +563,8 @@ pub(super) fn create_wallet_callbacks(tracker: &Arc<CallbackTracker>) -> FFIWall
     FFIWalletEventCallbacks {
         on_transaction_received: Some(on_transaction_received),
         on_transaction_status_changed: Some(on_transaction_status_changed),
-        on_balance_updated: Some(on_balance_updated),
+        on_block_update: Some(on_block_update),
+        on_sync_height_update: Some(on_sync_height_update),
         user_data: Arc::as_ptr(tracker) as *mut c_void,
     }
 }

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -432,8 +432,8 @@ extern "C" fn on_transaction_instant_locked(
         let bytes = unsafe { slice::from_raw_parts(islock_data, islock_len) }.to_vec();
         *tracker.last_islock_bytes.lock().unwrap_or_else(|e| e.into_inner()) = Some(bytes);
     }
-    tracker.transaction_instant_send_locked_count.fetch_add(1, Ordering::SeqCst);
     record_balance(tracker, balance);
+    tracker.transaction_instant_send_locked_count.fetch_add(1, Ordering::SeqCst);
     tracing::debug!("on_transaction_instant_locked");
 }
 

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -492,8 +492,8 @@ extern "C" fn on_block_update(
     if records_added > 0 {
         tracker.block_processed_wallet_record_count.fetch_add(records_added, Ordering::SeqCst);
     }
-    tracker.block_processed_wallet_count.fetch_add(1, Ordering::SeqCst);
     record_balance(tracker, balance);
+    tracker.block_processed_wallet_count.fetch_add(1, Ordering::SeqCst);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
     tracing::info!(
         "on_block_update: wallet={}, height={}, inserted={}, updated={}, matured={}",

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -69,7 +69,7 @@ pub(super) struct CallbackTracker {
     pub(super) received_account_indices: Mutex<Vec<u32>>,
     pub(super) block_account_indices: Mutex<Vec<u32>>,
 
-    // Per-record bucketing observed on `BlockUpdate` changes, in delivery
+    // Per-record bucketing observed on `BlockProcessed` changes, in delivery
     // order. Each entry is `true` when the record was delivered via the
     // `inserted` array, `false` when delivered via `updated`. Lets tests
     // assert that confirmation of a previously-known mempool transaction
@@ -379,7 +379,7 @@ fn record_balance(tracker: &CallbackTracker, balance: *const FFIBalance) {
     tracker.last_unconfirmed.store(b.unconfirmed, Ordering::SeqCst);
 }
 
-extern "C" fn on_transaction_received(
+extern "C" fn on_transaction_detected(
     wallet_id: *const c_char,
     record: *const FFITransactionRecord,
     balance: *const FFIBalance,
@@ -414,33 +414,31 @@ extern "C" fn on_transaction_received(
     record_balance(tracker, balance);
     tracker.transaction_received_count.fetch_add(1, Ordering::SeqCst);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
-    tracing::info!("on_transaction_received: wallet={}, account={:?}", wallet_str, account_log);
+    tracing::info!("on_transaction_detected: wallet={}, account={:?}", wallet_str, account_log);
 }
 
-extern "C" fn on_transaction_status_changed(
+extern "C" fn on_transaction_instant_locked(
     _wallet_id: *const c_char,
     _txid: *const [u8; 32],
-    context: key_wallet_ffi::types::FFITransactionContext,
+    islock_data: *const u8,
+    islock_len: usize,
     balance: *const FFIBalance,
     user_data: *mut c_void,
 ) {
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
-    if let key_wallet_ffi::types::FFITransactionContextType::InstantSend = context.context_type {
-        if !context.islock_data.is_null() && context.islock_len > 0 {
-            let bytes =
-                unsafe { slice::from_raw_parts(context.islock_data, context.islock_len) }.to_vec();
-            *tracker.last_islock_bytes.lock().unwrap_or_else(|e| e.into_inner()) = Some(bytes);
-        }
+    if !islock_data.is_null() && islock_len > 0 {
+        let bytes = unsafe { slice::from_raw_parts(islock_data, islock_len) }.to_vec();
+        *tracker.last_islock_bytes.lock().unwrap_or_else(|e| e.into_inner()) = Some(bytes);
     }
     tracker.transaction_instant_send_locked_count.fetch_add(1, Ordering::SeqCst);
     record_balance(tracker, balance);
-    tracing::debug!("on_transaction_status_changed");
+    tracing::debug!("on_transaction_instant_locked");
 }
 
 #[allow(clippy::too_many_arguments)]
-extern "C" fn on_block_update(
+extern "C" fn on_wallet_block_processed(
     wallet_id: *const c_char,
     height: u32,
     inserted: *const FFITransactionRecord,
@@ -496,7 +494,7 @@ extern "C" fn on_block_update(
     tracker.block_processed_wallet_count.fetch_add(1, Ordering::SeqCst);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
     tracing::info!(
-        "on_block_update: wallet={}, height={}, inserted={}, updated={}, matured={}",
+        "on_wallet_block_processed: wallet={}, height={}, inserted={}, updated={}, matured={}",
         wallet_str,
         height,
         inserted_count,
@@ -505,7 +503,11 @@ extern "C" fn on_block_update(
     );
 }
 
-extern "C" fn on_sync_height_update(wallet_id: *const c_char, height: u32, user_data: *mut c_void) {
+extern "C" fn on_sync_height_advanced(
+    wallet_id: *const c_char,
+    height: u32,
+    user_data: *mut c_void,
+) {
     let Some(tracker) = (unsafe { tracker_from(user_data) }) else {
         return;
     };
@@ -515,7 +517,7 @@ extern "C" fn on_sync_height_update(wallet_id: *const c_char, height: u32, user_
     tracker.last_synced_height.store(height, Ordering::SeqCst);
     tracker.synced_height_updated_count.fetch_add(1, Ordering::SeqCst);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
-    tracing::info!("on_sync_height_update: wallet={}, height={}", wallet_str, height);
+    tracing::info!("on_sync_height_advanced: wallet={}, height={}", wallet_str, height);
 }
 
 /// Create sync callbacks with all event handlers wired to the tracker.
@@ -561,10 +563,10 @@ pub(super) fn create_network_callbacks(tracker: &Arc<CallbackTracker>) -> FFINet
 /// Arc outlives all callback invocations.
 pub(super) fn create_wallet_callbacks(tracker: &Arc<CallbackTracker>) -> FFIWalletEventCallbacks {
     FFIWalletEventCallbacks {
-        on_transaction_received: Some(on_transaction_received),
-        on_transaction_status_changed: Some(on_transaction_status_changed),
-        on_block_update: Some(on_block_update),
-        on_sync_height_update: Some(on_sync_height_update),
+        on_transaction_detected: Some(on_transaction_detected),
+        on_transaction_instant_locked: Some(on_transaction_instant_locked),
+        on_block_processed: Some(on_wallet_block_processed),
+        on_sync_height_advanced: Some(on_sync_height_advanced),
         user_data: Arc::as_ptr(tracker) as *mut c_void,
     }
 }

--- a/dash-spv-ffi/tests/dashd_sync/context.rs
+++ b/dash-spv-ffi/tests/dashd_sync/context.rs
@@ -35,7 +35,7 @@ use key_wallet_ffi::managed_account::{
 use key_wallet_ffi::managed_wallet::{
     managed_wallet_get_next_bip44_receive_address, managed_wallet_info_free,
 };
-use key_wallet_ffi::types::FFIAccountType;
+use key_wallet_ffi::types::FFIAccountKind;
 use key_wallet_ffi::wallet::wallet_free_const;
 use key_wallet_ffi::wallet_manager::{
     wallet_manager_add_wallet_from_mnemonic, wallet_manager_get_managed_wallet_info,
@@ -313,7 +313,7 @@ impl FFITestContext {
     ) -> T {
         let wm = self.session.wallet_manager as *const FFIWalletManager;
         let result =
-            managed_wallet_get_account(wm, wallet_id.as_ptr(), 0, FFIAccountType::StandardBIP44);
+            managed_wallet_get_account(wm, wallet_id.as_ptr(), 0, FFIAccountKind::StandardBIP44);
         assert!(
             result.error_code == 0 && !result.account.is_null(),
             "Failed to get BIP44 account 0"

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use dash_spv::test_utils::{DashdTestContext, TestChain};
+use dash_spv_ffi::FFIAccountKind;
 use dashcore::hashes::Hash;
 use dashcore::Amount;
 
@@ -100,31 +101,62 @@ fn test_all_callbacks_during_sync() {
         );
         drop(connected_peers);
 
-        // Wait for wallet callbacks (they travel on a separate channel from sync events)
-        tracker.wait_for_callback(&tracker.transaction_received_count, 0, "transaction_received");
-        tracker.wait_for_callback(&tracker.balance_updated_count, 0, "balance_updated");
+        // Wait for wallet callbacks (they travel on a separate channel from sync events).
+        // Wait on `block_processed_wallet_count` because it is bumped last in the
+        // callback, after all per-record state has been written. Reading the
+        // record counter afterwards is therefore guaranteed to see the matching
+        // increment.
+        tracker.wait_for_callback(&tracker.block_processed_wallet_count, 0, "block_processed");
 
         // Validate wallet event callbacks (test wallet has transactions)
-        let tx_received = tracker.transaction_received_count.load(Ordering::SeqCst);
-        let balance_updated = tracker.balance_updated_count.load(Ordering::SeqCst);
-        let tx_status_changed = tracker.transaction_status_changed_count.load(Ordering::SeqCst);
+        let block_records = tracker.block_processed_wallet_record_count.load(Ordering::SeqCst);
+        let block_changes = tracker.block_processed_wallet_count.load(Ordering::SeqCst);
+        let received = tracker.transaction_received_count.load(Ordering::SeqCst);
+        let instant_send_locked =
+            tracker.transaction_instant_send_locked_count.load(Ordering::SeqCst);
 
         tracing::info!(
-            "Wallet: tx_received={}, tx_status_changed={}, balance_updated={}",
-            tx_received,
-            tx_status_changed,
-            balance_updated
+            "Wallet: received={}, instant_send_locked={}, block_changes={}, block_records={}",
+            received,
+            instant_send_locked,
+            block_changes,
+            block_records
         );
 
         assert!(
-            tx_received > 0,
-            "on_transaction_received should fire for wallet with transactions"
+            block_records > 0,
+            "on_block_processed should deliver records for a wallet with transactions"
+        );
+        assert!(
+            block_changes > 0,
+            "on_block_processed should fire for blocks containing wallet records"
         );
         assert_eq!(
-            tx_status_changed, 0,
-            "on_transaction_status_changed should not fire here, all transactions are confirmed."
+            received, 0,
+            "on_transaction_received must not fire during historical block sync"
         );
-        assert!(balance_updated > 0, "on_balance_updated should fire for wallet with transactions");
+        assert_eq!(
+            instant_send_locked, 0,
+            "on_transaction_instant_send_locked should not fire during initial sync"
+        );
+
+        // Validate SyncedHeightUpdated callback (atomicity boundary for persistence flush).
+        // Wait explicitly for the callback because it travels on the same wallet
+        // broadcast channel as `BlockProcessed` but is dispatched separately,
+        // so observing block-processed records does not guarantee it has fired yet.
+        tracker.wait_for_callback(&tracker.synced_height_updated_count, 0, "synced_height_updated");
+        let synced_height_fired = tracker.synced_height_updated_count.load(Ordering::SeqCst);
+        let last_synced_height = tracker.last_synced_height.load(Ordering::SeqCst);
+        assert!(
+            synced_height_fired > 0,
+            "on_synced_height_updated should fire at least once during sync"
+        );
+        assert!(
+            last_synced_height >= dashd.initial_height,
+            "last_synced_height ({}) should be at least initial_height ({}) after sync",
+            last_synced_height,
+            dashd.initial_height
+        );
 
         // Validate sync cycle (initial sync is cycle 0)
         let last_sync_cycle = tracker.last_sync_cycle.load(Ordering::SeqCst);
@@ -211,14 +243,53 @@ fn test_all_callbacks_during_sync() {
             "best height from peers should match initial height"
         );
 
-        // Validate transaction data from initial sync
-        let received_txs = tracker.received_transactions.lock().unwrap();
-        assert!(!received_txs.is_empty(), "should have received transactions during sync");
+        // Validate transaction data from initial sync. Historical sync only
+        // touches the block-processed callback (off-chain callback must
+        // remain silent during initial sync), so assert against that bucket
+        // explicitly.
+        let block_received = tracker.block_received_transactions.lock().unwrap();
+        assert!(!block_received.is_empty(), "should have received block records during sync");
         assert!(
-            received_txs.iter().any(|&(_, amount)| amount != 0),
-            "at least one received transaction amount should be non-zero"
+            block_received.iter().any(|&(_, amount)| amount != 0),
+            "at least one block-record net_amount should be non-zero"
         );
-        drop(received_txs);
+        drop(block_received);
+
+        // Every record observed during initial sync is a fresh insertion
+        // (no prior mempool sighting), so each must arrive in the `inserted`
+        // bucket of `BlockUpdate`.
+        let bucket = tracker.block_record_inserted.lock().unwrap();
+        assert!(!bucket.is_empty(), "block records should be captured");
+        assert!(
+            bucket.iter().all(|inserted| *inserted),
+            "every block record during historical sync should arrive via `inserted`, got: {:?}",
+            *bucket
+        );
+        drop(bucket);
+
+        // Validate the BIP-44 account discriminant + index reach the FFI
+        // boundary intact: every change observed during historical sync
+        // belongs to the default BIP-44 account (index 0) of the test wallet.
+        let account_types = tracker.block_account_types.lock().unwrap();
+        let account_indices = tracker.block_account_indices.lock().unwrap();
+        assert!(!account_types.is_empty(), "block account types should be captured");
+        assert_eq!(
+            account_types.len(),
+            account_indices.len(),
+            "block account types and indices must be paired 1:1"
+        );
+        assert!(
+            account_types.iter().all(|t| *t == FFIAccountKind::StandardBIP44),
+            "every block change should carry FFIAccountKind::StandardBIP44, got: {:?}",
+            *account_types
+        );
+        assert!(
+            account_indices.iter().all(|i| *i == 0),
+            "every BIP-44 change should carry account_index = 0, got: {:?}",
+            *account_indices
+        );
+        drop(account_indices);
+        drop(account_types);
 
         // Masternodes are disabled in test config, so these should not fire
         let masternode_updated = tracker.masternode_state_updated_count.load(Ordering::SeqCst);
@@ -260,14 +331,37 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         tracing::info!("Initial sync complete");
 
         // Record callback counts before post-sync operations
-        let tx_received_before = tracker.transaction_received_count.load(Ordering::SeqCst);
-        let balance_updated_before = tracker.balance_updated_count.load(Ordering::SeqCst);
+        let received_before = tracker.transaction_received_count.load(Ordering::SeqCst);
+        let block_changes_before = tracker.block_processed_wallet_count.load(Ordering::SeqCst);
+        let block_records_before =
+            tracker.block_processed_wallet_record_count.load(Ordering::SeqCst);
 
-        // Send DASH to the wallet and mine a block
+        // Send DASH to the wallet. Wait for the off-chain callback before
+        // mining so the SPV node observes the transaction in the mempool.
+        // If we mine immediately, the block path can deliver the transaction
+        // first and the off-chain callback would never fire.
         let receive_address = ctx.get_receive_address(&wallet_id);
         let send_amount = Amount::from_sat(100_000_000);
         let txid = dashd.node.send_to_address(&receive_address, send_amount);
         tracing::info!("Sent {} to wallet, txid: {}", send_amount, txid);
+
+        tracker.wait_for_callback(
+            &tracker.transaction_received_count,
+            received_before,
+            "transaction_received",
+        );
+
+        // The off-chain callback updates `last_unconfirmed` with the
+        // post-event balance. Snapshot it now, before mining. After
+        // confirmation the block-processed callback overwrites the same
+        // field back toward zero, so this is the only window in which the
+        // unconfirmed-balance update is observable.
+        let unconfirmed_after_mempool = tracker.last_unconfirmed.load(Ordering::SeqCst);
+        assert!(
+            unconfirmed_after_mempool > 0,
+            "balance.unconfirmed should be positive after mempool receipt, got {}",
+            unconfirmed_after_mempool
+        );
 
         let miner_address = dashd.node.get_new_address_from_wallet("default");
         dashd.node.generate_blocks(1, &miner_address);
@@ -275,44 +369,42 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         // Wait for incremental sync to complete
         ctx.wait_for_sync(dashd.initial_height + 1);
 
-        // Wait for wallet callbacks (they travel on a separate channel from sync events)
+        // Wait for the block-processed callback. The per-callback counter is
+        // bumped last in the callback, so observing it incremented guarantees
+        // the per-record vectors and counters have already been updated.
         tracker.wait_for_callback(
-            &tracker.transaction_received_count,
-            tx_received_before,
-            "transaction_received",
-        );
-        tracker.wait_for_callback(
-            &tracker.balance_updated_count,
-            balance_updated_before,
-            "balance_updated",
+            &tracker.block_processed_wallet_count,
+            block_changes_before,
+            "block_processed",
         );
 
         // Verify on_transaction_received fired for the new transaction
-        let tx_received_after = tracker.transaction_received_count.load(Ordering::SeqCst);
+        let received_after = tracker.transaction_received_count.load(Ordering::SeqCst);
         assert!(
-            tx_received_after > tx_received_before,
+            received_after > received_before,
             "on_transaction_received should fire for post-sync transaction: {} -> {}",
-            tx_received_before,
-            tx_received_after
+            received_before,
+            received_after
         );
         tracing::info!(
-            "Transaction callback verified: {} -> {}",
-            tx_received_before,
-            tx_received_after
+            "Off-chain transaction callback verified: {} -> {}",
+            received_before,
+            received_after
         );
 
-        // Verify the sent txid appears in the callback data with a non-zero
-        // net_amount.  The SPV wallet and dashd share the same mnemonic so the
-        // transaction is an internal transfer (wallet owns both inputs and
-        // outputs); net_amount therefore equals approximately -fee, not the
-        // nominal send amount.
+        // Verify the sent txid appears in the off-chain callback data with a
+        // non-zero net_amount. Asserting against the off-chain bucket (rather
+        // than the union of off-chain + block records) ensures the off-chain
+        // callback specifically delivered the txid — a broken off-chain
+        // callback that pushed the wrong txid wouldn't be masked by the
+        // block path. The SPV wallet and dashd share the same mnemonic so
+        // the transaction is an internal transfer (wallet owns both inputs
+        // and outputs); net_amount therefore equals approximately -fee, not
+        // the nominal send amount.
         let sent_txid_bytes = *txid.as_byte_array();
         let received_txs = tracker.received_transactions.lock().unwrap();
         let sent_entry = received_txs.iter().find(|&&(id, _)| id == sent_txid_bytes);
-        assert!(
-            sent_entry.is_some(),
-            "sent txid should appear in received transaction callback data"
-        );
+        assert!(sent_entry.is_some(), "sent txid should appear in transaction callback data");
         let &(_, net_amount) = sent_entry.unwrap();
         // Internal transfer: net_amount = received - sent = (send_amount + change) - input = -fee.
         // The fee must be negative, non-zero, and small (< 0.001 DASH).
@@ -323,20 +415,58 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         );
         drop(received_txs);
 
-        let balance_updated_after = tracker.balance_updated_count.load(Ordering::SeqCst);
+        // Verify the off-chain callback delivered the BIP-44 account
+        // discriminant + index 0 (default test account).
+        let received_types = tracker.received_account_types.lock().unwrap();
+        let received_indices = tracker.received_account_indices.lock().unwrap();
+        assert!(
+            received_types.iter().all(|t| *t == FFIAccountKind::StandardBIP44),
+            "off-chain callback should deliver FFIAccountKind::StandardBIP44, got: {:?}",
+            *received_types
+        );
+        assert!(
+            received_indices.iter().all(|i| *i == 0),
+            "off-chain BIP-44 callback should deliver account_index = 0, got: {:?}",
+            *received_indices
+        );
+        drop(received_indices);
+        drop(received_types);
+
+        // The post-sync block confirms a transaction that was already known
+        // from the mempool, so the corresponding `BlockUpdate` change must
+        // arrive in the `updated` bucket rather than `inserted`. Slice by
+        // the pre-captured index so only post-sync entries are checked,
+        // avoiding masking by any `updated` entry that might appear during
+        // initial sync.
+        let block_bucket = tracker.block_record_inserted.lock().unwrap();
+        assert!(
+            block_bucket.len() >= block_records_before as usize,
+            "block_record_inserted length ({}) < block_records_before ({}): counter/vector mismatch",
+            block_bucket.len(),
+            block_records_before
+        );
+        let new_bucket = &block_bucket[block_records_before as usize..];
+        assert!(
+            new_bucket.iter().any(|inserted| !inserted),
+            "post-sync block confirming a known mempool tx should arrive in the \
+             `updated` bucket, got: {:?}",
+            new_bucket
+        );
+        drop(block_bucket);
+
+        let block_records_after =
+            tracker.block_processed_wallet_record_count.load(Ordering::SeqCst);
         tracing::info!(
-            "Balance updated callback verified: {} -> {}",
-            balance_updated_before,
-            balance_updated_after
+            "Block-processed record callback verified: {} -> {}",
+            block_records_before,
+            block_records_after
         );
 
-        // Verify balance data from callback reflects a positive spendable balance
-        let last_spendable = tracker.last_spendable.load(Ordering::SeqCst);
-        assert!(
-            last_spendable > 0,
-            "last_spendable from on_balance_updated should be positive after receiving funds"
-        );
-        tracing::info!("Balance data verified: last_spendable={}", last_spendable);
+        // Verify balance data from the most recent wallet event reflects a positive
+        // confirmed balance.
+        let last_confirmed = tracker.last_confirmed.load(Ordering::SeqCst);
+        assert!(last_confirmed > 0, "last_confirmed should be positive after receiving funds");
+        tracing::info!("Balance data verified: last_confirmed={}", last_confirmed);
 
         // Record connect count before disconnect
         let connect_before = tracker.peer_connected_count.load(Ordering::SeqCst);

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -133,7 +133,7 @@ fn test_all_callbacks_during_sync() {
         );
         assert_eq!(
             received, 0,
-            "on_transaction_received must not fire during historical block sync"
+            "on_transaction_detected must not fire during historical block sync"
         );
         assert_eq!(
             instant_send_locked, 0,
@@ -257,7 +257,7 @@ fn test_all_callbacks_during_sync() {
 
         // Every record observed during initial sync is a fresh insertion
         // (no prior mempool sighting), so each must arrive in the `inserted`
-        // bucket of `BlockUpdate`.
+        // bucket of `BlockProcessed`.
         let bucket = tracker.block_record_inserted.lock().unwrap();
         assert!(!bucket.is_empty(), "block records should be captured");
         assert!(
@@ -305,7 +305,7 @@ fn test_all_callbacks_during_sync() {
 /// Verify wallet and network callbacks fire correctly after initial sync completes.
 ///
 /// After initial sync, sends DASH to the wallet and mines a block. Verifies that
-/// on_transaction_received and on_balance_updated callbacks fire. Then disconnects
+/// on_transaction_detected and on_balance_updated callbacks fire. Then disconnects
 /// dashd peers and verifies on_peer_disconnected fires, followed by on_peer_connected
 /// after automatic reconnection.
 #[test]
@@ -378,11 +378,11 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
             "block_processed",
         );
 
-        // Verify on_transaction_received fired for the new transaction
+        // Verify on_transaction_detected fired for the new transaction
         let received_after = tracker.transaction_received_count.load(Ordering::SeqCst);
         assert!(
             received_after > received_before,
-            "on_transaction_received should fire for post-sync transaction: {} -> {}",
+            "on_transaction_detected should fire for post-sync transaction: {} -> {}",
             received_before,
             received_after
         );
@@ -433,7 +433,7 @@ fn test_callbacks_post_sync_transactions_and_disconnect() {
         drop(received_types);
 
         // The post-sync block confirms a transaction that was already known
-        // from the mempool, so the corresponding `BlockUpdate` change must
+        // from the mempool, so the corresponding `BlockProcessed` change must
         // arrive in the `updated` bucket rather than `inserted`. Slice by
         // the pre-captured index so only post-sync entries are checked,
         // avoiding masking by any `updated` entry that might appear during

--- a/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_transaction.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::Ordering;
 
 use dash_spv::test_utils::{DashdTestContext, TestChain};
+use dash_spv_ffi::FFIAccountKind;
 use dashcore::hashes::Hash;
 use dashcore::Amount;
 
@@ -47,7 +48,10 @@ fn test_ffi_sync_then_generate_blocks() {
 
         // Generate a block containing a wallet transaction and wait for sync.
         let cycle_before = ctx.tracker().last_sync_cycle.load(Ordering::SeqCst);
-        let tx_received_before = ctx.tracker().transaction_received_count.load(Ordering::SeqCst);
+        let block_changes_before =
+            ctx.tracker().block_processed_wallet_count.load(Ordering::SeqCst);
+        let block_records_before =
+            ctx.tracker().block_processed_wallet_record_count.load(Ordering::SeqCst);
         let receive_address = ctx.get_receive_address(&wallet_id);
         let send_amount = Amount::from_sat(100_000_000);
         let txid = dashd.node.send_to_address(&receive_address, send_amount);
@@ -66,22 +70,69 @@ fn test_ffi_sync_then_generate_blocks() {
             cycle_after_first
         );
 
-        // Wait for wallet callback (travels on a separate channel from sync events)
+        // Wait for wallet callback (travels on a separate channel from sync events).
+        // The per-callback counter is bumped last in the callback, so observing
+        // it incremented guarantees the per-record vectors are also updated.
         ctx.tracker().wait_for_callback(
-            &ctx.tracker().transaction_received_count,
-            tx_received_before,
-            "transaction_received",
+            &ctx.tracker().block_processed_wallet_count,
+            block_changes_before,
+            "block_processed",
         );
 
-        // Verify the transaction was received via wallet callback
-        let received_txs = ctx.tracker().received_transactions.lock().unwrap();
+        // Verify the transaction was received via the block-processed callback
+        let received_txs = ctx.tracker().block_received_transactions.lock().unwrap();
         let txid_bytes = *txid.as_byte_array();
         assert!(
             received_txs.iter().any(|&(txid, _)| txid == txid_bytes),
-            "Wallet callback should have received txid {}",
+            "Block-processed callback should have received txid {}",
             txid
         );
         drop(received_txs);
+
+        // Verify per-record bucketing was captured for the post-sync block.
+        let bucket = ctx.tracker().block_record_inserted.lock().unwrap();
+        assert!(
+            bucket.len() >= block_records_before as usize,
+            "block_record_inserted length ({}) < block_records_before ({}): counter/vector mismatch",
+            bucket.len(),
+            block_records_before
+        );
+        let new_bucket = &bucket[block_records_before as usize..];
+        assert!(
+            !new_bucket.is_empty(),
+            "block_record_inserted should be populated for the post-sync block"
+        );
+        drop(bucket);
+
+        // Verify the BIP-44 account discriminant + index were delivered for
+        // the post-sync block records.
+        let types = ctx.tracker().block_account_types.lock().unwrap();
+        let indices = ctx.tracker().block_account_indices.lock().unwrap();
+        assert!(
+            types.len() >= block_records_before as usize,
+            "block_account_types length ({}) < block_records_before ({}): counter/vector mismatch",
+            types.len(),
+            block_records_before
+        );
+        assert_eq!(
+            types.len(),
+            indices.len(),
+            "block account types and indices must be paired 1:1"
+        );
+        let new_types = &types[block_records_before as usize..];
+        let new_indices = &indices[block_records_before as usize..];
+        assert!(
+            new_types.iter().all(|t| *t == FFIAccountKind::StandardBIP44),
+            "post-sync block changes should carry FFIAccountKind::StandardBIP44, got: {:?}",
+            new_types
+        );
+        assert!(
+            new_indices.iter().all(|i| *i == 0),
+            "post-sync BIP-44 changes should carry account_index = 0, got: {:?}",
+            new_indices
+        );
+        drop(indices);
+        drop(types);
 
         // Verify via wallet query as well
         assert!(

--- a/dash-spv/tests/dashd_sync/helpers.rs
+++ b/dash-spv/tests/dashd_sync/helpers.rs
@@ -126,7 +126,7 @@ pub(super) async fn wait_for_network_event(
     }
 }
 
-/// Wait for a wallet `TransactionReceived` event within the given timeout.
+/// Wait for a wallet `TransactionDetected` event within the given timeout.
 /// Accepts both plain mempool and InstantSend-locked mempool arrivals.
 /// Returns `Some(txid)` if received, `None` on timeout.
 pub(super) async fn wait_for_mempool_tx(
@@ -141,7 +141,7 @@ pub(super) async fn wait_for_mempool_tx(
             _ = &mut timeout => return None,
             result = receiver.recv() => {
                 match result {
-                    Ok(WalletEvent::TransactionReceived { ref record, .. })
+                    Ok(WalletEvent::TransactionDetected { ref record, .. })
                         if matches!(
                             record.context,
                             TransactionContext::Mempool | TransactionContext::InstantSend(_)
@@ -184,13 +184,13 @@ pub(super) async fn wait_for_mempool_synced(
     }
 }
 
-/// Assert that no mempool `TransactionReceived` event arrives within the given duration.
+/// Assert that no mempool `TransactionDetected` event arrives within the given duration.
 pub(super) async fn assert_no_mempool_tx(
     receiver: &mut broadcast::Receiver<WalletEvent>,
     wait: Duration,
 ) {
     if let Some(txid) = wait_for_mempool_tx(receiver, wait).await {
-        panic!("Unexpected TransactionReceived event with txid: {}", txid);
+        panic!("Unexpected TransactionDetected event with txid: {}", txid);
     }
 }
 
@@ -327,7 +327,7 @@ pub(super) async fn wait_for_mempool_txs_both(
         for _ in 0..count {
             let txid = wait_for_mempool_tx(receiver, timeout)
                 .await
-                .expect("Expected TransactionReceived event");
+                .expect("Expected TransactionDetected event");
             txids.insert(txid);
         }
         txids

--- a/dash-spv/tests/dashd_sync/helpers.rs
+++ b/dash-spv/tests/dashd_sync/helpers.rs
@@ -126,7 +126,8 @@ pub(super) async fn wait_for_network_event(
     }
 }
 
-/// Wait for a wallet `TransactionReceived` event with mempool status within the given timeout.
+/// Wait for a wallet `TransactionReceived` event within the given timeout.
+/// Accepts both plain mempool and InstantSend-locked mempool arrivals.
 /// Returns `Some(txid)` if received, `None` on timeout.
 pub(super) async fn wait_for_mempool_tx(
     receiver: &mut broadcast::Receiver<WalletEvent>,
@@ -140,7 +141,14 @@ pub(super) async fn wait_for_mempool_tx(
             _ = &mut timeout => return None,
             result = receiver.recv() => {
                 match result {
-                    Ok(WalletEvent::TransactionReceived { ref record, .. }) if record.context == TransactionContext::Mempool => return Some(record.txid),
+                    Ok(WalletEvent::TransactionReceived { ref record, .. })
+                        if matches!(
+                            record.context,
+                            TransactionContext::Mempool | TransactionContext::InstantSend(_)
+                        ) =>
+                    {
+                        return Some(record.txid);
+                    }
                     Ok(_) => continue,
                     Err(_) => return None,
                 }
@@ -182,7 +190,7 @@ pub(super) async fn assert_no_mempool_tx(
     wait: Duration,
 ) {
     if let Some(txid) = wait_for_mempool_tx(receiver, wait).await {
-        panic!("Unexpected mempool TransactionReceived event with txid: {}", txid);
+        panic!("Unexpected TransactionReceived event with txid: {}", txid);
     }
 }
 
@@ -319,7 +327,7 @@ pub(super) async fn wait_for_mempool_txs_both(
         for _ in 0..count {
             let txid = wait_for_mempool_tx(receiver, timeout)
                 .await
-                .expect("Expected mempool TransactionReceived event");
+                .expect("Expected TransactionReceived event");
             txids.insert(txid);
         }
         txids

--- a/dash-spv/tests/dashd_sync/tests_mempool.rs
+++ b/dash-spv/tests/dashd_sync/tests_mempool.rs
@@ -38,7 +38,7 @@ async fn test_mempool_detects_incoming_tx() {
 
     let mempool_txid = wait_for_mempool_tx_both(&mut fa, &mut bf, MEMPOOL_TIMEOUT)
         .await
-        .expect("Expected TransactionReceived event");
+        .expect("Expected TransactionDetected event");
     assert_eq!(mempool_txid, txid, "Mempool event txid should match sent txid");
 
     fa.stop().await;
@@ -106,7 +106,7 @@ async fn test_mempool_to_confirmed_lifecycle() {
 
     let mempool_txid = wait_for_mempool_tx_both(&mut fa, &mut bf, MEMPOOL_TIMEOUT)
         .await
-        .expect("Expected TransactionReceived event");
+        .expect("Expected TransactionDetected event");
     assert_eq!(mempool_txid, txid);
 
     // Mine the transaction
@@ -552,7 +552,7 @@ async fn test_broadcast_transaction_local_detection() {
     // The locally dispatched transaction should be picked up by the mempool manager
     let detected = wait_for_mempool_tx_both(&mut fa, &mut bf, MEMPOOL_TIMEOUT)
         .await
-        .expect("Expected TransactionReceived event after broadcast");
+        .expect("Expected TransactionDetected event after broadcast");
     assert_eq!(detected, txid, "Detected txid should match broadcast txid");
 
     // Step 4: Mine the broadcast tx and verify it transitions to confirmed

--- a/dash-spv/tests/dashd_sync/tests_mempool.rs
+++ b/dash-spv/tests/dashd_sync/tests_mempool.rs
@@ -38,7 +38,7 @@ async fn test_mempool_detects_incoming_tx() {
 
     let mempool_txid = wait_for_mempool_tx_both(&mut fa, &mut bf, MEMPOOL_TIMEOUT)
         .await
-        .expect("Expected mempool TransactionReceived event");
+        .expect("Expected TransactionReceived event");
     assert_eq!(mempool_txid, txid, "Mempool event txid should match sent txid");
 
     fa.stop().await;
@@ -106,7 +106,7 @@ async fn test_mempool_to_confirmed_lifecycle() {
 
     let mempool_txid = wait_for_mempool_tx_both(&mut fa, &mut bf, MEMPOOL_TIMEOUT)
         .await
-        .expect("Expected mempool TransactionReceived event");
+        .expect("Expected TransactionReceived event");
     assert_eq!(mempool_txid, txid);
 
     // Mine the transaction
@@ -552,7 +552,7 @@ async fn test_broadcast_transaction_local_detection() {
     // The locally dispatched transaction should be picked up by the mempool manager
     let detected = wait_for_mempool_tx_both(&mut fa, &mut bf, MEMPOOL_TIMEOUT)
         .await
-        .expect("Expected mempool TransactionReceived event after broadcast");
+        .expect("Expected TransactionReceived event after broadcast");
     assert_eq!(detected, txid, "Detected txid should match broadcast txid");
 
     // Step 4: Mine the broadcast tx and verify it transitions to confirmed

--- a/key-wallet-ffi/FFI_API.md
+++ b/key-wallet-ffi/FFI_API.md
@@ -887,7 +887,7 @@ Free managed wallet info  # Safety  - `managed_wallet` must be a valid pointer t
 #### `managed_wallet_generate_addresses_to_index`
 
 ```c
-managed_wallet_generate_addresses_to_index(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, account_type: FFIAccountType, account_index: c_uint, pool_type: FFIAddressPoolType, target_index: c_uint, error: *mut FFIError,) -> bool
+managed_wallet_generate_addresses_to_index(managed_wallet: *mut FFIManagedWalletInfo, wallet: *const FFIWallet, account_type: FFIAccountKind, account_index: c_uint, pool_type: FFIAddressPoolType, target_index: c_uint, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -903,7 +903,7 @@ Generate addresses up to a specific index in a pool  This ensures that addresses
 #### `managed_wallet_get_account`
 
 ```c
-managed_wallet_get_account(manager: *const FFIWalletManager, wallet_id: *const u8, account_index: c_uint, account_type: FFIAccountType,) -> FFIManagedCoreAccountResult
+managed_wallet_get_account(manager: *const FFIWalletManager, wallet_id: *const u8, account_index: c_uint, account_type: FFIAccountKind,) -> FFIManagedCoreAccountResult
 ```
 
 **Description:**
@@ -951,7 +951,7 @@ Get number of accounts in a managed wallet  # Safety  - `manager` must be a vali
 #### `managed_wallet_get_address_pool_info`
 
 ```c
-managed_wallet_get_address_pool_info(managed_wallet: *const FFIManagedWalletInfo, account_type: FFIAccountType, account_index: c_uint, pool_type: FFIAddressPoolType, info_out: *mut FFIAddressPoolInfo, error: *mut FFIError,) -> bool
+managed_wallet_get_address_pool_info(managed_wallet: *const FFIManagedWalletInfo, account_type: FFIAccountKind, account_index: c_uint, pool_type: FFIAddressPoolType, info_out: *mut FFIAddressPoolInfo, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -1175,7 +1175,7 @@ Mark an address as used in the pool  This updates the pool's tracking of which a
 #### `managed_wallet_set_gap_limit`
 
 ```c
-managed_wallet_set_gap_limit(managed_wallet: *mut FFIManagedWalletInfo, account_type: FFIAccountType, account_index: c_uint, pool_type: FFIAddressPoolType, gap_limit: c_uint, error: *mut FFIError,) -> bool
+managed_wallet_set_gap_limit(managed_wallet: *mut FFIManagedWalletInfo, account_type: FFIAccountKind, account_index: c_uint, pool_type: FFIAddressPoolType, gap_limit: c_uint, error: *mut FFIError,) -> bool
 ```
 
 **Description:**
@@ -1191,7 +1191,7 @@ Set the gap limit for an address pool  The gap limit determines how many unused 
 #### `wallet_add_account`
 
 ```c
-wallet_add_account(wallet: *mut FFIWallet, account_type: crate::types::FFIAccountType, account_index: c_uint,) -> crate::types::FFIAccountResult
+wallet_add_account(wallet: *mut FFIWallet, account_type: crate::types::FFIAccountKind, account_index: c_uint,) -> crate::types::FFIAccountResult
 ```
 
 **Description:**
@@ -1207,7 +1207,7 @@ This function dereferences a raw pointer to FFIWallet. The caller must ensure th
 #### `wallet_add_account_with_string_xpub`
 
 ```c
-wallet_add_account_with_string_xpub(wallet: *mut FFIWallet, account_type: crate::types::FFIAccountType, account_index: c_uint, xpub_string: *const c_char,) -> crate::types::FFIAccountResult
+wallet_add_account_with_string_xpub(wallet: *mut FFIWallet, account_type: crate::types::FFIAccountKind, account_index: c_uint, xpub_string: *const c_char,) -> crate::types::FFIAccountResult
 ```
 
 **Description:**
@@ -1223,7 +1223,7 @@ This function dereferences raw pointers. The caller must ensure that: - The wall
 #### `wallet_add_account_with_xpub_bytes`
 
 ```c
-wallet_add_account_with_xpub_bytes(wallet: *mut FFIWallet, account_type: crate::types::FFIAccountType, account_index: c_uint, xpub_bytes: *const u8, xpub_len: usize,) -> crate::types::FFIAccountResult
+wallet_add_account_with_xpub_bytes(wallet: *mut FFIWallet, account_type: crate::types::FFIAccountKind, account_index: c_uint, xpub_bytes: *const u8, xpub_len: usize,) -> crate::types::FFIAccountResult
 ```
 
 **Description:**
@@ -1575,7 +1575,7 @@ Free a const wallet handle  This is a const-safe wrapper for wallet_free() that 
 #### `wallet_get_account`
 
 ```c
-wallet_get_account(wallet: *const FFIWallet, account_index: c_uint, account_type: FFIAccountType,) -> FFIAccountResult
+wallet_get_account(wallet: *const FFIWallet, account_index: c_uint, account_type: FFIAccountKind,) -> FFIAccountResult
 ```
 
 **Description:**
@@ -2313,14 +2313,14 @@ Free an account handle  # Safety  - `account` must be a valid pointer to an FFIA
 #### `account_get_account_type`
 
 ```c
-account_get_account_type(account: *const FFIAccount, out_index: *mut c_uint,) -> FFIAccountType
+account_get_account_type(account: *const FFIAccount, out_index: *mut c_uint,) -> FFIAccountKind
 ```
 
 **Description:**
-Get the account type of an account  # Safety  - `account` must be a valid pointer to an FFIAccount instance - `out_index` must be a valid pointer to a c_uint where the index will be stored - Returns FFIAccountType::StandardBIP44 with index 0 if the account is null
+Get the account type of an account  # Safety  - `account` must be a valid pointer to an FFIAccount instance - `out_index` must be a valid pointer to a c_uint where the index will be stored - Returns FFIAccountKind::StandardBIP44 with index 0 if the account is null
 
 **Safety:**
-- `account` must be a valid pointer to an FFIAccount instance - `out_index` must be a valid pointer to a c_uint where the index will be stored - Returns FFIAccountType::StandardBIP44 with index 0 if the account is null
+- `account` must be a valid pointer to an FFIAccount instance - `out_index` must be a valid pointer to a c_uint where the index will be stored - Returns FFIAccountKind::StandardBIP44 with index 0 if the account is null
 
 **Module:** `account`
 
@@ -2407,7 +2407,7 @@ bls_account_free(account: *mut FFIBLSAccount) -> ()
 #### `bls_account_get_account_type`
 
 ```c
-bls_account_get_account_type(account: *const FFIBLSAccount, out_index: *mut c_uint,) -> FFIAccountType
+bls_account_get_account_type(account: *const FFIBLSAccount, out_index: *mut c_uint,) -> FFIAccountKind
 ```
 
 **Module:** `account`
@@ -2493,7 +2493,7 @@ eddsa_account_free(account: *mut FFIEdDSAAccount) -> ()
 #### `eddsa_account_get_account_type`
 
 ```c
-eddsa_account_get_account_type(account: *const FFIEdDSAAccount, out_index: *mut c_uint,) -> FFIAccountType
+eddsa_account_get_account_type(account: *const FFIEdDSAAccount, out_index: *mut c_uint,) -> FFIAccountKind
 ```
 
 **Module:** `account`
@@ -3077,7 +3077,7 @@ Free transactions array returned by managed_core_account_get_transactions  # Saf
 #### `managed_core_account_get_account_type`
 
 ```c
-managed_core_account_get_account_type(account: *const FFIManagedCoreAccount, index_out: *mut c_uint,) -> FFIAccountType
+managed_core_account_get_account_type(account: *const FFIManagedCoreAccount, index_out: *mut c_uint,) -> FFIAccountKind
 ```
 
 **Description:**

--- a/key-wallet-ffi/src/account.rs
+++ b/key-wallet-ffi/src/account.rs
@@ -2,7 +2,7 @@
 
 use crate::deref_ptr;
 use crate::error::{FFIError, FFIErrorCode};
-use crate::types::{FFIAccountResult, FFIAccountType, FFIWallet};
+use crate::types::{FFIAccountKind, FFIAccountResult, FFIWallet};
 use dash_network::ffi::FFINetwork;
 #[cfg(feature = "bls")]
 use key_wallet::account::BLSAccount;
@@ -83,7 +83,7 @@ impl FFIEdDSAAccount {
 pub unsafe extern "C" fn wallet_get_account(
     wallet: *const FFIWallet,
     account_index: c_uint,
-    account_type: FFIAccountType,
+    account_type: FFIAccountKind,
 ) -> FFIAccountResult {
     if wallet.is_null() {
         return FFIAccountResult::error(FFIErrorCode::InvalidInput, "Wallet is null".to_string());
@@ -270,22 +270,22 @@ pub unsafe extern "C" fn account_get_parent_wallet_id(account: *const FFIAccount
 ///
 /// - `account` must be a valid pointer to an FFIAccount instance
 /// - `out_index` must be a valid pointer to a c_uint where the index will be stored
-/// - Returns FFIAccountType::StandardBIP44 with index 0 if the account is null
+/// - Returns FFIAccountKind::StandardBIP44 with index 0 if the account is null
 #[no_mangle]
 pub unsafe extern "C" fn account_get_account_type(
     account: *const FFIAccount,
     out_index: *mut c_uint,
-) -> FFIAccountType {
+) -> FFIAccountKind {
     if account.is_null() || out_index.is_null() {
         if !out_index.is_null() {
             *out_index = 0;
         }
-        return FFIAccountType::StandardBIP44;
+        return FFIAccountKind::StandardBIP44;
     }
 
     let account = &*account;
     let (account_type, index, registration_index) =
-        FFIAccountType::from_account_type(&account.inner().account_type);
+        FFIAccountKind::from_account_type(&account.inner().account_type);
 
     // For IdentityTopUp, the registration_index is the relevant index
     *out_index = registration_index.unwrap_or(index);
@@ -385,23 +385,23 @@ pub unsafe extern "C" fn bls_account_get_parent_wallet_id(
 ///
 /// - `account` must be a valid pointer to an FFIBLSAccount instance
 /// - `out_index` must be a valid pointer to a c_uint where the index will be stored
-/// - Returns FFIAccountType::StandardBIP44 with index 0 if the account is null
+/// - Returns FFIAccountKind::StandardBIP44 with index 0 if the account is null
 #[cfg(feature = "bls")]
 #[no_mangle]
 pub unsafe extern "C" fn bls_account_get_account_type(
     account: *const FFIBLSAccount,
     out_index: *mut c_uint,
-) -> FFIAccountType {
+) -> FFIAccountKind {
     if account.is_null() || out_index.is_null() {
         if !out_index.is_null() {
             *out_index = 0;
         }
-        return FFIAccountType::StandardBIP44;
+        return FFIAccountKind::StandardBIP44;
     }
 
     let account = &*account;
     let (account_type, index, registration_index) =
-        FFIAccountType::from_account_type(&account.inner().account_type);
+        FFIAccountKind::from_account_type(&account.inner().account_type);
 
     // For IdentityTopUp, the registration_index is the relevant index
     *out_index = registration_index.unwrap_or(index);
@@ -502,23 +502,23 @@ pub unsafe extern "C" fn eddsa_account_get_parent_wallet_id(
 ///
 /// - `account` must be a valid pointer to an FFIEdDSAAccount instance
 /// - `out_index` must be a valid pointer to a c_uint where the index will be stored
-/// - Returns FFIAccountType::StandardBIP44 with index 0 if the account is null
+/// - Returns FFIAccountKind::StandardBIP44 with index 0 if the account is null
 #[cfg(feature = "eddsa")]
 #[no_mangle]
 pub unsafe extern "C" fn eddsa_account_get_account_type(
     account: *const FFIEdDSAAccount,
     out_index: *mut c_uint,
-) -> FFIAccountType {
+) -> FFIAccountKind {
     if account.is_null() || out_index.is_null() {
         if !out_index.is_null() {
             *out_index = 0;
         }
-        return FFIAccountType::StandardBIP44;
+        return FFIAccountKind::StandardBIP44;
     }
 
     let account = &*account;
     let (account_type, index, registration_index) =
-        FFIAccountType::from_account_type(&account.inner().account_type);
+        FFIAccountKind::from_account_type(&account.inner().account_type);
 
     // For IdentityTopUp, the registration_index is the relevant index
     *out_index = registration_index.unwrap_or(index);

--- a/key-wallet-ffi/src/account_collection.rs
+++ b/key-wallet-ffi/src/account_collection.rs
@@ -1119,7 +1119,7 @@ mod tests {
             options.option_type = crate::types::FFIAccountCreationOptionType::AllAccounts;
 
             // Add provider operator keys account type
-            let special_types = [crate::types::FFIAccountType::ProviderOperatorKeys];
+            let special_types = [crate::types::FFIAccountKind::ProviderOperatorKeys];
             options.special_account_types = special_types.as_ptr();
             options.special_account_types_count = special_types.len();
 
@@ -1166,7 +1166,7 @@ mod tests {
             options.option_type = crate::types::FFIAccountCreationOptionType::AllAccounts;
 
             // Add provider platform keys account type
-            let special_types = [crate::types::FFIAccountType::ProviderPlatformKeys];
+            let special_types = [crate::types::FFIAccountKind::ProviderPlatformKeys];
             options.special_account_types = special_types.as_ptr();
             options.special_account_types_count = special_types.len();
 
@@ -1215,10 +1215,10 @@ mod tests {
 
             // Add various special accounts
             let special_types = [
-                crate::types::FFIAccountType::ProviderVotingKeys,
-                crate::types::FFIAccountType::ProviderOwnerKeys,
-                crate::types::FFIAccountType::IdentityRegistration,
-                crate::types::FFIAccountType::IdentityInvitation,
+                crate::types::FFIAccountKind::ProviderVotingKeys,
+                crate::types::FFIAccountKind::ProviderOwnerKeys,
+                crate::types::FFIAccountKind::IdentityRegistration,
+                crate::types::FFIAccountKind::IdentityInvitation,
             ];
             options.special_account_types = special_types.as_ptr();
             options.special_account_types_count = special_types.len();
@@ -1353,10 +1353,10 @@ mod tests {
 
             // Add various special accounts
             let special_types = [
-                crate::types::FFIAccountType::ProviderVotingKeys,
-                crate::types::FFIAccountType::ProviderOwnerKeys,
-                crate::types::FFIAccountType::IdentityRegistration,
-                crate::types::FFIAccountType::IdentityInvitation,
+                crate::types::FFIAccountKind::ProviderVotingKeys,
+                crate::types::FFIAccountKind::ProviderOwnerKeys,
+                crate::types::FFIAccountKind::IdentityRegistration,
+                crate::types::FFIAccountKind::IdentityInvitation,
             ];
             options.special_account_types = special_types.as_ptr();
             options.special_account_types_count = special_types.len();

--- a/key-wallet-ffi/src/account_derivation_tests.rs
+++ b/key-wallet-ffi/src/account_derivation_tests.rs
@@ -7,7 +7,7 @@ mod tests {
     use crate::derivation::*;
     use crate::error::{FFIError, FFIErrorCode};
     use crate::keys::{extended_private_key_free, private_key_free};
-    use crate::types::FFIAccountType;
+    use crate::types::FFIAccountKind;
     use crate::wallet;
     use dash_network::ffi::FFINetwork;
 
@@ -35,7 +35,7 @@ mod tests {
 
         // Get account 0 (BIP44)
         let account = unsafe {
-            crate::account::wallet_get_account(wallet, 0, FFIAccountType::StandardBIP44).account
+            crate::account::wallet_get_account(wallet, 0, FFIAccountKind::StandardBIP44).account
         };
         assert!(!account.is_null());
 
@@ -133,7 +133,7 @@ mod tests {
 
         // Get account 0 (BIP44)
         let account = unsafe {
-            crate::account::wallet_get_account(wallet, 0, FFIAccountType::StandardBIP44).account
+            crate::account::wallet_get_account(wallet, 0, FFIAccountKind::StandardBIP44).account
         };
         assert!(!account.is_null());
 
@@ -186,7 +186,7 @@ mod tests {
         };
         assert!(!wallet.is_null());
         let account = unsafe {
-            crate::account::wallet_get_account(wallet, 0, FFIAccountType::StandardBIP44).account
+            crate::account::wallet_get_account(wallet, 0, FFIAccountKind::StandardBIP44).account
         };
         assert!(!account.is_null());
 

--- a/key-wallet-ffi/src/account_tests.rs
+++ b/key-wallet-ffi/src/account_tests.rs
@@ -3,14 +3,14 @@
 mod tests {
     use super::super::*;
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::FFIAccountType;
+    use crate::types::FFIAccountKind;
     use crate::wallet;
     use std::ffi::CString;
     use std::ptr;
 
     #[test]
     fn test_wallet_get_account_null_wallet() {
-        let result = unsafe { wallet_get_account(ptr::null(), 0, FFIAccountType::StandardBIP44) };
+        let result = unsafe { wallet_get_account(ptr::null(), 0, FFIAccountKind::StandardBIP44) };
 
         assert!(result.account.is_null());
         assert_ne!(result.error_code, 0);
@@ -42,7 +42,7 @@ mod tests {
         };
 
         // Try to get the default account (should exist)
-        let result = unsafe { wallet_get_account(wallet, 0, FFIAccountType::StandardBIP44) };
+        let result = unsafe { wallet_get_account(wallet, 0, FFIAccountKind::StandardBIP44) };
 
         // Note: Since the account may not exist yet (depends on wallet creation logic),
         // we just check that the call doesn't return an error for invalid parameters
@@ -109,18 +109,18 @@ mod tests {
 
     #[test]
     fn test_account_type_values() {
-        // Test FFIAccountType enum values
-        assert_eq!(FFIAccountType::StandardBIP44 as u32, 0);
-        assert_eq!(FFIAccountType::StandardBIP32 as u32, 1);
-        assert_eq!(FFIAccountType::CoinJoin as u32, 2);
-        assert_eq!(FFIAccountType::IdentityRegistration as u32, 3);
-        assert_eq!(FFIAccountType::IdentityTopUp as u32, 4);
-        assert_eq!(FFIAccountType::IdentityTopUpNotBoundToIdentity as u32, 5);
-        assert_eq!(FFIAccountType::IdentityInvitation as u32, 6);
-        assert_eq!(FFIAccountType::ProviderVotingKeys as u32, 7);
-        assert_eq!(FFIAccountType::ProviderOwnerKeys as u32, 8);
-        assert_eq!(FFIAccountType::ProviderOperatorKeys as u32, 9);
-        assert_eq!(FFIAccountType::ProviderPlatformKeys as u32, 10);
+        // Test FFIAccountKind enum values
+        assert_eq!(FFIAccountKind::StandardBIP44 as u32, 0);
+        assert_eq!(FFIAccountKind::StandardBIP32 as u32, 1);
+        assert_eq!(FFIAccountKind::CoinJoin as u32, 2);
+        assert_eq!(FFIAccountKind::IdentityRegistration as u32, 3);
+        assert_eq!(FFIAccountKind::IdentityTopUp as u32, 4);
+        assert_eq!(FFIAccountKind::IdentityTopUpNotBoundToIdentity as u32, 5);
+        assert_eq!(FFIAccountKind::IdentityInvitation as u32, 6);
+        assert_eq!(FFIAccountKind::ProviderVotingKeys as u32, 7);
+        assert_eq!(FFIAccountKind::ProviderOwnerKeys as u32, 8);
+        assert_eq!(FFIAccountKind::ProviderOperatorKeys as u32, 9);
+        assert_eq!(FFIAccountKind::ProviderPlatformKeys as u32, 10);
     }
 
     #[test]
@@ -144,7 +144,7 @@ mod tests {
         assert_eq!(error.code, FFIErrorCode::Success);
 
         // Get an account
-        let result = unsafe { wallet_get_account(wallet, 0, FFIAccountType::StandardBIP44) };
+        let result = unsafe { wallet_get_account(wallet, 0, FFIAccountKind::StandardBIP44) };
 
         if !result.account.is_null() {
             // Test all the getter functions
@@ -167,7 +167,7 @@ mod tests {
                 // Test get account type
                 let mut index = 999u32;
                 let account_type = account_get_account_type(result.account, &mut index);
-                assert_eq!(account_type as u32, FFIAccountType::StandardBIP44 as u32);
+                assert_eq!(account_type as u32, FFIAccountKind::StandardBIP44 as u32);
                 assert_eq!(index, 0); // Account index should be 0
 
                 // Test is watch only - should be false for a wallet created from mnemonic
@@ -206,12 +206,12 @@ mod tests {
 
         let mut index = 0u32;
         let account_type = unsafe { account_get_account_type(ptr::null(), &mut index) };
-        assert_eq!(account_type as u32, FFIAccountType::StandardBIP44 as u32);
+        assert_eq!(account_type as u32, FFIAccountKind::StandardBIP44 as u32);
         assert_eq!(index, 0);
 
         // Test with null out_index
         let account_type = unsafe { account_get_account_type(ptr::null(), ptr::null_mut()) };
-        assert_eq!(account_type as u32, FFIAccountType::StandardBIP44 as u32);
+        assert_eq!(account_type as u32, FFIAccountKind::StandardBIP44 as u32);
 
         let is_watch_only = unsafe { account_get_is_watch_only(ptr::null()) };
         assert!(!is_watch_only);

--- a/key-wallet-ffi/src/address_pool.rs
+++ b/key-wallet-ffi/src/address_pool.rs
@@ -8,7 +8,7 @@ use std::os::raw::{c_char, c_uint};
 
 use crate::error::{FFIError, FFIErrorCode};
 use crate::managed_wallet::FFIManagedWalletInfo;
-use crate::types::{FFIAccountType, FFIWallet};
+use crate::types::{FFIAccountKind, FFIWallet};
 use crate::utils::rust_string_to_c;
 use crate::{check_ptr, deref_ptr, deref_ptr_mut, unwrap_or_return};
 use key_wallet::account::ManagedAccountCollection;
@@ -285,7 +285,7 @@ pub struct FFIAddressPoolInfo {
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_get_address_pool_info(
     managed_wallet: *const FFIManagedWalletInfo,
-    account_type: FFIAccountType,
+    account_type: FFIAccountKind,
     account_index: c_uint,
     pool_type: FFIAddressPoolType,
     info_out: *mut FFIAddressPoolInfo,
@@ -372,7 +372,7 @@ pub unsafe extern "C" fn managed_wallet_get_address_pool_info(
 #[no_mangle]
 pub unsafe extern "C" fn managed_wallet_set_gap_limit(
     managed_wallet: *mut FFIManagedWalletInfo,
-    account_type: FFIAccountType,
+    account_type: FFIAccountKind,
     account_index: c_uint,
     pool_type: FFIAddressPoolType,
     gap_limit: c_uint,
@@ -447,7 +447,7 @@ pub unsafe extern "C" fn managed_wallet_set_gap_limit(
 pub unsafe extern "C" fn managed_wallet_generate_addresses_to_index(
     managed_wallet: *mut FFIManagedWalletInfo,
     wallet: *const FFIWallet,
-    account_type: FFIAccountType,
+    account_type: FFIAccountKind,
     account_index: c_uint,
     pool_type: FFIAddressPoolType,
     target_index: c_uint,
@@ -977,7 +977,7 @@ mod tests {
                 manager,
                 wallet_ids_out,
                 0,
-                FFIAccountType::StandardBIP44,
+                FFIAccountKind::StandardBIP44,
             );
 
             assert!(!result.account.is_null());
@@ -1076,7 +1076,7 @@ mod tests {
                 manager,
                 wallet_ids_out,
                 0,
-                FFIAccountType::StandardBIP44,
+                FFIAccountKind::StandardBIP44,
             );
 
             assert!(!result.account.is_null());

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -14,7 +14,7 @@ use crate::address_pool::{FFIAddressPool, FFIAddressPoolType};
 use crate::check_ptr;
 use crate::error::{FFIError, FFIErrorCode};
 use crate::types::{
-    FFIAccountType, FFIInputDetail, FFIOutputDetail, FFITransactionContext,
+    FFIAccountKind, FFIInputDetail, FFIOutputDetail, FFITransactionContext,
     FFITransactionDirection, FFITransactionType,
 };
 use crate::wallet_manager::FFIWalletManager;
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn managed_wallet_get_account(
     manager: *const FFIWalletManager,
     wallet_id: *const u8,
     account_index: c_uint,
-    account_type: FFIAccountType,
+    account_type: FFIAccountKind,
 ) -> FFIManagedCoreAccountResult {
     if manager.is_null() {
         return FFIManagedCoreAccountResult::error(
@@ -529,9 +529,9 @@ pub unsafe extern "C" fn managed_core_account_get_parent_wallet_id(
 pub unsafe extern "C" fn managed_core_account_get_account_type(
     account: *const FFIManagedCoreAccount,
     index_out: *mut c_uint,
-) -> FFIAccountType {
+) -> FFIAccountKind {
     if account.is_null() {
-        return FFIAccountType::StandardBIP44; // Default type
+        return FFIAccountKind::StandardBIP44; // Default type
     }
 
     let account = &*account;
@@ -551,36 +551,36 @@ pub unsafe extern "C" fn managed_core_account_get_account_type(
         } => {
             use key_wallet::account::StandardAccountType;
             match standard_account_type {
-                StandardAccountType::BIP44Account => FFIAccountType::StandardBIP44,
-                StandardAccountType::BIP32Account => FFIAccountType::StandardBIP32,
+                StandardAccountType::BIP44Account => FFIAccountKind::StandardBIP44,
+                StandardAccountType::BIP32Account => FFIAccountKind::StandardBIP32,
             }
         }
         AccountType::CoinJoin {
             ..
-        } => FFIAccountType::CoinJoin,
-        AccountType::IdentityRegistration => FFIAccountType::IdentityRegistration,
+        } => FFIAccountKind::CoinJoin,
+        AccountType::IdentityRegistration => FFIAccountKind::IdentityRegistration,
         AccountType::IdentityTopUp {
             ..
-        } => FFIAccountType::IdentityTopUp,
+        } => FFIAccountKind::IdentityTopUp,
         AccountType::IdentityTopUpNotBoundToIdentity => {
-            FFIAccountType::IdentityTopUpNotBoundToIdentity
+            FFIAccountKind::IdentityTopUpNotBoundToIdentity
         }
-        AccountType::IdentityInvitation => FFIAccountType::IdentityInvitation,
-        AccountType::AssetLockAddressTopUp => FFIAccountType::AssetLockAddressTopUp,
-        AccountType::AssetLockShieldedAddressTopUp => FFIAccountType::AssetLockShieldedAddressTopUp,
-        AccountType::ProviderVotingKeys => FFIAccountType::ProviderVotingKeys,
-        AccountType::ProviderOwnerKeys => FFIAccountType::ProviderOwnerKeys,
-        AccountType::ProviderOperatorKeys => FFIAccountType::ProviderOperatorKeys,
-        AccountType::ProviderPlatformKeys => FFIAccountType::ProviderPlatformKeys,
+        AccountType::IdentityInvitation => FFIAccountKind::IdentityInvitation,
+        AccountType::AssetLockAddressTopUp => FFIAccountKind::AssetLockAddressTopUp,
+        AccountType::AssetLockShieldedAddressTopUp => FFIAccountKind::AssetLockShieldedAddressTopUp,
+        AccountType::ProviderVotingKeys => FFIAccountKind::ProviderVotingKeys,
+        AccountType::ProviderOwnerKeys => FFIAccountKind::ProviderOwnerKeys,
+        AccountType::ProviderOperatorKeys => FFIAccountKind::ProviderOperatorKeys,
+        AccountType::ProviderPlatformKeys => FFIAccountKind::ProviderPlatformKeys,
         AccountType::DashpayReceivingFunds {
             ..
-        } => FFIAccountType::DashpayReceivingFunds,
+        } => FFIAccountKind::DashpayReceivingFunds,
         AccountType::DashpayExternalAccount {
             ..
-        } => FFIAccountType::DashpayExternalAccount,
+        } => FFIAccountKind::DashpayExternalAccount,
         AccountType::PlatformPayment {
             ..
-        } => FFIAccountType::PlatformPayment,
+        } => FFIAccountKind::PlatformPayment,
     }
 }
 
@@ -664,6 +664,134 @@ pub unsafe extern "C" fn managed_core_account_get_utxo_count(
     account.inner().utxos.len() as c_uint
 }
 
+/// FFI-compatible owning-account descriptor for a [`FFITransactionRecord`].
+///
+/// Mirrors the Rust-side `TransactionRecord::account_type`. `kind` is the
+/// discriminant; `index` is the primary index (`0` for variants that have no
+/// meaningful primary index — identity-singletons, provider-key, asset-lock);
+/// `index_secondary` carries the secondary index (`registration_index` for
+/// `IdentityTopUp`, `key_class` for `PlatformPayment`) or `-1` when not
+/// applicable. The `identity_user` and `identity_friend` pointers are non-null
+/// only for the Dashpay variants and point to 32-byte identity hashes owned by
+/// this struct (freed by its `Drop` impl). `key_class` is `-1` unless
+/// this is a `PlatformPayment` record, in which case it carries the `key_class`
+/// hardened index (also exposed in `index_secondary` for symmetry with the
+/// existing FFI tuple contract).
+#[repr(C)]
+pub struct FFIAccountType {
+    /// Discriminant identifying the owning account variant.
+    pub kind: FFIAccountKind,
+    /// Primary account index for variants that carry one.
+    pub index: u32,
+    /// Secondary account index when applicable, `-1` otherwise.
+    pub index_secondary: i32,
+    /// Pointer to the 32-byte `user_identity_id` of the Dashpay account that
+    /// owns this record, null when the account is not a Dashpay variant. The
+    /// pointee is owned by this struct and freed when it is dropped.
+    pub identity_user: *const [u8; 32],
+    /// Pointer to the 32-byte `friend_identity_id` of the Dashpay account
+    /// that owns this record, null when the account is not a Dashpay variant.
+    /// The pointee is owned by this struct and freed when it is dropped.
+    pub identity_friend: *const [u8; 32],
+    /// `PlatformPayment` `key_class` hardened index, `-1` for any other
+    /// account variant. Mirrors `index_secondary` for `PlatformPayment`.
+    pub key_class: i32,
+}
+
+impl From<&AccountType> for FFIAccountType {
+    fn from(account_type: &AccountType) -> Self {
+        use key_wallet::account::StandardAccountType;
+        let (kind, index, index_secondary) = match *account_type {
+            AccountType::Standard {
+                index,
+                standard_account_type: StandardAccountType::BIP44Account,
+            } => (FFIAccountKind::StandardBIP44, index, -1),
+            AccountType::Standard {
+                index,
+                standard_account_type: StandardAccountType::BIP32Account,
+            } => (FFIAccountKind::StandardBIP32, index, -1),
+            AccountType::CoinJoin {
+                index,
+            } => (FFIAccountKind::CoinJoin, index, -1),
+            AccountType::IdentityRegistration => (FFIAccountKind::IdentityRegistration, 0, -1),
+            AccountType::IdentityTopUp {
+                registration_index,
+            } => (FFIAccountKind::IdentityTopUp, registration_index, -1),
+            AccountType::IdentityTopUpNotBoundToIdentity => {
+                (FFIAccountKind::IdentityTopUpNotBoundToIdentity, 0, -1)
+            }
+            AccountType::IdentityInvitation => (FFIAccountKind::IdentityInvitation, 0, -1),
+            AccountType::AssetLockAddressTopUp => (FFIAccountKind::AssetLockAddressTopUp, 0, -1),
+            AccountType::AssetLockShieldedAddressTopUp => {
+                (FFIAccountKind::AssetLockShieldedAddressTopUp, 0, -1)
+            }
+            AccountType::ProviderVotingKeys => (FFIAccountKind::ProviderVotingKeys, 0, -1),
+            AccountType::ProviderOwnerKeys => (FFIAccountKind::ProviderOwnerKeys, 0, -1),
+            AccountType::ProviderOperatorKeys => (FFIAccountKind::ProviderOperatorKeys, 0, -1),
+            AccountType::ProviderPlatformKeys => (FFIAccountKind::ProviderPlatformKeys, 0, -1),
+            AccountType::DashpayReceivingFunds {
+                index,
+                ..
+            } => (FFIAccountKind::DashpayReceivingFunds, index, -1),
+            AccountType::DashpayExternalAccount {
+                index,
+                ..
+            } => (FFIAccountKind::DashpayExternalAccount, index, -1),
+            AccountType::PlatformPayment {
+                account,
+                key_class,
+            } => (FFIAccountKind::PlatformPayment, account, key_class as i32),
+        };
+
+        let (identity_user, identity_friend) = match *account_type {
+            AccountType::DashpayReceivingFunds {
+                user_identity_id,
+                friend_identity_id,
+                ..
+            }
+            | AccountType::DashpayExternalAccount {
+                user_identity_id,
+                friend_identity_id,
+                ..
+            } => (
+                Box::into_raw(Box::new(user_identity_id)) as *const [u8; 32],
+                Box::into_raw(Box::new(friend_identity_id)) as *const [u8; 32],
+            ),
+            _ => (std::ptr::null(), std::ptr::null()),
+        };
+
+        let key_class = match *account_type {
+            AccountType::PlatformPayment {
+                key_class,
+                ..
+            } => key_class as i32,
+            _ => -1,
+        };
+
+        FFIAccountType {
+            kind,
+            index,
+            index_secondary,
+            identity_user,
+            identity_friend,
+            key_class,
+        }
+    }
+}
+
+impl Drop for FFIAccountType {
+    fn drop(&mut self) {
+        if !self.identity_user.is_null() {
+            let _ = unsafe { Box::from_raw(self.identity_user as *mut [u8; 32]) };
+            self.identity_user = std::ptr::null();
+        }
+        if !self.identity_friend.is_null() {
+            let _ = unsafe { Box::from_raw(self.identity_friend as *mut [u8; 32]) };
+            self.identity_friend = std::ptr::null();
+        }
+    }
+}
+
 /// FFI-compatible transaction record
 ///
 /// Heap-allocated fields are freed automatically when the record is dropped
@@ -682,6 +810,8 @@ pub struct FFITransactionRecord {
     pub direction: FFITransactionDirection,
     /// Fee if known, 0 if unknown
     pub fee: u64,
+    /// Owning-account descriptor (discriminant + indices + identity ids).
+    pub account_type: FFIAccountType,
     /// Input details array
     pub input_details: *mut FFIInputDetail,
     /// Number of input details
@@ -706,6 +836,8 @@ impl From<&TransactionRecord> for FFITransactionRecord {
         let transaction_type = FFITransactionType::from(value.transaction_type);
         let direction = FFITransactionDirection::from(value.direction);
         let fee = value.fee.unwrap_or(0);
+
+        let account_type = FFIAccountType::from(&value.account_type);
 
         // Serialize transaction bytes
         let tx_slice = dashcore::consensus::serialize(&value.transaction).into_boxed_slice();
@@ -750,6 +882,7 @@ impl From<&TransactionRecord> for FFITransactionRecord {
             transaction_type,
             direction,
             fee,
+            account_type,
             input_details,
             input_details_count,
             output_details,
@@ -1488,7 +1621,7 @@ mod tests {
                 manager,
                 wallet_ids_out,
                 0,
-                FFIAccountType::StandardBIP44,
+                FFIAccountKind::StandardBIP44,
             );
 
             assert!(!result.account.is_null());
@@ -1550,7 +1683,7 @@ mod tests {
 
             // Try to get a non-existent CoinJoin account
             let mut result =
-                managed_wallet_get_account(manager, wallet_ids_out, 0, FFIAccountType::CoinJoin);
+                managed_wallet_get_account(manager, wallet_ids_out, 0, FFIAccountKind::CoinJoin);
 
             assert!(result.account.is_null());
             assert_ne!(result.error_code, 0);
@@ -1677,7 +1810,7 @@ mod tests {
                 manager,
                 wallet_ids_out,
                 0,
-                FFIAccountType::StandardBIP44,
+                FFIAccountKind::StandardBIP44,
             );
 
             assert!(!result.account.is_null());
@@ -1693,7 +1826,7 @@ mod tests {
             // Test get_account_type
             let mut index_out: c_uint = 999; // Initialize with unexpected value
             let account_type = managed_core_account_get_account_type(account, &mut index_out);
-            assert_eq!(account_type, FFIAccountType::StandardBIP44);
+            assert_eq!(account_type, FFIAccountKind::StandardBIP44);
             assert_eq!(index_out, 0);
 
             // Test get_is_watch_only
@@ -1745,7 +1878,7 @@ mod tests {
 
             let mut index_out: c_uint = 0;
             let account_type = managed_core_account_get_account_type(ptr::null(), &mut index_out);
-            assert_eq!(account_type, FFIAccountType::StandardBIP44); // Default type
+            assert_eq!(account_type, FFIAccountKind::StandardBIP44); // Default type
 
             let is_watch_only = managed_core_account_get_is_watch_only(ptr::null());
             assert!(!is_watch_only);
@@ -1795,7 +1928,7 @@ mod tests {
                 manager,
                 wallet_ids_out,
                 0,
-                FFIAccountType::StandardBIP44,
+                FFIAccountKind::StandardBIP44,
             );
             assert!(!result.account.is_null());
 
@@ -1853,7 +1986,7 @@ mod tests {
                 manager,
                 wallet_ids_out,
                 0,
-                FFIAccountType::StandardBIP44,
+                FFIAccountKind::StandardBIP44,
             );
 
             assert!(!result.account.is_null());
@@ -1939,7 +2072,7 @@ mod tests {
 
             // Get CoinJoin account
             let cj_result =
-                managed_wallet_get_account(manager, wallet_ids_out, 0, FFIAccountType::CoinJoin);
+                managed_wallet_get_account(manager, wallet_ids_out, 0, FFIAccountKind::CoinJoin);
             assert!(!cj_result.account.is_null());
 
             let cj_account = cj_result.account;
@@ -2014,6 +2147,14 @@ mod tests {
             transaction_type: FFITransactionType::Standard,
             direction: FFITransactionDirection::Incoming,
             fee: 226,
+            account_type: FFIAccountType {
+                kind: FFIAccountKind::StandardBIP44,
+                index: 0,
+                index_secondary: -1,
+                identity_user: std::ptr::null(),
+                identity_friend: std::ptr::null(),
+                key_class: -1,
+            },
             input_details_count: input_slice.len(),
             input_details: Box::into_raw(input_slice) as *mut FFIInputDetail,
             output_details_count: output_slice.len(),
@@ -2038,6 +2179,14 @@ mod tests {
             transaction_type: FFITransactionType::Standard,
             direction: FFITransactionDirection::Outgoing,
             fee: 0,
+            account_type: FFIAccountType {
+                kind: FFIAccountKind::StandardBIP44,
+                index: 0,
+                index_secondary: -1,
+                identity_user: std::ptr::null(),
+                identity_friend: std::ptr::null(),
+                key_class: -1,
+            },
             input_details: std::ptr::null_mut(),
             input_details_count: 0,
             output_details: std::ptr::null_mut(),

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -716,7 +716,7 @@ impl From<&AccountType> for FFIAccountType {
             AccountType::IdentityRegistration => (FFIAccountKind::IdentityRegistration, 0, -1),
             AccountType::IdentityTopUp {
                 registration_index,
-            } => (FFIAccountKind::IdentityTopUp, registration_index, -1),
+            } => (FFIAccountKind::IdentityTopUp, 0, registration_index as i32),
             AccountType::IdentityTopUpNotBoundToIdentity => {
                 (FFIAccountKind::IdentityTopUpNotBoundToIdentity, 0, -1)
             }

--- a/key-wallet-ffi/src/transaction_checking.rs
+++ b/key-wallet-ffi/src/transaction_checking.rs
@@ -26,7 +26,7 @@ use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 /// Account type match result
 #[repr(C)]
 pub struct FFIAccountMatch {
-    /// Account type ID (matches FFIAccountType enum values)
+    /// Account type ID (matches FFIAccountKind enum values)
     pub account_type: c_uint,
     /// Account index (if applicable)
     pub account_index: c_uint,

--- a/key-wallet-ffi/src/types.rs
+++ b/key-wallet-ffi/src/types.rs
@@ -203,7 +203,7 @@ pub enum FFIStandardAccountType {
 /// - Provider accounts: Various masternode provider key types (voting, owner, operator, platform)
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum FFIAccountType {
+pub enum FFIAccountKind {
     /// Standard BIP44 account (m/44'/coin_type'/account'/x/x)
     StandardBIP44 = 0,
     /// Standard BIP32 account (m/account'/x/x)
@@ -238,42 +238,42 @@ pub enum FFIAccountType {
     AssetLockShieldedAddressTopUp = 15,
 }
 
-impl FFIAccountType {
+impl FFIAccountKind {
     /// Convert to AccountType with the provided index (used where applicable).
     /// For types needing an index (e.g., IdentityTopUp.registration_index), the provided index is used.
     pub fn to_account_type(self, index: u32) -> key_wallet::AccountType {
         use key_wallet::account::account_type::StandardAccountType;
         match self {
-            FFIAccountType::StandardBIP44 => key_wallet::AccountType::Standard {
+            FFIAccountKind::StandardBIP44 => key_wallet::AccountType::Standard {
                 index,
                 standard_account_type: StandardAccountType::BIP44Account,
             },
-            FFIAccountType::StandardBIP32 => key_wallet::AccountType::Standard {
+            FFIAccountKind::StandardBIP32 => key_wallet::AccountType::Standard {
                 index,
                 standard_account_type: StandardAccountType::BIP32Account,
             },
-            FFIAccountType::CoinJoin => key_wallet::AccountType::CoinJoin {
+            FFIAccountKind::CoinJoin => key_wallet::AccountType::CoinJoin {
                 index,
             },
-            FFIAccountType::IdentityRegistration => key_wallet::AccountType::IdentityRegistration,
-            FFIAccountType::IdentityTopUp => {
+            FFIAccountKind::IdentityRegistration => key_wallet::AccountType::IdentityRegistration,
+            FFIAccountKind::IdentityTopUp => {
                 // IdentityTopUp requires a registration_index
                 key_wallet::AccountType::IdentityTopUp {
                     registration_index: index,
                 }
             }
-            FFIAccountType::IdentityTopUpNotBoundToIdentity => {
+            FFIAccountKind::IdentityTopUpNotBoundToIdentity => {
                 key_wallet::AccountType::IdentityTopUpNotBoundToIdentity
             }
-            FFIAccountType::IdentityInvitation => key_wallet::AccountType::IdentityInvitation,
-            FFIAccountType::AssetLockAddressTopUp => key_wallet::AccountType::AssetLockAddressTopUp,
-            FFIAccountType::AssetLockShieldedAddressTopUp => {
+            FFIAccountKind::IdentityInvitation => key_wallet::AccountType::IdentityInvitation,
+            FFIAccountKind::AssetLockAddressTopUp => key_wallet::AccountType::AssetLockAddressTopUp,
+            FFIAccountKind::AssetLockShieldedAddressTopUp => {
                 key_wallet::AccountType::AssetLockShieldedAddressTopUp
             }
-            FFIAccountType::ProviderVotingKeys => key_wallet::AccountType::ProviderVotingKeys,
-            FFIAccountType::ProviderOwnerKeys => key_wallet::AccountType::ProviderOwnerKeys,
-            FFIAccountType::ProviderOperatorKeys => key_wallet::AccountType::ProviderOperatorKeys,
-            FFIAccountType::ProviderPlatformKeys => key_wallet::AccountType::ProviderPlatformKeys,
+            FFIAccountKind::ProviderVotingKeys => key_wallet::AccountType::ProviderVotingKeys,
+            FFIAccountKind::ProviderOwnerKeys => key_wallet::AccountType::ProviderOwnerKeys,
+            FFIAccountKind::ProviderOperatorKeys => key_wallet::AccountType::ProviderOperatorKeys,
+            FFIAccountKind::ProviderPlatformKeys => key_wallet::AccountType::ProviderPlatformKeys,
             // DashPay variants require additional identity IDs (user_identity_id and friend_identity_id)
             // that are not part of the current FFI API. These types cannot be constructed via this
             // conversion path. Attempting to use them is a programming error.
@@ -285,25 +285,25 @@ impl FFIAccountType {
             //   - Or extend to_account_type to accept optional identity ID parameters
             //
             // Until then, attempting to convert these variants will panic to prevent silent misrouting.
-            FFIAccountType::DashpayReceivingFunds => {
+            FFIAccountKind::DashpayReceivingFunds => {
                 panic!(
-                    "FFIAccountType::DashpayReceivingFunds cannot be converted to AccountType \
+                    "FFIAccountKind::DashpayReceivingFunds cannot be converted to AccountType \
                      without user_identity_id and friend_identity_id. The FFI API does not yet \
                      support passing these 32-byte identity IDs. This is a programming error - \
                      DashPay account creation must use a different API path."
                 );
             }
-            FFIAccountType::DashpayExternalAccount => {
+            FFIAccountKind::DashpayExternalAccount => {
                 panic!(
-                    "FFIAccountType::DashpayExternalAccount cannot be converted to AccountType \
+                    "FFIAccountKind::DashpayExternalAccount cannot be converted to AccountType \
                      without user_identity_id and friend_identity_id. The FFI API does not yet \
                      support passing these 32-byte identity IDs. This is a programming error - \
                      DashPay account creation must use a different API path."
                 );
             }
-            FFIAccountType::PlatformPayment => {
+            FFIAccountKind::PlatformPayment => {
                 panic!(
-                    "FFIAccountType::PlatformPayment cannot be converted to AccountType \
+                    "FFIAccountKind::PlatformPayment cannot be converted to AccountType \
                      without account and key_class indices. The FFI API does not yet \
                      support passing these values. This is a programming error - \
                      Platform Payment account creation must use a different API path."
@@ -314,7 +314,7 @@ impl FFIAccountType {
 
     /// Convert from AccountType to FFI representation
     ///
-    /// Returns: (FFIAccountType, primary_index, optional_secondary_index)
+    /// Returns: (FFIAccountKind, primary_index, optional_secondary_index)
     ///
     /// # Panics
     ///
@@ -331,41 +331,41 @@ impl FFIAccountType {
                 index,
                 standard_account_type,
             } => match standard_account_type {
-                StandardAccountType::BIP44Account => (FFIAccountType::StandardBIP44, *index, None),
-                StandardAccountType::BIP32Account => (FFIAccountType::StandardBIP32, *index, None),
+                StandardAccountType::BIP44Account => (FFIAccountKind::StandardBIP44, *index, None),
+                StandardAccountType::BIP32Account => (FFIAccountKind::StandardBIP32, *index, None),
             },
             key_wallet::AccountType::CoinJoin {
                 index,
-            } => (FFIAccountType::CoinJoin, *index, None),
+            } => (FFIAccountKind::CoinJoin, *index, None),
             key_wallet::AccountType::IdentityRegistration => {
-                (FFIAccountType::IdentityRegistration, 0, None)
+                (FFIAccountKind::IdentityRegistration, 0, None)
             }
             key_wallet::AccountType::IdentityTopUp {
                 registration_index,
-            } => (FFIAccountType::IdentityTopUp, 0, Some(*registration_index)),
+            } => (FFIAccountKind::IdentityTopUp, 0, Some(*registration_index)),
             key_wallet::AccountType::IdentityTopUpNotBoundToIdentity => {
-                (FFIAccountType::IdentityTopUpNotBoundToIdentity, 0, None)
+                (FFIAccountKind::IdentityTopUpNotBoundToIdentity, 0, None)
             }
             key_wallet::AccountType::IdentityInvitation => {
-                (FFIAccountType::IdentityInvitation, 0, None)
+                (FFIAccountKind::IdentityInvitation, 0, None)
             }
             key_wallet::AccountType::AssetLockAddressTopUp => {
-                (FFIAccountType::AssetLockAddressTopUp, 0, None)
+                (FFIAccountKind::AssetLockAddressTopUp, 0, None)
             }
             key_wallet::AccountType::AssetLockShieldedAddressTopUp => {
-                (FFIAccountType::AssetLockShieldedAddressTopUp, 0, None)
+                (FFIAccountKind::AssetLockShieldedAddressTopUp, 0, None)
             }
             key_wallet::AccountType::ProviderVotingKeys => {
-                (FFIAccountType::ProviderVotingKeys, 0, None)
+                (FFIAccountKind::ProviderVotingKeys, 0, None)
             }
             key_wallet::AccountType::ProviderOwnerKeys => {
-                (FFIAccountType::ProviderOwnerKeys, 0, None)
+                (FFIAccountKind::ProviderOwnerKeys, 0, None)
             }
             key_wallet::AccountType::ProviderOperatorKeys => {
-                (FFIAccountType::ProviderOperatorKeys, 0, None)
+                (FFIAccountKind::ProviderOperatorKeys, 0, None)
             }
             key_wallet::AccountType::ProviderPlatformKeys => {
-                (FFIAccountType::ProviderPlatformKeys, 0, None)
+                (FFIAccountKind::ProviderPlatformKeys, 0, None)
             }
             key_wallet::AccountType::DashpayReceivingFunds {
                 index,
@@ -375,7 +375,7 @@ impl FFIAccountType {
                 // Cannot convert DashPay accounts to FFI without losing identity ID information
                 panic!(
                     "Cannot convert AccountType::DashpayReceivingFunds (index={}, user_id={:?}, friend_id={:?}) \
-                     to FFI representation. The current FFI tuple format (FFIAccountType, u32, Option<u32>) \
+                     to FFI representation. The current FFI tuple format (FFIAccountKind, u32, Option<u32>) \
                      cannot represent the two 32-byte identity IDs required by DashPay accounts. \
                      This would result in silent data loss. A dedicated FFI API for DashPay accounts is needed.",
                     index,
@@ -391,7 +391,7 @@ impl FFIAccountType {
                 // Cannot convert DashPay accounts to FFI without losing identity ID information
                 panic!(
                     "Cannot convert AccountType::DashpayExternalAccount (index={}, user_id={:?}, friend_id={:?}) \
-                     to FFI representation. The current FFI tuple format (FFIAccountType, u32, Option<u32>) \
+                     to FFI representation. The current FFI tuple format (FFIAccountKind, u32, Option<u32>) \
                      cannot represent the two 32-byte identity IDs required by DashPay accounts. \
                      This would result in silent data loss. A dedicated FFI API for DashPay accounts is needed.",
                     index,
@@ -402,7 +402,7 @@ impl FFIAccountType {
             key_wallet::AccountType::PlatformPayment {
                 account,
                 key_class,
-            } => (FFIAccountType::PlatformPayment, *account, Some(*key_class)),
+            } => (FFIAccountKind::PlatformPayment, *account, Some(*key_class)),
         }
     }
 }
@@ -499,8 +499,8 @@ pub struct FFIWalletAccountCreationOptions {
 
     /// For SpecificAccounts: Additional special account types to create
     /// (e.g., IdentityRegistration, ProviderKeys, etc.)
-    /// This is an array of FFIAccountType values
-    pub special_account_types: *const FFIAccountType,
+    /// This is an array of FFIAccountKind values
+    pub special_account_types: *const FFIAccountKind,
     pub special_account_types_count: usize,
 }
 
@@ -956,21 +956,21 @@ mod tests {
     #[should_panic(expected = "DashpayReceivingFunds cannot be converted to AccountType")]
     fn test_dashpay_receiving_funds_to_account_type_panics() {
         // This should panic because we cannot construct a DashPay account without identity IDs
-        let _ = FFIAccountType::DashpayReceivingFunds.to_account_type(0);
+        let _ = FFIAccountKind::DashpayReceivingFunds.to_account_type(0);
     }
 
     #[test]
     #[should_panic(expected = "DashpayExternalAccount cannot be converted to AccountType")]
     fn test_dashpay_external_account_to_account_type_panics() {
         // This should panic because we cannot construct a DashPay account without identity IDs
-        let _ = FFIAccountType::DashpayExternalAccount.to_account_type(0);
+        let _ = FFIAccountKind::DashpayExternalAccount.to_account_type(0);
     }
 
     #[test]
     #[should_panic(expected = "PlatformPayment cannot be converted to AccountType")]
     fn test_platform_payment_to_account_type_panics() {
         // This should panic because we cannot construct a Platform Payment account without indices
-        let _ = FFIAccountType::PlatformPayment.to_account_type(0);
+        let _ = FFIAccountKind::PlatformPayment.to_account_type(0);
     }
 
     #[test]
@@ -982,7 +982,7 @@ mod tests {
             user_identity_id: [1u8; 32],
             friend_identity_id: [2u8; 32],
         };
-        let _ = FFIAccountType::from_account_type(&account_type);
+        let _ = FFIAccountKind::from_account_type(&account_type);
     }
 
     #[test]
@@ -994,13 +994,13 @@ mod tests {
             user_identity_id: [1u8; 32],
             friend_identity_id: [2u8; 32],
         };
-        let _ = FFIAccountType::from_account_type(&account_type);
+        let _ = FFIAccountKind::from_account_type(&account_type);
     }
 
     #[test]
     fn test_non_dashpay_conversions_work() {
         // Verify that non-DashPay types still convert correctly
-        let standard_bip44 = FFIAccountType::StandardBIP44.to_account_type(5);
+        let standard_bip44 = FFIAccountKind::StandardBIP44.to_account_type(5);
         assert!(matches!(
             standard_bip44,
             key_wallet::AccountType::Standard {
@@ -1009,7 +1009,7 @@ mod tests {
             }
         ));
 
-        let coinjoin = FFIAccountType::CoinJoin.to_account_type(3);
+        let coinjoin = FFIAccountKind::CoinJoin.to_account_type(3);
         assert!(matches!(
             coinjoin,
             key_wallet::AccountType::CoinJoin {
@@ -1018,8 +1018,8 @@ mod tests {
         ));
 
         // Test reverse conversion
-        let (ffi_type, index, _) = FFIAccountType::from_account_type(&standard_bip44);
-        assert_eq!(ffi_type, FFIAccountType::StandardBIP44);
+        let (ffi_type, index, _) = FFIAccountKind::from_account_type(&standard_bip44);
+        assert_eq!(ffi_type, FFIAccountKind::StandardBIP44);
         assert_eq!(index, 5);
     }
 

--- a/key-wallet-ffi/src/wallet.rs
+++ b/key-wallet-ffi/src/wallet.rs
@@ -335,10 +335,10 @@ pub unsafe extern "C" fn wallet_free_const(wallet: *const FFIWallet) {
 #[no_mangle]
 pub unsafe extern "C" fn wallet_add_account(
     wallet: *mut FFIWallet,
-    account_type: crate::types::FFIAccountType,
+    account_type: crate::types::FFIAccountKind,
     account_index: c_uint,
 ) -> crate::types::FFIAccountResult {
-    use crate::types::FFIAccountType;
+    use crate::types::FFIAccountKind;
 
     if wallet.is_null() {
         return crate::types::FFIAccountResult::error(
@@ -349,7 +349,7 @@ pub unsafe extern "C" fn wallet_add_account(
 
     // Check for account types that require special handling
     match account_type {
-        FFIAccountType::PlatformPayment => {
+        FFIAccountKind::PlatformPayment => {
             return crate::types::FFIAccountResult::error(
                 FFIErrorCode::InvalidInput,
                 "PlatformPayment accounts require account and key_class indices. \
@@ -357,7 +357,7 @@ pub unsafe extern "C" fn wallet_add_account(
                     .to_string(),
             );
         }
-        FFIAccountType::DashpayReceivingFunds => {
+        FFIAccountKind::DashpayReceivingFunds => {
             return crate::types::FFIAccountResult::error(
                 FFIErrorCode::InvalidInput,
                 "DashpayReceivingFunds accounts require identity IDs. \
@@ -365,7 +365,7 @@ pub unsafe extern "C" fn wallet_add_account(
                     .to_string(),
             );
         }
-        FFIAccountType::DashpayExternalAccount => {
+        FFIAccountKind::DashpayExternalAccount => {
             return crate::types::FFIAccountResult::error(
                 FFIErrorCode::InvalidInput,
                 "DashpayExternalAccount accounts require identity IDs. \
@@ -553,12 +553,12 @@ pub unsafe extern "C" fn wallet_add_dashpay_external_account_with_xpub_bytes(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_add_account_with_xpub_bytes(
     wallet: *mut FFIWallet,
-    account_type: crate::types::FFIAccountType,
+    account_type: crate::types::FFIAccountKind,
     account_index: c_uint,
     xpub_bytes: *const u8,
     xpub_len: usize,
 ) -> crate::types::FFIAccountResult {
-    use crate::types::FFIAccountType;
+    use crate::types::FFIAccountKind;
 
     if wallet.is_null() {
         return crate::types::FFIAccountResult::error(
@@ -576,7 +576,7 @@ pub unsafe extern "C" fn wallet_add_account_with_xpub_bytes(
 
     // Check for account types that require special handling
     match account_type {
-        FFIAccountType::PlatformPayment => {
+        FFIAccountKind::PlatformPayment => {
             return crate::types::FFIAccountResult::error(
                 FFIErrorCode::InvalidInput,
                 "PlatformPayment accounts require account and key_class indices. \
@@ -584,7 +584,7 @@ pub unsafe extern "C" fn wallet_add_account_with_xpub_bytes(
                     .to_string(),
             );
         }
-        FFIAccountType::DashpayReceivingFunds => {
+        FFIAccountKind::DashpayReceivingFunds => {
             return crate::types::FFIAccountResult::error(
                 FFIErrorCode::InvalidInput,
                 "DashpayReceivingFunds accounts require identity IDs. \
@@ -592,7 +592,7 @@ pub unsafe extern "C" fn wallet_add_account_with_xpub_bytes(
                     .to_string(),
             );
         }
-        FFIAccountType::DashpayExternalAccount => {
+        FFIAccountKind::DashpayExternalAccount => {
             return crate::types::FFIAccountResult::error(
                 FFIErrorCode::InvalidInput,
                 "DashpayExternalAccount accounts require identity IDs. \
@@ -677,11 +677,11 @@ pub unsafe extern "C" fn wallet_add_account_with_xpub_bytes(
 #[no_mangle]
 pub unsafe extern "C" fn wallet_add_account_with_string_xpub(
     wallet: *mut FFIWallet,
-    account_type: crate::types::FFIAccountType,
+    account_type: crate::types::FFIAccountKind,
     account_index: c_uint,
     xpub_string: *const c_char,
 ) -> crate::types::FFIAccountResult {
-    use crate::types::FFIAccountType;
+    use crate::types::FFIAccountKind;
 
     if wallet.is_null() {
         return crate::types::FFIAccountResult::error(
@@ -699,7 +699,7 @@ pub unsafe extern "C" fn wallet_add_account_with_string_xpub(
 
     // Check for account types that require special handling
     match account_type {
-        FFIAccountType::PlatformPayment => {
+        FFIAccountKind::PlatformPayment => {
             return crate::types::FFIAccountResult::error(
                 FFIErrorCode::InvalidInput,
                 "PlatformPayment accounts require account and key_class indices. \
@@ -707,7 +707,7 @@ pub unsafe extern "C" fn wallet_add_account_with_string_xpub(
                     .to_string(),
             );
         }
-        FFIAccountType::DashpayReceivingFunds => {
+        FFIAccountKind::DashpayReceivingFunds => {
             return crate::types::FFIAccountResult::error(
                 FFIErrorCode::InvalidInput,
                 "DashpayReceivingFunds accounts require identity IDs. \
@@ -715,7 +715,7 @@ pub unsafe extern "C" fn wallet_add_account_with_string_xpub(
                     .to_string(),
             );
         }
-        FFIAccountType::DashpayExternalAccount => {
+        FFIAccountKind::DashpayExternalAccount => {
             return crate::types::FFIAccountResult::error(
                 FFIErrorCode::InvalidInput,
                 "DashpayExternalAccount accounts require identity IDs. \

--- a/key-wallet-ffi/src/wallet_tests.rs
+++ b/key-wallet-ffi/src/wallet_tests.rs
@@ -4,7 +4,7 @@
 mod wallet_tests {
     use crate::account::account_free;
     use crate::error::{FFIError, FFIErrorCode};
-    use crate::types::FFIAccountType;
+    use crate::types::FFIAccountKind;
     use crate::wallet;
     use dash_network::ffi::FFINetwork;
     use std::ffi::CString;
@@ -284,7 +284,7 @@ mod wallet_tests {
 
         // Test adding account - check if it succeeds or fails gracefully
         let result =
-            unsafe { wallet::wallet_add_account(wallet, FFIAccountType::StandardBIP44, 1) };
+            unsafe { wallet::wallet_add_account(wallet, FFIAccountKind::StandardBIP44, 1) };
         // Some implementations may not support adding accounts, so just verify it doesn't crash
         // and the error code is set appropriately
         assert!(!result.account.is_null() || result.error_code != 0);
@@ -313,7 +313,7 @@ mod wallet_tests {
     fn test_wallet_add_account_null() {
         // Test with null wallet
         let result = unsafe {
-            wallet::wallet_add_account(ptr::null_mut(), FFIAccountType::StandardBIP44, 0)
+            wallet::wallet_add_account(ptr::null_mut(), FFIAccountKind::StandardBIP44, 0)
         };
         assert!(result.account.is_null());
         assert_ne!(result.error_code, 0);

--- a/key-wallet-ffi/tests/test_managed_account_collection.rs
+++ b/key-wallet-ffi/tests/test_managed_account_collection.rs
@@ -101,10 +101,10 @@ fn test_managed_account_collection_with_special_accounts() {
 
         // Add various special accounts
         let special_types = [
-            key_wallet_ffi::types::FFIAccountType::ProviderVotingKeys,
-            key_wallet_ffi::types::FFIAccountType::ProviderOwnerKeys,
-            key_wallet_ffi::types::FFIAccountType::IdentityRegistration,
-            key_wallet_ffi::types::FFIAccountType::IdentityInvitation,
+            key_wallet_ffi::types::FFIAccountKind::ProviderVotingKeys,
+            key_wallet_ffi::types::FFIAccountKind::ProviderOwnerKeys,
+            key_wallet_ffi::types::FFIAccountKind::IdentityRegistration,
+            key_wallet_ffi::types::FFIAccountKind::IdentityInvitation,
         ];
         options.special_account_types = special_types.as_ptr();
         options.special_account_types_count = special_types.len();
@@ -229,9 +229,9 @@ fn test_managed_account_collection_summary() {
 
         // Add various special accounts
         let special_types = [
-            key_wallet_ffi::types::FFIAccountType::ProviderVotingKeys,
-            key_wallet_ffi::types::FFIAccountType::ProviderOwnerKeys,
-            key_wallet_ffi::types::FFIAccountType::IdentityRegistration,
+            key_wallet_ffi::types::FFIAccountKind::ProviderVotingKeys,
+            key_wallet_ffi::types::FFIAccountKind::ProviderOwnerKeys,
+            key_wallet_ffi::types::FFIAccountKind::IdentityRegistration,
         ];
         options.special_account_types = special_types.as_ptr();
         options.special_account_types_count = special_types.len();
@@ -310,8 +310,8 @@ fn test_managed_account_collection_summary_data() {
 
         // Add various special accounts
         let special_types = [
-            key_wallet_ffi::types::FFIAccountType::IdentityRegistration,
-            key_wallet_ffi::types::FFIAccountType::IdentityInvitation,
+            key_wallet_ffi::types::FFIAccountKind::IdentityRegistration,
+            key_wallet_ffi::types::FFIAccountKind::IdentityInvitation,
         ];
         options.special_account_types = special_types.as_ptr();
         options.special_account_types_count = special_types.len();

--- a/key-wallet-manager/Cargo.toml
+++ b/key-wallet-manager/Cargo.toml
@@ -18,6 +18,7 @@ key-wallet = { path = "../key-wallet", default-features = false }
 dashcore = { path = "../dash" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
+tracing = "0.1"
 zeroize = { version = "1.8", features = ["derive"] }
 rayon = { version = "1.11", optional = true }
 bincode = { version = "2.0.1", optional = true }

--- a/key-wallet-manager/src/accessors.rs
+++ b/key-wallet-manager/src/accessors.rs
@@ -178,27 +178,8 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
     }
 
     /// Snapshot the current balance of every managed wallet.
-    pub(crate) fn snapshot_balances(&self) -> Vec<(WalletId, WalletCoreBalance)> {
+    pub(crate) fn snapshot_balances(&self) -> BTreeMap<WalletId, WalletCoreBalance> {
         self.wallet_infos.iter().map(|(id, info)| (*id, info.balance())).collect()
-    }
-
-    /// Emit `BalanceUpdated` events for wallets whose balance differs from the snapshot.
-    pub(crate) fn emit_balance_changes(&self, old_balances: &[(WalletId, WalletCoreBalance)]) {
-        for (wallet_id, old_balance) in old_balances {
-            if let Some(info) = self.wallet_infos.get(wallet_id) {
-                let new_balance = info.balance();
-                if *old_balance != new_balance {
-                    let event = WalletEvent::BalanceUpdated {
-                        wallet_id: *wallet_id,
-                        confirmed: new_balance.confirmed(),
-                        unconfirmed: new_balance.unconfirmed(),
-                        immature: new_balance.immature(),
-                        locked: new_balance.locked(),
-                    };
-                    let _ = self.event_sender.send(event);
-                }
-            }
-        }
     }
 
     /// Get all outpoints from wallet UTXOs across all managed wallets.

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -1,529 +1,117 @@
 use super::test_helpers::*;
 use super::*;
 use crate::wallet_interface::WalletInterface;
+use dashcore::block::{Block, Header, Version};
+use dashcore::blockdata::script::Builder;
+use dashcore::blockdata::transaction::special_transaction::asset_lock::AssetLockPayload;
+use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
 use dashcore::bls_sig_utils::BLSSignature;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::hash_types::CycleHash;
 use dashcore::hashes::Hash;
-use dashcore::BlockHash;
-use key_wallet::transaction_checking::BlockInfo;
+use dashcore::opcodes;
+use dashcore::{
+    BlockHash, CompactTarget, OutPoint, ScriptBuf, TxIn, TxMerkleNode, TxOut, Txid, Witness,
+};
+use key_wallet::account::StandardAccountType;
+use key_wallet::AccountType;
+
+fn make_block(txdata: Vec<Transaction>, seed: u8, time: u32) -> Block {
+    Block {
+        header: Header {
+            version: Version::default(),
+            prev_blockhash: BlockHash::from_byte_array([seed; 32]),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time,
+            bits: CompactTarget::from_consensus(0x1d00ffff),
+            nonce: 0,
+        },
+        txdata,
+    }
+}
+
+fn make_coinbase_paying_to(addr: &Address, value: u64) -> Transaction {
+    Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: Txid::all_zeros(),
+                vout: 0xffffffff,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: 0xffffffff,
+            witness: Witness::default(),
+        }],
+        output: vec![TxOut {
+            value,
+            script_pubkey: addr.script_pubkey(),
+        }],
+        special_transaction_payload: None,
+    }
+}
 
 // ---------------------------------------------------------------------------
-// Lifecycle flow tests
+// Mempool path
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_mempool_to_confirmed_event_flow() {
+async fn test_mempool_tx_emits_single_event_with_balance() {
     let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
     let mut rx = manager.subscribe_events();
     let tx = create_tx_paying_to(&addr, 0xaa);
 
-    // First time in mempool — validate all event fields
-    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true, true).await;
-    let event = assert_single_event(&mut rx);
-    match event {
+    manager.process_mempool_transaction(&tx, None).await;
+
+    let events = drain_events(&mut rx);
+    assert_eq!(events.len(), 1, "exactly one event expected, got {:?}", events);
+    match &events[0] {
         WalletEvent::TransactionReceived {
-            wallet_id: ev_wid,
+            wallet_id: wid,
             record,
-            ..
+            balance,
         } => {
-            assert_eq!(record.context, TransactionContext::Mempool);
+            assert_eq!(*wid, wallet_id);
             assert_eq!(record.txid, tx.txid());
-            assert_eq!(ev_wid, wallet_id);
+            assert_eq!(record.context, TransactionContext::Mempool);
             assert_eq!(record.net_amount, TX_AMOUNT as i64);
+            assert!(matches!(
+                record.account_type,
+                AccountType::Standard {
+                    index: 0,
+                    standard_account_type: StandardAccountType::BIP44Account
+                }
+            ));
+            assert_eq!(balance.unconfirmed(), TX_AMOUNT);
+            assert_eq!(balance.confirmed(), 0);
         }
         other => panic!("expected TransactionReceived, got {:?}", other),
     }
-
-    // Same tx now confirmed in a block
-    let block_ctx = TransactionContext::InBlock(BlockInfo::new(
-        100,
-        BlockHash::from_byte_array([0xaa; 32]),
-        1000,
-    ));
-    manager.check_transaction_in_all_wallets(&tx, block_ctx, true, true).await;
-    let event = assert_single_event(&mut rx);
-    match event {
-        WalletEvent::TransactionStatusChanged {
-            wallet_id: ev_wid,
-            txid: ev_txid,
-            status,
-        } => {
-            assert_eq!(ev_wid, wallet_id);
-            assert_eq!(ev_txid, tx.txid());
-            assert!(
-                matches!(
-                                    status,
-                TransactionContext::InBlock(info) if info.height() == 100
-                                ),
-                "expected InBlock(100), got {:?}",
-                status
-            );
-        }
-        other => panic!("expected TransactionStatusChanged, got {:?}", other),
-    }
 }
 
 #[tokio::test]
-async fn test_mempool_to_instantsend_to_confirmed_event_flow() {
-    assert_lifecycle_flow(
-        &[
-            TransactionContext::Mempool,
-            TransactionContext::InstantSend(InstantLock::default()),
-            TransactionContext::InBlock(BlockInfo::new(
-                200,
-                BlockHash::from_byte_array([0xbb; 32]),
-                2000,
-            )),
-        ],
-        0xbb,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_first_seen_in_block_event_flow() {
-    assert_lifecycle_flow(
-        &[TransactionContext::InBlock(BlockInfo::new(
-            1000,
-            BlockHash::from_byte_array([0xdd; 32]),
-            10000,
-        ))],
-        0xdd,
-    )
-    .await;
-}
-
-// ---------------------------------------------------------------------------
-// Duplicate suppression tests
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_duplicate_mempool_emits_no_event() {
-    assert_context_suppressed(
-        &[TransactionContext::Mempool],
-        TransactionContext::Mempool,
-        None,
-        0x11,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_duplicate_instantsend_emits_no_event() {
-    assert_context_suppressed(
-        &[TransactionContext::Mempool, TransactionContext::InstantSend(InstantLock::default())],
-        TransactionContext::InstantSend(InstantLock::default()),
-        None,
-        0x22,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_duplicate_confirmed_emits_no_event() {
-    let block_ctx = TransactionContext::InBlock(BlockInfo::new(
-        300,
-        BlockHash::from_byte_array([0x33; 32]),
-        3000,
-    ));
-    let block_ctx2 = block_ctx.clone();
-    assert_context_suppressed(&[block_ctx], block_ctx2, Some(300), 0x33).await;
-}
-
-// ---------------------------------------------------------------------------
-// Edge case tests
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_first_seen_as_instantsend_then_duplicate() {
-    assert_context_suppressed(
-        &[TransactionContext::InstantSend(InstantLock::default())],
-        TransactionContext::InstantSend(InstantLock::default()),
-        None,
-        0x55,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_late_instantsend_after_confirmation_is_ignored() {
-    assert_context_suppressed(
-        &[
-            TransactionContext::Mempool,
-            TransactionContext::InBlock(BlockInfo::new(
-                800,
-                BlockHash::from_byte_array([0x77; 32]),
-                8000,
-            )),
-        ],
-        TransactionContext::InstantSend(InstantLock::default()),
-        Some(800),
-        0x77,
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn test_mempool_after_instantsend_is_suppressed() {
-    assert_context_suppressed(
-        &[TransactionContext::Mempool, TransactionContext::InstantSend(InstantLock::default())],
-        TransactionContext::Mempool,
-        None,
-        0xab,
-    )
-    .await;
-}
-
-// ---------------------------------------------------------------------------
-// BalanceUpdated event tests
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_mempool_tx_emits_balance_updated() {
+async fn test_mempool_tx_with_instant_lock_emits_received_event_with_locked_balance() {
     let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
     let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xf1);
-
-    manager.process_mempool_transaction(&tx, None).await;
-
-    let events = drain_events(&mut rx);
-    let balance_events: Vec<_> =
-        events.iter().filter(|e| matches!(e, WalletEvent::BalanceUpdated { .. })).collect();
-    assert_eq!(balance_events.len(), 1, "expected exactly 1 BalanceUpdated, got {:?}", events);
-    assert!(
-        matches!(
-            balance_events[0],
-            WalletEvent::BalanceUpdated {
-                wallet_id: wid,
-                unconfirmed,
-                confirmed,
-                ..
-            } if *wid == wallet_id && *unconfirmed == TX_AMOUNT && *confirmed == 0
-        ),
-        "expected BalanceUpdated with unconfirmed={TX_AMOUNT}, confirmed=0, got {:?}",
-        balance_events[0]
-    );
-}
-
-#[tokio::test]
-async fn test_instantsend_tx_emits_balance_updated_spendable() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xf2);
+    let tx = create_tx_paying_to(&addr, 0xbb);
 
     manager.process_mempool_transaction(&tx, Some(dummy_instant_lock(tx.txid()))).await;
 
     let events = drain_events(&mut rx);
-    let balance_events: Vec<_> =
-        events.iter().filter(|e| matches!(e, WalletEvent::BalanceUpdated { .. })).collect();
-    assert_eq!(balance_events.len(), 1, "expected exactly 1 BalanceUpdated, got {:?}", events);
-    assert!(
-        matches!(
-            balance_events[0],
-            WalletEvent::BalanceUpdated {
-                wallet_id: wid,
-                confirmed,
-                unconfirmed,
-                ..
-            } if *wid == wallet_id && *confirmed == TX_AMOUNT && *unconfirmed == 0
-        ),
-        "expected BalanceUpdated with confirmed={TX_AMOUNT}, unconfirmed=0, got {:?}",
-        balance_events[0]
-    );
-}
-
-#[tokio::test]
-async fn test_mempool_to_instantsend_transitions_balance() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xf3);
-
-    // Mempool tx: balance should be unconfirmed
-    manager.process_mempool_transaction(&tx, None).await;
-    let events = drain_events(&mut rx);
-    assert!(
-        events.iter().any(|e| matches!(
-            e,
-            WalletEvent::BalanceUpdated {
-                wallet_id: wid,
-                unconfirmed,
-                confirmed,
-                ..
-            } if *wid == wallet_id && *unconfirmed == TX_AMOUNT && *confirmed == 0
-        )),
-        "expected unconfirmed balance after mempool, got {:?}",
-        events
-    );
-
-    // IS lock: balance should move from unconfirmed to confirmed
-    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
-    let events = drain_events(&mut rx);
-    assert!(
-        events.iter().any(|e| matches!(
-            e,
-            WalletEvent::BalanceUpdated {
-                wallet_id: wid,
-                confirmed,
-                unconfirmed,
-                ..
-            } if *wid == wallet_id && *confirmed == TX_AMOUNT && *unconfirmed == 0
-        )),
-        "expected confirmed balance after IS lock, got {:?}",
-        events
-    );
-}
-
-#[tokio::test]
-async fn test_process_instant_send_lock_updates_transaction_record_context() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let tx = create_tx_paying_to(&addr, 0xf4);
-
-    // Process as mempool transaction first
-    manager.process_mempool_transaction(&tx, None).await;
-
-    // Verify record starts with Mempool context
-    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
-    let record = history.iter().find(|r| r.txid == tx.txid()).unwrap();
-    assert_eq!(record.context, TransactionContext::Mempool);
-
-    // Create a rich InstantLock with a non-default cyclehash
-    let lock = InstantLock {
-        txid: tx.txid(),
-        cyclehash: CycleHash::from_byte_array([0xab; 32]),
-        signature: BLSSignature::from([0xcd; 96]),
-        ..InstantLock::default()
-    };
-
-    manager.process_instant_send_lock(lock.clone());
-
-    // Verify the transaction record context was updated to InstantSend
-    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
-    let record = history.iter().find(|r| r.txid == tx.txid()).unwrap();
-    assert_eq!(
-        record.context,
-        TransactionContext::InstantSend(lock),
-        "transaction record context should be updated to InstantSend with matching lock"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Production API tests
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_process_instant_send_lock_for_unknown_txid() {
-    let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-
-    let unknown_txid = dashcore::Txid::from_byte_array([0xee; 32]);
-    let balance_before = manager.wallet_infos.get(&wallet_id).unwrap().balance();
-
-    manager.process_instant_send_lock(dummy_instant_lock(unknown_txid));
-
-    assert_no_events(&mut rx);
-    let balance_after = manager.wallet_infos.get(&wallet_id).unwrap().balance();
-    assert_eq!(balance_before, balance_after);
-}
-
-#[tokio::test]
-async fn test_process_instant_send_lock_dedup() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let tx = create_tx_paying_to(&addr, 0xe1);
-
-    manager.process_mempool_transaction(&tx, None).await;
-    let mut rx = manager.subscribe_events();
-
-    // First IS lock should emit events
-    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
-    let events = drain_events(&mut rx);
-    assert!(
-        events.iter().any(|e| matches!(
-            e,
-            WalletEvent::TransactionStatusChanged {
-                wallet_id: wid,
-                status: TransactionContext::InstantSend(_),
-                ..
-            } if *wid == wallet_id
-        )),
-        "expected TransactionStatusChanged(InstantSend) with correct wallet_id, got {:?}",
-        events
-    );
-    assert!(
-        events.iter().any(
-            |e| matches!(e, WalletEvent::BalanceUpdated { wallet_id: wid, .. } if *wid == wallet_id)
-        ),
-        "expected BalanceUpdated for wallet, got {:?}",
-        events
-    );
-
-    // Second IS lock should be a no-op
-    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
-    assert_no_events(&mut rx);
-}
-
-#[tokio::test]
-async fn test_process_instant_send_lock_after_block_confirmation() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let tx = create_tx_paying_to(&addr, 0xe2);
-
-    // Process as IS mempool tx, then confirm in block
-    manager.process_mempool_transaction(&tx, Some(dummy_instant_lock(tx.txid()))).await;
-    let block_ctx = TransactionContext::InBlock(BlockInfo::new(
-        500,
-        BlockHash::from_byte_array([0xe2; 32]),
-        5000,
-    ));
-    manager.check_transaction_in_all_wallets(&tx, block_ctx, true, true).await;
-
-    // IS lock after block confirmation is a no-op (already tracked via mempool IS)
-    let mut rx = manager.subscribe_events();
-    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
-    assert_no_events(&mut rx);
-
-    // Confirm height preserved
-    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
-    let records: Vec<_> = history.iter().filter(|r| r.txid == tx.txid()).collect();
-    assert_eq!(records.len(), 1);
-    assert_eq!(records[0].height(), Some(500));
-}
-
-#[tokio::test]
-async fn test_mixed_instantsend_paths_no_duplicate_events() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xf0);
-
-    // Mempool first
-    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true, true).await;
-    drain_events(&mut rx);
-
-    // IS lock via process_instant_send_lock (network IS lock message)
-    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
-    let events = drain_events(&mut rx);
-    assert!(
-        events.iter().any(|e| matches!(
-            e,
-            WalletEvent::TransactionStatusChanged {
-                wallet_id: wid,
-                status: TransactionContext::InstantSend(_),
-                ..
-            } if *wid == wallet_id
-        )),
-        "expected TransactionStatusChanged(InstantSend) with correct wallet_id, got {:?}",
-        events
-    );
-
-    // Same IS lock via check_transaction_in_all_wallets (block/tx processing path)
-    // should be suppressed — no duplicate event
-    let is_lock = dummy_instant_lock(tx.txid());
-    manager
-        .check_transaction_in_all_wallets(&tx, TransactionContext::InstantSend(is_lock), true, true)
-        .await;
-    assert_no_events(&mut rx);
-}
-
-#[tokio::test]
-async fn test_mixed_instantsend_paths_reverse_no_duplicate_events() {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xf1);
-
-    // Mempool first
-    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true, true).await;
-    drain_events(&mut rx);
-
-    // IS lock via check_transaction_in_all_wallets first
-    let is_lock = dummy_instant_lock(tx.txid());
-    manager
-        .check_transaction_in_all_wallets(
-            &tx,
-            TransactionContext::InstantSend(is_lock.clone()),
-            true,
-            true,
-        )
-        .await;
-    let events = drain_events(&mut rx);
-    assert!(
-        events.iter().any(|e| matches!(
-            e,
-            WalletEvent::TransactionStatusChanged {
-                wallet_id: wid,
-                status: TransactionContext::InstantSend(_),
-                ..
-            } if *wid == wallet_id
-        )),
-        "expected TransactionStatusChanged(InstantSend) with correct wallet_id, got {:?}",
-        events
-    );
-
-    // Same IS lock via process_instant_send_lock — should be suppressed
-    manager.process_instant_send_lock(is_lock);
-    assert_no_events(&mut rx);
-}
-
-#[tokio::test]
-async fn test_process_block_emits_events() {
-    use dashcore::blockdata::block::{Block, Header, Version};
-    use dashcore::hashes::Hash;
-    use dashcore::{BlockHash, CompactTarget, TxMerkleNode};
-
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xe3);
-
-    let block = Block {
-        header: Header {
-            version: Version::default(),
-            prev_blockhash: BlockHash::all_zeros(),
-            merkle_root: TxMerkleNode::all_zeros(),
-            time: 12345,
-            bits: CompactTarget::from_consensus(0x1d00ffff),
-            nonce: 0,
-        },
-        txdata: vec![tx],
-    };
-
-    let result = manager.process_block(&block, 1000).await;
-    assert_eq!(result.new_txids.len(), 1);
-
-    let events = drain_events(&mut rx);
-    let event = events
-        .iter()
-        .find(|e| matches!(e, WalletEvent::TransactionReceived { .. }))
-        .unwrap_or_else(|| {
-            panic!("expected TransactionReceived from process_block, got {:?}", events)
-        });
-
-    match event {
+    assert_eq!(events.len(), 1, "one event expected for first-seen IS-locked tx, got {:?}", events);
+    match &events[0] {
         WalletEvent::TransactionReceived {
-            account_index,
+            wallet_id: wid,
             record,
-            ..
+            balance,
         } => {
-            assert!(
-                matches!(
-                    record.context,
-                    TransactionContext::InBlock(info) if info.height() == 1000
-                ),
-                "expected InBlock at height 1000, got {:?}",
-                record.context
-            );
-            assert_eq!(*account_index, 0);
-            assert!(
-                !record.input_details.is_empty() || !record.output_details.is_empty(),
-                "expected non-empty details"
-            );
+            assert_eq!(*wid, wallet_id);
+            assert!(matches!(record.context, TransactionContext::InstantSend(_)));
+            assert_eq!(balance.confirmed(), TX_AMOUNT);
+            assert_eq!(balance.unconfirmed(), 0);
         }
-        _ => unreachable!(),
+        other => panic!("expected TransactionReceived with IS context, got {:?}", other),
     }
-    assert!(
-        events.iter().any(
-            |e| matches!(e, WalletEvent::BalanceUpdated { wallet_id: wid, .. } if *wid == wallet_id)
-        ),
-        "expected BalanceUpdated from process_block, got {:?}",
-        events
-    );
 }
 
 #[tokio::test]
@@ -533,7 +121,6 @@ async fn test_irrelevant_mempool_tx_emits_no_events() {
     let (mut manager, _wallet_id, _addr) = setup_manager_with_wallet();
     let mut rx = manager.subscribe_events();
 
-    // Create a tx paying to a random script that doesn't match any wallet address
     let random_script =
         ScriptBuf::new_p2pkh(&PublicKey::from_slice(&[2; 33]).unwrap().pubkey_hash());
     let tx = Transaction {
@@ -556,132 +143,452 @@ async fn test_irrelevant_mempool_tx_emits_no_events() {
     };
 
     let result = manager.process_mempool_transaction(&tx, None).await;
-
     assert!(!result.is_relevant);
-    assert_eq!(result.net_amount, 0);
     assert_no_events(&mut rx);
 }
 
 // ---------------------------------------------------------------------------
-// Edge case tests
+// InstantSend path
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_instantsend_to_chainlocked_event_flow() {
-    assert_lifecycle_flow(
-        &[
-            TransactionContext::InstantSend(InstantLock::default()),
-            TransactionContext::InChainLockedBlock(BlockInfo::new(
-                1600,
-                BlockHash::from_byte_array([0xc3; 32]),
-                16000,
-            )),
-        ],
-        0xc3,
-    )
-    .await;
-}
+async fn test_instant_send_lock_on_known_mempool_tx_emits_status_changed_event() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let tx = create_tx_paying_to(&addr, 0xe1);
 
-#[tokio::test]
-async fn test_mempool_to_block_to_chainlocked_event_flow() {
-    let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
+    // First see the tx as plain mempool
+    manager.process_mempool_transaction(&tx, None).await;
+    let pre_lock_balance = manager.get_wallet_info(&wallet_id).unwrap().balance();
+    assert_eq!(pre_lock_balance.confirmed(), 0);
+    assert_eq!(pre_lock_balance.unconfirmed(), TX_AMOUNT);
     let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xc4);
 
-    // Step 1: mempool — emits TransactionReceived
-    manager.check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true, true).await;
-    let event = assert_single_event(&mut rx);
-    assert!(
-        matches!(
-            &event,
-            WalletEvent::TransactionReceived { record, .. }
-            if record.context == TransactionContext::Mempool
-        ),
-        "expected TransactionReceived(Mempool), got {:?}",
-        event
-    );
+    let lock = InstantLock {
+        txid: tx.txid(),
+        cyclehash: CycleHash::from_byte_array([0xab; 32]),
+        signature: BLSSignature::from([0xcd; 96]),
+        ..InstantLock::default()
+    };
+    manager.process_instant_send_lock(lock.clone());
 
-    // Step 2: block confirmation — emits TransactionStatusChanged
-    let block_ctx = TransactionContext::InBlock(BlockInfo::new(
-        1700,
-        BlockHash::from_byte_array([0xc4; 32]),
-        17000,
-    ));
-    manager.check_transaction_in_all_wallets(&tx, block_ctx, true, true).await;
-    let event = assert_single_event(&mut rx);
-    assert!(
-        matches!(
-            event,
-            WalletEvent::TransactionStatusChanged {
-                status: TransactionContext::InBlock(_),
-                ..
+    let events = drain_events(&mut rx);
+    assert_eq!(events.len(), 1, "exactly one event expected, got {:?}", events);
+    match &events[0] {
+        WalletEvent::TransactionStatusChanged {
+            wallet_id: wid,
+            txid,
+            status,
+            balance,
+        } => {
+            assert_eq!(*wid, wallet_id);
+            assert_eq!(*txid, tx.txid());
+            match status {
+                TransactionContext::InstantSend(emitted_lock) => assert_eq!(*emitted_lock, lock),
+                other => panic!("expected InstantSend context, got {:?}", other),
             }
-        ),
-        "expected TransactionStatusChanged(InBlock), got {:?}",
-        event
-    );
+            assert_eq!(balance.confirmed(), TX_AMOUNT);
+            assert_eq!(balance.unconfirmed(), 0);
+        }
+        other => panic!("expected TransactionStatusChanged, got {:?}", other),
+    }
+}
 
-    // Step 3: chain lock on already-confirmed tx — no event (wallet doesn't
-    // track chain lock state separately from block confirmation)
-    let cl_ctx = TransactionContext::InChainLockedBlock(BlockInfo::new(
-        1700,
-        BlockHash::from_byte_array([0xc4; 32]),
-        17000,
-    ));
-    manager.check_transaction_in_all_wallets(&tx, cl_ctx, true, true).await;
+#[tokio::test]
+async fn test_instant_send_lock_dedup_second_is_silent() {
+    let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
+    let tx = create_tx_paying_to(&addr, 0xe2);
+
+    manager.process_mempool_transaction(&tx, None).await;
+    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
+
+    let mut rx = manager.subscribe_events();
+    manager.process_instant_send_lock(dummy_instant_lock(tx.txid()));
     assert_no_events(&mut rx);
 }
 
 #[tokio::test]
-async fn test_chainlocked_block_event_flow() {
+async fn test_instant_send_lock_for_unknown_txid_is_silent() {
+    let (mut manager, _wallet_id, _addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let unknown_txid = Txid::from_byte_array([0xee; 32]);
+
+    manager.process_instant_send_lock(dummy_instant_lock(unknown_txid));
+    assert_no_events(&mut rx);
+}
+
+#[tokio::test]
+async fn test_late_instant_send_lock_after_block_confirmation_emits_event() {
+    // A late IS-lock for a transaction that was already confirmed in a block
+    // currently downgrades the record context from `InBlock(_)` back to
+    // `InstantSend(_)` and re-emits `TransactionStatusChanged`. This test
+    // pins down that observable behavior so any future change (silently
+    // ignoring the late lock, rejecting it at the record layer) shows up as a
+    // test failure rather than a silent semantic drift.
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let tx = create_tx_paying_to(&addr, 0xe3);
+
+    // Confirm the transaction in a block first.
+    let block = make_block(vec![tx.clone()], 0xe3, 4000);
+    manager.process_block(&block, 300).await;
+
+    let mut rx = manager.subscribe_events();
+    let lock = InstantLock {
+        txid: tx.txid(),
+        cyclehash: CycleHash::from_byte_array([0xab; 32]),
+        signature: BLSSignature::from([0xcd; 96]),
+        ..InstantLock::default()
+    };
+    manager.process_instant_send_lock(lock.clone());
+
+    let events = drain_events(&mut rx);
+    let status_changed = events
+        .iter()
+        .find(|e| matches!(e, WalletEvent::TransactionStatusChanged { .. }))
+        .unwrap_or_else(|| {
+            panic!(
+                "late IS-lock for an already-confirmed tx currently emits \
+                 TransactionStatusChanged, got: {:?}",
+                events
+            )
+        });
+    match status_changed {
+        WalletEvent::TransactionStatusChanged {
+            wallet_id: wid,
+            txid,
+            status,
+            ..
+        } => {
+            assert_eq!(*wid, wallet_id);
+            assert_eq!(*txid, tx.txid());
+            match status {
+                TransactionContext::InstantSend(emitted_lock) => assert_eq!(*emitted_lock, lock),
+                other => panic!("expected InstantSend context, got {:?}", other),
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Block path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_block_with_new_tx_emits_inserted_record() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let tx = create_tx_paying_to(&addr, 0xcc);
+    let block = make_block(vec![tx.clone()], 0xcc, 1000);
+
+    let result = manager.process_block(&block, 100).await;
+    assert_eq!(result.new_txids.len(), 1);
+
+    let events = drain_events(&mut rx);
+    assert_eq!(events.len(), 1, "one event per affected wallet expected, got {:?}", events);
+    match &events[0] {
+        WalletEvent::BlockUpdate {
+            wallet_id: wid,
+            height,
+            inserted,
+            updated,
+            matured,
+            balance,
+        } => {
+            assert_eq!(*wid, wallet_id);
+            assert_eq!(*height, 100);
+            assert_eq!(inserted.len(), 1);
+            assert!(updated.is_empty());
+            assert!(matured.is_empty());
+            assert!(matches!(
+                inserted[0].account_type,
+                AccountType::Standard {
+                    index: 0,
+                    standard_account_type: StandardAccountType::BIP44Account
+                }
+            ));
+            assert_eq!(inserted[0].txid, tx.txid());
+            assert!(matches!(
+                inserted[0].context,
+                TransactionContext::InBlock(info) if info.height() == 100
+            ));
+            assert_eq!(balance.confirmed(), TX_AMOUNT);
+        }
+        other => panic!("expected BlockUpdate, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_block_confirming_known_mempool_tx_emits_updated_record() {
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let tx = create_tx_paying_to(&addr, 0xdd);
+
+    // Seen in mempool first
+    manager.process_mempool_transaction(&tx, None).await;
+
+    let mut rx = manager.subscribe_events();
+    let block = make_block(vec![tx.clone()], 0xdd, 2000);
+    manager.process_block(&block, 200).await;
+
+    let events = drain_events(&mut rx);
+    assert_eq!(events.len(), 1, "one BlockUpdate expected, got {:?}", events);
+    match &events[0] {
+        WalletEvent::BlockUpdate {
+            wallet_id: wid,
+            height,
+            inserted,
+            updated,
+            matured,
+            balance,
+        } => {
+            assert_eq!(*wid, wallet_id);
+            assert_eq!(*height, 200);
+            assert!(inserted.is_empty());
+            assert_eq!(updated.len(), 1);
+            assert!(matured.is_empty());
+            assert_eq!(updated[0].txid, tx.txid());
+            // Confirmation moves balance from unconfirmed to confirmed
+            assert_eq!(balance.confirmed(), TX_AMOUNT);
+            assert_eq!(balance.unconfirmed(), 0);
+        }
+        other => panic!("expected BlockUpdate with updated record, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_block_with_index_less_account_tx_carries_account_type() {
+    // Index-less account variants (`IdentityRegistration`, `IdentityTopUpNotBound`,
+    // `IdentityInvitation`, `AssetLockAddressTopUp`, `AssetLockShieldedAddressTopUp`,
+    // `Provider*`) used to be silently dropped on the way out of `wallet_checker.rs`
+    // because the old emission code only kept matches whose `account_index()` was
+    // `Some(_)`. Verify they now flow through with the right `AccountType`.
+    let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
+
+    let xpub = manager
+        .get_wallet(&wallet_id)
+        .expect("wallet")
+        .accounts
+        .identity_registration
+        .as_ref()
+        .expect("default wallet should have an IdentityRegistration account")
+        .account_xpub;
+    let identity_address = manager
+        .get_wallet_info_mut(&wallet_id)
+        .expect("wallet info")
+        .identity_registration_managed_account_mut()
+        .expect("managed IdentityRegistration account")
+        .next_address(Some(&xpub), true)
+        .expect("identity registration address");
+
+    // Build a DIP-2 AssetLock transaction whose `credit_outputs` pay to the
+    // identity registration address. AssetLock funds aren't spendable on the
+    // Core chain, so balance does not shift, but the account does receive a
+    // record — which is exactly what we want to observe in `BlockUpdate`.
+    let tx = Transaction {
+        version: 3,
+        lock_time: 0,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: Txid::from_byte_array([0xee; 32]),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: u32::MAX,
+            witness: Witness::default(),
+        }],
+        output: vec![TxOut {
+            value: 100_000_000,
+            script_pubkey: Builder::new()
+                .push_opcode(opcodes::all::OP_RETURN)
+                .push_slice([0u8; 20])
+                .into_script(),
+        }],
+        special_transaction_payload: Some(TransactionPayload::AssetLockPayloadType(
+            AssetLockPayload {
+                version: 1,
+                credit_outputs: vec![TxOut {
+                    value: 100_000_000,
+                    script_pubkey: identity_address.script_pubkey(),
+                }],
+            },
+        )),
+    };
+
+    let mut rx = manager.subscribe_events();
+    let block = make_block(vec![tx.clone()], 0xee, 9999);
+    manager.process_block(&block, 9000).await;
+
+    let events = drain_events(&mut rx);
+    let block_event = events
+        .iter()
+        .find(|e| matches!(e, WalletEvent::BlockUpdate { .. }))
+        .unwrap_or_else(|| panic!("expected a BlockUpdate event, got {:?}", events));
+
+    match block_event {
+        WalletEvent::BlockUpdate {
+            wallet_id: wid,
+            inserted,
+            ..
+        } => {
+            assert_eq!(*wid, wallet_id);
+            let identity_record = inserted
+                .iter()
+                .find(|r| matches!(r.account_type, AccountType::IdentityRegistration))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "expected an inserted record for AccountType::IdentityRegistration, \
+                         got: {:?}",
+                        inserted
+                    )
+                });
+            assert_eq!(identity_record.txid, tx.txid());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[tokio::test]
+async fn test_empty_block_for_idle_wallet_emits_nothing() {
+    let (mut manager, _wallet_id, _addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    let block = make_block(Vec::new(), 0x55, 3000);
+
+    manager.process_block(&block, 50).await;
+    assert_no_events(&mut rx);
+}
+
+#[tokio::test]
+async fn test_block_update_carries_matured_coinbase_record() {
+    // A coinbase received at height H matures at H + 100. Process the
+    // coinbase block first, then advance the chain past maturity by
+    // processing further blocks. The block whose height crosses H + 100
+    // must carry the matured coinbase in `BlockUpdate.matured`.
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let coinbase_tx = make_coinbase_paying_to(&addr, 5_000_000_000);
+    let coinbase_height = 100;
+    let coinbase_block = make_block(vec![coinbase_tx.clone()], 0xc0, 4000);
+    manager.process_block(&coinbase_block, coinbase_height).await;
+
+    // Advance to maturity height. With coinbase_height = 100, maturity is at
+    // height 200. Processing block 200 must surface the matured record.
+    let mut rx = manager.subscribe_events();
+    let mature_block = make_block(Vec::new(), 0xc1, 5000);
+    manager.process_block(&mature_block, coinbase_height + 100).await;
+
+    let events = drain_events(&mut rx);
+    let block_event = events
+        .iter()
+        .find(|e| matches!(e, WalletEvent::BlockUpdate { matured, .. } if !matured.is_empty()))
+        .unwrap_or_else(|| {
+            panic!("expected a BlockUpdate carrying matured coinbase, got {:?}", events)
+        });
+
+    match block_event {
+        WalletEvent::BlockUpdate {
+            wallet_id: wid,
+            height,
+            inserted,
+            updated,
+            matured,
+            ..
+        } => {
+            assert_eq!(*wid, wallet_id);
+            assert_eq!(*height, coinbase_height + 100);
+            assert!(inserted.is_empty());
+            assert!(updated.is_empty());
+            assert_eq!(matured.len(), 1);
+            assert_eq!(matured[0].txid, coinbase_tx.txid());
+        }
+        _ => unreachable!(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SyncHeightUpdate
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_update_synced_height_emits_event_per_wallet() {
+    let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+
+    manager.update_synced_height(1000);
+
+    let synced_events: Vec<_> = drain_events(&mut rx)
+        .into_iter()
+        .filter_map(|e| match e {
+            WalletEvent::SyncHeightUpdate {
+                wallet_id,
+                height,
+            } => Some((wallet_id, height)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(synced_events, vec![(wallet_id, 1000)]);
+}
+
+#[tokio::test]
+async fn test_update_synced_height_does_not_re_emit_when_unchanged() {
+    let (mut manager, _wallet_id, _addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+
+    manager.update_synced_height(2000);
+    drain_events(&mut rx);
+
+    // Re-calling with the same height must not emit another SyncHeightUpdate
+    manager.update_synced_height(2000);
+    let events = drain_events(&mut rx);
+    assert!(
+        !events.iter().any(|e| matches!(e, WalletEvent::SyncHeightUpdate { .. })),
+        "no SyncHeightUpdate should fire when height did not advance, got {:?}",
+        events
+    );
+
+    // Going backwards also must not emit
+    manager.update_synced_height(1500);
+    let events = drain_events(&mut rx);
+    assert!(
+        !events.iter().any(|e| matches!(e, WalletEvent::SyncHeightUpdate { .. })),
+        "no SyncHeightUpdate should fire when height went backwards, got {:?}",
+        events
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Dry run and irrelevant paths
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_check_transaction_does_not_emit_events_directly() {
+    // Event emission is the caller's responsibility; the low-level check
+    // function never emits so batch callers can defer emission until after
+    // their own balance refresh.
     let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
     let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xc1);
+    let tx = create_tx_paying_to(&addr, 0xd1);
 
-    let ctx = TransactionContext::InChainLockedBlock(BlockInfo::new(
-        2000,
-        BlockHash::from_byte_array([0xc1; 32]),
-        20000,
-    ));
-    manager.check_transaction_in_all_wallets(&tx, ctx, true, true).await;
-    let event = assert_single_event(&mut rx);
-    assert!(
-        matches!(
-            &event,
-            WalletEvent::TransactionReceived { record, .. }
-            if matches!(record.context, TransactionContext::InChainLockedBlock(info) if info.height() == 2000)
-        ),
-        "expected TransactionReceived(InChainLockedBlock at 2000), got {:?}",
-        event
-    );
+    let result = manager
+        .check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true, true)
+        .await;
+    assert!(!result.affected_wallets.is_empty());
+    assert!(!result.per_wallet_new_records.is_empty());
+    assert_no_events(&mut rx);
 }
 
 #[tokio::test]
 async fn test_check_transaction_dry_run_does_not_persist_state() {
     let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
     let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, 0xd1);
+    let tx = create_tx_paying_to(&addr, 0xd2);
 
-    // Dry run: update_state_if_found = false
     let result = manager
         .check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, false, false)
         .await;
-
     assert!(!result.affected_wallets.is_empty());
-    assert_eq!(result.total_received, TX_AMOUNT);
     assert_no_events(&mut rx);
 
-    // Call again — should still report as relevant (state not persisted)
-    let result2 = manager
-        .check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, false, false)
-        .await;
-    assert!(!result2.affected_wallets.is_empty());
-    assert_eq!(result2.total_received, TX_AMOUNT);
-    assert_no_events(&mut rx);
-
-    // Now persist — should still report as new since dry runs didn't record it
-    let result3 = manager
+    // Subsequent persist should still see the tx as new
+    let result = manager
         .check_transaction_in_all_wallets(&tx, TransactionContext::Mempool, true, true)
         .await;
-    assert!(result3.is_new_transaction);
+    assert!(result.is_new_transaction);
 }

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -66,7 +66,7 @@ async fn test_mempool_tx_emits_single_event_with_balance() {
     let events = drain_events(&mut rx);
     assert_eq!(events.len(), 1, "exactly one event expected, got {:?}", events);
     match &events[0] {
-        WalletEvent::TransactionReceived {
+        WalletEvent::TransactionDetected {
             wallet_id: wid,
             record,
             balance,
@@ -85,12 +85,12 @@ async fn test_mempool_tx_emits_single_event_with_balance() {
             assert_eq!(balance.unconfirmed(), TX_AMOUNT);
             assert_eq!(balance.confirmed(), 0);
         }
-        other => panic!("expected TransactionReceived, got {:?}", other),
+        other => panic!("expected TransactionDetected, got {:?}", other),
     }
 }
 
 #[tokio::test]
-async fn test_mempool_tx_with_instant_lock_emits_received_event_with_locked_balance() {
+async fn test_mempool_tx_with_instant_lock_emits_detected_event_with_locked_balance() {
     let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
     let mut rx = manager.subscribe_events();
     let tx = create_tx_paying_to(&addr, 0xbb);
@@ -100,7 +100,7 @@ async fn test_mempool_tx_with_instant_lock_emits_received_event_with_locked_bala
     let events = drain_events(&mut rx);
     assert_eq!(events.len(), 1, "one event expected for first-seen IS-locked tx, got {:?}", events);
     match &events[0] {
-        WalletEvent::TransactionReceived {
+        WalletEvent::TransactionDetected {
             wallet_id: wid,
             record,
             balance,
@@ -110,7 +110,7 @@ async fn test_mempool_tx_with_instant_lock_emits_received_event_with_locked_bala
             assert_eq!(balance.confirmed(), TX_AMOUNT);
             assert_eq!(balance.unconfirmed(), 0);
         }
-        other => panic!("expected TransactionReceived with IS context, got {:?}", other),
+        other => panic!("expected TransactionDetected with IS context, got {:?}", other),
     }
 }
 
@@ -152,7 +152,7 @@ async fn test_irrelevant_mempool_tx_emits_no_events() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_instant_send_lock_on_known_mempool_tx_emits_status_changed_event() {
+async fn test_instant_send_lock_on_known_mempool_tx_emits_instant_locked_event() {
     let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
     let tx = create_tx_paying_to(&addr, 0xe1);
 
@@ -174,22 +174,19 @@ async fn test_instant_send_lock_on_known_mempool_tx_emits_status_changed_event()
     let events = drain_events(&mut rx);
     assert_eq!(events.len(), 1, "exactly one event expected, got {:?}", events);
     match &events[0] {
-        WalletEvent::TransactionStatusChanged {
+        WalletEvent::TransactionInstantLocked {
             wallet_id: wid,
             txid,
-            status,
+            instant_lock,
             balance,
         } => {
             assert_eq!(*wid, wallet_id);
             assert_eq!(*txid, tx.txid());
-            match status {
-                TransactionContext::InstantSend(emitted_lock) => assert_eq!(*emitted_lock, lock),
-                other => panic!("expected InstantSend context, got {:?}", other),
-            }
+            assert_eq!(*instant_lock, lock);
             assert_eq!(balance.confirmed(), TX_AMOUNT);
             assert_eq!(balance.unconfirmed(), 0);
         }
-        other => panic!("expected TransactionStatusChanged, got {:?}", other),
+        other => panic!("expected TransactionInstantLocked, got {:?}", other),
     }
 }
 
@@ -220,7 +217,7 @@ async fn test_instant_send_lock_for_unknown_txid_is_silent() {
 async fn test_late_instant_send_lock_after_block_confirmation_emits_event() {
     // A late IS-lock for a transaction that was already confirmed in a block
     // currently downgrades the record context from `InBlock(_)` back to
-    // `InstantSend(_)` and re-emits `TransactionStatusChanged`. This test
+    // `InstantSend(_)` and re-emits `TransactionInstantLocked`. This test
     // pins down that observable behavior so any future change (silently
     // ignoring the late lock, rejecting it at the record layer) shows up as a
     // test failure rather than a silent semantic drift.
@@ -241,29 +238,26 @@ async fn test_late_instant_send_lock_after_block_confirmation_emits_event() {
     manager.process_instant_send_lock(lock.clone());
 
     let events = drain_events(&mut rx);
-    let status_changed = events
+    let lock_event = events
         .iter()
-        .find(|e| matches!(e, WalletEvent::TransactionStatusChanged { .. }))
+        .find(|e| matches!(e, WalletEvent::TransactionInstantLocked { .. }))
         .unwrap_or_else(|| {
             panic!(
                 "late IS-lock for an already-confirmed tx currently emits \
-                 TransactionStatusChanged, got: {:?}",
+                 TransactionInstantLocked, got: {:?}",
                 events
             )
         });
-    match status_changed {
-        WalletEvent::TransactionStatusChanged {
+    match lock_event {
+        WalletEvent::TransactionInstantLocked {
             wallet_id: wid,
             txid,
-            status,
+            instant_lock,
             ..
         } => {
             assert_eq!(*wid, wallet_id);
             assert_eq!(*txid, tx.txid());
-            match status {
-                TransactionContext::InstantSend(emitted_lock) => assert_eq!(*emitted_lock, lock),
-                other => panic!("expected InstantSend context, got {:?}", other),
-            }
+            assert_eq!(*instant_lock, lock);
         }
         _ => unreachable!(),
     }
@@ -286,7 +280,7 @@ async fn test_block_with_new_tx_emits_inserted_record() {
     let events = drain_events(&mut rx);
     assert_eq!(events.len(), 1, "one event per affected wallet expected, got {:?}", events);
     match &events[0] {
-        WalletEvent::BlockUpdate {
+        WalletEvent::BlockProcessed {
             wallet_id: wid,
             height,
             inserted,
@@ -313,7 +307,7 @@ async fn test_block_with_new_tx_emits_inserted_record() {
             ));
             assert_eq!(balance.confirmed(), TX_AMOUNT);
         }
-        other => panic!("expected BlockUpdate, got {:?}", other),
+        other => panic!("expected BlockProcessed, got {:?}", other),
     }
 }
 
@@ -330,9 +324,9 @@ async fn test_block_confirming_known_mempool_tx_emits_updated_record() {
     manager.process_block(&block, 200).await;
 
     let events = drain_events(&mut rx);
-    assert_eq!(events.len(), 1, "one BlockUpdate expected, got {:?}", events);
+    assert_eq!(events.len(), 1, "one BlockProcessed expected, got {:?}", events);
     match &events[0] {
-        WalletEvent::BlockUpdate {
+        WalletEvent::BlockProcessed {
             wallet_id: wid,
             height,
             inserted,
@@ -350,7 +344,7 @@ async fn test_block_confirming_known_mempool_tx_emits_updated_record() {
             assert_eq!(balance.confirmed(), TX_AMOUNT);
             assert_eq!(balance.unconfirmed(), 0);
         }
-        other => panic!("expected BlockUpdate with updated record, got {:?}", other),
+        other => panic!("expected BlockProcessed with updated record, got {:?}", other),
     }
 }
 
@@ -382,7 +376,7 @@ async fn test_block_with_index_less_account_tx_carries_account_type() {
     // Build a DIP-2 AssetLock transaction whose `credit_outputs` pay to the
     // identity registration address. AssetLock funds aren't spendable on the
     // Core chain, so balance does not shift, but the account does receive a
-    // record — which is exactly what we want to observe in `BlockUpdate`.
+    // record — which is exactly what we want to observe in `BlockProcessed`.
     let tx = Transaction {
         version: 3,
         lock_time: 0,
@@ -420,11 +414,11 @@ async fn test_block_with_index_less_account_tx_carries_account_type() {
     let events = drain_events(&mut rx);
     let block_event = events
         .iter()
-        .find(|e| matches!(e, WalletEvent::BlockUpdate { .. }))
-        .unwrap_or_else(|| panic!("expected a BlockUpdate event, got {:?}", events));
+        .find(|e| matches!(e, WalletEvent::BlockProcessed { .. }))
+        .unwrap_or_else(|| panic!("expected a BlockProcessed event, got {:?}", events));
 
     match block_event {
-        WalletEvent::BlockUpdate {
+        WalletEvent::BlockProcessed {
             wallet_id: wid,
             inserted,
             ..
@@ -457,11 +451,11 @@ async fn test_empty_block_for_idle_wallet_emits_nothing() {
 }
 
 #[tokio::test]
-async fn test_block_update_carries_matured_coinbase_record() {
+async fn test_block_processed_carries_matured_coinbase_record() {
     // A coinbase received at height H matures at H + 100. Process the
     // coinbase block first, then advance the chain past maturity by
     // processing further blocks. The block whose height crosses H + 100
-    // must carry the matured coinbase in `BlockUpdate.matured`.
+    // must carry the matured coinbase in `BlockProcessed.matured`.
     let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
     let coinbase_tx = make_coinbase_paying_to(&addr, 5_000_000_000);
     let coinbase_height = 100;
@@ -477,13 +471,13 @@ async fn test_block_update_carries_matured_coinbase_record() {
     let events = drain_events(&mut rx);
     let block_event = events
         .iter()
-        .find(|e| matches!(e, WalletEvent::BlockUpdate { matured, .. } if !matured.is_empty()))
+        .find(|e| matches!(e, WalletEvent::BlockProcessed { matured, .. } if !matured.is_empty()))
         .unwrap_or_else(|| {
-            panic!("expected a BlockUpdate carrying matured coinbase, got {:?}", events)
+            panic!("expected a BlockProcessed carrying matured coinbase, got {:?}", events)
         });
 
     match block_event {
-        WalletEvent::BlockUpdate {
+        WalletEvent::BlockProcessed {
             wallet_id: wid,
             height,
             inserted,
@@ -503,7 +497,7 @@ async fn test_block_update_carries_matured_coinbase_record() {
 }
 
 // ---------------------------------------------------------------------------
-// SyncHeightUpdate
+// SyncHeightAdvanced
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -516,7 +510,7 @@ async fn test_update_synced_height_emits_event_per_wallet() {
     let synced_events: Vec<_> = drain_events(&mut rx)
         .into_iter()
         .filter_map(|e| match e {
-            WalletEvent::SyncHeightUpdate {
+            WalletEvent::SyncHeightAdvanced {
                 wallet_id,
                 height,
             } => Some((wallet_id, height)),
@@ -534,12 +528,12 @@ async fn test_update_synced_height_does_not_re_emit_when_unchanged() {
     manager.update_synced_height(2000);
     drain_events(&mut rx);
 
-    // Re-calling with the same height must not emit another SyncHeightUpdate
+    // Re-calling with the same height must not emit another SyncHeightAdvanced
     manager.update_synced_height(2000);
     let events = drain_events(&mut rx);
     assert!(
-        !events.iter().any(|e| matches!(e, WalletEvent::SyncHeightUpdate { .. })),
-        "no SyncHeightUpdate should fire when height did not advance, got {:?}",
+        !events.iter().any(|e| matches!(e, WalletEvent::SyncHeightAdvanced { .. })),
+        "no SyncHeightAdvanced should fire when height did not advance, got {:?}",
         events
     );
 
@@ -547,8 +541,8 @@ async fn test_update_synced_height_does_not_re_emit_when_unchanged() {
     manager.update_synced_height(1500);
     let events = drain_events(&mut rx);
     assert!(
-        !events.iter().any(|e| matches!(e, WalletEvent::SyncHeightUpdate { .. })),
-        "no SyncHeightUpdate should fire when height went backwards, got {:?}",
+        !events.iter().any(|e| matches!(e, WalletEvent::SyncHeightAdvanced { .. })),
+        "no SyncHeightAdvanced should fire when height went backwards, got {:?}",
         events
     );
 }

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -4,10 +4,10 @@
 //! triggered it and the wallet's new balance after the change. Consumers can
 //! persist the transaction(s) and balance atomically off a single event.
 
+use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::Txid;
 use key_wallet::managed_account::transaction_record::TransactionRecord;
-use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::WalletCoreBalance;
 
 use crate::WalletId;
@@ -22,7 +22,7 @@ pub enum WalletEvent {
     /// First time the wallet sees an off-chain wallet-relevant transaction
     /// (mempool, or directly via an InstantSend lock — in that case
     /// `record.context` is `InstantSend(..)`).
-    TransactionReceived {
+    TransactionDetected {
         /// ID of the affected wallet.
         wallet_id: WalletId,
         /// The full transaction record with all details.
@@ -30,16 +30,15 @@ pub enum WalletEvent {
         /// Wallet balance after the transaction was recorded.
         balance: WalletCoreBalance,
     },
-    /// A previously-seen off-chain wallet-relevant transaction had its state
-    /// changed. Currently fires only for InstantSend locks applied
-    /// to a known mempool tx.
-    TransactionStatusChanged {
+    /// An InstantSend lock was applied to a previously-seen off-chain
+    /// wallet-relevant transaction.
+    TransactionInstantLocked {
         /// ID of the affected wallet.
         wallet_id: WalletId,
         /// Transaction ID.
         txid: Txid,
-        /// New transaction context.
-        status: TransactionContext,
+        /// The InstantSend lock now applied to the transaction.
+        instant_lock: InstantLock,
         /// Wallet balance after the status change.
         balance: WalletCoreBalance,
     },
@@ -49,7 +48,7 @@ pub enum WalletEvent {
     /// previously-known records that just confirmed, `matured` is older
     /// coinbase records that crossed the maturity threshold as the scanned
     /// height advanced.
-    BlockUpdate {
+    BlockProcessed {
         /// ID of the affected wallet.
         wallet_id: WalletId,
         /// Height of the block that was processed.
@@ -67,8 +66,8 @@ pub enum WalletEvent {
     /// The wallet's scan cursor advanced because the filter pipeline
     /// committed a batch covering blocks up to `height`. No records or
     /// balance — consumers persist this as a checkpoint atomically with
-    /// any records/balance from prior `BlockUpdate` events in the batch.
-    SyncHeightUpdate {
+    /// any records/balance from prior `BlockProcessed` events in the batch.
+    SyncHeightAdvanced {
         /// ID of the affected wallet.
         wallet_id: WalletId,
         /// New scanned height for the wallet.
@@ -80,19 +79,19 @@ impl WalletEvent {
     /// ID of the wallet this event pertains to.
     pub fn wallet_id(&self) -> WalletId {
         match self {
-            WalletEvent::TransactionReceived {
+            WalletEvent::TransactionDetected {
                 wallet_id,
                 ..
             }
-            | WalletEvent::TransactionStatusChanged {
+            | WalletEvent::TransactionInstantLocked {
                 wallet_id,
                 ..
             }
-            | WalletEvent::BlockUpdate {
+            | WalletEvent::BlockProcessed {
                 wallet_id,
                 ..
             }
-            | WalletEvent::SyncHeightUpdate {
+            | WalletEvent::SyncHeightAdvanced {
                 wallet_id,
                 ..
             } => *wallet_id,
@@ -102,28 +101,24 @@ impl WalletEvent {
     /// Short description for logging.
     pub fn description(&self) -> String {
         match self {
-            WalletEvent::TransactionReceived {
+            WalletEvent::TransactionDetected {
                 record,
                 balance,
                 ..
             } => {
                 format!(
-                    "TransactionReceived(txid={}, context={}, balance={})",
+                    "TransactionDetected(txid={}, context={}, balance={})",
                     record.txid, record.context, balance
                 )
             }
-            WalletEvent::TransactionStatusChanged {
+            WalletEvent::TransactionInstantLocked {
                 txid,
-                status,
                 balance,
                 ..
             } => {
-                format!(
-                    "TransactionStatusChanged(txid={}, status={}, balance={})",
-                    txid, status, balance
-                )
+                format!("TransactionInstantLocked(txid={}, balance={})", txid, balance)
             }
-            WalletEvent::BlockUpdate {
+            WalletEvent::BlockProcessed {
                 height,
                 inserted,
                 updated,
@@ -132,7 +127,7 @@ impl WalletEvent {
                 ..
             } => {
                 format!(
-                    "BlockUpdate(height={}, inserted={}, updated={}, matured={}, balance={})",
+                    "BlockProcessed(height={}, inserted={}, updated={}, matured={}, balance={})",
                     height,
                     inserted.len(),
                     updated.len(),
@@ -140,11 +135,11 @@ impl WalletEvent {
                     balance
                 )
             }
-            WalletEvent::SyncHeightUpdate {
+            WalletEvent::SyncHeightAdvanced {
                 height,
                 ..
             } => {
-                format!("SyncHeightUpdate(height={})", height)
+                format!("SyncHeightAdvanced(height={})", height)
             }
         }
     }

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -1,30 +1,38 @@
 //! Wallet events for notifying consumers of wallet state changes.
 //!
-//! These events are emitted by the WalletManager when significant wallet
-//! operations occur, allowing consumers to receive push-based notifications.
+//! Each variant is self-contained: it carries the transaction record(s) that
+//! triggered it and the wallet's new balance after the change. Consumers can
+//! persist the transaction(s) and balance atomically off a single event.
 
-use dashcore::{Amount, SignedAmount, Txid};
+use dashcore::prelude::CoreBlockHeight;
+use dashcore::Txid;
 use key_wallet::managed_account::transaction_record::TransactionRecord;
 use key_wallet::transaction_checking::TransactionContext;
+use key_wallet::WalletCoreBalance;
 
 use crate::WalletId;
 
 /// Events emitted by the wallet manager.
 ///
-/// Each event represents a meaningful wallet state change that consumers
-/// may want to react to.
+/// Each event represents a meaningful wallet state change. Events that
+/// modify balance carry the wallet's balance *after* the change so
+/// consumers can persist the record(s) and balance atomically.
 #[derive(Debug, Clone)]
 pub enum WalletEvent {
-    /// A transaction relevant to the wallet was received for the first time.
+    /// First time the wallet sees an off-chain wallet-relevant transaction
+    /// (mempool, or directly via an InstantSend lock — in that case
+    /// `record.context` is `InstantSend(..)`).
     TransactionReceived {
         /// ID of the affected wallet.
         wallet_id: WalletId,
-        /// Account index within the wallet.
-        account_index: u32,
         /// The full transaction record with all details.
         record: Box<TransactionRecord>,
+        /// Wallet balance after the transaction was recorded.
+        balance: WalletCoreBalance,
     },
-    /// The confirmation status of a previously seen transaction has changed.
+    /// A previously-seen off-chain wallet-relevant transaction had its state
+    /// changed. Currently fires only for InstantSend locks applied
+    /// to a known mempool tx.
     TransactionStatusChanged {
         /// ID of the affected wallet.
         wallet_id: WalletId,
@@ -32,58 +40,111 @@ pub enum WalletEvent {
         txid: Txid,
         /// New transaction context.
         status: TransactionContext,
+        /// Wallet balance after the status change.
+        balance: WalletCoreBalance,
     },
-    /// The wallet balance has changed.
-    BalanceUpdated {
+    /// A block was processed for a wallet. Carries records bucketed by what
+    /// happened to them in this block, plus the post-block balance.
+    /// `inserted` is records first stored in this block, `updated` is
+    /// previously-known records that just confirmed, `matured` is older
+    /// coinbase records that crossed the maturity threshold as the scanned
+    /// height advanced.
+    BlockUpdate {
         /// ID of the affected wallet.
         wallet_id: WalletId,
-        /// New confirmed balance in duffs (mature, in a block or InstantSend-locked).
-        confirmed: u64,
-        /// New unconfirmed balance in duffs (mature, mempool-only). Also spendable.
-        unconfirmed: u64,
-        /// New immature balance (coinbase UTXOs not yet mature).
-        immature: u64,
-        /// New locked balance (UTXOs reserved for specific purposes like CoinJoin)
-        locked: u64,
+        /// Height of the block that was processed.
+        height: CoreBlockHeight,
+        /// Records first stored for this wallet in this block.
+        inserted: Vec<TransactionRecord>,
+        /// Previously-known records confirmed by this block.
+        updated: Vec<TransactionRecord>,
+        /// Older coinbase records whose maturity threshold was crossed by
+        /// this height advance.
+        matured: Vec<TransactionRecord>,
+        /// Wallet balance after the block was processed.
+        balance: WalletCoreBalance,
+    },
+    /// The wallet's scan cursor advanced because the filter pipeline
+    /// committed a batch covering blocks up to `height`. No records or
+    /// balance — consumers persist this as a checkpoint atomically with
+    /// any records/balance from prior `BlockUpdate` events in the batch.
+    SyncHeightUpdate {
+        /// ID of the affected wallet.
+        wallet_id: WalletId,
+        /// New scanned height for the wallet.
+        height: CoreBlockHeight,
     },
 }
 
 impl WalletEvent {
-    /// Get a short description of this event for logging.
+    /// ID of the wallet this event pertains to.
+    pub fn wallet_id(&self) -> WalletId {
+        match self {
+            WalletEvent::TransactionReceived {
+                wallet_id,
+                ..
+            }
+            | WalletEvent::TransactionStatusChanged {
+                wallet_id,
+                ..
+            }
+            | WalletEvent::BlockUpdate {
+                wallet_id,
+                ..
+            }
+            | WalletEvent::SyncHeightUpdate {
+                wallet_id,
+                ..
+            } => *wallet_id,
+        }
+    }
+
+    /// Short description for logging.
     pub fn description(&self) -> String {
         match self {
             WalletEvent::TransactionReceived {
                 record,
+                balance,
                 ..
             } => {
                 format!(
-                    "TransactionReceived(txid={}, amount={}, status={})",
-                    record.txid,
-                    SignedAmount::from_sat(record.net_amount),
-                    record.context
+                    "TransactionReceived(txid={}, context={}, balance={})",
+                    record.txid, record.context, balance
                 )
             }
             WalletEvent::TransactionStatusChanged {
                 txid,
                 status,
-                ..
-            } => {
-                format!("TransactionStatusChanged(txid={}, status={})", txid, status)
-            }
-            WalletEvent::BalanceUpdated {
-                confirmed,
-                unconfirmed,
-                immature,
-                locked,
+                balance,
                 ..
             } => {
                 format!(
-                    "BalanceUpdated(confirmed={}, unconfirmed={}, immature={}, locked={})",
-                    Amount::from_sat(*confirmed),
-                    Amount::from_sat(*unconfirmed),
-                    Amount::from_sat(*immature),
-                    Amount::from_sat(*locked)
+                    "TransactionStatusChanged(txid={}, status={}, balance={})",
+                    txid, status, balance
                 )
+            }
+            WalletEvent::BlockUpdate {
+                height,
+                inserted,
+                updated,
+                matured,
+                balance,
+                ..
+            } => {
+                format!(
+                    "BlockUpdate(height={}, inserted={}, updated={}, matured={}, balance={})",
+                    height,
+                    inserted.len(),
+                    updated.len(),
+                    matured.len(),
+                    balance
+                )
+            }
+            WalletEvent::SyncHeightUpdate {
+                height,
+                ..
+            } => {
+                format!("SyncHeightUpdate(height={})", height)
             }
         }
     }

--- a/key-wallet-manager/src/lib.rs
+++ b/key-wallet-manager/src/lib.rs
@@ -27,6 +27,7 @@ pub use wallet_interface::{BlockProcessingResult, MempoolTransactionResult, Wall
 use dashcore::blockdata::transaction::Transaction;
 use dashcore::prelude::CoreBlockHeight;
 use key_wallet::account::AccountCollection;
+use key_wallet::managed_account::transaction_record::TransactionRecord;
 use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::wallet::managed_wallet_info::transaction_building::AccountTypePreference;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
@@ -80,6 +81,11 @@ pub struct CheckTransactionsResult {
     pub total_sent: u64,
     /// Addresses involved across all wallets
     pub involved_addresses: Vec<Address>,
+    /// Records newly recorded by this check, grouped by wallet.
+    pub per_wallet_new_records: BTreeMap<WalletId, Vec<TransactionRecord>>,
+    /// Records whose state was updated by this check (confirmation or
+    /// InstantSend lock on a previously stored record), grouped by wallet.
+    pub per_wallet_updated_records: BTreeMap<WalletId, Vec<TransactionRecord>>,
 }
 
 /// High-level wallet manager that manages multiple wallets
@@ -442,7 +448,11 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
     }
 
     /// Check a transaction against all wallets and update their states if relevant.
-    /// Returns affected wallets and any new addresses generated during gap limit maintenance.
+    ///
+    /// Collects — but does not emit — the per-wallet records affected by the
+    /// check. Callers are responsible for emitting the appropriate
+    /// `WalletEvent` *after* refreshing wallet balances so events never
+    /// carry a stale balance.
     pub async fn check_transaction_in_all_wallets(
         &mut self,
         tx: &Transaction,
@@ -490,23 +500,19 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
                         }
                     }
 
-                    if check_result.is_new_transaction {
-                        for (account_index, record) in check_result.new_records {
-                            let event = WalletEvent::TransactionReceived {
-                                wallet_id,
-                                account_index,
-                                record: Box::new(record),
-                            };
-                            let _ = self.event_sender.send(event);
-                        }
-                    } else if check_result.state_modified {
-                        // Known transaction whose state was modified (confirmation or IS-lock).
-                        let event = WalletEvent::TransactionStatusChanged {
-                            wallet_id,
-                            txid: tx.txid(),
-                            status: context.clone(),
-                        };
-                        let _ = self.event_sender.send(event);
+                    if !check_result.new_records.is_empty() {
+                        result
+                            .per_wallet_new_records
+                            .entry(wallet_id)
+                            .or_default()
+                            .extend(check_result.new_records);
+                    }
+                    if !check_result.updated_records.is_empty() {
+                        result
+                            .per_wallet_updated_records
+                            .entry(wallet_id)
+                            .or_default()
+                            .extend(check_result.updated_records);
                     }
                 }
 

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -21,12 +21,6 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         let mut result = BlockProcessingResult::default();
         let info = BlockInfo::new(height, block.block_hash(), block.header.time);
 
-        let snapshot = self.snapshot_balances();
-        let prior_heights: BTreeMap<WalletId, CoreBlockHeight> = self
-            .wallet_infos
-            .iter()
-            .map(|(id, info)| (*id, info.last_processed_height()))
-            .collect();
         let mut per_wallet_inserted: BTreeMap<WalletId, Vec<TransactionRecord>> = BTreeMap::new();
         let mut per_wallet_updated: BTreeMap<WalletId, Vec<TransactionRecord>> = BTreeMap::new();
 
@@ -54,43 +48,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             }
         }
 
-        // Collect matured coinbase records before advancing the height so the
-        // (old, new] window is well-defined per wallet.
-        let mut per_wallet_matured: BTreeMap<WalletId, Vec<TransactionRecord>> = BTreeMap::new();
-        for (wallet_id, info) in &self.wallet_infos {
-            let old_height = prior_heights.get(wallet_id).copied().unwrap_or(0);
-            let matured = info.matured_coinbase_records(old_height, height);
-            if !matured.is_empty() {
-                per_wallet_matured.insert(*wallet_id, matured);
-            }
-        }
-
-        // Advance heights and refresh balances. Event emission happens below
-        // so each wallet's event carries the post-advance balance.
-        for info in self.wallet_infos.values_mut() {
-            info.update_last_processed_height(height);
-        }
-
-        for (wallet_id, info) in &self.wallet_infos {
-            let new_balance = info.balance();
-            let inserted = per_wallet_inserted.remove(wallet_id).unwrap_or_default();
-            let updated = per_wallet_updated.remove(wallet_id).unwrap_or_default();
-            let matured = per_wallet_matured.remove(wallet_id).unwrap_or_default();
-            let balance_changed = snapshot.get(wallet_id).copied() != Some(new_balance);
-
-            if !inserted.is_empty() || !updated.is_empty() || !matured.is_empty() || balance_changed
-            {
-                let event = WalletEvent::BlockUpdate {
-                    wallet_id: *wallet_id,
-                    height,
-                    inserted,
-                    updated,
-                    matured,
-                    balance: new_balance,
-                };
-                let _ = self.event_sender.send(event);
-            }
-        }
+        self.finalize_block_advance(height, per_wallet_inserted, per_wallet_updated);
 
         result
     }
@@ -190,43 +148,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
     }
 
     fn update_last_processed_height(&mut self, height: CoreBlockHeight) {
-        let snapshot = self.snapshot_balances();
-        let prior_heights: BTreeMap<WalletId, CoreBlockHeight> = self
-            .wallet_infos
-            .iter()
-            .map(|(id, info)| (*id, info.last_processed_height()))
-            .collect();
-
-        let mut per_wallet_matured: BTreeMap<WalletId, Vec<TransactionRecord>> = BTreeMap::new();
-        for (wallet_id, info) in &self.wallet_infos {
-            let old_height = prior_heights.get(wallet_id).copied().unwrap_or(0);
-            let matured = info.matured_coinbase_records(old_height, height);
-            if !matured.is_empty() {
-                per_wallet_matured.insert(*wallet_id, matured);
-            }
-        }
-
-        for info in self.wallet_infos.values_mut() {
-            info.update_last_processed_height(height);
-        }
-
-        for (wallet_id, info) in &self.wallet_infos {
-            let new_balance = info.balance();
-            let matured = per_wallet_matured.remove(wallet_id).unwrap_or_default();
-            let balance_changed = snapshot.get(wallet_id).copied() != Some(new_balance);
-
-            if !matured.is_empty() || balance_changed {
-                let event = WalletEvent::BlockUpdate {
-                    wallet_id: *wallet_id,
-                    height,
-                    inserted: Vec::new(),
-                    updated: Vec::new(),
-                    matured,
-                    balance: new_balance,
-                };
-                let _ = self.event_sender.send(event);
-            }
-        }
+        self.finalize_block_advance(height, BTreeMap::new(), BTreeMap::new());
     }
 
     fn synced_height(&self) -> CoreBlockHeight {
@@ -306,6 +228,65 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             self.network,
             details.join("\n")
         )
+    }
+}
+
+impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
+    /// Advance every wallet's last-processed height to `height`, collect the
+    /// matured-coinbase window `(prior, height]` per wallet, and emit a
+    /// `BlockUpdate` event for each wallet whose balance changed or whose
+    /// `inserted`/`updated`/`matured` lists are non-empty. Snapshots are taken
+    /// before the advance so events carry the post-advance balance.
+    fn finalize_block_advance(
+        &mut self,
+        height: CoreBlockHeight,
+        mut per_wallet_inserted: BTreeMap<WalletId, Vec<TransactionRecord>>,
+        mut per_wallet_updated: BTreeMap<WalletId, Vec<TransactionRecord>>,
+    ) {
+        let snapshot = self.snapshot_balances();
+        let prior_heights: BTreeMap<WalletId, CoreBlockHeight> = self
+            .wallet_infos
+            .iter()
+            .map(|(id, info)| (*id, info.last_processed_height()))
+            .collect();
+
+        // Collect matured coinbase records before advancing the height so the
+        // (old, new] window is well-defined per wallet.
+        let mut per_wallet_matured: BTreeMap<WalletId, Vec<TransactionRecord>> = BTreeMap::new();
+        for (wallet_id, info) in &self.wallet_infos {
+            let old_height = prior_heights.get(wallet_id).copied().unwrap_or(0);
+            let matured = info.matured_coinbase_records(old_height, height);
+            if !matured.is_empty() {
+                per_wallet_matured.insert(*wallet_id, matured);
+            }
+        }
+
+        // Advance heights and refresh balances. Event emission happens below
+        // so each wallet's event carries the post-advance balance.
+        for info in self.wallet_infos.values_mut() {
+            info.update_last_processed_height(height);
+        }
+
+        for (wallet_id, info) in &self.wallet_infos {
+            let new_balance = info.balance();
+            let inserted = per_wallet_inserted.remove(wallet_id).unwrap_or_default();
+            let updated = per_wallet_updated.remove(wallet_id).unwrap_or_default();
+            let matured = per_wallet_matured.remove(wallet_id).unwrap_or_default();
+            let balance_changed = snapshot.get(wallet_id).copied() != Some(new_balance);
+
+            if !inserted.is_empty() || !updated.is_empty() || !matured.is_empty() || balance_changed
+            {
+                let event = WalletEvent::BlockUpdate {
+                    wallet_id: *wallet_id,
+                    height,
+                    inserted,
+                    updated,
+                    matured,
+                    balance: new_balance,
+                };
+                let _ = self.event_sender.send(event);
+            }
+        }
     }
 }
 

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -1,12 +1,14 @@
 use crate::wallet_interface::{BlockProcessingResult, MempoolTransactionResult, WalletInterface};
-use crate::{WalletEvent, WalletManager};
+use crate::{WalletEvent, WalletId, WalletManager};
 use async_trait::async_trait;
 use core::fmt::Write as _;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::prelude::CoreBlockHeight;
 use dashcore::{Address, Block, Transaction};
+use key_wallet::managed_account::transaction_record::TransactionRecord;
 use key_wallet::transaction_checking::{BlockInfo, TransactionContext};
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+use std::collections::BTreeMap;
 use tokio::sync::broadcast;
 
 #[async_trait]
@@ -19,7 +21,15 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         let mut result = BlockProcessingResult::default();
         let info = BlockInfo::new(height, block.block_hash(), block.header.time);
 
-        // Process each transaction using the base manager
+        let snapshot = self.snapshot_balances();
+        let prior_heights: BTreeMap<WalletId, CoreBlockHeight> = self
+            .wallet_infos
+            .iter()
+            .map(|(id, info)| (*id, info.last_processed_height()))
+            .collect();
+        let mut per_wallet_inserted: BTreeMap<WalletId, Vec<TransactionRecord>> = BTreeMap::new();
+        let mut per_wallet_updated: BTreeMap<WalletId, Vec<TransactionRecord>> = BTreeMap::new();
+
         for tx in &block.txdata {
             let context = TransactionContext::InBlock(info);
 
@@ -35,9 +45,52 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             }
 
             result.new_addresses.extend(check_result.new_addresses);
+
+            for (wallet_id, records) in check_result.per_wallet_new_records {
+                per_wallet_inserted.entry(wallet_id).or_default().extend(records);
+            }
+            for (wallet_id, records) in check_result.per_wallet_updated_records {
+                per_wallet_updated.entry(wallet_id).or_default().extend(records);
+            }
         }
 
-        self.update_last_processed_height(height);
+        // Collect matured coinbase records before advancing the height so the
+        // (old, new] window is well-defined per wallet.
+        let mut per_wallet_matured: BTreeMap<WalletId, Vec<TransactionRecord>> = BTreeMap::new();
+        for (wallet_id, info) in &self.wallet_infos {
+            let old_height = prior_heights.get(wallet_id).copied().unwrap_or(0);
+            let matured = info.matured_coinbase_records(old_height, height);
+            if !matured.is_empty() {
+                per_wallet_matured.insert(*wallet_id, matured);
+            }
+        }
+
+        // Advance heights and refresh balances. Event emission happens below
+        // so each wallet's event carries the post-advance balance.
+        for info in self.wallet_infos.values_mut() {
+            info.update_last_processed_height(height);
+        }
+
+        for (wallet_id, info) in &self.wallet_infos {
+            let new_balance = info.balance();
+            let inserted = per_wallet_inserted.remove(wallet_id).unwrap_or_default();
+            let updated = per_wallet_updated.remove(wallet_id).unwrap_or_default();
+            let matured = per_wallet_matured.remove(wallet_id).unwrap_or_default();
+            let balance_changed = snapshot.get(wallet_id).copied() != Some(new_balance);
+
+            if !inserted.is_empty() || !updated.is_empty() || !matured.is_empty() || balance_changed
+            {
+                let event = WalletEvent::BlockUpdate {
+                    wallet_id: *wallet_id,
+                    height,
+                    inserted,
+                    updated,
+                    matured,
+                    balance: new_balance,
+                };
+                let _ = self.event_sender.send(event);
+            }
+        }
 
         result
     }
@@ -47,14 +100,13 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         tx: &Transaction,
         instant_lock: Option<InstantLock>,
     ) -> MempoolTransactionResult {
-        let context = match instant_lock {
+        let context = match instant_lock.as_ref() {
             Some(lock) => {
                 debug_assert_eq!(lock.txid, tx.txid(), "InstantLock txid must match transaction");
-                TransactionContext::InstantSend(lock)
+                TransactionContext::InstantSend(lock.clone())
             }
             None => TransactionContext::Mempool,
         };
-        let snapshot = self.snapshot_balances();
         let check_result = self.check_transaction_in_all_wallets(tx, context, true, false).await;
 
         let is_relevant = !check_result.affected_wallets.is_empty();
@@ -64,13 +116,49 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             0
         };
 
-        // Refresh cached balances only for affected wallets
+        // Refresh cached balances for affected wallets before emitting so
+        // every event carries a post-change balance.
         for wallet_id in &check_result.affected_wallets {
             if let Some(info) = self.wallet_infos.get_mut(wallet_id) {
                 info.update_balance();
             }
         }
-        self.emit_balance_changes(&snapshot);
+
+        for (wallet_id, records) in check_result.per_wallet_new_records {
+            let Some(info) = self.wallet_infos.get(&wallet_id) else {
+                continue;
+            };
+            let balance = info.balance();
+            for record in records {
+                let event = WalletEvent::TransactionReceived {
+                    wallet_id,
+                    record: Box::new(record),
+                    balance,
+                };
+                let _ = self.event_sender.send(event);
+            }
+        }
+
+        if let Some(lock) = instant_lock {
+            for (wallet_id, records) in check_result.per_wallet_updated_records {
+                if records.is_empty() {
+                    continue;
+                }
+                let Some(info) = self.wallet_infos.get(&wallet_id) else {
+                    continue;
+                };
+                let balance = info.balance();
+                for record in records {
+                    let event = WalletEvent::TransactionStatusChanged {
+                        wallet_id,
+                        txid: record.txid,
+                        status: TransactionContext::InstantSend(lock.clone()),
+                        balance,
+                    };
+                    let _ = self.event_sender.send(event);
+                }
+            }
+        }
 
         MempoolTransactionResult {
             is_relevant,
@@ -103,12 +191,42 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
     fn update_last_processed_height(&mut self, height: CoreBlockHeight) {
         let snapshot = self.snapshot_balances();
+        let prior_heights: BTreeMap<WalletId, CoreBlockHeight> = self
+            .wallet_infos
+            .iter()
+            .map(|(id, info)| (*id, info.last_processed_height()))
+            .collect();
 
-        for (_wallet_id, info) in self.wallet_infos.iter_mut() {
+        let mut per_wallet_matured: BTreeMap<WalletId, Vec<TransactionRecord>> = BTreeMap::new();
+        for (wallet_id, info) in &self.wallet_infos {
+            let old_height = prior_heights.get(wallet_id).copied().unwrap_or(0);
+            let matured = info.matured_coinbase_records(old_height, height);
+            if !matured.is_empty() {
+                per_wallet_matured.insert(*wallet_id, matured);
+            }
+        }
+
+        for info in self.wallet_infos.values_mut() {
             info.update_last_processed_height(height);
         }
 
-        self.emit_balance_changes(&snapshot);
+        for (wallet_id, info) in &self.wallet_infos {
+            let new_balance = info.balance();
+            let matured = per_wallet_matured.remove(wallet_id).unwrap_or_default();
+            let balance_changed = snapshot.get(wallet_id).copied() != Some(new_balance);
+
+            if !matured.is_empty() || balance_changed {
+                let event = WalletEvent::BlockUpdate {
+                    wallet_id: *wallet_id,
+                    height,
+                    inserted: Vec::new(),
+                    updated: Vec::new(),
+                    matured,
+                    balance: new_balance,
+                };
+                let _ = self.event_sender.send(event);
+            }
+        }
     }
 
     fn synced_height(&self) -> CoreBlockHeight {
@@ -116,8 +234,15 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
     }
 
     fn update_synced_height(&mut self, height: CoreBlockHeight) {
-        for (_wallet_id, info) in self.wallet_infos.iter_mut() {
+        for (wallet_id, info) in self.wallet_infos.iter_mut() {
+            let advanced = height > info.synced_height();
             info.update_synced_height(height);
+            if advanced {
+                let _ = self.event_sender.send(WalletEvent::SyncHeightUpdate {
+                    wallet_id: *wallet_id,
+                    height,
+                });
+            }
         }
     }
 
@@ -127,11 +252,11 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
     fn process_instant_send_lock(&mut self, instant_lock: InstantLock) {
         let txid = instant_lock.txid;
-        let snapshot = self.snapshot_balances();
 
         let mut affected_wallets = Vec::new();
         for (wallet_id, info) in self.wallet_infos.iter_mut() {
             if info.mark_instant_send_utxos(&txid, &instant_lock) {
+                info.update_balance();
                 affected_wallets.push(*wallet_id);
             }
         }
@@ -140,16 +265,18 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             return;
         }
 
-        for wallet_id in &affected_wallets {
-            let event = WalletEvent::TransactionStatusChanged {
-                wallet_id: *wallet_id,
-                txid,
-                status: TransactionContext::InstantSend(instant_lock.clone()),
+        let context = TransactionContext::InstantSend(instant_lock);
+        for wallet_id in affected_wallets {
+            let Some(info) = self.wallet_infos.get(&wallet_id) else {
+                continue;
             };
-            let _ = self.event_sender().send(event);
+            let _ = self.event_sender().send(WalletEvent::TransactionStatusChanged {
+                wallet_id,
+                txid,
+                status: context.clone(),
+                balance: info.balance(),
+            });
         }
-
-        self.emit_balance_changes(&snapshot);
     }
 
     async fn describe(&self) -> String {
@@ -228,27 +355,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_process_mempool_transaction_balance_events() {
+    async fn test_process_mempool_transaction_emits_event() {
         let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
         let mut rx = manager.subscribe_events();
 
-        // Relevant tx should emit BalanceUpdated
+        // Relevant tx should emit TransactionReceived carrying the balance
         let tx = create_tx_paying_to(&addr, 0xaa);
         manager.process_mempool_transaction(&tx, None).await;
 
         let mut found = false;
         while let Ok(event) = rx.try_recv() {
-            if let WalletEvent::BalanceUpdated {
-                unconfirmed,
+            if let WalletEvent::TransactionReceived {
+                balance,
+                record,
                 ..
             } = event
             {
-                assert!(unconfirmed > 0, "unconfirmed balance should increase");
+                assert_eq!(record.txid, tx.txid(), "event should carry the mempool tx");
+                assert!(balance.unconfirmed() > 0, "unconfirmed balance should increase");
                 found = true;
                 break;
             }
         }
-        assert!(found, "should emit BalanceUpdated for mempool transaction");
+        assert!(found, "should emit TransactionReceived for mempool transaction");
 
         // Irrelevant tx should not emit any events
         let unrelated_tx = Transaction {
@@ -276,27 +405,54 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_process_block_emits_balance_updated() {
+    async fn test_process_block_emits_block_update() {
         let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
         let tx = create_tx_paying_to(&addr, 0xcc);
-        let block = make_block(vec![tx]);
+        let block = make_block(vec![tx.clone()]);
 
         let mut rx = manager.subscribe_events();
         manager.process_block(&block, 100).await;
 
         let mut found = false;
         while let Ok(event) = rx.try_recv() {
-            if let WalletEvent::BalanceUpdated {
-                confirmed,
+            if let WalletEvent::BlockUpdate {
+                height,
+                inserted,
+                balance,
                 ..
             } = event
             {
-                assert!(confirmed > 0, "confirmed balance should increase after block");
+                assert_eq!(height, 100);
+                assert!(balance.confirmed() > 0, "confirmed balance should increase after block");
+                assert_eq!(inserted.len(), 1);
+                assert_eq!(inserted[0].txid, tx.txid());
                 found = true;
                 break;
             }
         }
-        assert!(found, "should emit BalanceUpdated for block processing");
+        assert!(found, "should emit BlockUpdate for block processing");
+    }
+
+    #[tokio::test]
+    async fn test_update_synced_height_emits_sync_height_update() {
+        let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
+        let mut rx = manager.subscribe_events();
+
+        manager.update_synced_height(500);
+
+        let mut found = false;
+        while let Ok(event) = rx.try_recv() {
+            if let WalletEvent::SyncHeightUpdate {
+                wallet_id: evt_wallet_id,
+                height,
+            } = event
+            {
+                assert_eq!(evt_wallet_id, wallet_id);
+                assert_eq!(height, 500);
+                found = true;
+            }
+        }
+        assert!(found, "should emit SyncHeightUpdate on update_synced_height");
     }
 
     #[tokio::test]

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -88,7 +88,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             };
             let balance = info.balance();
             for record in records {
-                let event = WalletEvent::TransactionReceived {
+                let event = WalletEvent::TransactionDetected {
                     wallet_id,
                     record: Box::new(record),
                     balance,
@@ -107,10 +107,10 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
                 };
                 let balance = info.balance();
                 for record in records {
-                    let event = WalletEvent::TransactionStatusChanged {
+                    let event = WalletEvent::TransactionInstantLocked {
                         wallet_id,
                         txid: record.txid,
-                        status: TransactionContext::InstantSend(lock.clone()),
+                        instant_lock: lock.clone(),
                         balance,
                     };
                     let _ = self.event_sender.send(event);
@@ -160,7 +160,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             let advanced = height > info.synced_height();
             info.update_synced_height(height);
             if advanced {
-                let _ = self.event_sender.send(WalletEvent::SyncHeightUpdate {
+                let _ = self.event_sender.send(WalletEvent::SyncHeightAdvanced {
                     wallet_id: *wallet_id,
                     height,
                 });
@@ -187,15 +187,14 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
             return;
         }
 
-        let context = TransactionContext::InstantSend(instant_lock);
         for wallet_id in affected_wallets {
             let Some(info) = self.wallet_infos.get(&wallet_id) else {
                 continue;
             };
-            let _ = self.event_sender().send(WalletEvent::TransactionStatusChanged {
+            let _ = self.event_sender().send(WalletEvent::TransactionInstantLocked {
                 wallet_id,
                 txid,
-                status: context.clone(),
+                instant_lock: instant_lock.clone(),
                 balance: info.balance(),
             });
         }
@@ -234,7 +233,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
     /// Advance every wallet's last-processed height to `height`, collect the
     /// matured-coinbase window `(prior, height]` per wallet, and emit a
-    /// `BlockUpdate` event for each wallet whose balance changed or whose
+    /// `BlockProcessed` event for each wallet whose balance changed or whose
     /// `inserted`/`updated`/`matured` lists are non-empty. Snapshots are taken
     /// before the advance so events carry the post-advance balance.
     fn finalize_block_advance(
@@ -276,7 +275,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
 
             if !inserted.is_empty() || !updated.is_empty() || !matured.is_empty() || balance_changed
             {
-                let event = WalletEvent::BlockUpdate {
+                let event = WalletEvent::BlockProcessed {
                     wallet_id: *wallet_id,
                     height,
                     inserted,
@@ -340,13 +339,13 @@ mod tests {
         let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
         let mut rx = manager.subscribe_events();
 
-        // Relevant tx should emit TransactionReceived carrying the balance
+        // Relevant tx should emit TransactionDetected carrying the balance
         let tx = create_tx_paying_to(&addr, 0xaa);
         manager.process_mempool_transaction(&tx, None).await;
 
         let mut found = false;
         while let Ok(event) = rx.try_recv() {
-            if let WalletEvent::TransactionReceived {
+            if let WalletEvent::TransactionDetected {
                 balance,
                 record,
                 ..
@@ -358,7 +357,7 @@ mod tests {
                 break;
             }
         }
-        assert!(found, "should emit TransactionReceived for mempool transaction");
+        assert!(found, "should emit TransactionDetected for mempool transaction");
 
         // Irrelevant tx should not emit any events
         let unrelated_tx = Transaction {
@@ -386,7 +385,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_process_block_emits_block_update() {
+    async fn test_process_block_emits_block_processed() {
         let (mut manager, _wallet_id, addr) = setup_manager_with_wallet();
         let tx = create_tx_paying_to(&addr, 0xcc);
         let block = make_block(vec![tx.clone()]);
@@ -396,7 +395,7 @@ mod tests {
 
         let mut found = false;
         while let Ok(event) = rx.try_recv() {
-            if let WalletEvent::BlockUpdate {
+            if let WalletEvent::BlockProcessed {
                 height,
                 inserted,
                 balance,
@@ -411,11 +410,11 @@ mod tests {
                 break;
             }
         }
-        assert!(found, "should emit BlockUpdate for block processing");
+        assert!(found, "should emit BlockProcessed for block processing");
     }
 
     #[tokio::test]
-    async fn test_update_synced_height_emits_sync_height_update() {
+    async fn test_update_synced_height_emits_sync_height_advanced() {
         let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
         let mut rx = manager.subscribe_events();
 
@@ -423,7 +422,7 @@ mod tests {
 
         let mut found = false;
         while let Ok(event) = rx.try_recv() {
-            if let WalletEvent::SyncHeightUpdate {
+            if let WalletEvent::SyncHeightAdvanced {
                 wallet_id: evt_wallet_id,
                 height,
             } = event
@@ -433,7 +432,7 @@ mod tests {
                 found = true;
             }
         }
-        assert!(found, "should emit SyncHeightUpdate on update_synced_height");
+        assert!(found, "should emit SyncHeightAdvanced on update_synced_height");
     }
 
     #[tokio::test]

--- a/key-wallet-manager/src/test_helpers.rs
+++ b/key-wallet-manager/src/test_helpers.rs
@@ -59,79 +59,8 @@ pub(crate) fn drain_events(rx: &mut broadcast::Receiver<WalletEvent>) -> Vec<Wal
     events
 }
 
-/// Drain events from the receiver, assert exactly one was emitted, and return it.
-pub(crate) fn assert_single_event(rx: &mut broadcast::Receiver<WalletEvent>) -> WalletEvent {
-    let events = drain_events(rx);
-    assert_eq!(events.len(), 1, "expected 1 event, got {}: {:?}", events.len(), events);
-    events.into_iter().next().unwrap()
-}
-
 /// Drain events and assert none were emitted.
 pub(crate) fn assert_no_events(rx: &mut broadcast::Receiver<WalletEvent>) {
     let events = drain_events(rx);
     assert!(events.is_empty(), "expected no events, got {}: {:?}", events.len(), events);
-}
-
-/// Submit a transaction through a sequence of contexts and verify the event flow.
-///
-/// The first context produces a `TransactionReceived` event; each subsequent
-/// context produces a `TransactionStatusChanged` event.
-pub(crate) async fn assert_lifecycle_flow(contexts: &[TransactionContext], input_seed: u8) {
-    assert!(!contexts.is_empty(), "at least one context required");
-
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, input_seed);
-
-    for (i, ctx) in contexts.iter().enumerate() {
-        manager.check_transaction_in_all_wallets(&tx, ctx.clone(), true, true).await;
-        let event = assert_single_event(&mut rx);
-
-        if i == 0 {
-            assert!(
-                matches!(&event, WalletEvent::TransactionReceived { wallet_id: wid, record, .. } if *wid == wallet_id && record.context == *ctx),
-                "context[{}]: expected TransactionReceived with wallet_id and status {:?}, got {:?}",
-                i,
-                ctx,
-                event
-            );
-        } else {
-            assert!(
-                matches!(&event, WalletEvent::TransactionStatusChanged { wallet_id: wid, status, .. } if *wid == wallet_id && status == ctx),
-                "context[{}]: expected TransactionStatusChanged with wallet_id and status {:?}, got {:?}",
-                i,
-                ctx,
-                event
-            );
-        }
-    }
-}
-
-/// Submit a transaction through `setup_contexts`, drain events, then submit with
-/// `suppressed_context` and assert no event is emitted. Optionally verify
-/// the stored height.
-pub(crate) async fn assert_context_suppressed(
-    setup_contexts: &[TransactionContext],
-    suppressed_context: TransactionContext,
-    expected_height: Option<u32>,
-    input_seed: u8,
-) {
-    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
-    let mut rx = manager.subscribe_events();
-    let tx = create_tx_paying_to(&addr, input_seed);
-
-    for ctx in setup_contexts {
-        manager.check_transaction_in_all_wallets(&tx, ctx.clone(), true, true).await;
-        drain_events(&mut rx);
-    }
-
-    manager.check_transaction_in_all_wallets(&tx, suppressed_context, true, true).await;
-    assert_no_events(&mut rx);
-
-    let history = manager.wallet_transaction_history(&wallet_id).unwrap();
-    let records: Vec<_> = history.iter().filter(|r| r.txid == tx.txid()).collect();
-    assert_eq!(records.len(), 1);
-    if let Some(height) = expected_height {
-        assert_eq!(records[0].height(), Some(height));
-    }
 }

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -526,6 +526,7 @@ impl ManagedCoreAccount {
 
         let tx_record = TransactionRecord::new(
             tx.clone(),
+            self.account_type.to_account_type(),
             context.clone(),
             transaction_type,
             direction,

--- a/key-wallet/src/managed_account/transaction_record.rs
+++ b/key-wallet/src/managed_account/transaction_record.rs
@@ -3,6 +3,7 @@
 //! This module contains the transaction record structure used to track
 //! transactions associated with accounts.
 
+use crate::account::AccountType;
 use crate::error::Error;
 use crate::transaction_checking::transaction_router::TransactionType;
 use crate::transaction_checking::{BlockInfo, TransactionContext};
@@ -79,6 +80,8 @@ pub struct TransactionRecord {
     pub transaction: Transaction,
     /// Transaction ID
     pub txid: Txid,
+    /// Account this record belongs to.
+    pub account_type: AccountType,
     /// The context in which this transaction was last seen
     pub context: TransactionContext,
     /// Classification of the transaction type
@@ -98,9 +101,13 @@ pub struct TransactionRecord {
 }
 
 impl TransactionRecord {
-    /// Create a new transaction record with the given context
+    /// Create a new transaction record with the given context.
+    ///
+    /// `account_type` identifies the owning account.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         transaction: Transaction,
+        account_type: AccountType,
         context: TransactionContext,
         transaction_type: TransactionType,
         direction: TransactionDirection,
@@ -111,6 +118,7 @@ impl TransactionRecord {
         let txid = transaction.txid();
         Self {
             txid,
+            account_type,
             transaction,
             context,
             transaction_type,
@@ -194,8 +202,16 @@ impl TransactionRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::account::StandardAccountType;
     use dashcore::hashes::Hash;
     use dashcore::BlockHash;
+
+    fn test_account_type() -> AccountType {
+        AccountType::Standard {
+            index: 0,
+            standard_account_type: StandardAccountType::BIP44Account,
+        }
+    }
 
     fn test_block_context(height: u32) -> TransactionContext {
         TransactionContext::InBlock(BlockInfo::new(height, BlockHash::all_zeros(), 1234567890))
@@ -208,6 +224,7 @@ mod tests {
     ) -> TransactionRecord {
         TransactionRecord::new(
             tx,
+            test_account_type(),
             context,
             TransactionType::Standard,
             TransactionDirection::Incoming,
@@ -264,6 +281,7 @@ mod tests {
 
         let outgoing = TransactionRecord::new(
             tx.clone(),
+            test_account_type(),
             TransactionContext::Mempool,
             TransactionType::Standard,
             TransactionDirection::Outgoing,
@@ -277,6 +295,7 @@ mod tests {
 
         let internal = TransactionRecord::new(
             tx.clone(),
+            test_account_type(),
             TransactionContext::Mempool,
             TransactionType::Standard,
             TransactionDirection::Internal,
@@ -289,6 +308,7 @@ mod tests {
 
         let coinjoin = TransactionRecord::new(
             tx,
+            test_account_type(),
             TransactionContext::Mempool,
             TransactionType::CoinJoin,
             TransactionDirection::CoinJoin,

--- a/key-wallet/src/tests/spent_outpoints_tests.rs
+++ b/key-wallet/src/tests/spent_outpoints_tests.rs
@@ -3,7 +3,7 @@
 use dashcore::blockdata::transaction::{OutPoint, Transaction};
 use dashcore::{TxIn, Txid};
 
-use crate::account::TransactionRecord;
+use crate::account::{AccountType, StandardAccountType, TransactionRecord};
 use crate::managed_account::transaction_record::TransactionDirection;
 use crate::managed_account::ManagedCoreAccount;
 use crate::transaction_checking::{TransactionContext, TransactionType};
@@ -39,6 +39,10 @@ fn receive_only_tx() -> Transaction {
 fn record_from_tx(tx: &Transaction) -> TransactionRecord {
     TransactionRecord::new(
         tx.clone(),
+        AccountType::Standard {
+            index: 0,
+            standard_account_type: StandardAccountType::BIP44Account,
+        },
         TransactionContext::Mempool,
         TransactionType::Standard,
         TransactionDirection::Incoming,

--- a/key-wallet/src/transaction_checking/account_checker.rs
+++ b/key-wallet/src/transaction_checking/account_checker.rs
@@ -46,8 +46,15 @@ pub struct TransactionCheckResult {
     pub total_received_for_credit_conversion: u64,
     /// New addresses generated during gap limit maintenance
     pub new_addresses: Vec<Address>,
-    /// Transaction records created for new transactions, paired with their account index
-    pub new_records: Vec<(u32, TransactionRecord)>,
+    /// Transaction records created for new transactions. Each record carries
+    /// its owning [`AccountType`](crate::account::AccountType) on
+    /// `record.account_type`, so consumers can recover it without an external
+    /// pairing.
+    pub new_records: Vec<TransactionRecord>,
+    /// Transaction records updated by this check (confirmation or IS-lock
+    /// applied to a previously stored record). Each record carries its owning
+    /// `AccountType` on `record.account_type`.
+    pub updated_records: Vec<TransactionRecord>,
 }
 
 /// Enum representing the type of Core account that matched with embedded data
@@ -376,6 +383,7 @@ impl ManagedAccountCollection {
             total_received_for_credit_conversion: 0,
             new_addresses: Vec::new(),
             new_records: Vec::new(),
+            updated_records: Vec::new(),
         };
 
         for account_type in account_types {

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -132,10 +132,17 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                     account.record_transaction(tx, &account_match, context.clone(), tx_type);
                 result.new_records.push(record);
                 result.state_modified = true;
-            } else if account.confirm_transaction(tx, &account_match, context.clone(), tx_type) {
-                result.state_modified = true;
-                if let Some(record) = account.transactions.get(&tx.txid()) {
-                    result.updated_records.push(record.clone());
+            } else {
+                let existed_before = account.transactions.contains_key(&tx.txid());
+                if account.confirm_transaction(tx, &account_match, context.clone(), tx_type) {
+                    result.state_modified = true;
+                    if let Some(record) = account.transactions.get(&tx.txid()) {
+                        if existed_before {
+                            result.updated_records.push(record.clone());
+                        } else {
+                            result.new_records.push(record.clone());
+                        }
+                    }
                 }
             }
 

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -94,17 +94,33 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                 if already_confirmed {
                     return result;
                 }
-                // Mark UTXOs as IS-locked and update the transaction context
-                for account_match in &result.affected_accounts {
-                    if let Some(account) = self
+                // Mark UTXOs as IS-locked and update the transaction context.
+                // An account can match (its address pool detects the tx) without
+                // already holding a record — backfill via `record_transaction`
+                // before marking UTXOs so the freshly registered UTXOs get the
+                // IS-lock flag too.
+                for account_match in result.affected_accounts.clone() {
+                    let Some(account) = self
                         .accounts
                         .get_by_account_type_match_mut(&account_match.account_type_match)
-                    {
+                    else {
+                        continue;
+                    };
+                    if account.transactions.contains_key(&txid) {
                         account.mark_utxos_instant_send(&txid);
                         if let Some(record) = account.transactions.get_mut(&txid) {
                             record.update_context(context.clone());
                             result.updated_records.push(record.clone());
                         }
+                    } else {
+                        let record = account.record_transaction(
+                            tx,
+                            &account_match,
+                            context.clone(),
+                            tx_type,
+                        );
+                        account.mark_utxos_instant_send(&txid);
+                        result.new_records.push(record);
                     }
                 }
                 if update_balance {
@@ -206,6 +222,7 @@ impl WalletTransactionChecker for ManagedWalletInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::account::account_type::StandardAccountType;
     use crate::managed_account::transaction_record::{OutputRole, TransactionDirection};
     use crate::test_utils::TestWalletContext;
     use crate::transaction_checking::BlockInfo;
@@ -213,7 +230,7 @@ mod tests {
     use crate::wallet::initialization::WalletAccountCreationOptions;
     use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
     use crate::wallet::{ManagedWalletInfo, Wallet};
-    use crate::Network;
+    use crate::{AccountType, Network};
     use dashcore::blockdata::script::ScriptBuf;
     use dashcore::blockdata::transaction::Transaction;
     use dashcore::ephemerealdata::instant_lock::InstantLock;
@@ -987,6 +1004,121 @@ mod tests {
         assert!(!result2.is_new_transaction);
         assert_eq!(ctx.managed_wallet.balance().spendable(), 150_000);
         assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
+    }
+
+    /// Test that the InstantSend branch backfills a `TransactionRecord` on accounts
+    /// that match the transaction but have no prior record. This mirrors the
+    /// confirmation path's backfill: a tx pays outputs to two accounts but only
+    /// the first holds a record (e.g., a missed mempool delivery on the second
+    /// account); when the IS lock arrives, the wallet-level `is_new` is `false`,
+    /// yet the second account must still be backfilled or its UTXOs would be
+    /// IS-locked without a matching `TransactionRecord`.
+    #[tokio::test]
+    async fn test_instantsend_backfills_missing_record_in_other_account() {
+        let mut wallet =
+            Wallet::new_random(Network::Testnet, WalletAccountCreationOptions::Default)
+                .expect("Should create wallet");
+        wallet
+            .add_account(
+                AccountType::Standard {
+                    index: 1,
+                    standard_account_type: StandardAccountType::BIP44Account,
+                },
+                None,
+            )
+            .expect("Should add second BIP44 account");
+
+        let mut managed_wallet =
+            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string());
+
+        let xpub0 = wallet
+            .accounts
+            .standard_bip44_accounts
+            .get(&0)
+            .expect("Should have BIP44 account 0")
+            .account_xpub;
+        let address0 = managed_wallet
+            .bip44_managed_account_at_index_mut(0)
+            .expect("Should have managed account 0")
+            .next_receive_address(Some(&xpub0), true)
+            .expect("Should generate address for account 0");
+
+        let xpub1 = wallet
+            .accounts
+            .standard_bip44_accounts
+            .get(&1)
+            .expect("Should have BIP44 account 1")
+            .account_xpub;
+        let address1 = managed_wallet
+            .bip44_managed_account_at_index_mut(1)
+            .expect("Should have managed account 1")
+            .next_receive_address(Some(&xpub1), true)
+            .expect("Should generate address for account 1");
+
+        // Build a tx with outputs to both accounts.
+        let mut tx = Transaction::dummy(&address0, 0..1, &[100_000]);
+        tx.output.push(TxOut {
+            value: 50_000,
+            script_pubkey: address1.script_pubkey(),
+        });
+        let txid = tx.txid();
+
+        // Process as mempool first so both accounts record the tx.
+        let mut wallet_mut = wallet;
+        let mempool_result = managed_wallet
+            .check_core_transaction(&tx, TransactionContext::Mempool, &mut wallet_mut, true, true)
+            .await;
+        assert!(mempool_result.is_relevant);
+        assert!(mempool_result.is_new_transaction);
+        assert_eq!(mempool_result.affected_accounts.len(), 2);
+
+        // Drop the record + UTXOs from account 1 to simulate a missed delivery
+        // there. Account 0 keeps the record so wallet-level `is_new` will be
+        // `false` when the IS lock arrives, exercising the backfill branch.
+        let account1 = managed_wallet
+            .bip44_managed_account_at_index_mut(1)
+            .expect("Should have managed account 1");
+        account1.transactions.remove(&txid);
+        account1.utxos.clear();
+        assert!(!account1.transactions.contains_key(&txid));
+        assert!(account1.utxos.is_empty());
+
+        let is_result = managed_wallet
+            .check_core_transaction(
+                &tx,
+                TransactionContext::InstantSend(InstantLock::default()),
+                &mut wallet_mut,
+                true,
+                true,
+            )
+            .await;
+        assert!(is_result.is_relevant);
+        assert!(!is_result.is_new_transaction, "Account 0 still holds the record");
+        assert!(is_result.state_modified);
+
+        // Account 0 was already known: classified as updated.
+        assert_eq!(is_result.updated_records.len(), 1);
+        assert_eq!(is_result.updated_records[0].txid, txid);
+        // Account 1 was backfilled: classified as new.
+        assert_eq!(is_result.new_records.len(), 1);
+        assert_eq!(is_result.new_records[0].txid, txid);
+
+        // Both accounts should now hold the record with IS context and IS-locked UTXOs.
+        for account_index in 0..=1 {
+            let account = managed_wallet
+                .bip44_managed_account_at_index(account_index)
+                .expect("Should have account");
+            let record = account
+                .transactions
+                .get(&txid)
+                .expect("Both accounts should hold the record after IS backfill");
+            assert!(matches!(record.context, TransactionContext::InstantSend(_)));
+            assert!(
+                account.utxos.values().any(|u| u.outpoint.txid == txid && u.is_instantlocked),
+                "Account {account_index} should have an IS-locked UTXO from this tx"
+            );
+        }
+        assert!(managed_wallet.instant_send_locks.contains(&txid));
     }
 
     /// Test that `confirm_transaction` backfills a `TransactionRecord` when the account

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -103,6 +103,7 @@ impl WalletTransactionChecker for ManagedWalletInfo {
                         account.mark_utxos_instant_send(&txid);
                         if let Some(record) = account.transactions.get_mut(&txid) {
                             record.update_context(context.clone());
+                            result.updated_records.push(record.clone());
                         }
                     }
                 }
@@ -129,12 +130,13 @@ impl WalletTransactionChecker for ManagedWalletInfo {
             if is_new {
                 let record =
                     account.record_transaction(tx, &account_match, context.clone(), tx_type);
-                if let Some(account_index) = account_match.account_type_match.account_index() {
-                    result.new_records.push((account_index, record));
-                }
+                result.new_records.push(record);
                 result.state_modified = true;
             } else if account.confirm_transaction(tx, &account_match, context.clone(), tx_type) {
                 result.state_modified = true;
+                if let Some(record) = account.transactions.get(&tx.txid()) {
+                    result.updated_records.push(record.clone());
+                }
             }
 
             for address_info in account_match.account_type_match.all_involved_addresses() {

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -99,6 +99,18 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Record that the durable wallet sync checkpoint has advanced to `current_height`.
     fn update_synced_height(&mut self, current_height: u32);
 
+    /// Records whose coinbase maturity threshold lies in
+    /// `(old_height, new_height]`, i.e. coinbase records that just matured
+    /// during the height advance from `old_height` to `new_height`.
+    ///
+    /// Returns clones of the matured records so the caller can include them
+    /// in atomic events without mutating wallet state.
+    fn matured_coinbase_records(
+        &self,
+        old_height: CoreBlockHeight,
+        new_height: CoreBlockHeight,
+    ) -> Vec<TransactionRecord>;
+
     /// Mark UTXOs for a transaction as InstantSend-locked across all accounts
     /// and update the corresponding transaction record context.
     /// Returns `true` if any UTXO was newly marked.
@@ -257,6 +269,32 @@ impl WalletInfoInterface for ManagedWalletInfo {
 
     fn update_synced_height(&mut self, current_height: u32) {
         self.metadata.synced_height = current_height;
+    }
+
+    fn matured_coinbase_records(
+        &self,
+        old_height: CoreBlockHeight,
+        new_height: CoreBlockHeight,
+    ) -> Vec<TransactionRecord> {
+        if new_height <= old_height {
+            return Vec::new();
+        }
+        let mut matured = Vec::new();
+        for account in self.accounts.all_accounts() {
+            for record in account.transactions.values() {
+                if !record.transaction.is_coin_base() {
+                    continue;
+                }
+                let Some(record_height) = record.height() else {
+                    continue;
+                };
+                let maturity_height = record_height.saturating_add(100);
+                if maturity_height > old_height && maturity_height <= new_height {
+                    matured.push(record.clone());
+                }
+            }
+        }
+        matured
     }
 
     fn mark_instant_send_utxos(&mut self, txid: &Txid, lock: &InstantLock) -> bool {


### PR DESCRIPTION
Reshape `WalletEvent` so each variant carries the records or context needed to persist a wallet update atomically off a single event, alongside the post-change balance.

The variant set is now:

- `TransactionReceived { wallet_id, record, balance }`. Fires when the wallet first sees an off-chain transaction.
- `TransactionStatusChanged { wallet_id, txid, context, balance }`. Fires when a known off-chain transaction has its state change. Currently fires only for InstantSend locks.
- `BlockUpdate { wallet_id, height, inserted, updated, matured, balance }`. Carries records bucketed by what happened to them in the block, plus the post-block balance.
- `SyncHeightUpdate { wallet_id, height }`. Marks a filter-batch checkpoint.

`TransactionRecord` carries `account_type` directly, identifying the owning account. `WalletInfoInterface` gains a `matured_coinbase_records` method that enumerates coinbase records crossing the maturity threshold during a height advance, populating `BlockUpdate.matured`.

The FFI groups the flattened account-discriminator fields into an `FFIAccountType` struct and renames the prior discriminant enum to `FFIAccountKind`.

Based on: 
- #689 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Wallet events now include post-change balances (confirmed/unconfirmed/immature/locked) and explicit account identification in every notification.
  * Block processing reports counts of inserted, updated, and matured transactions for clearer visibility.

* **New Features**
  * Instant-lock (InstantSend) notifications with associated balances.
  * Explicit sync-height advancement events.

* **API**
  * FFI account-type identifiers consolidated/renamed to a single account-kind form; related account selection APIs updated.

* **Tests**
  * End-to-end and unit tests updated to validate new event, balance and block semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->