### PR TITLE
fix(key-wallet): track self-send change in confirmed balance

### DIFF
--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -336,6 +336,18 @@ impl ManagedCoreAccount {
                     .iter()
                     .map(|info| info.address.clone())
                     .collect();
+                let change_addrs: BTreeSet<_> = account_match
+                    .account_type_match
+                    .involved_change_addresses()
+                    .iter()
+                    .map(|info| info.address.clone())
+                    .collect();
+
+                // Detect a self-send: this account owns at least one input being
+                // spent. `account_match.sent` is computed by matching inputs against
+                // this account's UTXO set, so a non-zero value means we owned at
+                // least one of the spent outpoints.
+                let has_owned_input = account_match.sent > 0;
 
                 let txid = tx.txid();
                 let mut utxos_changed = false;
@@ -364,6 +376,13 @@ impl ManagedCoreAccount {
                                 continue;
                             }
 
+                            // A change output from a transaction that also spends one of our
+                            // own UTXOs is just our previously-tracked funds returning. Treat
+                            // it as confirmed even in the mempool so the user's confirmed
+                            // balance does not appear to drop by the entire input value while
+                            // the change waits in the mempool.
+                            let is_self_send_change =
+                                has_owned_input && change_addrs.contains(&addr);
                             let txout = dashcore::TxOut {
                                 value: output.value,
                                 script_pubkey: output.script_pubkey.clone(),
@@ -371,7 +390,7 @@ impl ManagedCoreAccount {
                             let block_height = context.block_info().map_or(0, |info| info.height);
                             let mut utxo =
                                 Utxo::new(outpoint, txout, addr, block_height, tx.is_coin_base());
-                            utxo.is_confirmed = context.confirmed();
+                            utxo.is_confirmed = context.confirmed() || is_self_send_change;
                             utxo.is_instantlocked =
                                 matches!(context, TransactionContext::InstantSend(_));
                             self.utxos.insert(outpoint, utxo);

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -376,12 +376,13 @@ impl ManagedCoreAccount {
                                 continue;
                             }
 
-                            // Mark change outputs (output to one of our internal addresses
-                            // from a transaction that also spends one of our own UTXOs) so
-                            // `update_balance` can credit them to the confirmed bucket even
-                            // before the parent transaction settles — they are just our
-                            // previously-tracked funds returning to us.
-                            let is_change_output = has_owned_input && change_addrs.contains(&addr);
+                            // Flag outputs from a "trusted" mempool transaction we created —
+                            // one that spends at least one of our own UTXOs and pays this
+                            // output back to one of our internal (change) addresses. Such
+                            // an output is just our previously-tracked funds returning, so
+                            // `update_balance` credits it to the confirmed bucket even
+                            // before the parent transaction settles.
+                            let is_trusted_output = has_owned_input && change_addrs.contains(&addr);
                             let txout = dashcore::TxOut {
                                 value: output.value,
                                 script_pubkey: output.script_pubkey.clone(),
@@ -392,7 +393,7 @@ impl ManagedCoreAccount {
                             utxo.is_confirmed = context.confirmed();
                             utxo.is_instantlocked =
                                 matches!(context, TransactionContext::InstantSend(_));
-                            utxo.is_change = is_change_output;
+                            utxo.is_trusted = is_trusted_output;
                             self.utxos.insert(outpoint, utxo);
                             utxos_changed = true;
                         }
@@ -590,12 +591,12 @@ impl ManagedCoreAccount {
     /// Update the account balance.
     ///
     /// Mature, non-locked UTXOs land in either the `confirmed` bucket
-    /// (in a block, InstantSend-locked, or a self-send change output)
-    /// or the `unconfirmed` bucket (mempool only). Self-send change is
-    /// surfaced as confirmed because it is just our previously-tracked
-    /// funds returning — see [`Utxo::is_change`]. Both buckets are
-    /// spendable per [`Utxo::is_spendable`]; the split is only for
-    /// display.
+    /// (in a block, InstantSend-locked, or trusted mempool change) or
+    /// the `unconfirmed` bucket (untrusted mempool only). Trusted
+    /// mempool change is surfaced as confirmed because it is just our
+    /// previously-tracked funds returning — see [`Utxo::is_trusted`].
+    /// Both buckets are spendable per [`Utxo::is_spendable`]; the split
+    /// is only for display.
     pub fn update_balance(&mut self, last_processed_height: u32) {
         let mut confirmed = 0;
         let mut unconfirmed = 0;
@@ -607,7 +608,7 @@ impl ManagedCoreAccount {
                 locked += value;
             } else if !utxo.is_mature(last_processed_height) {
                 immature += value;
-            } else if utxo.is_confirmed || utxo.is_instantlocked || utxo.is_change {
+            } else if utxo.is_confirmed || utxo.is_instantlocked || utxo.is_trusted {
                 confirmed += value;
             } else {
                 unconfirmed += value;

--- a/key-wallet/src/managed_account/mod.rs
+++ b/key-wallet/src/managed_account/mod.rs
@@ -376,13 +376,12 @@ impl ManagedCoreAccount {
                                 continue;
                             }
 
-                            // A change output from a transaction that also spends one of our
-                            // own UTXOs is just our previously-tracked funds returning. Treat
-                            // it as confirmed even in the mempool so the user's confirmed
-                            // balance does not appear to drop by the entire input value while
-                            // the change waits in the mempool.
-                            let is_self_send_change =
-                                has_owned_input && change_addrs.contains(&addr);
+                            // Mark change outputs (output to one of our internal addresses
+                            // from a transaction that also spends one of our own UTXOs) so
+                            // `update_balance` can credit them to the confirmed bucket even
+                            // before the parent transaction settles — they are just our
+                            // previously-tracked funds returning to us.
+                            let is_change_output = has_owned_input && change_addrs.contains(&addr);
                             let txout = dashcore::TxOut {
                                 value: output.value,
                                 script_pubkey: output.script_pubkey.clone(),
@@ -390,9 +389,10 @@ impl ManagedCoreAccount {
                             let block_height = context.block_info().map_or(0, |info| info.height);
                             let mut utxo =
                                 Utxo::new(outpoint, txout, addr, block_height, tx.is_coin_base());
-                            utxo.is_confirmed = context.confirmed() || is_self_send_change;
+                            utxo.is_confirmed = context.confirmed();
                             utxo.is_instantlocked =
                                 matches!(context, TransactionContext::InstantSend(_));
+                            utxo.is_change = is_change_output;
                             self.utxos.insert(outpoint, utxo);
                             utxos_changed = true;
                         }
@@ -590,9 +590,12 @@ impl ManagedCoreAccount {
     /// Update the account balance.
     ///
     /// Mature, non-locked UTXOs land in either the `confirmed` bucket
-    /// (in a block or InstantSend-locked) or the `unconfirmed` bucket
-    /// (mempool only). Both are spendable per [`Utxo::is_spendable`];
-    /// the split is only for display.
+    /// (in a block, InstantSend-locked, or a self-send change output)
+    /// or the `unconfirmed` bucket (mempool only). Self-send change is
+    /// surfaced as confirmed because it is just our previously-tracked
+    /// funds returning — see [`Utxo::is_change`]. Both buckets are
+    /// spendable per [`Utxo::is_spendable`]; the split is only for
+    /// display.
     pub fn update_balance(&mut self, last_processed_height: u32) {
         let mut confirmed = 0;
         let mut unconfirmed = 0;
@@ -604,7 +607,7 @@ impl ManagedCoreAccount {
                 locked += value;
             } else if !utxo.is_mature(last_processed_height) {
                 immature += value;
-            } else if utxo.is_confirmed || utxo.is_instantlocked {
+            } else if utxo.is_confirmed || utxo.is_instantlocked || utxo.is_change {
                 confirmed += value;
             } else {
                 unconfirmed += value;

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -1791,19 +1791,21 @@ mod tests {
         assert!(!record.is_confirmed());
         assert_eq!(record.direction, TransactionDirection::Outgoing);
 
-        // The change UTXO should be flagged as confirmed despite the parent tx
-        // being unconfirmed in the mempool — because we own one of its inputs.
+        // The change UTXO should be flagged via `is_change` so that
+        // `update_balance` credits it to the confirmed bucket, despite the
+        // parent transaction still being in the mempool.
         let change_outpoint = OutPoint {
             txid: spend_tx.txid(),
             vout: 1,
         };
         let change_utxo =
             ctx.bip44_account().utxos.get(&change_outpoint).expect("change UTXO recorded");
-        assert!(
-            change_utxo.is_confirmed,
-            "change output from a self-send should be tracked as confirmed"
-        );
+        // The parent transaction is still in the mempool, so `is_confirmed`
+        // stays false; the change-ness is what shifts the UTXO into the
+        // confirmed balance bucket.
+        assert!(!change_utxo.is_confirmed);
         assert!(!change_utxo.is_instantlocked);
+        assert!(change_utxo.is_change, "self-send change UTXO should be flagged");
         assert_eq!(change_utxo.txout.value, change_amount);
 
         // Account-level balance: change lives in `confirmed`, not `unconfirmed`.
@@ -1829,6 +1831,7 @@ mod tests {
 
         let utxo = ctx.first_utxo();
         assert!(!utxo.is_confirmed, "external mempool payment must stay unconfirmed");
+        assert!(!utxo.is_change, "external payment is not a self-send change");
         assert_eq!(ctx.managed_wallet.balance().confirmed(), 0);
         assert_eq!(ctx.managed_wallet.balance().unconfirmed(), payment_value);
     }

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -1718,4 +1718,118 @@ mod tests {
         assert_eq!(record.output_details.len(), 1, "One output to our CoinJoin address");
         assert_eq!(record.output_details[0].role, OutputRole::Received);
     }
+
+    /// A change output produced by a mempool transaction that also spends one of
+    /// our own UTXOs is just our previously-tracked funds returning. It should
+    /// land in the confirmed balance rather than the unconfirmed balance, so the
+    /// user's confirmed total does not appear to drop by the entire input value
+    /// while the change waits in the mempool.
+    #[tokio::test]
+    async fn test_self_send_change_in_mempool_lands_in_confirmed_balance() {
+        let mut ctx = TestWalletContext::new_random();
+        let external_address = Address::p2pkh(
+            &dashcore::PublicKey::from_slice(&[0x02; 33]).expect("pubkey"),
+            Network::Testnet,
+        );
+
+        // Confirmed funding UTXO at the receive address.
+        let funding_value = 1_000_000u64;
+        let funding_tx = Transaction::dummy(&ctx.receive_address, 0..1, &[funding_value]);
+        let block_context = TransactionContext::InBlock(BlockInfo::new(
+            100,
+            BlockHash::from_slice(&[1u8; 32]).expect("hash"),
+            1_700_000_000,
+        ));
+        ctx.check_transaction(&funding_tx, block_context).await;
+        assert_eq!(ctx.managed_wallet.balance().confirmed(), funding_value);
+        assert_eq!(ctx.managed_wallet.balance().unconfirmed(), 0);
+
+        let change_address = ctx
+            .managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("account")
+            .next_change_address(Some(&ctx.xpub), true)
+            .expect("change address");
+
+        // Spend the funding UTXO: send some out, send the rest back to ourselves
+        // as change. The transaction is broadcast into the mempool.
+        let send_amount = 600_000u64;
+        let fee = 1_000u64;
+        let change_amount = funding_value - send_amount - fee;
+        let spend_tx = Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: funding_tx.txid(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: 0xffffffff,
+                witness: dashcore::Witness::new(),
+            }],
+            output: vec![
+                TxOut {
+                    value: send_amount,
+                    script_pubkey: external_address.script_pubkey(),
+                },
+                TxOut {
+                    value: change_amount,
+                    script_pubkey: change_address.script_pubkey(),
+                },
+            ],
+            special_transaction_payload: None,
+        };
+
+        let result = ctx.check_transaction(&spend_tx, TransactionContext::Mempool).await;
+        assert!(result.is_relevant);
+        assert!(result.is_new_transaction);
+
+        // The transaction record itself is still tagged as mempool.
+        let record = ctx.transaction(&spend_tx.txid());
+        assert_eq!(record.context, TransactionContext::Mempool);
+        assert!(!record.is_confirmed());
+        assert_eq!(record.direction, TransactionDirection::Outgoing);
+
+        // The change UTXO should be flagged as confirmed despite the parent tx
+        // being unconfirmed in the mempool — because we own one of its inputs.
+        let change_outpoint = OutPoint {
+            txid: spend_tx.txid(),
+            vout: 1,
+        };
+        let change_utxo =
+            ctx.bip44_account().utxos.get(&change_outpoint).expect("change UTXO recorded");
+        assert!(
+            change_utxo.is_confirmed,
+            "change output from a self-send should be tracked as confirmed"
+        );
+        assert!(!change_utxo.is_instantlocked);
+        assert_eq!(change_utxo.txout.value, change_amount);
+
+        // Account-level balance: change lives in `confirmed`, not `unconfirmed`.
+        assert_eq!(ctx.managed_wallet.balance().confirmed(), change_amount);
+        assert_eq!(ctx.managed_wallet.balance().unconfirmed(), 0);
+        assert_eq!(ctx.managed_wallet.balance().spendable(), change_amount);
+    }
+
+    /// Sibling of `test_self_send_change_in_mempool_lands_in_confirmed_balance`:
+    /// when the wallet receives a mempool payment but does not own any of the
+    /// inputs, an output that happens to land on one of our addresses must
+    /// remain in the unconfirmed bucket. The "self-send" carve-out only applies
+    /// when at least one input is one of our own UTXOs.
+    #[tokio::test]
+    async fn test_external_mempool_payment_remains_unconfirmed() {
+        let mut ctx = TestWalletContext::new_random();
+        let payment_value = 250_000u64;
+        let payment_tx = Transaction::dummy(&ctx.receive_address, 0..1, &[payment_value]);
+
+        let result = ctx.check_transaction(&payment_tx, TransactionContext::Mempool).await;
+        assert!(result.is_relevant);
+        assert!(result.is_new_transaction);
+
+        let utxo = ctx.first_utxo();
+        assert!(!utxo.is_confirmed, "external mempool payment must stay unconfirmed");
+        assert_eq!(ctx.managed_wallet.balance().confirmed(), 0);
+        assert_eq!(ctx.managed_wallet.balance().unconfirmed(), payment_value);
+    }
 }

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -1791,7 +1791,7 @@ mod tests {
         assert!(!record.is_confirmed());
         assert_eq!(record.direction, TransactionDirection::Outgoing);
 
-        // The change UTXO should be flagged via `is_change` so that
+        // The change UTXO should be flagged via `is_trusted` so that
         // `update_balance` credits it to the confirmed bucket, despite the
         // parent transaction still being in the mempool.
         let change_outpoint = OutPoint {
@@ -1801,11 +1801,11 @@ mod tests {
         let change_utxo =
             ctx.bip44_account().utxos.get(&change_outpoint).expect("change UTXO recorded");
         // The parent transaction is still in the mempool, so `is_confirmed`
-        // stays false; the change-ness is what shifts the UTXO into the
+        // stays false; the trust signal is what shifts the UTXO into the
         // confirmed balance bucket.
         assert!(!change_utxo.is_confirmed);
         assert!(!change_utxo.is_instantlocked);
-        assert!(change_utxo.is_change, "self-send change UTXO should be flagged");
+        assert!(change_utxo.is_trusted, "self-send change UTXO should be trusted");
         assert_eq!(change_utxo.txout.value, change_amount);
 
         // Account-level balance: change lives in `confirmed`, not `unconfirmed`.
@@ -1831,7 +1831,7 @@ mod tests {
 
         let utxo = ctx.first_utxo();
         assert!(!utxo.is_confirmed, "external mempool payment must stay unconfirmed");
-        assert!(!utxo.is_change, "external payment is not a self-send change");
+        assert!(!utxo.is_trusted, "external payment is not a self-send change");
         assert_eq!(ctx.managed_wallet.balance().confirmed(), 0);
         assert_eq!(ctx.managed_wallet.balance().unconfirmed(), payment_value);
     }

--- a/key-wallet/src/utxo.rs
+++ b/key-wallet/src/utxo.rs
@@ -32,13 +32,13 @@ pub struct Utxo {
     pub is_instantlocked: bool,
     /// Whether this UTXO is locked (not available for spending)
     pub is_locked: bool,
-    /// Whether this UTXO is the change output of a transaction we created —
-    /// i.e. the parent transaction also spends one of our own UTXOs and pays
-    /// this output back to one of our internal (change) addresses. Such a
+    /// Whether this UTXO comes from a "trusted" mempool transaction — one we
+    /// created ourselves, recognised because it spends at least one of our
+    /// own UTXOs and pays this output back to one of our addresses. Such a
     /// UTXO is treated as already-confirmed funds for balance display, since
-    /// it is just our previously-tracked balance returning to us.
-    #[cfg_attr(feature = "serde", serde(default))]
-    pub is_change: bool,
+    /// it is just our previously-tracked balance returning to us. Mirrors
+    /// Bitcoin Core's `CWalletTx::IsTrusted` concept.
+    pub is_trusted: bool,
 }
 
 impl Utxo {
@@ -59,7 +59,7 @@ impl Utxo {
             is_confirmed: false,
             is_instantlocked: false,
             is_locked: false,
-            is_change: false,
+            is_trusted: false,
         }
     }
 

--- a/key-wallet/src/utxo.rs
+++ b/key-wallet/src/utxo.rs
@@ -32,6 +32,13 @@ pub struct Utxo {
     pub is_instantlocked: bool,
     /// Whether this UTXO is locked (not available for spending)
     pub is_locked: bool,
+    /// Whether this UTXO is the change output of a transaction we created —
+    /// i.e. the parent transaction also spends one of our own UTXOs and pays
+    /// this output back to one of our internal (change) addresses. Such a
+    /// UTXO is treated as already-confirmed funds for balance display, since
+    /// it is just our previously-tracked balance returning to us.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub is_change: bool,
 }
 
 impl Utxo {
@@ -52,6 +59,7 @@ impl Utxo {
             is_confirmed: false,
             is_instantlocked: false,
             is_locked: false,
+            is_change: false,
         }
     }
 

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -782,6 +782,7 @@ mod tests {
             is_confirmed: true,
             is_instantlocked: false,
             is_locked: false,
+            is_change: false,
         };
         info.accounts
             .standard_bip44_accounts

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -782,7 +782,7 @@ mod tests {
             is_confirmed: true,
             is_instantlocked: false,
             is_locked: false,
-            is_change: false,
+            is_trusted: false,
         };
         info.accounts
             .standard_bip44_accounts


### PR DESCRIPTION
## Summary

When a mempool transaction spends one of our own UTXOs and pays change back to an internal address, the resulting change UTXO was being placed in the **unconfirmed** balance bucket. From a user's perspective the confirmed balance appeared to drop by the entire input value as soon as the spend was broadcast — even though the change is just previously-tracked funds returning.

This PR teaches `ManagedCoreAccount::update_utxos` to recognize that situation and mark the change UTXO as confirmed even while the parent transaction is still in the mempool. The condition is:

- the output address is in the account's internal (change) pool, **and**
- this account owns at least one input being spent (`account_match.sent > 0`)

The transaction record itself still reports `TransactionContext::Mempool` and `is_confirmed() == false`; only the change UTXO's confirmation flag (and therefore the balance bucket it lands in) is adjusted.

External / receive outputs are unchanged. Incoming mempool payments where we do not own an input keep the prior unconfirmed treatment.

## Test plan

- [x] `cargo test -p key-wallet --lib` (461 passing, including 2 new tests)
  - `test_self_send_change_in_mempool_lands_in_confirmed_balance` exercises the new path: a confirmed funding UTXO is spent in mempool with change to our internal pool; the change UTXO is `is_confirmed = true` and the wallet balance reports `confirmed = change_amount`, `unconfirmed = 0`.
  - `test_external_mempool_payment_remains_unconfirmed` is the regression guard: a fresh mempool payment we receive (no owned input) stays in the unconfirmed bucket.
- [x] `cargo test -p key-wallet-manager --lib`
- [x] `cargo test -p dash-spv --lib`
- [x] `cargo clippy -p key-wallet --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --check -p key-wallet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced mempool transaction handling for more accurate balance reporting. Self-sent transactions that spend wallet inputs and return change to wallet addresses now have their change UTXOs counted as confirmed balance immediately, rather than waiting for block confirmation. External payments remain unconfirmed until they appear on-chain.

* **Tests**
  * Added comprehensive tests for mempool transaction balance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->