### PR TITLE
refactor(key-wallet): rename `ManagedCoreAccount.account_type`

### DIFF
--- a/dash-spv/tests/dashd_sync/setup.rs
+++ b/dash-spv/tests/dashd_sync/setup.rs
@@ -146,7 +146,7 @@ impl TestContext {
         let ManagedAccountType::Standard {
             external_addresses,
             ..
-        } = &account.account_type
+        } = &account.managed_account_type
         else {
             panic!("Account 0 is not a Standard account type");
         };

--- a/key-wallet-ffi/src/address_pool.rs
+++ b/key-wallet-ffi/src/address_pool.rs
@@ -310,7 +310,7 @@ pub unsafe extern "C" fn managed_wallet_get_address_pool_info(
             if let key_wallet::managed_account::managed_account_type::ManagedAccountType::Standard {
                 external_addresses,
                 ..
-            } = &managed_account.account_type {
+            } = &managed_account.managed_account_type {
                 external_addresses
             } else {
                 (*error).set(FFIErrorCode::InvalidInput, "Account type does not have external address pool");
@@ -322,7 +322,7 @@ pub unsafe extern "C" fn managed_wallet_get_address_pool_info(
             if let key_wallet::managed_account::managed_account_type::ManagedAccountType::Standard {
                 internal_addresses,
                 ..
-            } = &managed_account.account_type {
+            } = &managed_account.managed_account_type {
                 internal_addresses
             } else {
                 (*error).set(FFIErrorCode::InvalidInput, "Account type does not have internal address pool");
@@ -331,7 +331,7 @@ pub unsafe extern "C" fn managed_wallet_get_address_pool_info(
         }
         FFIAddressPoolType::Single => {
             // Get the first (and only) address pool for non-standard accounts
-            let pools = managed_account.account_type.address_pools();
+            let pools = managed_account.managed_account_type.address_pools();
             if pools.is_empty() {
                 (*error).set(FFIErrorCode::InvalidInput, "Account has no address pools");
                 return false;
@@ -395,7 +395,7 @@ pub unsafe extern "C" fn managed_wallet_set_gap_limit(
             if let key_wallet::managed_account::managed_account_type::ManagedAccountType::Standard {
                 external_addresses,
                 ..
-            } = &mut managed_account.account_type {
+            } = &mut managed_account.managed_account_type {
                 external_addresses
             } else {
                 (*error).set(FFIErrorCode::InvalidInput, "Account type does not have external address pool");
@@ -407,7 +407,7 @@ pub unsafe extern "C" fn managed_wallet_set_gap_limit(
             if let key_wallet::managed_account::managed_account_type::ManagedAccountType::Standard {
                 internal_addresses,
                 ..
-            } = &mut managed_account.account_type {
+            } = &mut managed_account.managed_account_type {
                 internal_addresses
             } else {
                 (*error).set(FFIErrorCode::InvalidInput, "Account type does not have internal address pool");
@@ -416,7 +416,7 @@ pub unsafe extern "C" fn managed_wallet_set_gap_limit(
         }
         FFIAddressPoolType::Single => {
             // Get the first (and only) address pool for non-standard accounts
-            let pools = managed_account.account_type.address_pools_mut();
+            let pools = managed_account.managed_account_type.address_pools_mut();
             if pools.is_empty() {
                 (*error).set(FFIErrorCode::InvalidInput, "Account has no address pools");
                 return false;
@@ -482,7 +482,7 @@ pub unsafe extern "C" fn managed_wallet_generate_addresses_to_index(
             if let key_wallet::managed_account::managed_account_type::ManagedAccountType::Standard {
                 external_addresses,
                 ..
-            } = &mut managed_account.account_type {
+            } = &mut managed_account.managed_account_type {
                 {
                     let current = external_addresses.highest_generated.unwrap_or(0);
                     if target_index > current {
@@ -502,7 +502,7 @@ pub unsafe extern "C" fn managed_wallet_generate_addresses_to_index(
             if let key_wallet::managed_account::managed_account_type::ManagedAccountType::Standard {
                 internal_addresses,
                 ..
-            } = &mut managed_account.account_type {
+            } = &mut managed_account.managed_account_type {
                 {
                     let current = internal_addresses.highest_generated.unwrap_or(0);
                     if target_index > current {
@@ -519,7 +519,7 @@ pub unsafe extern "C" fn managed_wallet_generate_addresses_to_index(
         }
         FFIAddressPoolType::Single => {
             // Get the first (and only) address pool for non-standard accounts
-            let mut pools = managed_account.account_type.address_pools_mut();
+            let mut pools = managed_account.managed_account_type.address_pools_mut();
             if pools.is_empty() {
                 (*error).set(FFIErrorCode::InvalidInput, "Account has no address pools");
                 return false;

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -536,7 +536,7 @@ pub unsafe extern "C" fn managed_core_account_get_account_type(
 
     let account = &*account;
     let managed_account = account.inner();
-    let account_type_rust = managed_account.account_type.to_account_type();
+    let account_type_rust = managed_account.managed_account_type.to_account_type();
 
     // Set the index if output pointer is provided
     if !index_out.is_null() {
@@ -1078,7 +1078,7 @@ pub unsafe extern "C" fn managed_core_account_get_index(
     }
 
     let account = &*account;
-    account.inner().account_type.index_or_default()
+    account.inner().managed_account_type.index_or_default()
 }
 
 /// Get the external address pool from a managed account
@@ -1102,7 +1102,7 @@ pub unsafe extern "C" fn managed_core_account_get_external_address_pool(
     let managed_account = account.inner();
 
     // Get external address pool if this is a standard account
-    match &managed_account.account_type {
+    match &managed_account.managed_account_type {
         key_wallet::managed_account::managed_account_type::ManagedAccountType::Standard {
             external_addresses,
             ..
@@ -1138,7 +1138,7 @@ pub unsafe extern "C" fn managed_core_account_get_internal_address_pool(
     let managed_account = account.inner();
 
     // Get internal address pool if this is a standard account
-    match &managed_account.account_type {
+    match &managed_account.managed_account_type {
         key_wallet::managed_account::managed_account_type::ManagedAccountType::Standard {
             internal_addresses,
             ..
@@ -1182,7 +1182,7 @@ pub unsafe extern "C" fn managed_core_account_get_address_pool(
     match pool_type {
         FFIAddressPoolType::External => {
             // Only standard accounts have external pools
-            match &managed_account.account_type {
+            match &managed_account.managed_account_type {
                 ManagedAccountType::Standard {
                     external_addresses,
                     ..
@@ -1198,7 +1198,7 @@ pub unsafe extern "C" fn managed_core_account_get_address_pool(
         }
         FFIAddressPoolType::Internal => {
             // Only standard accounts have internal pools
-            match &managed_account.account_type {
+            match &managed_account.managed_account_type {
                 ManagedAccountType::Standard {
                     internal_addresses,
                     ..
@@ -1214,7 +1214,7 @@ pub unsafe extern "C" fn managed_core_account_get_address_pool(
         }
         FFIAddressPoolType::Single => {
             // Get the single address pool for non-standard accounts
-            let pool_ref = match &managed_account.account_type {
+            let pool_ref = match &managed_account.managed_account_type {
                 ManagedAccountType::Standard {
                     ..
                 } => {

--- a/key-wallet-ffi/src/managed_wallet.rs
+++ b/key-wallet-ffi/src/managed_wallet.rs
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn managed_wallet_get_bip_44_external_address_range(
     let addresses = if let key_wallet::account::ManagedAccountType::Standard {
         external_addresses,
         ..
-    } = &mut managed_account.account_type
+    } = &mut managed_account.managed_account_type
     {
         unwrap_or_return!(
             external_addresses.address_range(start_index, end_index, &key_source),
@@ -250,7 +250,7 @@ pub unsafe extern "C" fn managed_wallet_get_bip_44_internal_address_range(
     let addresses = if let key_wallet::account::ManagedAccountType::Standard {
         internal_addresses,
         ..
-    } = &mut managed_account.account_type
+    } = &mut managed_account.managed_account_type
     {
         unwrap_or_return!(
             internal_addresses.address_range(start_index, end_index, &key_source),

--- a/key-wallet-ffi/src/transaction.rs
+++ b/key-wallet-ffi/src/transaction.rs
@@ -194,7 +194,7 @@ pub unsafe extern "C" fn wallet_build_and_sign_transaction(
                 HashMap::new();
 
             // Collect from all address pools (receive, change, etc.)
-            for pool in managed_account.account_type.address_pools() {
+            for pool in managed_account.managed_account_type.address_pools() {
                 for addr_info in pool.addresses.values() {
                     address_to_path.insert(addr_info.address.clone(), addr_info.path.clone());
                 }

--- a/key-wallet/src/managed_account/managed_account_collection.rs
+++ b/key-wallet/src/managed_account/managed_account_collection.rs
@@ -72,7 +72,7 @@ macro_rules! get_by_account_type_match_impl {
                 account_index,
                 involved_addresses,
             } => $self.dashpay_receival_accounts.$values().find(|account| {
-                match &account.account_type {
+                match &account.managed_account_type {
                     ManagedAccountType::DashpayReceivingFunds {
                         index,
                         addresses,
@@ -90,7 +90,7 @@ macro_rules! get_by_account_type_match_impl {
                 account_index,
                 involved_addresses,
             } => $self.dashpay_external_accounts.$values().find(|account| {
-                match &account.account_type {
+                match &account.managed_account_type {
                     ManagedAccountType::DashpayExternalAccount {
                         index,
                         addresses,
@@ -269,7 +269,7 @@ impl ManagedAccountCollection {
     pub fn insert(&mut self, account: ManagedCoreAccount) -> Result<(), crate::error::Error> {
         use crate::account::StandardAccountType;
 
-        match &account.account_type {
+        match &account.managed_account_type {
             ManagedAccountType::Standard {
                 index,
                 standard_account_type,

--- a/key-wallet/src/managed_account/managed_account_trait.rs
+++ b/key-wallet/src/managed_account/managed_account_trait.rs
@@ -15,11 +15,11 @@ use dashcore::Txid;
 
 /// Common trait for all managed account types
 pub trait ManagedAccountTrait {
-    /// Get the account type
-    fn account_type(&self) -> &ManagedAccountType;
+    /// Get the managed account type
+    fn managed_account_type(&self) -> &ManagedAccountType;
 
-    /// Get mutable account type
-    fn account_type_mut(&mut self) -> &mut ManagedAccountType;
+    /// Get mutable managed account type
+    fn managed_account_type_mut(&mut self) -> &mut ManagedAccountType;
 
     /// Get the network
     fn network(&self) -> Network;
@@ -53,11 +53,11 @@ pub trait ManagedAccountTrait {
 
     /// Get the account index
     fn index(&self) -> Option<u32> {
-        self.account_type().index()
+        self.managed_account_type().index()
     }
 
     /// Get the account index or 0 if none exists
     fn index_or_default(&self) -> u32 {
-        self.account_type().index_or_default()
+        self.managed_account_type().index_or_default()
     }
 }

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -51,7 +51,7 @@ pub mod transaction_record;
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct ManagedCoreAccount {
     /// Account type with embedded address pools and index
-    pub account_type: ManagedAccountType,
+    pub managed_account_type: ManagedAccountType,
     /// Network this account belongs to
     pub network: Network,
     /// Account metadata
@@ -76,9 +76,13 @@ pub struct ManagedCoreAccount {
 
 impl ManagedCoreAccount {
     /// Create a new managed account
-    pub fn new(account_type: ManagedAccountType, network: Network, is_watch_only: bool) -> Self {
+    pub fn new(
+        managed_account_type: ManagedAccountType,
+        network: Network,
+        is_watch_only: bool,
+    ) -> Self {
         Self {
-            account_type,
+            managed_account_type,
             network,
             metadata: AccountMetadata::default(),
             is_watch_only,
@@ -169,17 +173,17 @@ impl ManagedCoreAccount {
 
     /// Get the account index
     pub fn index(&self) -> Option<u32> {
-        self.account_type.index()
+        self.managed_account_type.index()
     }
 
     /// Get the account index or 0 if none exists
     pub fn index_or_default(&self) -> u32 {
-        self.account_type.index_or_default()
+        self.managed_account_type.index_or_default()
     }
 
     /// Get the managed account type
     pub fn managed_type(&self) -> &ManagedAccountType {
-        &self.account_type
+        &self.managed_account_type
     }
 
     /// Get the next unused receive address index for standard accounts
@@ -190,7 +194,7 @@ impl ManagedCoreAccount {
         if let ManagedAccountType::Standard {
             external_addresses,
             ..
-        } = &self.account_type
+        } = &self.managed_account_type
         {
             // Get the first unused address or the next index after the last used one
             if let Some(addr) = external_addresses.unused_addresses().first() {
@@ -213,7 +217,7 @@ impl ManagedCoreAccount {
         if let ManagedAccountType::Standard {
             internal_addresses,
             ..
-        } = &self.account_type
+        } = &self.managed_account_type
         {
             // Get the first unused address or the next index after the last used one
             if let Some(addr) = internal_addresses.unused_addresses().first() {
@@ -230,7 +234,7 @@ impl ManagedCoreAccount {
 
     /// Get the next unused address index for single-pool account types
     pub fn get_next_address_index(&self) -> Option<u32> {
-        match &self.account_type {
+        match &self.managed_account_type {
             ManagedAccountType::Standard {
                 ..
             } => self.get_next_receive_address_index(),
@@ -302,7 +306,7 @@ impl ManagedCoreAccount {
 
         // Use the account type's mark_address_used method
         // The address pools already track gap limits internally
-        self.account_type.mark_address_used(address)
+        self.managed_account_type.mark_address_used(address)
     }
 
     /// Add new ones for received outputs, remove spent ones
@@ -313,7 +317,7 @@ impl ManagedCoreAccount {
         context: TransactionContext,
     ) {
         // Update UTXOs only for spendable account types
-        match &mut self.account_type {
+        match &mut self.managed_account_type {
             ManagedAccountType::Standard {
                 ..
             }
@@ -526,7 +530,7 @@ impl ManagedCoreAccount {
 
         let tx_record = TransactionRecord::new(
             tx.clone(),
-            self.account_type.to_account_type(),
+            self.managed_account_type.to_account_type(),
             context.clone(),
             transaction_type,
             direction,
@@ -593,22 +597,22 @@ impl ManagedCoreAccount {
 
     /// Get all addresses from all pools
     pub fn all_addresses(&self) -> Vec<Address> {
-        self.account_type.all_addresses()
+        self.managed_account_type.all_addresses()
     }
 
     /// Check if an address belongs to this account
     pub fn contains_address(&self, address: &Address) -> bool {
-        self.account_type.contains_address(address)
+        self.managed_account_type.contains_address(address)
     }
 
     /// Check if a script pub key belongs to this account
     pub fn contains_script_pub_key(&self, script_pub_key: &ScriptBuf) -> bool {
-        self.account_type.contains_script_pub_key(script_pub_key)
+        self.managed_account_type.contains_script_pub_key(script_pub_key)
     }
 
     /// Get address info for a given address
     pub fn get_address_info(&self, address: &Address) -> Option<address_pool::AddressInfo> {
-        self.account_type.get_address_info(address)
+        self.managed_account_type.get_address_info(address)
     }
 
     /// Generate the next receive address using the optionally provided extended public key
@@ -624,7 +628,7 @@ impl ManagedCoreAccount {
         if let ManagedAccountType::Standard {
             external_addresses,
             ..
-        } = &mut self.account_type
+        } = &mut self.managed_account_type
         {
             // Create appropriate key source based on whether xpub is provided
             let key_source = match account_xpub {
@@ -658,7 +662,7 @@ impl ManagedCoreAccount {
         if let ManagedAccountType::Standard {
             internal_addresses,
             ..
-        } = &mut self.account_type
+        } = &mut self.managed_account_type
         {
             // Create appropriate key source based on whether xpub is provided
             let key_source = match account_xpub {
@@ -695,7 +699,7 @@ impl ManagedCoreAccount {
         if let ManagedAccountType::Standard {
             external_addresses,
             ..
-        } = &mut self.account_type
+        } = &mut self.managed_account_type
         {
             // Create appropriate key source based on whether xpub is provided
             let key_source = match account_xpub {
@@ -738,7 +742,7 @@ impl ManagedCoreAccount {
         if let ManagedAccountType::Standard {
             internal_addresses,
             ..
-        } = &mut self.account_type
+        } = &mut self.managed_account_type
         {
             // Create appropriate key source based on whether xpub is provided
             let key_source = match account_xpub {
@@ -774,7 +778,7 @@ impl ManagedCoreAccount {
         account_xpub: Option<&ExtendedPubKey>,
         add_to_state: bool,
     ) -> Result<Address, &'static str> {
-        match &mut self.account_type {
+        match &mut self.managed_account_type {
             ManagedAccountType::Standard {
                 ..
             } => Err("Standard accounts must use next_receive_address or next_change_address"),
@@ -871,7 +875,7 @@ impl ManagedCoreAccount {
         account_xpub: Option<&ExtendedPubKey>,
         add_to_state: bool,
     ) -> Result<address_pool::AddressInfo, &'static str> {
-        match &mut self.account_type {
+        match &mut self.managed_account_type {
             ManagedAccountType::Standard {
                 ..
             } => Err("Standard accounts must use next_receive_address_with_info or next_change_address_with_info"),
@@ -968,7 +972,7 @@ impl ManagedCoreAccount {
         account_xpub: Option<ExtendedBLSPubKey>,
         add_to_state: bool,
     ) -> Result<dashcore::blsful::PublicKey<dashcore::blsful::Bls12381G2Impl>, &'static str> {
-        match &mut self.account_type {
+        match &mut self.managed_account_type {
             ManagedAccountType::ProviderOperatorKeys {
                 addresses,
                 ..
@@ -1014,7 +1018,7 @@ impl ManagedCoreAccount {
         account_xpriv: crate::derivation_slip10::ExtendedEd25519PrivKey,
         add_to_state: bool,
     ) -> Result<(crate::derivation_slip10::VerifyingKey, AddressInfo), &'static str> {
-        match &mut self.account_type {
+        match &mut self.managed_account_type {
             ManagedAccountType::ProviderPlatformKeys {
                 addresses,
                 ..
@@ -1057,11 +1061,11 @@ impl ManagedCoreAccount {
         root_xpriv: &crate::wallet::root_extended_keys::RootExtendedPrivKey,
         network: Network,
     ) -> Result<[u8; 32], &'static str> {
-        if matches!(self.account_type, ManagedAccountType::Standard { .. }) {
+        if matches!(self.managed_account_type, ManagedAccountType::Standard { .. }) {
             return Err("Standard accounts must use next_receive_address or next_change_address");
         }
 
-        let mut pools = self.account_type.address_pools_mut();
+        let mut pools = self.managed_account_type.address_pools_mut();
         let pool = pools.first_mut().ok_or("Account has no address pool")?;
 
         let info = pool
@@ -1092,11 +1096,11 @@ impl ManagedCoreAccount {
     ///
     /// Only works for single-pool account types (not Standard accounts).
     pub fn peek_next_path(&mut self) -> Result<(crate::DerivationPath, u32), &'static str> {
-        if matches!(self.account_type, ManagedAccountType::Standard { .. }) {
+        if matches!(self.managed_account_type, ManagedAccountType::Standard { .. }) {
             return Err("Standard accounts must use next_receive_address or next_change_address");
         }
 
-        let mut pools = self.account_type.address_pools_mut();
+        let mut pools = self.managed_account_type.address_pools_mut();
         let pool = pools.first_mut().ok_or("Account has no address pool")?;
 
         let info = pool
@@ -1114,11 +1118,11 @@ impl ManagedCoreAccount {
     ///
     /// Only works for single-pool account types (not Standard accounts).
     pub fn mark_first_pool_index_used(&mut self, index: u32) -> Result<(), &'static str> {
-        if matches!(self.account_type, ManagedAccountType::Standard { .. }) {
+        if matches!(self.managed_account_type, ManagedAccountType::Standard { .. }) {
             return Err("Standard accounts must use next_receive_address or next_change_address");
         }
 
-        let mut pools = self.account_type.address_pools_mut();
+        let mut pools = self.managed_account_type.address_pools_mut();
         let pool = pools.first_mut().ok_or("Account has no address pool")?;
         pool.mark_index_used(index);
         Ok(())
@@ -1145,7 +1149,7 @@ impl ManagedCoreAccount {
 
     /// Get the derivation path for an address if it belongs to this account
     pub fn address_derivation_path(&self, address: &Address) -> Option<crate::DerivationPath> {
-        self.account_type.get_address_derivation_path(address)
+        self.managed_account_type.get_address_derivation_path(address)
     }
 
     /// Get the current timestamp (for metadata)
@@ -1158,7 +1162,7 @@ impl ManagedCoreAccount {
 
     /// Get total address count across all pools
     pub fn total_address_count(&self) -> usize {
-        self.account_type
+        self.managed_account_type
             .address_pools()
             .iter()
             .map(|pool| pool.stats().total_generated as usize)
@@ -1167,12 +1171,16 @@ impl ManagedCoreAccount {
 
     /// Get used address count across all pools
     pub fn used_address_count(&self) -> usize {
-        self.account_type.address_pools().iter().map(|pool| pool.stats().used_count as usize).sum()
+        self.managed_account_type
+            .address_pools()
+            .iter()
+            .map(|pool| pool.stats().used_count as usize)
+            .sum()
     }
 
     /// Get the external gap limit for standard accounts
     pub fn external_gap_limit(&self) -> Option<u32> {
-        match &self.account_type {
+        match &self.managed_account_type {
             ManagedAccountType::Standard {
                 external_addresses,
                 ..
@@ -1183,7 +1191,7 @@ impl ManagedCoreAccount {
 
     /// Get the internal gap limit for standard accounts
     pub fn internal_gap_limit(&self) -> Option<u32> {
-        match &self.account_type {
+        match &self.managed_account_type {
             ManagedAccountType::Standard {
                 internal_addresses,
                 ..
@@ -1194,7 +1202,7 @@ impl ManagedCoreAccount {
 
     /// Get the gap limit for non-standard (single-pool) accounts
     pub fn gap_limit(&self) -> Option<u32> {
-        match &self.account_type {
+        match &self.managed_account_type {
             ManagedAccountType::Standard {
                 ..
             } => None,
@@ -1259,12 +1267,12 @@ impl ManagedCoreAccount {
 }
 
 impl ManagedAccountTrait for ManagedCoreAccount {
-    fn account_type(&self) -> &ManagedAccountType {
-        &self.account_type
+    fn managed_account_type(&self) -> &ManagedAccountType {
+        &self.managed_account_type
     }
 
-    fn account_type_mut(&mut self) -> &mut ManagedAccountType {
-        &mut self.account_type
+    fn managed_account_type_mut(&mut self) -> &mut ManagedAccountType {
+        &mut self.managed_account_type
     }
 
     fn network(&self) -> Network {
@@ -1316,7 +1324,7 @@ impl<'de> Deserialize<'de> for ManagedCoreAccount {
     {
         #[derive(Deserialize)]
         struct Helper {
-            account_type: ManagedAccountType,
+            managed_account_type: ManagedAccountType,
             network: Network,
             metadata: AccountMetadata,
             is_watch_only: bool,
@@ -1335,7 +1343,7 @@ impl<'de> Deserialize<'de> for ManagedCoreAccount {
             .collect();
 
         Ok(ManagedCoreAccount {
-            account_type: helper.account_type,
+            managed_account_type: helper.managed_account_type,
             network: helper.network,
             metadata: helper.metadata,
             is_watch_only: helper.is_watch_only,

--- a/key-wallet/src/transaction_checking/account_checker.rs
+++ b/key-wallet/src/transaction_checking/account_checker.rs
@@ -517,7 +517,7 @@ impl ManagedAccountCollection {
 impl ManagedCoreAccount {
     /// Classify an address within this account
     pub fn classify_address(&self, address: &Address) -> AddressClassification {
-        match &self.account_type {
+        match &self.managed_account_type {
             ManagedAccountType::Standard {
                 external_addresses,
                 internal_addresses,
@@ -666,7 +666,7 @@ impl ManagedCoreAccount {
             || sent > 0;
 
         if has_addresses {
-            let account_type_match = match &self.account_type {
+            let account_type_match = match &self.managed_account_type {
                 ManagedAccountType::Standard {
                     standard_account_type,
                     ..
@@ -812,7 +812,7 @@ impl ManagedCoreAccount {
 
             if !involved_addresses.is_empty() {
                 // Create the appropriate CoreAccountTypeMatch for identity accounts
-                let account_type_match = match &self.account_type {
+                let account_type_match = match &self.managed_account_type {
                     ManagedAccountType::IdentityRegistration {
                         ..
                     } => CoreAccountTypeMatch::IdentityRegistration {
@@ -870,7 +870,7 @@ impl ManagedCoreAccount {
         // Only check if this is a provider voting keys account
         if let ManagedAccountType::ProviderVotingKeys {
             addresses,
-        } = &self.account_type
+        } = &self.managed_account_type
         {
             if let Some(payload) = &tx.special_transaction_payload {
                 let voting_key_hash = match payload {
@@ -915,7 +915,7 @@ impl ManagedCoreAccount {
         // Only check if this is a provider owner keys account
         if let ManagedAccountType::ProviderOwnerKeys {
             addresses,
-        } = &self.account_type
+        } = &self.managed_account_type
         {
             if let Some(payload) = &tx.special_transaction_payload {
                 let owner_key_hash = match payload {
@@ -955,7 +955,7 @@ impl ManagedCoreAccount {
         // Only check if this is a provider voting keys account
         if let ManagedAccountType::ProviderOperatorKeys {
             addresses,
-        } = &self.account_type
+        } = &self.managed_account_type
         {
             if let Some(payload) = &tx.special_transaction_payload {
                 let operator_public_key = match payload {
@@ -999,7 +999,7 @@ impl ManagedCoreAccount {
         // Only check if this is a provider voting keys account
         if let ManagedAccountType::ProviderPlatformKeys {
             addresses,
-        } = &self.account_type
+        } = &self.managed_account_type
         {
             if let Some(payload) = &tx.special_transaction_payload {
                 let platform_node_id = match payload {

--- a/key-wallet/src/transaction_checking/transaction_router/tests/routing.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/routing.rs
@@ -183,7 +183,7 @@ async fn test_transaction_routing_to_coinjoin_account() {
             if let ManagedAccountType::CoinJoin {
                 addresses,
                 ..
-            } = &mut managed_account.account_type
+            } = &mut managed_account.managed_account_type
             {
                 addresses.next_unused(&KeySource::Public(xpub), true).unwrap_or_else(|_| {
                     // If that fails, generate a dummy address for testing

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -175,7 +175,7 @@ impl WalletTransactionChecker for ManagedWalletInfo {
 
             let key_source = KeySource::Public(xpub);
             let rev_before = result.new_addresses.len();
-            for pool in account.account_type.address_pools_mut() {
+            for pool in account.managed_account_type.address_pools_mut() {
                 match pool.maintain_gap_limit(&key_source) {
                     Ok(addrs) => result.new_addresses.extend(addrs),
                     Err(e) => {
@@ -1650,7 +1650,7 @@ mod tests {
         let coinjoin_address = if let ManagedAccountType::CoinJoin {
             addresses,
             ..
-        } = &mut managed_account.account_type
+        } = &mut managed_account.managed_account_type
         {
             addresses.next_unused(&KeySource::Public(xpub), true).expect("coinjoin address")
         } else {

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -223,7 +223,7 @@ impl ManagedWalletInfo {
 
         let utxos: Vec<Utxo> = funding_account.utxos.values().cloned().collect();
         let mut address_to_path: HashMap<Address, DerivationPath> = HashMap::new();
-        for pool in funding_account.account_type.address_pools() {
+        for pool in funding_account.managed_account_type.address_pools() {
             for addr_info in pool.addresses.values() {
                 address_to_path.insert(addr_info.address.clone(), addr_info.path.clone());
             }
@@ -358,7 +358,7 @@ impl ManagedWalletInfo {
 
         let utxos: Vec<Utxo> = funding_account.utxos.values().cloned().collect();
         let mut address_to_path: HashMap<Address, DerivationPath> = HashMap::new();
-        for pool in funding_account.account_type.address_pools() {
+        for pool in funding_account.managed_account_type.address_pools() {
             for addr_info in pool.addresses.values() {
                 address_to_path.insert(addr_info.address.clone(), addr_info.path.clone());
             }


### PR DESCRIPTION
Rename `ManagedCoreAccount.account_type` (typed `ManagedAccountType`) to `managed_account_type` so call sites no longer read like `account_type.to_account_type()`, and to make clear it's the stateful variant rather than the bare `AccountType`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal naming consistency across the codebase for enhanced maintainability and code clarity. No changes to functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->