### PR TITLE
refactor(key-wallet): drop unused `is_watch_only` from `ManagedCoreAccount`

### DIFF
--- a/key-wallet-ffi/FFI_API.md
+++ b/key-wallet-ffi/FFI_API.md
@@ -4,7 +4,7 @@ This document provides a comprehensive reference for all FFI (Foreign Function I
 
 **Auto-generated**: This documentation is automatically generated from the source code. Do not edit manually.
 
-**Total Functions**: 259
+**Total Functions**: 258
 
 ## Table of Contents
 
@@ -140,7 +140,7 @@ Functions: 64
 
 ### Account Management
 
-Functions: 109
+Functions: 108
 
 | Function | Description | Module |
 |----------|-------------|--------|
@@ -238,7 +238,6 @@ Functions: 109
 | `managed_core_account_get_external_address_pool` | Get the external address pool from a managed account  This function returns... | managed_account |
 | `managed_core_account_get_index` | Get the account index from a managed account  Returns the primary account... | managed_account |
 | `managed_core_account_get_internal_address_pool` | Get the internal address pool from a managed account  This function returns... | managed_account |
-| `managed_core_account_get_is_watch_only` | Check if a managed account is watch-only  # Safety  - `account` must be a... | managed_account |
 | `managed_core_account_get_network` | Get the network of a managed account  # Safety  - `account` must be a valid... | managed_account |
 | `managed_core_account_get_transaction_count` | Get the number of transactions in a managed account  # Safety  - `account`... | managed_account |
 | `managed_core_account_get_transactions` | Get all transactions from a managed account  Returns an array of... | managed_account |
@@ -3165,22 +3164,6 @@ Get the internal address pool from a managed account  This function returns the 
 
 **Safety:**
 - `account` must be a valid pointer to an FFIManagedCoreAccount instance - The returned pool must be freed with `address_pool_free` when no longer needed
-
-**Module:** `managed_account`
-
----
-
-#### `managed_core_account_get_is_watch_only`
-
-```c
-managed_core_account_get_is_watch_only(account: *const FFIManagedCoreAccount,) -> bool
-```
-
-**Description:**
-Check if a managed account is watch-only  # Safety  - `account` must be a valid pointer to an FFIManagedCoreAccount instance
-
-**Safety:**
-- `account` must be a valid pointer to an FFIManagedCoreAccount instance
 
 **Module:** `managed_account`
 

--- a/key-wallet-ffi/src/managed_account.rs
+++ b/key-wallet-ffi/src/managed_account.rs
@@ -585,23 +585,6 @@ pub unsafe extern "C" fn managed_core_account_get_account_type(
     }
 }
 
-/// Check if a managed account is watch-only
-///
-/// # Safety
-///
-/// - `account` must be a valid pointer to an FFIManagedCoreAccount instance
-#[no_mangle]
-pub unsafe extern "C" fn managed_core_account_get_is_watch_only(
-    account: *const FFIManagedCoreAccount,
-) -> bool {
-    if account.is_null() {
-        return false;
-    }
-
-    let account = &*account;
-    account.inner().is_watch_only()
-}
-
 /// Get the balance of a managed account
 ///
 /// # Safety
@@ -1630,9 +1613,7 @@ mod tests {
             assert!(result.error_message.is_null());
 
             // Verify the account was created successfully
-            let account = &*result.account;
-            // Account should exist and be valid
-            assert!(!account.inner().is_watch_only());
+            let _account = &*result.account;
 
             // Clean up
             managed_core_account_free(result.account);
@@ -1830,10 +1811,6 @@ mod tests {
             assert_eq!(account_type, FFIAccountKind::StandardBIP44);
             assert_eq!(index_out, 0);
 
-            // Test get_is_watch_only
-            let is_watch_only = managed_core_account_get_is_watch_only(account);
-            assert!(!is_watch_only);
-
             // Test get_balance
             let mut balance_out = crate::types::FFIBalance {
                 confirmed: 999,
@@ -1880,9 +1857,6 @@ mod tests {
             let mut index_out: c_uint = 0;
             let account_type = managed_core_account_get_account_type(ptr::null(), &mut index_out);
             assert_eq!(account_type, FFIAccountKind::StandardBIP44); // Default type
-
-            let is_watch_only = managed_core_account_get_is_watch_only(ptr::null());
-            assert!(!is_watch_only);
 
             let tx_count = managed_core_account_get_transaction_count(ptr::null());
             assert_eq!(tx_count, 0);

--- a/key-wallet-ffi/src/managed_wallet.rs
+++ b/key-wallet-ffi/src/managed_wallet.rs
@@ -617,7 +617,6 @@ mod tests {
                 internal_addresses: internal_pool,
             },
             network,
-            false,
         );
 
         managed_collection.standard_bip44_accounts.insert(0, managed_account.clone());

--- a/key-wallet-ffi/src/utxo_tests.rs
+++ b/key-wallet-ffi/src/utxo_tests.rs
@@ -205,7 +205,6 @@ mod utxo_tests {
                         .unwrap(),
             },
             Network::Testnet,
-            false,
         );
 
         // Add multiple UTXOs
@@ -308,7 +307,6 @@ mod utxo_tests {
                         .unwrap(),
             },
             Network::Testnet,
-            false,
         );
 
         let utxos = Utxo::dummy_batch(0..2, 10000, 100, false, false);
@@ -334,7 +332,6 @@ mod utxo_tests {
                         .unwrap(),
             },
             Network::Testnet,
-            false,
         );
 
         let utxos = Utxo::dummy_batch(10..11, 20000, 200, false, false);
@@ -353,7 +350,6 @@ mod utxo_tests {
                     .unwrap(),
             },
             Network::Testnet,
-            false,
         );
 
         let utxos = Utxo::dummy_batch(20..22, 30000, 300, false, false);
@@ -412,7 +408,6 @@ mod utxo_tests {
                         .unwrap(),
             },
             Network::Testnet,
-            false,
         );
 
         let utxos = Utxo::dummy_batch(1..2, 10000, 100, false, false);

--- a/key-wallet/src/managed_account/managed_account_collection.rs
+++ b/key-wallet/src/managed_account/managed_account_collection.rs
@@ -514,7 +514,6 @@ impl ManagedAccountCollection {
         Self::create_managed_account_from_account_type(
             account.account_type,
             account.network,
-            account.is_watch_only,
             &key_source,
         )
     }
@@ -528,7 +527,6 @@ impl ManagedAccountCollection {
         Self::create_managed_account_from_account_type(
             account.account_type,
             account.network,
-            account.is_watch_only,
             &key_source,
         )
     }
@@ -547,16 +545,14 @@ impl ManagedAccountCollection {
         Self::create_managed_account_from_account_type(
             account.account_type,
             account.network,
-            account.is_watch_only,
             &key_source,
         )
     }
 
-    /// Create a ManagedAccount from an Account type with network and watch-only status
+    /// Create a ManagedAccount from an Account type with network
     fn create_managed_account_from_account_type(
         account_type: AccountType,
         network: Network,
-        is_watch_only: bool,
         key_source: &KeySource,
     ) -> Result<ManagedCoreFundsAccount, crate::error::Error> {
         // Get the derivation path for this account type
@@ -786,7 +782,7 @@ impl ManagedAccountCollection {
             }
         };
 
-        Ok(ManagedCoreFundsAccount::new(managed_type, network, is_watch_only))
+        Ok(ManagedCoreFundsAccount::new(managed_type, network))
     }
 
     /// Create a ManagedPlatformAccount from an Account for Platform Payment accounts

--- a/key-wallet/src/managed_account/managed_account_trait.rs
+++ b/key-wallet/src/managed_account/managed_account_trait.rs
@@ -38,9 +38,6 @@ pub trait ManagedAccountTrait {
     /// Get the network
     fn network(&self) -> Network;
 
-    /// Check if this is a watch-only account
-    fn is_watch_only(&self) -> bool;
-
     /// Get transactions
     fn transactions(&self) -> &BTreeMap<Txid, TransactionRecord>;
 

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -50,7 +50,7 @@ use std::collections::{BTreeSet, HashSet};
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct ManagedCoreFundsAccount {
     /// Shared keys-account state (address pools, transactions, network,
-    /// is_watch_only, monitor revision).
+    /// monitor revision).
     keys: ManagedCoreKeysAccount,
     /// Account balance information
     pub balance: WalletCoreBalance,
@@ -64,13 +64,9 @@ pub struct ManagedCoreFundsAccount {
 
 impl ManagedCoreFundsAccount {
     /// Create a new managed funds account
-    pub fn new(
-        managed_account_type: ManagedAccountType,
-        network: Network,
-        is_watch_only: bool,
-    ) -> Self {
+    pub fn new(managed_account_type: ManagedAccountType, network: Network) -> Self {
         Self {
-            keys: ManagedCoreKeysAccount::new(managed_account_type, network, is_watch_only),
+            keys: ManagedCoreKeysAccount::new(managed_account_type, network),
             balance: WalletCoreBalance::default(),
             utxos: BTreeMap::new(),
             spent_outpoints: HashSet::new(),
@@ -602,10 +598,6 @@ impl ManagedAccountTrait for ManagedCoreFundsAccount {
 
     fn network(&self) -> Network {
         self.keys.network()
-    }
-
-    fn is_watch_only(&self) -> bool {
-        self.keys.is_watch_only()
     }
 
     fn transactions(&self) -> &BTreeMap<Txid, TransactionRecord> {

--- a/key-wallet/src/managed_account/managed_core_keys_account.rs
+++ b/key-wallet/src/managed_account/managed_core_keys_account.rs
@@ -37,8 +37,6 @@ pub struct ManagedCoreKeysAccount {
     managed_account_type: ManagedAccountType,
     /// Network this account belongs to
     network: Network,
-    /// Whether this is a watch-only account
-    is_watch_only: bool,
     /// Transaction history for this account
     transactions: BTreeMap<Txid, TransactionRecord>,
     /// Revision counter incremented when the monitored address set changes
@@ -49,15 +47,10 @@ pub struct ManagedCoreKeysAccount {
 
 impl ManagedCoreKeysAccount {
     /// Create a new managed keys account
-    pub fn new(
-        managed_account_type: ManagedAccountType,
-        network: Network,
-        is_watch_only: bool,
-    ) -> Self {
+    pub fn new(managed_account_type: ManagedAccountType, network: Network) -> Self {
         Self {
             managed_account_type,
             network,
-            is_watch_only,
             transactions: BTreeMap::new(),
             monitor_revision: 0,
         }
@@ -81,7 +74,7 @@ impl ManagedCoreKeysAccount {
             .expect("Should succeed with NoKeySource")
         });
 
-        Self::new(managed_type, account.network, account.is_watch_only)
+        Self::new(managed_type, account.network)
     }
 
     /// Create a `ManagedCoreKeysAccount` from a [`BLSAccount`].
@@ -103,7 +96,7 @@ impl ManagedCoreKeysAccount {
             .expect("Should succeed with NoKeySource")
         });
 
-        Self::new(managed_type, account.network, account.is_watch_only)
+        Self::new(managed_type, account.network)
     }
 
     /// Create a `ManagedCoreKeysAccount` from an [`EdDSAAccount`].
@@ -118,7 +111,7 @@ impl ManagedCoreKeysAccount {
         )
         .expect("Should succeed with NoKeySource");
 
-        Self::new(managed_type, account.network, account.is_watch_only)
+        Self::new(managed_type, account.network)
     }
 }
 
@@ -133,10 +126,6 @@ impl ManagedAccountTrait for ManagedCoreKeysAccount {
 
     fn network(&self) -> Network {
         self.network
-    }
-
-    fn is_watch_only(&self) -> bool {
-        self.is_watch_only
     }
 
     fn transactions(&self) -> &BTreeMap<Txid, TransactionRecord> {

--- a/key-wallet/src/test_utils/account.rs
+++ b/key-wallet/src/test_utils/account.rs
@@ -34,6 +34,6 @@ impl ManagedCoreFundsAccount {
             internal_addresses: internal_pool,
         };
 
-        ManagedCoreFundsAccount::new(account_type, Network::Regtest, false)
+        ManagedCoreFundsAccount::new(account_type, Network::Regtest)
     }
 }


### PR DESCRIPTION
## Summary

The mutable `ManagedCoreAccount` carries an `is_watch_only: bool` that's just propagated from the immutable parent `Account`. Nothing in the workspace reads it for any decision — every `if watch-only { deny }` check (`key-wallet-ffi/src/keys.rs:85`, `key-wallet-ffi/src/account_derivation.rs:41,231,262`) reads `FFIAccount.inner().is_watch_only`, i.e. the immutable `Account`, not the managed copy. The denormalized field exists only as test assertions and an `#[no_mangle]` getter (`managed_core_account_get_is_watch_only`) that nothing in this repo invokes.

This drops:

- The `is_watch_only` field on `ManagedCoreAccount`
- The `is_watch_only` parameter on `ManagedCoreAccount::new` and the `create_managed_account_from_*` helpers
- `ManagedAccountTrait::is_watch_only`
- The `managed_core_account_get_is_watch_only` FFI export

`ManagedPlatformAccount.is_watch_only` and `managed_platform_account_get_is_watch_only` are unchanged.

## Breaking change

Any out-of-tree C/Swift consumer of `managed_core_account_get_is_watch_only` will need to switch to either:
- `account_get_is_watch_only` on the parent `FFIAccount`, or
- `wallet_is_watch_only` for the wallet-level status.

## Test plan

- [x] `cargo check --all` — clean
- [x] `cargo test -p key-wallet --lib` — 461 passed
- [x] `cargo test -p key-wallet-ffi --lib` — 217 passed
- [x] `cargo test -p key-wallet-manager --lib` — 31 passed
- [x] `cargo clippy --all-features --all-targets` — clean
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified managed account creation by removing the watch-only flag parameter from account initialization. Watch-only account detection and handling logic has been streamlined across the wallet's account management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->