### PR TITLE
chore(key-wallet-ffi): remove `wallet_create_managed_wallet`

### DIFF
--- a/key-wallet-ffi/FFI_API.md
+++ b/key-wallet-ffi/FFI_API.md
@@ -4,7 +4,7 @@ This document provides a comprehensive reference for all FFI (Foreign Function I
 
 **Auto-generated**: This documentation is automatically generated from the source code. Do not edit manually.
 
-**Total Functions**: 259
+**Total Functions**: 258
 
 ## Table of Contents
 
@@ -69,7 +69,7 @@ Functions: 19
 
 ### Wallet Operations
 
-Functions: 64
+Functions: 63
 
 | Function | Description | Module |
 |----------|-------------|--------|
@@ -115,7 +115,6 @@ Functions: 64
 | `wallet_create_from_mnemonic_with_options` | Create a new wallet from mnemonic with options  # Safety  - `mnemonic` must... | wallet |
 | `wallet_create_from_seed` | Create a new wallet from seed (backward compatibility)  # Safety  - `seed`... | wallet |
 | `wallet_create_from_seed_with_options` | Create a new wallet from seed with options  # Safety  - `seed` must be a... | wallet |
-| `wallet_create_managed_wallet` | Create a managed wallet from a regular wallet  This creates a... | transaction_checking |
 | `wallet_create_random` | Create a new random wallet (backward compatibility)  # Safety  - `error`... | wallet |
 | `wallet_create_random_with_options` | Create a new random wallet with options  # Safety  - `account_options` must... | wallet |
 | `wallet_derive_extended_private_key` | Derive extended private key at a specific path Returns an opaque... | keys |
@@ -1393,22 +1392,6 @@ Create a new wallet from seed with options  # Safety  - `seed` must be a valid p
 - `seed` must be a valid pointer to a byte array of `seed_len` length - `account_options` must be a valid pointer to FFIWalletAccountCreationOptions or null - `error` must be a valid pointer to an FFIError structure - The caller must ensure all pointers remain valid for the duration of this call
 
 **Module:** `wallet`
-
----
-
-#### `wallet_create_managed_wallet`
-
-```c
-wallet_create_managed_wallet(wallet: *const FFIWallet, error: *mut FFIError,) -> *mut FFIManagedWalletInfo
-```
-
-**Description:**
-Create a managed wallet from a regular wallet  This creates a ManagedWalletInfo instance from a Wallet, which includes address pools and transaction checking capabilities.  # Safety  - `wallet` must be a valid pointer to an FFIWallet - `error` must be a valid pointer to an FFIError - The returned pointer must be freed with `managed_wallet_info_free` (or `ffi_managed_wallet_free` for compatibility)
-
-**Safety:**
-- `wallet` must be a valid pointer to an FFIWallet - `error` must be a valid pointer to an FFIError - The returned pointer must be freed with `managed_wallet_info_free` (or `ffi_managed_wallet_free` for compatibility)
-
-**Module:** `transaction_checking`
 
 ---
 

--- a/key-wallet-ffi/src/transaction_checking.rs
+++ b/key-wallet-ffi/src/transaction_checking.rs
@@ -13,7 +13,7 @@ use crate::managed_wallet::{managed_wallet_info_free, FFIManagedWalletInfo};
 use crate::types::{
     transaction_context_from_ffi, FFIBlockInfo, FFITransactionContextType, FFIWallet,
 };
-use crate::{check_ptr, deref_ptr, deref_ptr_mut, unwrap_or_return};
+use crate::{check_ptr, deref_ptr_mut, unwrap_or_return};
 use dashcore::consensus::Decodable;
 use dashcore::Transaction;
 use key_wallet::transaction_checking::{
@@ -61,26 +61,6 @@ pub struct FFITransactionCheckResult {
     pub affected_accounts: *mut FFIAccountMatch,
     /// Number of affected accounts
     pub affected_accounts_count: c_uint,
-}
-
-/// Create a managed wallet from a regular wallet
-///
-/// This creates a ManagedWalletInfo instance from a Wallet, which includes
-/// address pools and transaction checking capabilities.
-///
-/// # Safety
-///
-/// - `wallet` must be a valid pointer to an FFIWallet
-/// - `error` must be a valid pointer to an FFIError
-/// - The returned pointer must be freed with `managed_wallet_info_free` (or `ffi_managed_wallet_free` for compatibility)
-#[no_mangle]
-pub unsafe extern "C" fn wallet_create_managed_wallet(
-    wallet: *const FFIWallet,
-    error: *mut FFIError,
-) -> *mut FFIManagedWalletInfo {
-    let wallet = deref_ptr!(wallet, error);
-    let managed_info = ManagedWalletInfo::from_wallet(wallet.inner(), 0);
-    Box::into_raw(Box::new(FFIManagedWalletInfo::new(managed_info)))
 }
 
 /// Check if a transaction belongs to the wallet


### PR DESCRIPTION
Removes the FFI constructor that produced a state-empty `FFIManagedWalletInfo` with no persistence path. The proper way to obtain a `FFIManagedWalletInfo` is via `wallet_manager_get_managed_wallet_info`, which borrows from a persistent `WalletManager`.

Regenerates `FFI_API.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated FFI API documentation reflecting reduction in available functions (from 259 to 258 total)

* **Refactor**
  * Removed wallet creation function from FFI interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->