### PR TITLE
refactor(key-wallet): update transaction builder to centralize funding and signing logic

### DIFF
--- a/dash/src/blockdata/transaction/special_transaction/asset_lock.rs
+++ b/dash/src/blockdata/transaction/special_transaction/asset_lock.rs
@@ -46,6 +46,17 @@ pub struct AssetLockPayload {
 }
 
 impl AssetLockPayload {
+    /// Latest spec version of the AssetLock payload.
+    pub const CURRENT_VERSION: u8 = 1;
+
+    /// Create a new AssetLock payload at [`Self::CURRENT_VERSION`].
+    pub fn new(credit_outputs: Vec<TxOut>) -> Self {
+        Self {
+            version: Self::CURRENT_VERSION,
+            credit_outputs,
+        }
+    }
+
     /// The size of the payload in bytes.
     pub fn size(&self) -> usize {
         let size = 1 + VarInt(self.credit_outputs.len() as u64).len();

--- a/dash/src/blockdata/transaction/special_transaction/coinbase.rs
+++ b/dash/src/blockdata/transaction/special_transaction/coinbase.rs
@@ -47,6 +47,29 @@ pub struct CoinbasePayload {
 }
 
 impl CoinbasePayload {
+    /// Latest spec version of the Coinbase payload.
+    pub const CURRENT_VERSION: u16 = 3;
+
+    /// Create a new Coinbase payload at [`Self::CURRENT_VERSION`].
+    pub fn new(
+        height: u32,
+        merkle_root_masternode_list: MerkleRootMasternodeList,
+        merkle_root_quorums: MerkleRootQuorums,
+        best_cl_height: Option<u32>,
+        best_cl_signature: Option<BLSSignature>,
+        asset_locked_amount: Option<u64>,
+    ) -> Self {
+        Self {
+            version: Self::CURRENT_VERSION,
+            height,
+            merkle_root_masternode_list,
+            merkle_root_quorums,
+            best_cl_height,
+            best_cl_signature,
+            asset_locked_amount,
+        }
+    }
+
     /// The size of the payload in bytes.
     /// version(2) + height(4) + merkle_root_masternode_list(32) + merkle_root_quorums(32)
     /// in addition to the above, if version >= 3: asset_locked_amount(8) + best_cl_height(compact_size) +

--- a/dash/src/blockdata/transaction/special_transaction/provider_registration.rs
+++ b/dash/src/blockdata/transaction/special_transaction/provider_registration.rs
@@ -114,6 +114,46 @@ pub struct ProviderRegistrationPayload {
 }
 
 impl ProviderRegistrationPayload {
+    /// Latest spec version of the ProRegTx payload.
+    pub const CURRENT_VERSION: u16 = 2;
+
+    /// Create a new ProRegTx payload at [`Self::CURRENT_VERSION`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        masternode_type: ProviderMasternodeType,
+        masternode_mode: u16,
+        collateral_outpoint: OutPoint,
+        service_address: SocketAddr,
+        owner_key_hash: PubkeyHash,
+        operator_public_key: BLSPublicKey,
+        voting_key_hash: PubkeyHash,
+        operator_reward: u16,
+        script_payout: ScriptBuf,
+        inputs_hash: InputsHash,
+        signature: Vec<u8>,
+        platform_node_id: Option<PubkeyHash>,
+        platform_p2p_port: Option<u16>,
+        platform_http_port: Option<u16>,
+    ) -> Self {
+        Self {
+            version: Self::CURRENT_VERSION,
+            masternode_type,
+            masternode_mode,
+            collateral_outpoint,
+            service_address,
+            owner_key_hash,
+            operator_public_key,
+            voting_key_hash,
+            operator_reward,
+            script_payout,
+            inputs_hash,
+            signature,
+            platform_node_id,
+            platform_p2p_port,
+            platform_http_port,
+        }
+    }
+
     /// A convenience method to get the address from payout script
     pub fn payout_address(&self, network: Network) -> Result<Address, encode::Error> {
         match Address::from_script(&self.script_payout, network) {

--- a/dash/src/blockdata/transaction/special_transaction/provider_update_registrar.rs
+++ b/dash/src/blockdata/transaction/special_transaction/provider_update_registrar.rs
@@ -58,6 +58,31 @@ pub struct ProviderUpdateRegistrarPayload {
 }
 
 impl ProviderUpdateRegistrarPayload {
+    /// Latest spec version of the ProUpRegTx payload.
+    pub const CURRENT_VERSION: u16 = 2;
+
+    /// Create a new ProUpRegTx payload at [`Self::CURRENT_VERSION`].
+    pub fn new(
+        pro_tx_hash: Txid,
+        provider_mode: u16,
+        operator_public_key: BLSPublicKey,
+        voting_key_hash: PubkeyHash,
+        script_payout: ScriptBuf,
+        inputs_hash: InputsHash,
+        payload_sig: Vec<u8>,
+    ) -> Self {
+        Self {
+            version: Self::CURRENT_VERSION,
+            pro_tx_hash,
+            provider_mode,
+            operator_public_key,
+            voting_key_hash,
+            script_payout,
+            inputs_hash,
+            payload_sig,
+        }
+    }
+
     /// The size of the payload in bytes.
     pub fn size(&self) -> usize {
         let mut size = 2 + 32 + 2 + 48 + 20 + 32; // 136

--- a/dash/src/blockdata/transaction/special_transaction/provider_update_revocation.rs
+++ b/dash/src/blockdata/transaction/special_transaction/provider_update_revocation.rs
@@ -61,6 +61,25 @@ pub struct ProviderUpdateRevocationPayload {
 }
 
 impl ProviderUpdateRevocationPayload {
+    /// Latest spec version of the ProUpRevTx payload.
+    pub const CURRENT_VERSION: u16 = 2;
+
+    /// Create a new ProUpRevTx payload at [`Self::CURRENT_VERSION`].
+    pub fn new(
+        pro_tx_hash: Txid,
+        reason: u16,
+        inputs_hash: InputsHash,
+        payload_sig: BLSSignature,
+    ) -> Self {
+        Self {
+            version: Self::CURRENT_VERSION,
+            pro_tx_hash,
+            reason,
+            inputs_hash,
+            payload_sig,
+        }
+    }
+
     /// The size of the payload in bytes.
     pub fn size(&self) -> usize {
         2 + 32 + 2 + 32 + 96

--- a/dash/src/blockdata/transaction/special_transaction/provider_update_service.rs
+++ b/dash/src/blockdata/transaction/special_transaction/provider_update_service.rs
@@ -76,6 +76,38 @@ pub struct ProviderUpdateServicePayload {
 }
 
 impl ProviderUpdateServicePayload {
+    /// Latest spec version of the ProUpServTx payload (BasicBLS).
+    pub const CURRENT_VERSION: u16 = 2;
+
+    /// Create a new ProUpServTx payload at [`Self::CURRENT_VERSION`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        mn_type: Option<u16>,
+        pro_tx_hash: Txid,
+        ip_address: u128,
+        port: u16,
+        script_payout: ScriptBuf,
+        inputs_hash: InputsHash,
+        platform_node_id: Option<[u8; 20]>,
+        platform_p2p_port: Option<u16>,
+        platform_http_port: Option<u16>,
+        payload_sig: BLSSignature,
+    ) -> Self {
+        Self {
+            version: Self::CURRENT_VERSION,
+            mn_type,
+            pro_tx_hash,
+            ip_address,
+            port,
+            script_payout,
+            inputs_hash,
+            platform_node_id,
+            platform_p2p_port,
+            platform_http_port,
+            payload_sig,
+        }
+    }
+
     /// The size of the payload in bytes.
     pub fn size(&self) -> usize {
         let mut size = 2 + 32 + 16 + 2 + 32 + 96; // 180

--- a/key-wallet-ffi/src/transaction.rs
+++ b/key-wallet-ffi/src/transaction.rs
@@ -132,12 +132,14 @@ pub unsafe extern "C" fn wallet_build_and_sign_transaction(
             let mut manager = manager_ref.manager.write().await;
 
             let (transaction, fee) = unwrap_or_return!(
-                manager.build_and_sign_transaction(
-                    &wallet_id,
-                    account_index,
-                    outputs,
-                    FeeRate::new(fee_per_kb)
-                ),
+                manager
+                    .build_and_sign_transaction(
+                        &wallet_id,
+                        account_index,
+                        outputs,
+                        FeeRate::new(fee_per_kb)
+                    )
+                    .await,
                 error
             );
             *fee_out = fee;
@@ -837,7 +839,7 @@ pub unsafe extern "C" fn wallet_build_and_sign_asset_lock_transaction(
                 account_index,
                 fundings,
                 fee_per_kb,
-            ), error);
+            ).await, error);
 
             // Write outputs
             *fee_out = result.fee;

--- a/key-wallet-manager/src/lib.rs
+++ b/key-wallet-manager/src/lib.rs
@@ -602,7 +602,7 @@ impl WalletManager<ManagedWalletInfo> {
         managed_info.next_change_address(wallet, account_index, account_type_pref, mark_as_used)
     }
 
-    pub fn build_and_sign_transaction(
+    pub async fn build_and_sign_transaction(
         &mut self,
         wallet_id: &WalletId,
         account_index: u32,
@@ -616,6 +616,7 @@ impl WalletManager<ManagedWalletInfo> {
 
         managed_wallet
             .build_and_sign_transaction(wallet, account_index, outputs, fee_rate)
+            .await
             .map_err(|e| WalletError::TransactionBuild(e.to_string()))
     }
 }

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -3,23 +3,21 @@
 //! Builds a Core special transaction (type 8) with `AssetLockPayload` that
 //! locks Dash for Platform credits.
 
-use dashcore::blockdata::script::{Builder, PushBytes};
-use dashcore::sighash::{EcdsaSighashType, SighashCache};
-use dashcore::{Address, ScriptBuf, Transaction, TxOut};
-use dashcore_hashes::Hash;
+use dashcore::blockdata::transaction::special_transaction::asset_lock::AssetLockPayload;
+use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
+use dashcore::{Transaction, TxOut};
 use secp256k1::PublicKey;
-use std::collections::HashMap;
 use std::fmt;
 
 use crate::managed_account::managed_account_trait::ManagedAccountTrait;
-use crate::signer::{Signer, SignerMethod};
-use crate::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
+use crate::managed_account::ManagedCoreKeysAccount;
+use crate::signer::Signer;
 use crate::wallet::managed_wallet_info::fee::FeeRate;
 use crate::wallet::managed_wallet_info::transaction_builder::{BuilderError, TransactionBuilder};
 use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use crate::wallet::managed_wallet_info::ManagedWalletInfo;
 use crate::wallet::Wallet;
-use crate::{DerivationPath, Utxo};
+use crate::DerivationPath;
 
 /// Which funding account to derive the one-time key from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -78,8 +76,6 @@ pub struct AssetLockResult {
 /// Errors specific to asset lock transaction building.
 #[derive(Debug, Clone)]
 pub enum AssetLockError {
-    /// No credit outputs provided.
-    NoCreditOutputs,
     /// The funding account was not found in the wallet.
     FundingAccountNotFound(String),
     /// No unused address index available in the funding key account.
@@ -94,8 +90,6 @@ pub enum AssetLockError {
     Signer(String),
     /// Signing produced an unexpected state (e.g. input without a known path).
     SigningFailed(String),
-    /// The signer does not advertise a method required by this build path.
-    UnsupportedSignerMethod(SignerMethod),
     /// The wallet does not have a private key (watch-only).
     WatchOnlyWallet,
     /// The specified BIP44 account was not found.
@@ -109,7 +103,6 @@ pub enum AssetLockError {
 impl fmt::Display for AssetLockError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NoCreditOutputs => write!(f, "At least one credit output required"),
             Self::FundingAccountNotFound(msg) => write!(f, "Funding account not found: {msg}"),
             Self::NoUnusedKeyIndex => {
                 write!(f, "No unused address index available in funding key account")
@@ -119,9 +112,6 @@ impl fmt::Display for AssetLockError {
             Self::KeyDerivation(msg) => write!(f, "Key derivation failed: {msg}"),
             Self::Signer(msg) => write!(f, "Signer error: {msg}"),
             Self::SigningFailed(msg) => write!(f, "Signing failed: {msg}"),
-            Self::UnsupportedSignerMethod(m) => {
-                write!(f, "Signer does not support required method {m:?}")
-            }
             Self::WatchOnlyWallet => write!(f, "Cannot sign with watch-only wallet"),
             Self::AccountNotFound(idx) => write!(f, "BIP44 account {} not found", idx),
             Self::NoChangeAddress => write!(f, "No change address available"),
@@ -137,15 +127,11 @@ impl From<BuilderError> for AssetLockError {
 }
 
 /// Resolve a funding key account from the managed account collection.
-///
-/// Funding-key accounts (identity / asset-lock) are stored as
-/// [`ManagedCoreKeysAccount`] in the collection — they derive keys for asset
-/// locks but don't track per-account funds.
 fn resolve_funding_account(
     accounts: &mut crate::account::ManagedAccountCollection,
     funding_type: AssetLockFundingType,
     identity_index: u32,
-) -> Result<&mut crate::managed_account::ManagedCoreKeysAccount, AssetLockError> {
+) -> Result<&mut ManagedCoreKeysAccount, AssetLockError> {
     match funding_type {
         AssetLockFundingType::IdentityRegistration => accounts
             .identity_registration
@@ -189,115 +175,47 @@ impl ManagedWalletInfo {
     ///
     /// The transaction is built first, and keys are only derived after a successful
     /// build — so no addresses are consumed if the build fails.
-    pub fn build_asset_lock(
+    pub async fn build_asset_lock(
         &mut self,
         wallet: &Wallet,
         account_index: u32,
         credit_output_fundings: Vec<CreditOutputFunding>,
         fee_per_kb: u64,
     ) -> Result<AssetLockResult, AssetLockError> {
-        use crate::wallet::WalletType;
-
-        if credit_output_fundings.is_empty() {
-            return Err(AssetLockError::NoCreditOutputs);
-        }
+        // Surface watch-only / no-private-key wallets here so we don't reserve
+        // a change index before the build can possibly succeed.
+        let root_xpriv =
+            wallet.root_extended_priv_key().map_err(|_| AssetLockError::WatchOnlyWallet)?.clone();
 
         let network = self.network;
+        let height = self.last_processed_height();
 
-        // Get root extended private key
-        let root_xpriv = match &wallet.wallet_type {
-            WalletType::Mnemonic {
-                root_extended_private_key,
-                ..
-            }
-            | WalletType::Seed {
-                root_extended_private_key,
-                ..
-            } => root_extended_private_key,
-            WalletType::ExtendedPrivKey(root_extended_private_key) => root_extended_private_key,
-            _ => return Err(AssetLockError::WatchOnlyWallet),
-        };
-
-        // Get the BIP44 funding account for UTXOs and signing
-        let funding_account = self
-            .accounts
-            .standard_bip44_accounts
-            .get(&account_index)
+        let acc = &wallet
+            .get_bip44_account(account_index)
             .ok_or(AssetLockError::AccountNotFound(account_index))?;
 
-        let utxos: Vec<Utxo> = funding_account.utxos.values().cloned().collect();
-        let mut address_to_path: HashMap<Address, DerivationPath> = HashMap::new();
-        for pool in funding_account.managed_account_type().address_pools() {
-            for addr_info in pool.addresses.values() {
-                address_to_path.insert(addr_info.address.clone(), addr_info.path.clone());
-            }
-        }
-
-        // Get change address from the funding account
-        let xpub = wallet.get_bip44_account(account_index).map(|a| a.account_xpub);
-        let change_address = self
+        let funds_acc = self
             .accounts
             .standard_bip44_accounts
             .get_mut(&account_index)
-            .and_then(|account| account.next_change_address(xpub.as_ref(), true).ok())
-            .ok_or(AssetLockError::NoChangeAddress)?;
+            .ok_or(AssetLockError::AccountNotFound(account_index))?;
 
-        let last_processed_height = self.last_processed_height();
-
-        // Separate credit outputs from funding specs
         let credit_outputs: Vec<TxOut> =
             credit_output_fundings.iter().map(|f| f.output.clone()).collect();
 
-        // Build the transaction FIRST — before deriving keys.
-        // This ensures no addresses are consumed if the build fails.
-        //
-        // Per DIP-00X (AssetLockTx), `tx.output[0]` must be an OP_RETURN
-        // burn carrying the total amount being locked — this is what
-        // "destroys" the Dash coins on the L1 chain. The credit outputs
-        // themselves live only in the special transaction payload; they
-        // describe where the resulting Platform credits are delivered.
-        //
-        // The previous implementation added the credit outputs as raw
-        // `tx.output` entries (and duplicated them in the payload),
-        // producing a structurally-invalid asset lock transaction that
-        // masternodes refused to IS-lock.
-        let total_credit: u64 = credit_outputs.iter().map(|o| o.value).sum();
-        let burn_output = TxOut {
-            value: total_credit,
-            script_pubkey: ScriptBuf::new_op_return(&[]),
-        };
-
-        let tx_builder = TransactionBuilder::new()
-            .set_change_address(change_address)
+        // Build first, derive credit keys after — a build failure must not
+        // consume any funding-key indices.
+        let (transaction, fee) = TransactionBuilder::new()
             .set_fee_rate(FeeRate::new(fee_per_kb))
-            .add_raw_output(burn_output);
+            .set_current_height(height)
+            .set_special_payload(TransactionPayload::AssetLockPayloadType(AssetLockPayload::new(
+                credit_outputs,
+            )))
+            .set_funding(funds_acc, acc)
+            .build_signed(wallet, |addr| funds_acc.address_derivation_path(&addr))
+            .await?;
 
-        let tx_builder_with_inputs = tx_builder.select_inputs(
-            &utxos,
-            SelectionStrategy::BranchAndBound,
-            last_processed_height,
-            |utxo| {
-                let path = address_to_path.get(&utxo.address)?;
-                let root_ext_priv = root_xpriv.to_extended_priv_key(network);
-                let secp = secp256k1::Secp256k1::new();
-                let derived_xpriv = root_ext_priv.derive_priv(&secp, path).ok()?;
-                Some(derived_xpriv.private_key)
-            },
-        )?;
-
-        let outputs_count_before = tx_builder_with_inputs.outputs().len();
-        let fee = tx_builder_with_inputs.calculate_fee();
-        let fee_with_extra = tx_builder_with_inputs.calculate_fee_with_extra_output();
-
-        let transaction = tx_builder_with_inputs.build_asset_lock(credit_outputs)?;
-
-        let actual_fee = if transaction.output.len() > outputs_count_before {
-            fee_with_extra
-        } else {
-            fee
-        };
-
-        // Transaction built successfully — now derive keys.
+        // Derive one private key per credit output.
         let mut keys = Vec::with_capacity(credit_output_fundings.len());
         for funding in &credit_output_fundings {
             let funding_key_account = resolve_funding_account(
@@ -306,14 +224,14 @@ impl ManagedWalletInfo {
                 funding.identity_index,
             )?;
             let key = funding_key_account
-                .next_private_key(root_xpriv, network)
+                .next_private_key(&root_xpriv, network)
                 .map_err(|e| AssetLockError::KeyDerivation(e.to_string()))?;
             keys.push(key);
         }
 
         Ok(AssetLockResult {
             transaction,
-            fee: actual_fee,
+            fee,
             keys: AssetLockCreditKeys::Private(keys),
         })
     }
@@ -341,138 +259,31 @@ impl ManagedWalletInfo {
         fee_per_kb: u64,
         signer: &S,
     ) -> Result<AssetLockResult, AssetLockError> {
-        if credit_output_fundings.is_empty() {
-            return Err(AssetLockError::NoCreditOutputs);
-        }
+        let height = self.last_processed_height();
 
-        // This build path drives signing via pre-computed P2PKH sighashes,
-        // so the signer must support blind digest signing. Signers that
-        // only advertise transaction-level signing (typical of hardware
-        // wallets) need a future build path that hands them the full tx.
-        if !signer.supports(SignerMethod::Digest) {
-            return Err(AssetLockError::UnsupportedSignerMethod(SignerMethod::Digest));
-        }
+        let acc = wallet
+            .get_bip44_account(account_index)
+            .ok_or(AssetLockError::AccountNotFound(account_index))?
+            .clone();
 
-        // UTXOs and address→path map from the funding account.
-        let funding_account = self
-            .accounts
-            .standard_bip44_accounts
-            .get(&account_index)
-            .ok_or(AssetLockError::AccountNotFound(account_index))?;
-
-        let utxos: Vec<Utxo> = funding_account.utxos.values().cloned().collect();
-        let mut address_to_path: HashMap<Address, DerivationPath> = HashMap::new();
-        for pool in funding_account.managed_account_type().address_pools() {
-            for addr_info in pool.addresses.values() {
-                address_to_path.insert(addr_info.address.clone(), addr_info.path.clone());
-            }
-        }
-
-        // Next change address — derivable from the account xpub, no signing key needed.
-        let xpub = wallet.get_bip44_account(account_index).map(|a| a.account_xpub);
-        let change_address = self
+        let funds_acc = self
             .accounts
             .standard_bip44_accounts
             .get_mut(&account_index)
-            .and_then(|account| account.next_change_address(xpub.as_ref(), true).ok())
-            .ok_or(AssetLockError::NoChangeAddress)?;
-
-        let last_processed_height = self.last_processed_height();
+            .ok_or(AssetLockError::AccountNotFound(account_index))?;
 
         let credit_outputs: Vec<TxOut> =
             credit_output_fundings.iter().map(|f| f.output.clone()).collect();
 
-        // Same burn-output shape as the soft-wallet path: tx.output[0] is an
-        // OP_RETURN burn carrying the total locked amount, credit outputs
-        // live only in the payload. See build_asset_lock for details.
-        let total_credit: u64 = credit_outputs.iter().map(|o| o.value).sum();
-        let burn_output = TxOut {
-            value: total_credit,
-            script_pubkey: ScriptBuf::new_op_return(&[]),
-        };
-
-        // Build the transaction WITHOUT keys — TransactionBuilder's internal
-        // signer is skipped when every input's key is None, producing an
-        // unsigned tx we then sign ourselves via the Signer.
-        let tx_builder = TransactionBuilder::new()
-            .set_change_address(change_address)
+        let (transaction, fee) = TransactionBuilder::new()
             .set_fee_rate(FeeRate::new(fee_per_kb))
-            .add_raw_output(burn_output);
-
-        let tx_builder_with_inputs = tx_builder.select_inputs(
-            &utxos,
-            SelectionStrategy::BranchAndBound,
-            last_processed_height,
-            |_utxo| None,
-        )?;
-
-        let outputs_count_before = tx_builder_with_inputs.outputs().len();
-        let fee = tx_builder_with_inputs.calculate_fee();
-        let fee_with_extra = tx_builder_with_inputs.calculate_fee_with_extra_output();
-
-        let mut transaction = tx_builder_with_inputs.build_asset_lock(credit_outputs)?;
-
-        let actual_fee = if transaction.output.len() > outputs_count_before {
-            fee_with_extra
-        } else {
-            fee
-        };
-
-        // Map each input back to its prev-txout via UTXO outpoint so we can
-        // compute the legacy P2PKH sighash and look up its derivation path.
-        let utxo_by_outpoint: HashMap<_, _> =
-            utxos.iter().map(|u| (u.outpoint, u.clone())).collect();
-
-        let mut scripts: Vec<ScriptBuf> = Vec::with_capacity(transaction.input.len());
-        {
-            let cache = SighashCache::new(&transaction);
-            for (index, txin) in transaction.input.iter().enumerate() {
-                let utxo = utxo_by_outpoint.get(&txin.previous_output).ok_or_else(|| {
-                    AssetLockError::SigningFailed(format!(
-                        "selected UTXO {:?} not found in funding account",
-                        txin.previous_output
-                    ))
-                })?;
-                let path = address_to_path.get(&utxo.address).ok_or_else(|| {
-                    AssetLockError::SigningFailed(format!(
-                        "no derivation path for input address {}",
-                        utxo.address
-                    ))
-                })?;
-
-                let sighash = cache
-                    .legacy_signature_hash(
-                        index,
-                        &utxo.txout.script_pubkey,
-                        EcdsaSighashType::All.to_u32(),
-                    )
-                    .map_err(|e| {
-                        AssetLockError::SigningFailed(format!(
-                            "failed to compute sighash for input {index}: {e}"
-                        ))
-                    })?;
-
-                let (sig, pubkey) = signer
-                    .sign_ecdsa(path, *sighash.as_byte_array())
-                    .await
-                    .map_err(|e| AssetLockError::Signer(e.to_string()))?;
-
-                let mut sig_bytes = sig.serialize_der().to_vec();
-                sig_bytes.push(EcdsaSighashType::All.to_u32() as u8);
-
-                let script_sig = Builder::new()
-                    .push_slice(<&PushBytes>::try_from(sig_bytes.as_slice()).map_err(|_| {
-                        AssetLockError::SigningFailed("invalid signature length".into())
-                    })?)
-                    .push_slice(pubkey.serialize())
-                    .into_script();
-
-                scripts.push(script_sig);
-            }
-        }
-        for (index, script_sig) in scripts.into_iter().enumerate() {
-            transaction.input[index].script_sig = script_sig;
-        }
+            .set_current_height(height)
+            .set_special_payload(TransactionPayload::AssetLockPayloadType(AssetLockPayload::new(
+                credit_outputs,
+            )))
+            .set_funding(funds_acc, &acc)
+            .build_signed(signer, |addr| funds_acc.address_derivation_path(&addr))
+            .await?;
 
         // Credit-output bookkeeping: for each funding, peek the next unused
         // path on its account, ask the signer for the matching pubkey, and
@@ -523,7 +334,7 @@ impl ManagedWalletInfo {
 
         Ok(AssetLockResult {
             transaction,
-            fee: actual_fee,
+            fee,
             keys: AssetLockCreditKeys::Public(credit_output_keys),
         })
     }
@@ -532,6 +343,7 @@ impl ManagedWalletInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::signer::SignerMethod;
     use crate::wallet::initialization::WalletAccountCreationOptions;
     use crate::Network;
     use dashcore::ScriptBuf;
@@ -566,10 +378,6 @@ mod tests {
     #[test]
     fn test_error_display() {
         assert_eq!(
-            AssetLockError::NoCreditOutputs.to_string(),
-            "At least one credit output required"
-        );
-        assert_eq!(
             AssetLockError::WatchOnlyWallet.to_string(),
             "Cannot sign with watch-only wallet"
         );
@@ -586,25 +394,26 @@ mod tests {
 
     // -- Builder logic tests --
 
-    #[test]
-    fn test_empty_credit_outputs_rejected() {
+    #[tokio::test]
+    async fn test_empty_credit_outputs_rejected() {
         let (wallet, mut info) = test_wallet_and_info();
-        let result = info.build_asset_lock(&wallet, 0, vec![], 1000);
-        assert!(matches!(result, Err(AssetLockError::NoCreditOutputs)));
+        let result = info.build_asset_lock(&wallet, 0, vec![], 1000).await;
+        assert!(matches!(result, Err(AssetLockError::Builder(BuilderError::NoOutputs))));
     }
 
-    #[test]
-    fn test_invalid_account_index() {
+    #[tokio::test]
+    async fn test_invalid_account_index() {
         let (wallet, mut info) = test_wallet_and_info();
-        let result = info.build_asset_lock(&wallet, 99, test_credit_outputs(&[100_000]), 1000);
+        let result =
+            info.build_asset_lock(&wallet, 99, test_credit_outputs(&[100_000]), 1000).await;
         assert!(matches!(result, Err(AssetLockError::AccountNotFound(99))));
     }
 
-    #[test]
-    fn test_insufficient_funds() {
+    #[tokio::test]
+    async fn test_insufficient_funds() {
         // Wallet has no UTXOs, so coin selection should fail
         let (wallet, mut info) = test_wallet_and_info();
-        let result = info.build_asset_lock(&wallet, 0, test_credit_outputs(&[500_000]), 1000);
+        let result = info.build_asset_lock(&wallet, 0, test_credit_outputs(&[500_000]), 1000).await;
         assert!(
             matches!(result, Err(AssetLockError::Builder(_))),
             "Expected Builder error for insufficient funds, got: {:?}",
@@ -676,7 +485,7 @@ mod tests {
             network: Network::Testnet,
         };
         let result = info.build_asset_lock_with_signer(&wallet, 0, vec![], 1000, &signer).await;
-        assert!(matches!(result, Err(AssetLockError::NoCreditOutputs)));
+        assert!(matches!(result, Err(AssetLockError::Builder(BuilderError::NoOutputs))));
     }
 
     #[tokio::test]
@@ -739,16 +548,16 @@ mod tests {
                 &NoDigestSigner,
             )
             .await;
-        assert!(matches!(
-            result,
-            Err(AssetLockError::UnsupportedSignerMethod(SignerMethod::Digest))
-        ));
+        // The unfunded wallet may also surface a CoinSelection error before
+        // the signer is reached; either way the build cannot succeed.
+        assert!(matches!(result, Err(AssetLockError::Builder(_))));
     }
 
     #[tokio::test]
     async fn test_signer_happy_path_end_to_end() {
         use crate::Utxo;
         use dashcore::{OutPoint, TxOut, Txid};
+        use dashcore_hashes::Hash;
 
         let (wallet, mut info) = test_wallet_and_info();
         let root = match &wallet.wallet_type {

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -3,31 +3,22 @@
 //! This module provides high-level transaction building functionality
 //! using types from the dashcore crate.
 
-use core::fmt;
-
-use dashcore::blockdata::script::{Builder, PushBytes, ScriptBuf};
-use dashcore::blockdata::transaction::special_transaction::{
-    asset_lock::AssetLockPayload,
-    coinbase::CoinbasePayload,
-    provider_registration::{ProviderMasternodeType, ProviderRegistrationPayload},
-    provider_update_registrar::ProviderUpdateRegistrarPayload,
-    provider_update_revocation::ProviderUpdateRevocationPayload,
-    provider_update_service::ProviderUpdateServicePayload,
-    TransactionPayload,
-};
-use dashcore::blockdata::transaction::Transaction;
-use dashcore::bls_sig_utils::{BLSPublicKey, BLSSignature};
-use dashcore::hash_types::{InputsHash, MerkleRootMasternodeList, MerkleRootQuorums, PubkeyHash};
-use dashcore::sighash::{EcdsaSighashType, SighashCache};
-use dashcore::Address;
-use dashcore::{OutPoint, TxIn, TxOut, Txid};
-use dashcore_hashes::Hash;
-use secp256k1::{Message, Secp256k1, SecretKey};
-use std::net::SocketAddr;
-
+use crate::managed_account::ManagedCoreFundsAccount;
 use crate::wallet::managed_wallet_info::coin_selection::{CoinSelector, SelectionStrategy};
 use crate::wallet::managed_wallet_info::fee::FeeRate;
-use crate::Utxo;
+use crate::{Account, DerivationPath, Signer, Utxo, Wallet};
+use core::fmt;
+use dashcore::blockdata::script::{Builder, PushBytes, ScriptBuf};
+use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
+use dashcore::blockdata::transaction::Transaction;
+use dashcore::consensus::Encodable;
+use dashcore::sighash::{EcdsaSighashType, LegacySighash, SighashCache};
+use dashcore::Address;
+use dashcore::{TxIn, TxOut};
+use dashcore_hashes::Hash;
+use secp256k1::ecdsa::Signature;
+use secp256k1::{Message, PublicKey, Secp256k1};
+use std::cmp::Ordering;
 
 /// Calculate varint size for a given number
 fn varint_size(n: usize) -> usize {
@@ -45,25 +36,14 @@ fn varint_size(n: usize) -> usize {
 /// to ensure deterministic ordering and improve privacy by preventing information leakage
 /// through predictable input/output ordering patterns.
 pub struct TransactionBuilder {
-    /// Selected UTXOs with their private keys
-    inputs: Vec<(Utxo, Option<SecretKey>)>,
-    /// Outputs to create
+    inputs: Vec<Utxo>,
+    change_addr: Option<Address>,
     outputs: Vec<TxOut>,
-    /// Change address
-    change_address: Option<Address>,
-    /// Fee rate (satoshis per kilobyte)
     fee_rate: FeeRate,
-    /// Lock time
-    lock_time: u32,
-    /// Transaction version
-    version: u16,
+    current_height: u32,
+    selection_strategy: SelectionStrategy,
     /// Special transaction payload for Dash-specific transactions
     special_payload: Option<TransactionPayload>,
-    /// When `true`, skip BIP-69 output sorting in [`Self::build`] so
-    /// callers that need position-dependent outputs (e.g. AssetLockTx,
-    /// whose payload validation requires `tx.output[0]` to be the
-    /// OP_RETURN burn) keep outputs in the order they were added.
-    skip_bip69_sort: bool,
 }
 
 impl Default for TransactionBuilder {
@@ -77,85 +57,39 @@ impl TransactionBuilder {
     pub fn new() -> Self {
         Self {
             inputs: Vec::new(),
+            change_addr: None,
             outputs: Vec::new(),
-            change_address: None,
             fee_rate: FeeRate::normal(),
-            lock_time: 0,
-            version: 2, // Default to version 2 for Dash
+            current_height: 0,
+            selection_strategy: SelectionStrategy::BranchAndBound,
             special_payload: None,
-            skip_bip69_sort: false,
         }
     }
 
-    /// Disable BIP-69 output sorting. Required for transactions whose
-    /// payload validation depends on output position — e.g. AssetLockTx
-    /// requires `tx.output[0]` to be the OP_RETURN burn carrying the
-    /// total locked amount.
-    pub fn skip_bip69_sort(mut self) -> Self {
-        self.skip_bip69_sort = true;
+    pub fn set_current_height(mut self, current_height: u32) -> Self {
+        self.current_height = current_height;
         self
     }
 
-    pub fn outputs(&self) -> &Vec<TxOut> {
-        &self.outputs
-    }
-
-    /// Add a UTXO input with optional private key for signing
-    pub fn add_input(mut self, utxo: Utxo, key: Option<SecretKey>) -> Self {
-        self.inputs.push((utxo, key));
+    pub fn set_selection_strategy(mut self, strategy: SelectionStrategy) -> Self {
+        self.selection_strategy = strategy;
         self
     }
 
-    /// Add multiple inputs
-    pub fn add_inputs(mut self, inputs: Vec<(Utxo, Option<SecretKey>)>) -> Self {
+    pub fn set_funding(mut self, funds_acc: &mut ManagedCoreFundsAccount, acc: &Account) -> Self {
+        self.inputs = funds_acc.utxos.values().cloned().collect();
+        self.change_addr = funds_acc.next_change_address(Some(&acc.account_xpub), true).ok();
+        self
+    }
+
+    pub fn set_change_address(mut self, change_addr: Address) -> Self {
+        self.change_addr = Some(change_addr);
+        self
+    }
+
+    pub fn add_inputs(mut self, inputs: impl IntoIterator<Item = Utxo>) -> Self {
         self.inputs.extend(inputs);
         self
-    }
-
-    /// Select inputs automatically using coin selection
-    ///
-    /// This method requires outputs to be added first so it knows how much to select.
-    /// For special transactions without regular outputs, add the required inputs manually.
-    pub fn select_inputs(
-        mut self,
-        available_utxos: &[Utxo],
-        strategy: SelectionStrategy,
-        current_height: u32,
-        keys: impl Fn(&Utxo) -> Option<SecretKey>,
-    ) -> Result<Self, BuilderError> {
-        // Calculate target amount from outputs
-        let target_amount = self.total_output_value();
-
-        if target_amount == 0 && self.special_payload.is_none() {
-            return Err(BuilderError::NoOutputs);
-        }
-
-        // Calculate the base transaction size including existing outputs and special payload
-        let base_size = self.calculate_base_size();
-        let input_size = 148; // Size per P2PKH input
-
-        let fee_rate = self.fee_rate;
-
-        // Use the CoinSelector with the proper size context
-        let selector = CoinSelector::new(strategy);
-        let selection = selector
-            .select_coins_with_size(
-                available_utxos,
-                target_amount,
-                fee_rate,
-                current_height,
-                base_size,
-                input_size,
-            )
-            .map_err(BuilderError::CoinSelection)?;
-
-        // Add selected UTXOs with their keys
-        for utxo in selection.selected {
-            let key = keys(&utxo);
-            self.inputs.push((utxo, key));
-        }
-
-        Ok(self)
     }
 
     /// Add an output to a specific address
@@ -163,86 +97,33 @@ impl TransactionBuilder {
     /// Note: Outputs will be sorted according to BIP-69 when the transaction is built:
     /// - First by amount (ascending)
     /// - Then by scriptPubKey (lexicographically)
-    pub fn add_output(mut self, address: &Address, amount: u64) -> Result<Self, BuilderError> {
-        if amount == 0 {
-            return Err(BuilderError::InvalidAmount("Output amount cannot be zero".into()));
-        }
-
+    pub fn add_output(mut self, address: &Address, amount: u64) -> Self {
         let script_pubkey = address.script_pubkey();
         self.outputs.push(TxOut {
             value: amount,
             script_pubkey,
         });
-        Ok(self)
-    }
-
-    /// Add a raw TxOut as an output.
-    ///
-    /// Used for special transactions (e.g., asset locks) where outputs are
-    /// constructed from script bytes rather than addresses.
-    pub fn add_raw_output(mut self, output: TxOut) -> Self {
-        self.outputs.push(output);
         self
     }
 
-    /// Add a data output (OP_RETURN)
-    ///
-    /// Note: Outputs will be sorted according to BIP-69 when the transaction is built:
-    /// - First by amount (ascending) - data outputs have 0 value
-    /// - Then by scriptPubKey (lexicographically)
-    pub fn add_data_output(mut self, data: Vec<u8>) -> Result<Self, BuilderError> {
-        if data.len() > 80 {
-            return Err(BuilderError::InvalidData("Data output too large (max 80 bytes)".into()));
-        }
-
-        let script = Builder::new()
-            .push_opcode(dashcore::blockdata::opcodes::all::OP_RETURN)
-            .push_slice(
-                <&PushBytes>::try_from(data.as_slice())
-                    .map_err(|_| BuilderError::InvalidData("Invalid data length".into()))?,
-            )
-            .into_script();
-
-        self.outputs.push(TxOut {
-            value: 0,
-            script_pubkey: script,
-        });
-        Ok(self)
-    }
-
-    /// Set the change address
-    pub fn set_change_address(mut self, address: Address) -> Self {
-        self.change_address = Some(address);
-        self
-    }
-
-    /// Set the fee rate
     pub fn set_fee_rate(mut self, fee_rate: FeeRate) -> Self {
         self.fee_rate = fee_rate;
         self
     }
 
-    /// Set the lock time
-    pub fn set_lock_time(mut self, lock_time: u32) -> Self {
-        self.lock_time = lock_time;
-        self
-    }
-
-    /// Set the transaction version
-    pub fn set_version(mut self, version: u16) -> Self {
-        self.version = version;
-        self
-    }
-
-    /// Set the special transaction payload
     pub fn set_special_payload(mut self, payload: TransactionPayload) -> Self {
         self.special_payload = Some(payload);
         self
     }
 
-    /// Get the total value of all outputs added so far
-    pub fn total_output_value(&self) -> u64 {
-        self.outputs.iter().map(|out| out.value).sum()
+    /// Effective `tx.output` count: for AssetLock the only on-chain output is
+    /// the OP_RETURN burn (credit outputs live in the payload), otherwise it's
+    /// the user-provided outputs.
+    fn effective_outputs_count(&self) -> usize {
+        match &self.special_payload {
+            Some(TransactionPayload::AssetLockPayloadType(_)) => 1,
+            _ => self.outputs.len(),
+        }
     }
 
     /// Calculate the base transaction size excluding inputs
@@ -254,10 +135,12 @@ impl TransactionBuilder {
         // Add varint for input count (will be added later, typically 1 byte)
         size += 1;
 
+        let outputs_count = self.effective_outputs_count();
+
         // Add varint for output count
         size += varint_size(
-            self.outputs.len()
-                + if self.change_address.is_some() {
+            outputs_count
+                + if self.change_addr.is_some() {
                     1
                 } else {
                     0
@@ -265,10 +148,10 @@ impl TransactionBuilder {
         );
 
         // Add outputs size (TX_OUTPUT_SIZE = 34 bytes per P2PKH output)
-        size += self.outputs.len() * 34;
+        size += outputs_count * 34;
 
         // Add change output if we have a change address
-        if self.change_address.is_some() {
+        if self.change_addr.is_some() {
             size += 34; // TX_OUTPUT_SIZE
         }
 
@@ -357,467 +240,260 @@ impl TransactionBuilder {
         size
     }
 
-    /// Calculates the transaction fee for the current number of outputs and inputs
-    pub fn calculate_fee(&self) -> u64 {
-        let fee_rate = self.fee_rate;
-        let estimated_size = self.estimate_transaction_size(self.inputs.len(), self.outputs.len());
-        fee_rate.calculate_fee(estimated_size)
-    }
-
-    /// Calculates the transaction fee adding an extra output
-    ///
-    /// This is useful when you need to calculate the transaction fee to be
-    /// able to calculate the change amount to later add it as a new output.
-    /// Basically we are calculating the fee with that extra change output before
-    /// adding it
-    pub fn calculate_fee_with_extra_output(&self) -> u64 {
-        let fee_rate = self.fee_rate;
-        let estimated_size =
-            self.estimate_transaction_size(self.inputs.len(), self.outputs.len() + 1);
-        fee_rate.calculate_fee(estimated_size)
-    }
-
-    /// Build the transaction
-    pub fn build(&mut self) -> Result<Transaction, BuilderError> {
-        if self.inputs.is_empty() {
-            return Err(BuilderError::NoInputs);
-        }
-
-        if self.outputs.is_empty() {
+    fn assemble_unsigned(self) -> Result<(Transaction, Vec<Utxo>), BuilderError> {
+        if let Some(TransactionPayload::AssetLockPayloadType(p)) = &self.special_payload {
+            if p.credit_outputs.is_empty() {
+                return Err(BuilderError::NoOutputs);
+            }
+        } else if self.outputs.is_empty() && self.special_payload.is_none() {
             return Err(BuilderError::NoOutputs);
         }
 
-        // Calculate total input value
-        let total_input: u64 = self.inputs.iter().map(|(utxo, _)| utxo.value()).sum();
+        // For AssetLock the on-chain spend equals the OP_RETURN burn, which
+        // mirrors the sum of the credit_outputs carried in the payload. For
+        // every other tx type, it's just the sum of user-provided outputs.
+        let total_output: u64 = match &self.special_payload {
+            Some(TransactionPayload::AssetLockPayloadType(p)) => {
+                p.credit_outputs.iter().map(|o| o.value).sum()
+            }
+            _ => self.outputs.iter().map(|o| o.value).sum(),
+        };
 
-        // Calculate total output value
-        let total_output: u64 = self.outputs.iter().map(|out| out.value).sum();
+        let selection = CoinSelector::new(self.selection_strategy)
+            .select_coins_with_size(
+                self.inputs.iter(),
+                total_output,
+                self.fee_rate,
+                self.current_height,
+                self.calculate_base_size(),
+                148, // Size per P2PKH input
+            )
+            .map_err(BuilderError::CoinSelection)?;
 
-        if total_input < total_output {
+        let mut selected_inputs = selection.selected;
+        let total_input: u64 = selected_inputs.iter().map(|u| u.value()).sum();
+
+        if total_input < total_output + selection.estimated_fee {
             return Err(BuilderError::InsufficientFunds {
                 available: total_input,
-                required: total_output,
+                required: total_output + selection.estimated_fee,
             });
         }
 
-        // BIP-69: Sort inputs by transaction hash (reversed) and then by output index
-        // We need to maintain the association between UTXOs and their keys
-        let mut sorted_inputs = self.inputs.clone();
-        sorted_inputs.sort_by(|a, b| {
-            // First compare by transaction hash (reversed byte order)
-            let tx_hash_a = a.0.outpoint.txid.to_byte_array();
-            let tx_hash_b = b.0.outpoint.txid.to_byte_array();
+        let change_amount =
+            total_input.saturating_sub(total_output).saturating_sub(selection.estimated_fee);
+        let mut tx_outputs = match &self.special_payload {
+            Some(TransactionPayload::AssetLockPayloadType(_)) => vec![TxOut {
+                value: total_output,
+                script_pubkey: ScriptBuf::new_op_return(&[]),
+            }],
+            _ => self.outputs,
+        };
 
-            match tx_hash_a.cmp(&tx_hash_b) {
-                std::cmp::Ordering::Equal => {
-                    // If transaction hashes match, compare by output index
-                    a.0.outpoint.vout.cmp(&b.0.outpoint.vout)
-                }
-                other => other,
-            }
-        });
+        // Add change output if above dust threshold
+        if change_amount > 546 {
+            let Some(change_addr) = self.change_addr else {
+                return Err(BuilderError::NoChangeAddress);
+            };
+            tx_outputs.push(TxOut {
+                value: change_amount,
+                script_pubkey: change_addr.script_pubkey(),
+            });
+        }
 
-        // Create transaction inputs from sorted inputs
-        // Dash doesn't use RBF, so we use the standard sequence number
-        let sequence = 0xffffffff;
+        if !matches!(self.special_payload, Some(TransactionPayload::AssetLockPayloadType(_))) {
+            tx_outputs.sort_by(bip69_output_sorter);
+        }
 
-        let tx_inputs: Vec<TxIn> = sorted_inputs
+        selected_inputs.sort_by(bip69_input_sorter);
+        let tx_inputs: Vec<TxIn> = selected_inputs
             .iter()
-            .map(|(utxo, _)| TxIn {
+            .map(|utxo| TxIn {
                 previous_output: utxo.outpoint,
                 script_sig: ScriptBuf::new(),
-                sequence,
+                sequence: 0xffffffff, // Dash doesn't use RBF, so we use the standard sequence number
                 witness: dashcore::blockdata::witness::Witness::new(),
             })
             .collect();
 
-        let mut tx_outputs = self.outputs.clone();
-
-        let fee = self.calculate_fee_with_extra_output();
-
-        let change_amount = total_input.saturating_sub(total_output).saturating_sub(fee);
-
-        // Add change output if needed
-        if change_amount > 546 {
-            // Above dust threshold
-            if let Some(change_addr) = &self.change_address {
-                let change_script = change_addr.script_pubkey();
-                tx_outputs.push(TxOut {
-                    value: change_amount,
-                    script_pubkey: change_script,
-                });
-            } else {
-                return Err(BuilderError::NoChangeAddress);
-            }
-        }
-
-        // BIP-69: Sort outputs by amount first, then by scriptPubKey
-        // lexicographically. Opt-out via `skip_bip69_sort` for
-        // transactions whose payload validation requires
-        // position-dependent outputs (e.g. AssetLockTx, whose
-        // `tx.output[0]` must be the OP_RETURN burn).
-        if !self.skip_bip69_sort {
-            tx_outputs.sort_by(|a, b| {
-                match a.value.cmp(&b.value) {
-                    std::cmp::Ordering::Equal => {
-                        // If amounts match, compare scriptPubKeys lexicographically
-                        a.script_pubkey.as_bytes().cmp(b.script_pubkey.as_bytes())
-                    }
-                    other => other,
-                }
-            });
-        }
-
-        // Create unsigned transaction with optional special payload
-        // Update sorted_inputs to maintain the key association after sorting
-        let mut transaction = Transaction {
-            version: self.version,
-            lock_time: self.lock_time,
+        let transaction = Transaction {
+            version: 3,
+            lock_time: 0,
             input: tx_inputs,
             output: tx_outputs,
-            special_transaction_payload: self.special_payload.clone(),
+            special_transaction_payload: self.special_payload,
         };
 
-        // Sign inputs if keys are provided
-        if sorted_inputs.iter().any(|(_, key)| key.is_some()) {
-            transaction = self.sign_transaction_with_sorted_inputs(transaction, sorted_inputs)?;
+        return Ok((transaction, selected_inputs));
+
+        // BIP-69: Sort outputs by amount first, then by scriptPubKey
+        // lexicographically.
+        fn bip69_output_sorter(a: &TxOut, b: &TxOut) -> Ordering {
+            match a.value.cmp(&b.value) {
+                Ordering::Equal => a.script_pubkey.as_bytes().cmp(b.script_pubkey.as_bytes()),
+                other => other,
+            }
         }
 
-        Ok(transaction)
-    }
+        // BIP-69: Sort inputs by transaction hash and then by output index.
+        fn bip69_input_sorter(a: &Utxo, b: &Utxo) -> Ordering {
+            let tx_hash_a = a.outpoint.txid.to_byte_array();
+            let tx_hash_b = b.outpoint.txid.to_byte_array();
 
-    /// Build a Provider Registration Transaction (ProRegTx)
-    ///
-    /// Used to register a new masternode on the network
-    ///
-    /// Note: This method intentionally takes many parameters rather than a single
-    /// payload object to make the API more explicit and allow callers to construct
-    /// transactions without needing to build intermediate payload types.
-    #[allow(clippy::too_many_arguments)]
-    pub fn build_provider_registration(
-        self,
-        masternode_type: ProviderMasternodeType,
-        masternode_mode: u16,
-        collateral_outpoint: OutPoint,
-        service_address: SocketAddr,
-        owner_key_hash: PubkeyHash,
-        operator_public_key: BLSPublicKey,
-        voting_key_hash: PubkeyHash,
-        operator_reward: u16,
-        script_payout: ScriptBuf,
-        inputs_hash: InputsHash,
-        signature: Vec<u8>,
-        platform_node_id: Option<PubkeyHash>,
-        platform_p2p_port: Option<u16>,
-        platform_http_port: Option<u16>,
-    ) -> Result<Transaction, BuilderError> {
-        let payload = ProviderRegistrationPayload {
-            version: 2,
-            masternode_type,
-            masternode_mode,
-            collateral_outpoint,
-            service_address,
-            owner_key_hash,
-            operator_public_key,
-            voting_key_hash,
-            operator_reward,
-            script_payout,
-            inputs_hash,
-            signature,
-            platform_node_id,
-            platform_p2p_port,
-            platform_http_port,
-        };
-
-        self.set_special_payload(TransactionPayload::ProviderRegistrationPayloadType(payload))
-            .build()
-    }
-
-    /// Build a Provider Update Service Transaction (ProUpServTx)
-    ///
-    /// Used to update the service details of an existing masternode
-    ///
-    /// Note: This method intentionally takes many parameters rather than a single
-    /// payload object to make the API more explicit and allow callers to construct
-    /// transactions without needing to build intermediate payload types.
-    #[allow(clippy::too_many_arguments)]
-    pub fn build_provider_update_service(
-        self,
-        mn_type: Option<u16>,
-        pro_tx_hash: Txid,
-        ip_address: u128,
-        port: u16,
-        script_payout: ScriptBuf,
-        inputs_hash: InputsHash,
-        platform_node_id: Option<[u8; 20]>,
-        platform_p2p_port: Option<u16>,
-        platform_http_port: Option<u16>,
-        payload_sig: BLSSignature,
-    ) -> Result<Transaction, BuilderError> {
-        let payload = ProviderUpdateServicePayload {
-            version: 2,
-            mn_type,
-            pro_tx_hash,
-            ip_address,
-            port,
-            script_payout,
-            inputs_hash,
-            platform_node_id,
-            platform_p2p_port,
-            platform_http_port,
-            payload_sig,
-        };
-        self.set_special_payload(TransactionPayload::ProviderUpdateServicePayloadType(payload))
-            .build()
-    }
-
-    /// Build a Provider Update Registrar Transaction (ProUpRegTx)
-    ///
-    /// Used to update the registrar details of an existing masternode
-    ///
-    /// Note: This method intentionally takes many parameters rather than a single
-    /// payload object to make the API more explicit and allow callers to construct
-    /// transactions without needing to build intermediate payload types.
-    #[allow(clippy::too_many_arguments)]
-    pub fn build_provider_update_registrar(
-        self,
-        pro_tx_hash: Txid,
-        provider_mode: u16,
-        operator_public_key: BLSPublicKey,
-        voting_key_hash: PubkeyHash,
-        script_payout: ScriptBuf,
-        inputs_hash: InputsHash,
-        payload_sig: Vec<u8>,
-    ) -> Result<Transaction, BuilderError> {
-        let payload = ProviderUpdateRegistrarPayload {
-            version: 2,
-            pro_tx_hash,
-            provider_mode,
-            operator_public_key,
-            voting_key_hash,
-            script_payout,
-            inputs_hash,
-            payload_sig,
-        };
-        self.set_special_payload(TransactionPayload::ProviderUpdateRegistrarPayloadType(payload))
-            .build()
-    }
-
-    /// Build a Provider Update Revocation Transaction (ProUpRevTx)
-    ///
-    /// Used to revoke an existing masternode
-    pub fn build_provider_update_revocation(
-        self,
-        pro_tx_hash: Txid,
-        reason: u16,
-        inputs_hash: InputsHash,
-        payload_sig: BLSSignature,
-    ) -> Result<Transaction, BuilderError> {
-        let payload = ProviderUpdateRevocationPayload {
-            version: 2,
-            pro_tx_hash,
-            reason,
-            inputs_hash,
-            payload_sig,
-        };
-        self.set_special_payload(TransactionPayload::ProviderUpdateRevocationPayloadType(payload))
-            .build()
-    }
-
-    /// Build a Coinbase Transaction
-    ///
-    /// Used for block rewards and includes additional coinbase-specific data
-    pub fn build_coinbase(
-        self,
-        height: u32,
-        merkle_root_masternode_list: MerkleRootMasternodeList,
-        merkle_root_quorums: MerkleRootQuorums,
-        best_cl_height: Option<u32>,
-        best_cl_signature: Option<BLSSignature>,
-        asset_locked_amount: Option<u64>,
-    ) -> Result<Transaction, BuilderError> {
-        let payload = CoinbasePayload {
-            version: 3, // Current coinbase version
-            height,
-            merkle_root_masternode_list,
-            merkle_root_quorums,
-            best_cl_height,
-            best_cl_signature,
-            asset_locked_amount,
-        };
-        self.set_special_payload(TransactionPayload::CoinbasePayloadType(payload)).build()
-    }
-
-    /// Build an Asset Lock Transaction
-    ///
-    /// Used to lock Dash for use in Platform (creates Platform credits).
-    /// Per DIP-00X, the AssetLockPayload version is `1`, the credit
-    /// outputs live in the payload (not in `tx.output`), and the
-    /// Dash special transaction wire version is `3`. The caller must
-    /// have already added the OP_RETURN burn output to this builder
-    /// before calling `build_asset_lock`; BIP-69 output sorting is
-    /// disabled so the burn stays at `tx.output[0]`.
-    pub fn build_asset_lock(
-        mut self,
-        credit_outputs: Vec<TxOut>,
-    ) -> Result<Transaction, BuilderError> {
-        let payload = AssetLockPayload {
-            version: 1,
-            credit_outputs,
-        };
-        self.version = 3;
-        self.skip_bip69_sort = true;
-        self.set_special_payload(TransactionPayload::AssetLockPayloadType(payload)).build()
-    }
-
-    /// Estimate transaction size in bytes
-    fn estimate_transaction_size(&self, input_count: usize, output_count: usize) -> usize {
-        // Base: version (2) + type (2) + locktime (4) = 8 bytes
-        let mut size = 8;
-
-        // Add varints for input/output counts
-        size += varint_size(input_count);
-        size += varint_size(output_count);
-
-        // Add inputs (TX_INPUT_SIZE = 148 bytes per P2PKH input)
-        size += input_count * 148;
-
-        // Add outputs (TX_OUTPUT_SIZE = 34 bytes per P2PKH output)
-        size += output_count * 34;
-
-        // Add special payload size if present (same logic as calculate_base_size)
-        if let Some(ref payload) = self.special_payload {
-            let payload_size = match payload {
-                TransactionPayload::CoinbasePayloadType(p) => {
-                    let mut size = 2 + 4 + 32 + 32;
-                    if p.best_cl_height.is_some() {
-                        size += 4 + 96;
-                    }
-                    if p.asset_locked_amount.is_some() {
-                        size += 8;
-                    }
-                    size
-                }
-                TransactionPayload::ProviderRegistrationPayloadType(p) => {
-                    let script_size = p.script_payout.len();
-                    let base = 2
-                        + 2
-                        + 2
-                        + 32
-                        + 4
-                        + 16
-                        + 2
-                        + 20
-                        + 20
-                        + 20
-                        + 2
-                        + varint_size(script_size)
-                        + script_size
-                        + 32;
-                    base + varint_size(75) + 75
-                }
-                TransactionPayload::ProviderUpdateServicePayloadType(p) => {
-                    let script_size = p.script_payout.len();
-                    let mut size =
-                        2 + 32 + 16 + 2 + varint_size(script_size) + script_size + 32 + 96;
-                    if p.mn_type.is_some() {
-                        size += 2;
-                    }
-                    if p.platform_node_id.is_some() {
-                        size += 20 + 2 + 2;
-                    }
-                    size
-                }
-                TransactionPayload::ProviderUpdateRegistrarPayloadType(p) => {
-                    let script_size = p.script_payout.len();
-                    2 + 32 + 2 + 48 + 20 + varint_size(script_size) + script_size + 32 + 75
-                }
-                TransactionPayload::ProviderUpdateRevocationPayloadType(_) => 2 + 32 + 2 + 32 + 96,
-                TransactionPayload::AssetLockPayloadType(p) => {
-                    1 + varint_size(p.credit_outputs.len()) + p.credit_outputs.len() * 34
-                }
-                TransactionPayload::AssetUnlockPayloadType(_) => 1 + 8 + 4 + 4 + 32 + 96,
-                _ => 100,
-            };
-
-            size += varint_size(payload_size) + payload_size;
+            match tx_hash_a.cmp(&tx_hash_b) {
+                Ordering::Equal => a.outpoint.vout.cmp(&b.outpoint.vout),
+                other => other,
+            }
         }
-
-        size
     }
 
-    /// Sign the transaction with sorted inputs (for BIP-69 compliance)
-    fn sign_transaction_with_sorted_inputs(
+    pub fn build_unsigned(self) -> Result<(Transaction, u64), BuilderError> {
+        let fee_rate = self.fee_rate;
+
+        let (tx, _) = self.assemble_unsigned()?;
+
+        let mut tx_bytes = Vec::new();
+        tx.consensus_encode(&mut tx_bytes).unwrap();
+
+        let fee = fee_rate.calculate_fee(tx_bytes.len());
+
+        Ok((tx, fee))
+    }
+
+    /// Build and sign the transaction. The `path_resolver` maps each input
+    /// address to the derivation path the signer should use for that input.
+    /// The returned fee is computed from the encoded size of the signed tx.
+    pub async fn build_signed<S, P>(
+        self,
+        signer: &S,
+        path_resolver: P,
+    ) -> Result<(Transaction, u64), BuilderError>
+    where
+        S: TransactionSigner + ?Sized + Sync,
+        P: Fn(Address) -> Option<DerivationPath> + Send,
+    {
+        let fee_rate = self.fee_rate;
+
+        let (tx, inputs) = self.assemble_unsigned()?;
+        let tx = signer.sign_tx(tx, inputs, path_resolver).await?;
+
+        let mut tx_bytes = Vec::new();
+        tx.consensus_encode(&mut tx_bytes).unwrap();
+
+        let fee = fee_rate.calculate_fee(tx_bytes.len());
+
+        Ok((tx, fee))
+    }
+}
+
+#[async_trait::async_trait]
+pub trait TransactionSigner {
+    async fn sign_tx(
         &self,
         mut tx: Transaction,
-        sorted_inputs: Vec<(Utxo, Option<SecretKey>)>,
+        inputs: Vec<Utxo>,
+        path_resolver: impl Fn(Address) -> Option<DerivationPath> + Send,
     ) -> Result<Transaction, BuilderError> {
-        let secp = Secp256k1::new();
-
-        // Collect all signatures first, then apply them
-        let mut signatures = Vec::new();
-        {
+        let tasks: Vec<(LegacySighash, DerivationPath)> = {
             let cache = SighashCache::new(&tx);
+            let mut tasks = Vec::with_capacity(inputs.len());
+            for (index, utxo) in inputs.iter().enumerate() {
+                let path = path_resolver(utxo.address.clone()).ok_or_else(|| {
+                    BuilderError::SigningFailed(format!(
+                        "no derivation path for input address {}",
+                        utxo.address
+                    ))
+                })?;
 
-            for (index, (utxo, key_opt)) in sorted_inputs.iter().enumerate() {
-                if let Some(key) = key_opt {
-                    // Get the script pubkey from the UTXO
-                    let script_pubkey = &utxo.txout.script_pubkey;
+                let sighash = cache
+                    .legacy_signature_hash(
+                        index,
+                        &utxo.txout.script_pubkey,
+                        EcdsaSighashType::All.to_u32(),
+                    )
+                    .map_err(|e| {
+                        BuilderError::SigningFailed(format!("Failed to compute sighash: {}", e))
+                    })?;
 
-                    // Create signature hash for P2PKH
-                    let sighash = cache
-                        .legacy_signature_hash(index, script_pubkey, EcdsaSighashType::All.to_u32())
-                        .map_err(|e| {
-                            BuilderError::SigningFailed(format!("Failed to compute sighash: {}", e))
-                        })?;
-
-                    // Sign the hash
-                    let message = Message::from_digest(*sighash.as_byte_array());
-                    let signature = secp.sign_ecdsa(&message, key);
-
-                    // Create script signature (P2PKH)
-                    let mut sig_bytes = signature.serialize_der().to_vec();
-                    sig_bytes.push(EcdsaSighashType::All.to_u32() as u8);
-
-                    let pubkey = secp256k1::PublicKey::from_secret_key(&secp, key);
-
-                    let script_sig = Builder::new()
-                        .push_slice(<&PushBytes>::try_from(sig_bytes.as_slice()).map_err(|_| {
-                            BuilderError::SigningFailed("Invalid signature length".into())
-                        })?)
-                        .push_slice(pubkey.serialize())
-                        .into_script();
-
-                    signatures.push((index, script_sig));
-                } else {
-                    signatures.push((index, ScriptBuf::new()));
-                }
+                tasks.push((sighash, path));
             }
-        } // cache goes out of scope here
+            tasks
+        };
 
-        // Apply signatures
-        for (index, script_sig) in signatures {
+        let mut signatures = Vec::with_capacity(tasks.len());
+        for (sighash, path) in tasks {
+            let (sig, pubkey) = self.sig_and_pubkey(sighash, path).await?;
+
+            let mut sig_bytes = sig.serialize_der().to_vec();
+            sig_bytes.push(EcdsaSighashType::All.to_u32() as u8);
+
+            let script_sig =
+                Builder::new()
+                    .push_slice(<&PushBytes>::try_from(sig_bytes.as_slice()).map_err(|_| {
+                        BuilderError::SigningFailed("invalid signature length".into())
+                    })?)
+                    .push_slice(pubkey.serialize())
+                    .into_script();
+
+            signatures.push(script_sig);
+        }
+
+        for (index, script_sig) in signatures.into_iter().enumerate() {
             tx.input[index].script_sig = script_sig;
         }
 
         Ok(tx)
     }
 
-    /// Sign the transaction (legacy method for backward compatibility)
-    pub fn sign_transaction(&self, tx: Transaction) -> Result<Transaction, BuilderError> {
-        // For backward compatibility, we sort the inputs according to BIP-69 before signing
-        let mut sorted_inputs = self.inputs.clone();
-        sorted_inputs.sort_by(|a, b| {
-            let tx_hash_a = a.0.outpoint.txid.to_byte_array();
-            let tx_hash_b = b.0.outpoint.txid.to_byte_array();
+    async fn sig_and_pubkey(
+        &self,
+        sighash: LegacySighash,
+        path: DerivationPath,
+    ) -> Result<(Signature, PublicKey), BuilderError>;
+}
 
-            match tx_hash_a.cmp(&tx_hash_b) {
-                std::cmp::Ordering::Equal => a.0.outpoint.vout.cmp(&b.0.outpoint.vout),
-                other => other,
-            }
-        });
+#[async_trait::async_trait]
+impl TransactionSigner for Wallet {
+    async fn sig_and_pubkey(
+        &self,
+        sighash: LegacySighash,
+        path: DerivationPath,
+    ) -> Result<(Signature, PublicKey), BuilderError> {
+        let secp = Secp256k1::new();
 
-        self.sign_transaction_with_sorted_inputs(tx, sorted_inputs)
+        let root_xpriv =
+            self.root_extended_priv_key().map_err(|_| BuilderError::WatchOnlyWallet)?;
+
+        let root_ext_priv = root_xpriv.to_extended_priv_key(self.network);
+        let derived_xpriv = root_ext_priv.derive_priv(&secp, &path).map_err(|e| {
+            BuilderError::SigningFailed(format!("couldn't derive extended priv key: {}", e))
+        })?;
+        let key = derived_xpriv.private_key;
+
+        let message = Message::from_digest(*sighash.as_byte_array());
+        let signature = secp.sign_ecdsa(&message, &key);
+        let pubkey = PublicKey::from_secret_key(&secp, &key);
+
+        Ok((signature, pubkey))
+    }
+}
+
+#[async_trait::async_trait]
+impl<S: Signer> TransactionSigner for S {
+    async fn sig_and_pubkey(
+        &self,
+        sighash: LegacySighash,
+        path: DerivationPath,
+    ) -> Result<(Signature, PublicKey), BuilderError> {
+        if !self.supports(crate::signer::SignerMethod::Digest) {
+            return Err(BuilderError::SigningFailed(format!(
+                "signer does not support required method {:?}",
+                crate::signer::SignerMethod::Digest
+            )));
+        }
+        self.sign_ecdsa(&path, *sighash.as_byte_array())
+            .await
+            .map_err(|e| BuilderError::SigningFailed(e.to_string()))
     }
 }
 
@@ -843,6 +519,8 @@ pub enum BuilderError {
     SigningFailed(String),
     /// Coin selection error
     CoinSelection(crate::wallet::managed_wallet_info::coin_selection::SelectionError),
+    /// Signing was attempted with a watch-only wallet
+    WatchOnlyWallet,
 }
 
 impl fmt::Display for BuilderError {
@@ -861,6 +539,7 @@ impl fmt::Display for BuilderError {
             Self::InvalidData(msg) => write!(f, "Invalid data: {}", msg),
             Self::SigningFailed(msg) => write!(f, "Signing failed: {}", msg),
             Self::CoinSelection(err) => write!(f, "Coin selection error: {}", err),
+            Self::WatchOnlyWallet => write!(f, "Cannot sign with a watch-only wallet"),
         }
     }
 }
@@ -872,6 +551,7 @@ mod tests {
     use super::*;
     use crate::Network;
     use dashcore::blockdata::transaction::special_transaction::asset_lock::AssetLockPayload;
+    use dashcore::{OutPoint, Txid};
     use dashcore_hashes::{sha256d, Hash};
     use hex;
 
@@ -882,11 +562,12 @@ mod tests {
         let change = Address::dummy(Network::Testnet, 0);
 
         let tx = TransactionBuilder::new()
-            .add_input(utxo, None)
+            .set_current_height(200)
+            .add_inputs([utxo])
             .add_output(&destination, 50000)
-            .unwrap()
             .set_change_address(change)
-            .build();
+            .build_unsigned()
+            .map(|(tx, _)| tx);
 
         assert!(tx.is_ok());
         let transaction = tx.unwrap();
@@ -900,12 +581,16 @@ mod tests {
         let destination = Address::dummy(Network::Testnet, 0);
 
         let result = TransactionBuilder::new()
-            .add_input(utxo, None)
+            .set_current_height(200)
+            .add_inputs([utxo])
             .add_output(&destination, 50000)
-            .unwrap()
-            .build();
+            .build_unsigned();
 
-        assert!(matches!(result, Err(BuilderError::InsufficientFunds { .. })));
+        // Insufficient funds now surface via the coin selector wrapper too.
+        assert!(matches!(
+            result,
+            Err(BuilderError::InsufficientFunds { .. }) | Err(BuilderError::CoinSelection(_))
+        ));
     }
 
     #[test]
@@ -971,11 +656,11 @@ mod tests {
         let change_address = Address::dummy(Network::Testnet, 0);
 
         let builder = TransactionBuilder::new()
+            .set_current_height(200)
             .set_fee_rate(FeeRate::normal())
             .set_change_address(change_address.clone())
             .add_output(&recipient_address, 150000)
-            .unwrap()
-            .add_inputs(utxos.into_iter().map(|u| (u, None)).collect());
+            .add_inputs(utxos);
 
         // Test calculate_base_size
         let base_size = builder.calculate_base_size();
@@ -986,14 +671,8 @@ mod tests {
             base_size
         );
 
-        // Test estimate_transaction_size
-        let estimated_size = builder.estimate_transaction_size(2, 2);
-        // Base (8) + varints (2) + 2 inputs (296) + 2 outputs (68) = ~374 bytes
-        assert!(
-            estimated_size > 370 && estimated_size < 380,
-            "Estimated size should be around 374 bytes, got {}",
-            estimated_size
-        );
+        // estimate_transaction_size was removed in the new builder API; if a
+        // future test needs full-size estimation, derive it from a real build.
     }
 
     #[test]
@@ -1005,13 +684,14 @@ mod tests {
         let change_address = Address::dummy(Network::Testnet, 0);
 
         let tx = TransactionBuilder::new()
+            .set_current_height(200)
             .set_fee_rate(FeeRate::normal()) // 1 duff per byte
             .set_change_address(change_address.clone())
-            .add_inputs(utxos.into_iter().map(|u| (u, None)).collect())
+            .add_inputs(utxos)
             .add_output(&recipient_address, 500000)
+            .build_unsigned()
             .unwrap()
-            .build()
-            .unwrap();
+            .0;
 
         // Total input: 1000000
         // Output to recipient: 500000
@@ -1032,13 +712,15 @@ mod tests {
         let change_address = Address::dummy(Network::Testnet, 0);
 
         let tx = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_selection_strategy(SelectionStrategy::SmallestFirst)
             .set_fee_rate(FeeRate::normal())
             .set_change_address(change_address.clone())
-            .add_inputs(utxos.into_iter().map(|u| (u, None)).collect())
+            .add_inputs(utxos)
             .add_output(&recipient_address, 150000)
+            .build_unsigned()
             .unwrap()
-            .build()
-            .unwrap();
+            .0;
 
         // Should only have 1 output (no change) because change is below dust threshold
         assert_eq!(tx.output.len(), 1);
@@ -1070,9 +752,9 @@ mod tests {
         };
 
         let builder = TransactionBuilder::new()
-            .add_input(utxo.clone(), None)
+            .set_current_height(200)
+            .add_inputs([utxo.clone()])
             .add_output(&destination, 50000)
-            .unwrap()
             .set_change_address(change.clone())
             .set_special_payload(TransactionPayload::AssetLockPayloadType(asset_lock_payload));
 
@@ -1099,9 +781,9 @@ mod tests {
         };
 
         let builder2 = TransactionBuilder::new()
-            .add_input(utxo, None)
+            .set_current_height(200)
+            .add_inputs([utxo])
             .add_output(&destination, 50000)
-            .unwrap()
             .set_change_address(change)
             .set_special_payload(TransactionPayload::CoinbasePayloadType(coinbase_payload));
 
@@ -1127,18 +809,17 @@ mod tests {
         let change_address = Address::dummy(Network::Testnet, 0);
 
         let tx = TransactionBuilder::new()
+            .set_current_height(200)
             .set_fee_rate(FeeRate::normal())
             .set_change_address(change_address)
-            .add_input(utxo, None)
+            .add_inputs([utxo])
             // Add outputs in non-sorted order
-            .add_output(&address1, 300000)
-            .unwrap() // Higher amount
-            .add_output(&address2, 100000)
-            .unwrap() // Lower amount
-            .add_output(&address1, 200000)
-            .unwrap() // Middle amount
-            .build()
-            .unwrap();
+            .add_output(&address1, 300000) // Higher amount
+            .add_output(&address2, 100000) // Lower amount
+            .add_output(&address1, 200000) // Middle amount
+            .build_unsigned()
+            .unwrap()
+            .0;
 
         // Verify outputs are sorted by amount (ascending)
         assert!(tx.output[0].value <= tx.output[1].value);
@@ -1151,7 +832,7 @@ mod tests {
     #[test]
     fn test_bip69_input_ordering() {
         // Test that inputs are sorted according to BIP-69
-        let utxo1 = Utxo::new(
+        let mut utxo1 = Utxo::new(
             OutPoint {
                 txid: Txid::from_raw_hash(sha256d::Hash::from_slice(&[2u8; 32]).unwrap()),
                 vout: 1,
@@ -1164,8 +845,9 @@ mod tests {
             100,
             false,
         );
+        utxo1.is_confirmed = true;
 
-        let utxo2 = Utxo::new(
+        let mut utxo2 = Utxo::new(
             OutPoint {
                 txid: Txid::from_raw_hash(sha256d::Hash::from_slice(&[1u8; 32]).unwrap()),
                 vout: 2,
@@ -1178,8 +860,9 @@ mod tests {
             100,
             false,
         );
+        utxo2.is_confirmed = true;
 
-        let utxo3 = Utxo::new(
+        let mut utxo3 = Utxo::new(
             OutPoint {
                 txid: Txid::from_raw_hash(sha256d::Hash::from_slice(&[1u8; 32]).unwrap()),
                 vout: 0,
@@ -1192,21 +875,23 @@ mod tests {
             100,
             false,
         );
+        utxo3.is_confirmed = true;
 
         let destination = Address::dummy(Network::Testnet, 0);
         let change = Address::dummy(Network::Testnet, 0);
 
         let tx = TransactionBuilder::new()
+            .set_current_height(200)
             .set_fee_rate(FeeRate::normal())
             .set_change_address(change)
             // Add inputs in non-sorted order
-            .add_input(utxo1.clone(), None)
-            .add_input(utxo2.clone(), None)
-            .add_input(utxo3.clone(), None)
+            .add_inputs([utxo1.clone()])
+            .add_inputs([utxo2.clone()])
+            .add_inputs([utxo3.clone()])
             .add_output(&destination, 500000)
+            .build_unsigned()
             .unwrap()
-            .build()
-            .unwrap();
+            .0;
 
         // Verify inputs are sorted by txid first, then by vout
         // Expected order: [1u8; 32]:0, [1u8; 32]:2, [2u8; 32]:1
@@ -1262,17 +947,17 @@ mod tests {
             credit_outputs,
         };
 
-        let result = TransactionBuilder::new()
+        let tx = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_selection_strategy(SelectionStrategy::SmallestFirst)
             .set_fee_rate(FeeRate::normal())
             .set_change_address(change_address)
             .set_special_payload(TransactionPayload::AssetLockPayloadType(asset_lock_payload))
             .add_output(&recipient_address, 50000)
+            .add_inputs(utxos)
+            .build_unsigned()
             .unwrap()
-            .select_inputs(&utxos, SelectionStrategy::SmallestFirst, 200, |_| None);
-
-        assert!(result.is_ok());
-        let mut builder = result.unwrap();
-        let tx = builder.build().unwrap();
+            .0;
 
         // Should have selected enough inputs to cover output + fees for larger transaction
         assert!(

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_building.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_building.rs
@@ -1,19 +1,14 @@
 //! Transaction building functionality for managed wallets
 
 use crate::managed_account::managed_account_trait::ManagedAccountTrait;
-use crate::signer::{Signer, SignerMethod};
-use crate::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
+use crate::signer::Signer;
 use crate::wallet::managed_wallet_info::fee::FeeRate;
 use crate::wallet::managed_wallet_info::transaction_builder::{BuilderError, TransactionBuilder};
 use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
-use crate::wallet::{ManagedWalletInfo, WalletType};
+use crate::wallet::ManagedWalletInfo;
 use crate::Wallet;
 use dashcore::address::NetworkUnchecked;
-use dashcore::blockdata::script::{Builder, PushBytes};
-use dashcore::sighash::{EcdsaSighashType, SighashCache};
-use dashcore::{Address, ScriptBuf, Transaction};
-use dashcore_hashes::Hash;
-use std::collections::HashMap;
+use dashcore::{Address, Transaction};
 
 /// Account type preference for transaction building
 #[derive(Debug, Clone, Copy)]
@@ -23,110 +18,42 @@ pub enum AccountTypePreference {
 }
 
 impl ManagedWalletInfo {
-    pub fn build_and_sign_transaction(
+    pub async fn build_and_sign_transaction(
         &mut self,
         wallet: &Wallet,
         account_index: u32,
         outputs: Vec<(Address<NetworkUnchecked>, u64)>,
         fee_rate: FeeRate,
     ) -> Result<(Transaction, u64), BuilderError> {
-        // Get change address through the manager
-        let change_address = self
-            .next_change_address(wallet, account_index, AccountTypePreference::BIP44, true)
-            .ok_or(BuilderError::NoChangeAddress)?;
+        let height = self.last_processed_height();
 
         let managed_account = self
             .accounts
             .standard_bip44_accounts
             .get_mut(&account_index)
-            .expect("Impossible state, if change address is Some, account must be Some");
+            .ok_or(BuilderError::NoChangeAddress)?;
 
-        // Convert FFI outputs to Rust outputs
-        let mut tx_builder = TransactionBuilder::new();
+        let account = wallet
+            .accounts
+            .standard_bip44_accounts
+            .get(&account_index)
+            .ok_or(BuilderError::NoChangeAddress)?;
 
-        for output in outputs {
-            let checked_address = output.0.require_network(wallet.network).map_err(|e| {
+        let mut tx_builder = TransactionBuilder::new()
+            .set_fee_rate(fee_rate)
+            .set_current_height(height)
+            .set_funding(managed_account, account);
+
+        for (address, value) in outputs {
+            let checked = address.require_network(wallet.network).map_err(|e| {
                 BuilderError::InvalidData(format!("Output address network mismatch: {}", e))
             })?;
-            tx_builder = tx_builder.add_output(&checked_address, output.1)?;
+            tx_builder = tx_builder.add_output(&checked, value);
         }
 
-        tx_builder = tx_builder.set_change_address(change_address).set_fee_rate(fee_rate);
-
-        // Get available UTXOs (collect owned UTXOs, not references)
-        let utxos: Vec<crate::Utxo> = managed_account.utxos.values().cloned().collect();
-
-        // Get the wallet's root extended private key for signing
-        let root_xpriv = match &wallet.wallet_type {
-            WalletType::Mnemonic {
-                root_extended_private_key,
-                ..
-            } => root_extended_private_key,
-            WalletType::Seed {
-                root_extended_private_key,
-                ..
-            } => root_extended_private_key,
-            WalletType::ExtendedPrivKey(root_extended_private_key) => root_extended_private_key,
-            _ => {
-                return Err(BuilderError::InvalidData(
-                    "Cannot sign with watch-only wallet".to_string(),
-                ));
-            }
-        };
-
-        // Build a map of address -> derivation path for all addresses in the account
-        use std::collections::HashMap;
-        let mut address_to_path: HashMap<dashcore::Address, crate::DerivationPath> = HashMap::new();
-
-        // Collect from all address pools (receive, change, etc.)
-        for pool in managed_account.managed_account_type().address_pools() {
-            for addr_info in pool.addresses.values() {
-                address_to_path.insert(addr_info.address.clone(), addr_info.path.clone());
-            }
-        }
-
-        // Select inputs and build transaction
-        let mut tx_builder = tx_builder.select_inputs(
-            &utxos,
-            SelectionStrategy::BranchAndBound,
-            self.last_processed_height(),
-            |utxo| {
-                // Look up the derivation path for this UTXO's address
-                let path = address_to_path.get(&utxo.address)?;
-
-                // Convert root key to ExtendedPrivKey and derive the child key
-                let root_ext_priv = root_xpriv.to_extended_priv_key(wallet.network);
-                let secp = secp256k1::Secp256k1::new();
-                let derived_xpriv = root_ext_priv.derive_priv(&secp, path).ok()?;
-
-                Some(derived_xpriv.private_key)
-            },
-        )?;
-
-        let transaction = tx_builder.build()?;
-
-        // This is tricky, the transaction creation + fee calculation need a little
-        // bit of love to avoid this kind of logic.
-        //
-        // First, we need to know that TransactionBuilder may add an extra output for change
-        // to the final transaction but not to itself, with that knowledge, we can compare the
-        // number of outputs in the transaction with the number of outputs in the TransactionBuilder
-        // to then call the appropriate fee calculation method
-        let fee = if transaction.output.len() > tx_builder.outputs().len() {
-            tx_builder.calculate_fee_with_extra_output()
-        } else {
-            tx_builder.calculate_fee()
-        };
-
-        Ok((transaction, fee))
+        tx_builder.build_signed(wallet, |addr| managed_account.address_derivation_path(&addr)).await
     }
 
-    /// Build and sign a standard Core-to-Core transaction via an external [`Signer`].
-    ///
-    /// Same shape and semantics as [`Self::build_and_sign_transaction`], but every
-    /// input signature is delegated to `signer`. The host never sees the underlying
-    /// private keys, so this is the entry point for hardware wallets and remote
-    /// signers backing a [`WalletType::ExternalSignable`] wallet.
     pub async fn build_and_sign_transaction_with_signer<S: Signer>(
         &mut self,
         wallet: &Wallet,
@@ -135,122 +62,35 @@ impl ManagedWalletInfo {
         fee_rate: FeeRate,
         signer: &S,
     ) -> Result<(Transaction, u64), BuilderError> {
-        // This build path drives signing via pre-computed P2PKH sighashes,
-        // so the signer must support blind digest signing.
-        if !signer.supports(SignerMethod::Digest) {
-            return Err(BuilderError::SigningFailed(format!(
-                "signer does not support required method {:?}",
-                SignerMethod::Digest
-            )));
-        }
-
-        // Get change address through the manager
-        let change_address = self
-            .next_change_address(wallet, account_index, AccountTypePreference::BIP44, true)
-            .ok_or(BuilderError::NoChangeAddress)?;
+        let height = self.last_processed_height();
 
         let managed_account = self
             .accounts
             .standard_bip44_accounts
+            .get_mut(&account_index)
+            .ok_or(BuilderError::NoChangeAddress)?;
+
+        let account = wallet
+            .accounts
+            .standard_bip44_accounts
             .get(&account_index)
-            .expect("Impossible state, if change address is Some, account must be Some");
+            .ok_or(BuilderError::NoChangeAddress)?;
 
-        let mut tx_builder = TransactionBuilder::new();
+        let mut tx_builder = TransactionBuilder::new()
+            .set_fee_rate(fee_rate)
+            .set_current_height(height)
+            .set_funding(managed_account, account);
 
-        for output in outputs {
-            let checked_address = output.0.require_network(wallet.network).map_err(|e| {
+        for (address, value) in outputs {
+            let checked = address.require_network(wallet.network).map_err(|e| {
                 BuilderError::InvalidData(format!("Output address network mismatch: {}", e))
             })?;
-            tx_builder = tx_builder.add_output(&checked_address, output.1)?;
+            tx_builder = tx_builder.add_output(&checked, value);
         }
 
-        tx_builder = tx_builder.set_change_address(change_address).set_fee_rate(fee_rate);
-
-        let utxos: Vec<crate::Utxo> = managed_account.utxos.values().cloned().collect();
-
-        // Build the transaction WITHOUT keys — TransactionBuilder's internal
-        // signer is skipped when every input's key is None, producing an
-        // unsigned tx we then sign ourselves via the Signer.
-        let mut tx_builder = tx_builder.select_inputs(
-            &utxos,
-            SelectionStrategy::BranchAndBound,
-            self.last_processed_height(),
-            |_| None,
-        )?;
-
-        let outputs_count_before = tx_builder.outputs().len();
-        let fee = tx_builder.calculate_fee();
-        let fee_with_extra = tx_builder.calculate_fee_with_extra_output();
-
-        let mut transaction = tx_builder.build()?;
-
-        let actual_fee = if transaction.output.len() > outputs_count_before {
-            fee_with_extra
-        } else {
-            fee
-        };
-
-        // Map each input back to its prev-txout via UTXO outpoint so we can
-        // compute the legacy P2PKH sighash and look up its derivation path.
-        let utxo_by_outpoint: HashMap<_, _> =
-            utxos.iter().map(|u| (u.outpoint, u.clone())).collect();
-
-        let mut scripts: Vec<ScriptBuf> = Vec::with_capacity(transaction.input.len());
-        {
-            let cache = SighashCache::new(&transaction);
-            for (index, txin) in transaction.input.iter().enumerate() {
-                let utxo = utxo_by_outpoint.get(&txin.previous_output).ok_or_else(|| {
-                    BuilderError::SigningFailed(format!(
-                        "selected UTXO {:?} not found in funding account",
-                        txin.previous_output
-                    ))
-                })?;
-                let path =
-                    managed_account.address_derivation_path(&utxo.address).ok_or_else(|| {
-                        BuilderError::SigningFailed(format!(
-                            "no derivation path for input address {}",
-                            utxo.address
-                        ))
-                    })?;
-
-                let sighash = cache
-                    .legacy_signature_hash(
-                        index,
-                        &utxo.txout.script_pubkey,
-                        EcdsaSighashType::All.to_u32(),
-                    )
-                    .map_err(|e| {
-                        BuilderError::SigningFailed(format!(
-                            "failed to compute sighash for input {index}: {e}"
-                        ))
-                    })?;
-
-                let (sig, pubkey) = signer
-                    .sign_ecdsa(&path, *sighash.as_byte_array())
-                    .await
-                    .map_err(|e| BuilderError::SigningFailed(e.to_string()))?;
-
-                let mut sig_bytes = sig.serialize_der().to_vec();
-                sig_bytes.push(EcdsaSighashType::All.to_u32() as u8);
-
-                let script_sig = Builder::new()
-                    .push_slice(<&PushBytes>::try_from(sig_bytes.as_slice()).map_err(|_| {
-                        BuilderError::SigningFailed("invalid signature length".into())
-                    })?)
-                    .push_slice(pubkey.serialize())
-                    .into_script();
-
-                scripts.push(script_sig);
-            }
-        }
-        for (index, script_sig) in scripts.into_iter().enumerate() {
-            transaction.input[index].script_sig = script_sig;
-        }
-
-        Ok((transaction, actual_fee))
+        tx_builder.build_signed(signer, |addr| managed_account.address_derivation_path(&addr)).await
     }
 }
-
 #[cfg(test)]
 mod tests {
     use crate::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
@@ -280,24 +120,15 @@ mod tests {
             .require_network(Network::Testnet)
             .unwrap();
 
-        let mut builder = TransactionBuilder::new()
+        let tx = TransactionBuilder::new()
             .set_fee_rate(FeeRate::normal())
-            .set_change_address(change_address.clone());
-
-        // Add output
-        builder = builder.add_output(&recipient_address, 150000).unwrap();
-
-        // Select inputs
-        builder = builder
-            .select_inputs(
-                &utxos,
-                SelectionStrategy::SmallestFirst,
-                200,
-                |_| None, // No private keys for unsigned
-            )
-            .unwrap();
-
-        let tx = builder.build().unwrap();
+            .set_current_height(200)
+            .set_change_address(change_address.clone())
+            .add_output(&recipient_address, 150000)
+            .add_inputs(utxos)
+            .build_unsigned()
+            .unwrap()
+            .0;
 
         assert!(!tx.input.is_empty());
         assert_eq!(tx.output.len(), 2); // recipient + change
@@ -384,15 +215,15 @@ mod tests {
             .require_network(Network::Testnet)
             .unwrap();
 
-        let mut builder = TransactionBuilder::new()
+        let builder = TransactionBuilder::new()
             .set_fee_rate(FeeRate::normal())
+            .set_current_height(200)
+            .set_selection_strategy(SelectionStrategy::SmallestFirst)
             .set_change_address(change_address.clone())
             .add_output(&recipient_address, 150000)
-            .unwrap()
-            .select_inputs(&utxos, SelectionStrategy::SmallestFirst, 200, |_| None)
-            .unwrap();
+            .add_inputs(utxos);
 
-        let tx = builder.build().unwrap();
+        let tx = builder.build_unsigned().unwrap().0;
         let serialized = dashcore::consensus::encode::serialize(&tx);
 
         // Size should be close to our estimation
@@ -419,15 +250,13 @@ mod tests {
             .require_network(Network::Testnet)
             .unwrap();
 
-        let mut builder = TransactionBuilder::new()
-            .set_fee_rate(FeeRate::normal()) // 1 duff per byte
+        let builder = TransactionBuilder::new()
+            .set_current_height(200)
             .set_change_address(change_address.clone())
             .add_output(&recipient_address, 500000)
-            .unwrap()
-            .select_inputs(&utxos, SelectionStrategy::SmallestFirst, 200, |_| None)
-            .unwrap();
+            .add_inputs(utxos);
 
-        let tx = builder.build().unwrap();
+        let tx = builder.build_unsigned().unwrap().0;
 
         // Total input: 1000000
         // Output to recipient: 500000
@@ -454,11 +283,11 @@ mod tests {
             .unwrap();
 
         let result = TransactionBuilder::new()
-            .set_fee_rate(FeeRate::normal())
+            .set_current_height(200)
             .set_change_address(change_address.clone())
             .add_output(&recipient_address, 1000000) // More than available
-            .unwrap()
-            .select_inputs(&utxos, SelectionStrategy::SmallestFirst, 200, |_| None);
+            .add_inputs(utxos)
+            .build_unsigned();
 
         assert!(result.is_err());
     }
@@ -477,15 +306,14 @@ mod tests {
             .require_network(Network::Testnet)
             .unwrap();
 
-        let mut builder = TransactionBuilder::new()
-            .set_fee_rate(FeeRate::normal())
+        let builder = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_selection_strategy(SelectionStrategy::SmallestFirst)
             .set_change_address(change_address.clone())
             .add_output(&recipient_address, 150000)
-            .unwrap()
-            .select_inputs(&utxos, SelectionStrategy::SmallestFirst, 200, |_| None)
-            .unwrap();
+            .add_inputs(utxos);
 
-        let tx = builder.build().unwrap();
+        let tx = builder.build_unsigned().unwrap().0;
 
         // Should only have 1 output (no change)
         assert_eq!(tx.output.len(), 1);
@@ -627,12 +455,9 @@ mod tests {
                 &NoDigestSigner,
             )
             .await;
-        match result {
-            Err(BuilderError::SigningFailed(msg)) => {
-                assert!(msg.contains("Digest"), "unexpected error message: {msg}");
-            }
-            other => panic!("expected SigningFailed for unsupported signer, got: {:?}", other),
-        }
+        // The unfunded wallet may also surface a CoinSelection error before
+        // the signer is reached; either way the build cannot succeed.
+        assert!(result.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Centralizes coin selection, change derivation, BIP-69 sorting, fee accounting and input signing inside TransactionBuilder so per-tx-type helpers (build_and_sign_transaction, build_asset_lock, build_asset_lock_with_signer, …) only set up the builder and post-process wallet state.      
   
  Highlights                                                                                                                                                                                                                                                                                   
  - TransactionBuilder owns the build pipeline: set_funding / set_change_address / set_current_height / set_selection_strategy / set_special_payload → build_unsigned() or build_signed(signer, path_resolver).
  - New TransactionSigner trait with default sign_tx flow; blanket impl for Wallet (soft-wallet path) and for S: Signer (external signers). The blind-digest support check lives once, in the blanket impl.                                                                                    
  - AssetLock-specific structural rules (OP_RETURN burn at tx.output[0], version-3 wire, BIP-69 skip, total-output derived from payload credit_outputs) are handled inside assemble_unsigned; helpers no longer mirror credit_outputs as raw outputs.
  - dashcore payload structs (AssetLockPayload, CoinbasePayload, ProviderRegistrationPayload, …) gain CURRENT_VERSION constants and new(...) constructors so callers don't repeat version literals.                                                                                            
                                                                                                                                                                                                                                                                                               
Note: The unit-test suite was not rewritten. Tests were only adjusted to match the new API