### PR TITLE
ci: bump `actions/cache` to v5 and `codecov/codecov-action` to v6

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,7 @@ jobs:
       # Set up dashd and test data for groups that need it
       - name: Cache dashd and test data
         if: matrix.group == 'spv' || matrix.group == 'ffi'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .rust-dashcore-test
           key: rust-dashcore-test-${{ inputs.os }}-${{ env.DASHVERSION }}-${{ env.TEST_DATA_REPO }}-${{ env.TEST_DATA_VERSION }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: inputs.coverage && steps.tests.outputs.crate_flags
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: lcov.info
           flags: ${{ steps.tests.outputs.crate_flags }}


### PR DESCRIPTION
Both actions now run on Node.js 24, silencing the Node.js 20 deprecation warnings GitHub Actions emits. `codecov/codecov-action@v6` also pulls in `actions/github-script@v8`, which removes the second deprecation notice surfaced via the codecov step.