### PR TITLE
feat(key-wallet): expose `instant_send_locks` accessor on `ManagedWalletInfo`

### DIFF
--- a/key-wallet/src/wallet/managed_wallet_info/mod.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/mod.rs
@@ -126,6 +126,17 @@ impl ManagedWalletInfo {
     pub fn increment_transactions(&mut self) {
         self.metadata.total_transactions += 1;
     }
+
+    /// Read-only access to the InstantSend lock txid set.
+    ///
+    /// Exposes `instant_send_locks` (a `pub(crate)` field marked
+    /// `serde(skip)`) so external diagnostic surfaces (e.g. the iOS
+    /// memory explorer) can list the txids that have received an
+    /// IS-lock without bypassing the encapsulation that keeps mutation
+    /// inside this crate.
+    pub fn instant_send_locks(&self) -> &HashSet<Txid> {
+        &self.instant_send_locks
+    }
 }
 
 /// Re-export types from account module for convenience


### PR DESCRIPTION
## Summary
- Adds a read-only `instant_send_locks() -> &HashSet<Txid>` getter on `ManagedWalletInfo`.
- The underlying field is `pub(crate)` and `#[serde(skip)]`; this accessor lets external diagnostic surfaces (e.g. the iOS memory explorer) enumerate IS-locked txids without relaxing the mutation boundary.

## Test plan
- [ ] `cargo build -p key-wallet`
- [ ] `cargo test -p key-wallet`
- [ ] Confirm consumer (iOS memory explorer) can list IS-locked txids via the new accessor

🤖 Generated with [Claude Code](https://claude.com/claude-code)