### PR TITLE
fix(key-wallet): gate serde-only imports in BLS derivation

### DIFF
--- a/key-wallet/src/derivation_bls_bip32.rs
+++ b/key-wallet/src/derivation_bls_bip32.rs
@@ -14,9 +14,9 @@ use dashcore_hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine};
 use std::error;
 
 // NOTE: We use Bls12381G2Impl for BLS keys (48-byte public keys)
-use dashcore::blsful::{Bls12381G2Impl, PublicKey as BlsPublicKey, SecretKey as BlsSecretKey};
 #[cfg(any(feature = "serde", feature = "bincode"))]
 use dashcore::blsful::SerializationFormat;
+use dashcore::blsful::{Bls12381G2Impl, PublicKey as BlsPublicKey, SecretKey as BlsSecretKey};
 
 use dashcore::Network;
 #[cfg(feature = "serde")]

--- a/key-wallet/src/derivation_bls_bip32.rs
+++ b/key-wallet/src/derivation_bls_bip32.rs
@@ -14,14 +14,12 @@ use dashcore_hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine};
 use std::error;
 
 // NOTE: We use Bls12381G2Impl for BLS keys (48-byte public keys)
-use dashcore::blsful::{
-    Bls12381G2Impl, PublicKey as BlsPublicKey, SecretKey as BlsSecretKey, SerializationFormat,
-};
-
-#[cfg(feature = "serde")]
-use serde;
+use dashcore::blsful::{Bls12381G2Impl, PublicKey as BlsPublicKey, SecretKey as BlsSecretKey};
+#[cfg(any(feature = "serde", feature = "bincode"))]
+use dashcore::blsful::SerializationFormat;
 
 use dashcore::Network;
+#[cfg(feature = "serde")]
 use serde::Deserialize;
 
 use crate::bip32::{ChainCode, ChildNumber, DerivationPath, Fingerprint};


### PR DESCRIPTION
## Summary
- The `bls` feature alone wouldn't compile on `key-wallet`: [`derivation_bls_bip32.rs`](key-wallet/src/derivation_bls_bip32.rs) imported `serde::Deserialize` ungated, even though the only use is `#[derive(Deserialize)]` inside `#[cfg(feature = "serde")]` blocks.
- `SerializationFormat` had the matching problem — only used by serde and bincode impls, but imported unconditionally (causing an unused-import warning in `--features bls`).
- Gate both imports on the features that actually consume them so `cargo check -p key-wallet --features bls` builds cleanly. Follow-up to [#700](https://github.com/dashpay/rust-dashcore/pull/700) which exposed `bls` / `eddsa` from `key-wallet-manager`.

## Test plan
- [x] `cargo check -p key-wallet` (default)
- [x] `cargo check -p key-wallet --features bls`
- [x] `cargo check -p key-wallet --features "bls,serde"`
- [x] `cargo check -p key-wallet --features "bls,bincode"`
- [x] `cargo check -p key-wallet --all-features`
- [x] `cargo check -p key-wallet-manager --features bls`
- [x] `cargo test -p key-wallet --features "bls,serde,bincode" --lib derivation_bls_bip32` — 16 BLS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)