### PR TITLE
chore(dash-spv): forbid `std::sync::Mutex` / `RwLock` via clippy

### DIFF
--- a/dash-spv/clippy.toml
+++ b/dash-spv/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-types = [
+    { path = "std::sync::Mutex", reason = "Use tokio::sync::Mutex instead" },
+    { path = "std::sync::RwLock", reason = "Use tokio::sync::RwLock instead" }
+]

--- a/dash-spv/src/lib.rs
+++ b/dash-spv/src/lib.rs
@@ -59,6 +59,8 @@
 //! - **Persistent storage**: Save and restore state between runs
 //! - **Extensive logging**: Built-in tracing support for debugging
 
+#![deny(clippy::disallowed_types)]
+
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 


### PR DESCRIPTION
Adds a `clippy.toml` with `disallowed-types` for `std::sync::Mutex` and `std::sync::RwLock` in dash-spv so callers are nudged toward the tokio equivalents (the crate is async/tokio throughout, a blocking lock can stall the runtime).