### PR TITLE
refactor(dash-spv): make logging a built-in event handler

### DIFF
--- a/dash-spv/src/client/event_handler.rs
+++ b/dash-spv/src/client/event_handler.rs
@@ -34,6 +34,36 @@ pub trait EventHandler: Send + Sync + 'static {
 /// No-op implementation for consumers that don't need event notifications.
 impl EventHandler for () {}
 
+/// Built-in handler that mirrors all events into `tracing` so consumers get
+/// log output once they install a tracing subscriber (e.g., via `init_logging`).
+///
+/// Attached automatically by `DashSpvClient::new` ahead of consumer-supplied
+/// handlers. To silence event logs without affecting other subscribers, set a
+/// per-target filter such as `dash_spv::client::event_handler=warn`.
+pub(crate) struct LoggingEventHandler;
+
+impl EventHandler for LoggingEventHandler {
+    fn on_sync_event(&self, event: &SyncEvent) {
+        tracing::info!("SyncEvent: {}", event.description());
+    }
+
+    fn on_network_event(&self, event: &NetworkEvent) {
+        tracing::info!("NetworkEvent: {}", event.description());
+    }
+
+    fn on_progress(&self, progress: &SyncProgress) {
+        tracing::info!("SyncProgress: {}", progress);
+    }
+
+    fn on_wallet_event(&self, event: &WalletEvent) {
+        tracing::info!("WalletEvent: {}", event.description());
+    }
+
+    fn on_error(&self, error: &str) {
+        tracing::error!("{}", error);
+    }
+}
+
 /// Spawns a task that monitors a broadcast channel and dispatches events to the handler.
 ///
 /// On failure, the error message is sent via `on_failure` so the coordinator can report

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -8,6 +8,7 @@
 //! - Genesis block initialization
 //! - Wallet data loading
 
+use super::event_handler::LoggingEventHandler;
 use super::{ClientConfig, DashSpvClient, EventHandler};
 use crate::chain::checkpoints::{mainnet_checkpoints, testnet_checkpoints, CheckpointManager};
 use crate::error::{Result, SpvError};
@@ -36,6 +37,10 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         wallet: Arc<RwLock<W>>,
         event_handlers: Vec<Arc<dyn EventHandler>>,
     ) -> Result<Self> {
+        let event_handlers: Vec<Arc<dyn EventHandler>> =
+            std::iter::once(Arc::new(LoggingEventHandler) as Arc<dyn EventHandler>)
+                .chain(event_handlers)
+                .collect();
         // Validate configuration
         config.validate().map_err(SpvError::Config)?;
 

--- a/dash-spv/src/client/mod.rs
+++ b/dash-spv/src/client/mod.rs
@@ -76,4 +76,28 @@ mod tests {
         let wallet_ref = client.wallet();
         let _wallet_guard = wallet_ref.read().await;
     }
+
+    #[tokio::test]
+    async fn client_attaches_builtin_logging_handler() {
+        let config = ClientConfig::mainnet()
+            .without_filters()
+            .without_masternodes()
+            .with_mempool_tracking(MempoolStrategy::FetchAll)
+            .with_storage_path(TempDir::new().unwrap().path());
+
+        let network_manager = MockNetworkManager::new();
+        let storage =
+            DiskStorageManager::with_temp_dir().await.expect("Failed to create tmp storage");
+        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
+
+        let client = DashSpvClient::new(config, network_manager, storage, wallet, Vec::new())
+            .await
+            .expect("client construction must succeed");
+
+        assert_eq!(
+            client.event_handlers.len(),
+            1,
+            "constructor should auto-attach the built-in logging handler",
+        );
+    }
 }

--- a/dash-spv/src/main.rs
+++ b/dash-spv/src/main.rs
@@ -5,11 +5,9 @@ use std::process;
 use std::sync::Arc;
 
 use clap::{Parser, ValueEnum};
-use dash_spv::network::NetworkEvent;
-use dash_spv::sync::{SyncEvent, SyncProgress};
-use dash_spv::{ClientConfig, DashSpvClient, EventHandler, LevelFilter, MempoolStrategy, Network};
+use dash_spv::{ClientConfig, DashSpvClient, LevelFilter, MempoolStrategy, Network};
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
-use key_wallet_manager::{WalletEvent, WalletManager};
+use key_wallet_manager::WalletManager;
 use tokio_util::sync::CancellationToken;
 
 /// Network selection for CLI
@@ -68,31 +66,6 @@ impl From<LogLevelArg> for LevelFilter {
             LogLevelArg::Debug => LevelFilter::DEBUG,
             LogLevelArg::Trace => LevelFilter::TRACE,
         }
-    }
-}
-
-/// Logs all SPV client events via tracing.
-struct LoggingEventHandler;
-
-impl EventHandler for LoggingEventHandler {
-    fn on_sync_event(&self, event: &SyncEvent) {
-        tracing::info!("{}", event.description());
-    }
-
-    fn on_network_event(&self, event: &NetworkEvent) {
-        tracing::info!("{}", event.description());
-    }
-
-    fn on_progress(&self, progress: &SyncProgress) {
-        tracing::info!("Sync progress: {}", progress);
-    }
-
-    fn on_wallet_event(&self, event: &WalletEvent) {
-        tracing::info!("Wallet: {}", event.description());
-    }
-
-    fn on_error(&self, error: &str) {
-        tracing::error!("{}", error);
     }
 }
 
@@ -326,25 +299,22 @@ async fn run_client<S: dash_spv::storage::StorageManager>(
     wallet: Arc<tokio::sync::RwLock<WalletManager<ManagedWalletInfo>>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Create and start the client
-    let client = match DashSpvClient::<
-        WalletManager<ManagedWalletInfo>,
-        dash_spv::network::manager::PeerNetworkManager,
-        S,
-    >::new(
-        config.clone(),
-        network_manager,
-        storage_manager,
-        wallet.clone(),
-        vec![Arc::new(LoggingEventHandler)],
-    )
-    .await
-    {
-        Ok(client) => client,
-        Err(e) => {
-            eprintln!("Failed to create SPV client: {}", e);
-            process::exit(1);
-        }
-    };
+    let client =
+        match DashSpvClient::<
+            WalletManager<ManagedWalletInfo>,
+            dash_spv::network::manager::PeerNetworkManager,
+            S,
+        >::new(
+            config.clone(), network_manager, storage_manager, wallet.clone(), Vec::new()
+        )
+        .await
+        {
+            Ok(client) => client,
+            Err(e) => {
+                eprintln!("Failed to create SPV client: {}", e);
+                process::exit(1);
+            }
+        };
 
     let shutdown_token = CancellationToken::new();
     let ctrl_c_token = shutdown_token.clone();


### PR DESCRIPTION
Move `LoggingEventHandler` out of the CLI binary and into `dash-spv` itself, then have `DashSpvClient::new` prepend it to the consumer-supplied handler list. Every consumer (CLI, FFI, integration tests, future embedders) now gets event log output for free as soon as a `tracing` subscriber is installed, instead of each one re-implementing the same bridge.

The handler is `pub(crate)` since consumers never need to construct or reference it. Per-event silencing is available through the standard `tracing` target filter `dash_spv::client::event_handler=warn`, so no opt-out flag is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Event logging is now built-in and automatically enabled for all clients, eliminating the need for manual logging configuration.

* **Tests**
  * Added test coverage to verify automatic event handler attachment during client initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->