### PR TITLE
refactor(key-wallet): drop unused `first_loaded_at` and `total_transactions` from `WalletMetadata`

### DIFF
--- a/key-wallet-manager/src/lib.rs
+++ b/key-wallet-manager/src/lib.rs
@@ -170,8 +170,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
 
         // Create managed wallet info from the wallet to properly initialize accounts
         // This ensures the ManagedAccountCollection is synchronized with the Wallet's accounts
-        let mut managed_info = T::from_wallet(&wallet, birth_height);
-        managed_info.set_first_loaded_at(current_timestamp());
+        let managed_info = T::from_wallet(&wallet, birth_height);
 
         // The wallet already has accounts created according to the provided options
         // No need to manually add accounts here since that's handled by from_mnemonic/from_mnemonic_with_passphrase
@@ -275,8 +274,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
         })?;
 
         // Add the wallet to the manager
-        let mut managed_info = T::from_wallet(&final_wallet, birth_height);
-        managed_info.set_first_loaded_at(current_timestamp());
+        let managed_info = T::from_wallet(&final_wallet, birth_height);
 
         self.wallets.insert(wallet_id, final_wallet);
         self.wallet_infos.insert(wallet_id, managed_info);
@@ -309,8 +307,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
         }
 
         // Create managed wallet info
-        let mut managed_info = T::from_wallet(&wallet, self.last_processed_height());
-        managed_info.set_first_loaded_at(current_timestamp());
+        let managed_info = T::from_wallet(&wallet, self.last_processed_height());
 
         self.wallets.insert(wallet_id, wallet);
         self.wallet_infos.insert(wallet_id, managed_info);
@@ -349,8 +346,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
         }
 
         // Create managed wallet info
-        let mut managed_info = T::from_wallet(&wallet, self.last_processed_height());
-        managed_info.set_first_loaded_at(current_timestamp());
+        let managed_info = T::from_wallet(&wallet, self.last_processed_height());
 
         self.wallets.insert(wallet_id, wallet);
         self.wallet_infos.insert(wallet_id, managed_info);
@@ -396,8 +392,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
         }
 
         // Create managed wallet info
-        let mut managed_info = T::from_wallet(&wallet, self.last_processed_height());
-        managed_info.set_first_loaded_at(current_timestamp());
+        let managed_info = T::from_wallet(&wallet, self.last_processed_height());
 
         self.wallets.insert(wallet_id, wallet);
         self.wallet_infos.insert(wallet_id, managed_info);
@@ -440,8 +435,7 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletManager<T> {
         // Create managed wallet info from the imported wallet, using the manager's
         // current aggregated last-processed height as the fallback birth height
         // since the serialized form does not preserve it.
-        let mut managed_info = T::from_wallet(&wallet, self.last_processed_height());
-        managed_info.set_first_loaded_at(current_timestamp());
+        let managed_info = T::from_wallet(&wallet, self.last_processed_height());
 
         self.wallets.insert(wallet_id, wallet);
         self.wallet_infos.insert(wallet_id, managed_info);

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -199,7 +199,6 @@ impl WalletTransactionChecker for ManagedWalletInfo {
             if context.is_instant_send() {
                 self.instant_send_locks.insert(txid);
             }
-            self.increment_transactions();
 
             let wallet_net = result.total_received as i64 - result.total_sent as i64;
             tracing::info!(
@@ -723,11 +722,6 @@ mod tests {
             "Transaction should be stored"
         );
         let tx_count_before = managed_account.transactions.len();
-        let total_tx_count_before = managed_wallet.metadata.total_transactions;
-        assert_eq!(
-            total_tx_count_before, 1,
-            "total_transactions should be 1 after first processing"
-        );
 
         // Second processing (simulating rescan) - should be marked as existing
         let result2 =
@@ -747,12 +741,6 @@ mod tests {
             managed_account.transactions.len(),
             tx_count_before,
             "Transaction count should not increase on rescan"
-        );
-
-        // Verify total_transactions metadata hasn't changed on rescan
-        assert_eq!(
-            managed_wallet.metadata.total_transactions, total_tx_count_before,
-            "total_transactions should not increase on rescan"
         );
 
         // Verify UTXO state is unchanged after rescan
@@ -880,8 +868,6 @@ mod tests {
         assert_eq!(ctx.transaction(&txid).context, TransactionContext::Mempool);
         assert!(!ctx.first_utxo().is_confirmed, "Mempool UTXO should be unconfirmed");
 
-        let total_tx_before = ctx.managed_wallet.metadata.total_transactions;
-
         // Same transaction now seen in a block
         let block_hash = BlockHash::from_slice(&[5u8; 32]).expect("Should create block hash");
         let block_context =
@@ -898,11 +884,6 @@ mod tests {
         assert_eq!(record.block_info().unwrap().block_hash, block_hash);
         assert_eq!(record.block_info().unwrap().timestamp, 1700000000);
         assert!(ctx.first_utxo().is_confirmed, "UTXO should now be confirmed");
-
-        assert_eq!(
-            ctx.managed_wallet.metadata.total_transactions, total_tx_before,
-            "total_transactions should not increase for confirmation of existing tx"
-        );
     }
 
     /// Test the full lifecycle: mempool -> IS -> block -> chain-locked block -> late IS
@@ -916,7 +897,6 @@ mod tests {
         assert_eq!(ctx.managed_wallet.balance().unconfirmed(), 200_000);
         assert_eq!(ctx.managed_wallet.balance().confirmed(), 0);
         assert_eq!(ctx.managed_wallet.balance().spendable(), 200_000);
-        assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
 
         // Stage 2: IS lock
         let is_lock = InstantLock {
@@ -930,7 +910,6 @@ mod tests {
         assert_eq!(ctx.managed_wallet.balance().unconfirmed(), 0);
         assert!(ctx.first_utxo().is_instantlocked);
         assert!(!ctx.first_utxo().is_confirmed);
-        assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
         assert!(ctx.managed_wallet.instant_send_locks.contains(&txid));
 
         // Verify the TransactionRecord stores the IS lock payload
@@ -966,7 +945,6 @@ mod tests {
         let result = ctx.check_transaction(&tx, cl_context).await;
         assert!(!result.is_new_transaction);
         assert_eq!(ctx.managed_wallet.balance().spendable(), 200_000);
-        assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
 
         // Stage 5: late IS lock on already-confirmed tx should be ignored
         let balance_before = ctx.managed_wallet.balance();
@@ -1004,7 +982,6 @@ mod tests {
             .await;
         assert!(!result2.is_new_transaction);
         assert_eq!(ctx.managed_wallet.balance().spendable(), 150_000);
-        assert_eq!(ctx.managed_wallet.metadata.total_transactions, 1);
     }
 
     /// Test that the InstantSend branch backfills a `TransactionRecord` on accounts

--- a/key-wallet/src/wallet/managed_wallet_info/mod.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/mod.rs
@@ -122,11 +122,6 @@ impl ManagedWalletInfo {
         self.network
     }
 
-    /// Increment the transaction count
-    pub fn increment_transactions(&mut self) {
-        self.metadata.total_transactions += 1;
-    }
-
     /// Read-only access to the InstantSend lock txid set.
     ///
     /// Exposes `instant_send_locks` (a `pub(crate)` field marked

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -52,12 +52,6 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Get the birth height of the wallet
     fn birth_height(&self) -> CoreBlockHeight;
 
-    /// Get the timestamp when first loaded
-    fn first_loaded_at(&self) -> u64;
-
-    /// Set the timestamp when first loaded
-    fn set_first_loaded_at(&mut self, timestamp: u64);
-
     /// Update last synced timestamp
     fn update_last_synced(&mut self, timestamp: u64);
 
@@ -178,14 +172,6 @@ impl WalletInfoInterface for ManagedWalletInfo {
 
     fn synced_height(&self) -> CoreBlockHeight {
         self.metadata.synced_height
-    }
-
-    fn first_loaded_at(&self) -> u64 {
-        self.metadata.first_loaded_at
-    }
-
-    fn set_first_loaded_at(&mut self, timestamp: u64) {
-        self.metadata.first_loaded_at = timestamp;
     }
 
     fn update_last_synced(&mut self, timestamp: u64) {

--- a/key-wallet/src/wallet/metadata.rs
+++ b/key-wallet/src/wallet/metadata.rs
@@ -12,8 +12,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WalletMetadata {
-    /// Wallet creation timestamp
-    pub first_loaded_at: u64,
     /// Birth height (when wallet was created/restored) - 0 (genesis) if unknown
     pub birth_height: CoreBlockHeight,
     /// Last processed block height
@@ -22,8 +20,6 @@ pub struct WalletMetadata {
     pub synced_height: CoreBlockHeight,
     /// Last sync timestamp
     pub last_synced: Option<u64>,
-    /// Total transactions
-    pub total_transactions: u64,
     /// Wallet version
     pub version: u32,
     /// Custom metadata fields

--- a/key-wallet/src/wallet/mod.rs
+++ b/key-wallet/src/wallet/mod.rs
@@ -425,7 +425,6 @@ mod tests {
         assert_eq!(managed_info.metadata.birth_height, 100);
         assert_eq!(managed_info.metadata.synced_height, 99);
         assert_eq!(managed_info.metadata.last_processed_height, 99);
-        assert_eq!(managed_info.metadata.first_loaded_at, 0); // Default value
         assert!(managed_info.metadata.last_synced.is_none());
 
         // Test updating metadata


### PR DESCRIPTION
## Summary
- Drops `first_loaded_at` and `total_transactions` from `WalletMetadata`; neither field is read by any consumer.
- Removes `WalletInfoInterface::{first_loaded_at, set_first_loaded_at}`, the `ManagedWalletInfo::increment_transactions` helper, and the six `WalletManager` call sites that wrote `first_loaded_at` after `from_wallet`.
- Strips test assertions in `wallet_checker` and `wallet/mod.rs` that exercised the removed fields.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test -p key-wallet -p key-wallet-manager`
- [x] `cargo clippy -p key-wallet -p key-wallet-manager --all-targets -- -D warnings`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)