### PR TITLE
feat(key-wallet-manager): expose bls and eddsa features

### DIFF
--- a/key-wallet-manager/Cargo.toml
+++ b/key-wallet-manager/Cargo.toml
@@ -12,6 +12,8 @@ default = []
 parallel-filters = ["dep:rayon"]
 bincode = ["key-wallet/bincode", "dep:bincode"]
 test-utils = ["key-wallet/test-utils"]
+bls = ["key-wallet/bls"]
+eddsa = ["key-wallet/eddsa"]
 
 [dependencies]
 key-wallet = { path = "../key-wallet", default-features = false }


### PR DESCRIPTION
## Summary
- Forward the `bls` and `eddsa` feature flags from `key-wallet` through `key-wallet-manager`, matching the layout already in `feat/platform-wallet2`.
- Lets downstream crates opt into BLS / EdDSA support through `key-wallet-manager` without needing a direct `key-wallet` dependency.

## Test plan
- [x] `cargo check -p key-wallet-manager` (default features)
- [x] `cargo check -p key-wallet-manager --features "bls,bincode"`
- [x] `cargo check -p key-wallet-manager --features "eddsa,bincode"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional `bls` feature flag for BLS cryptographic algorithm support
  * Introduced optional `eddsa` feature flag for EdDSA cryptographic algorithm support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->