### PR TITLE
fix(dash-spv): preserve in-progress sync state on peer disconnect

### DIFF
--- a/dash-spv/src/sync/block_headers/sync_manager.rs
+++ b/dash-spv/src/sync/block_headers/sync_manager.rs
@@ -36,7 +36,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for BlockHeadersMana
         &[MessageType::Headers, MessageType::Inv]
     }
 
-    fn clear_in_flight_state(&mut self) {
+    fn on_disconnect(&mut self) {
         // Drop only per-peer in-flight bookkeeping. Segment topology and
         // validated chain state per segment (current_tip_hash, current_height,
         // buffered_headers, complete) are preserved so a reconnect can resume

--- a/dash-spv/src/sync/blocks/manager.rs
+++ b/dash-spv/src/sync/blocks/manager.rs
@@ -327,4 +327,41 @@ mod tests {
             "wallet_out was not in the routed set, must not be processed"
         );
     }
+
+    /// `on_disconnect` for `BlocksManager` keeps the downloaded buffer, the
+    /// per-block wallet routing, and the `filters_sync_complete` flag, and
+    /// moves any in-flight `getdata`s back to pending so the next
+    /// `send_pending` reissues them. Without this preservation, blocks waiting
+    /// in `downloaded` for height ordering would be dropped, leaving
+    /// `FiltersManager.tracker` entries that never get decremented.
+    #[tokio::test]
+    async fn test_on_disconnect_preserves_pipeline_work() {
+        use dashcore::block::Header;
+        use dashcore::{Block, TxMerkleNode};
+        use dashcore_hashes::Hash;
+
+        let mut manager = create_test_manager().await;
+        manager.filters_sync_complete = true;
+
+        let header = Header {
+            version: dashcore::blockdata::block::Version::from_consensus(1),
+            prev_blockhash: dashcore::BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 0,
+            bits: dashcore::CompactTarget::from_consensus(0),
+            nonce: 0,
+        };
+        let block = Block {
+            header,
+            txdata: vec![],
+        };
+
+        // Already-downloaded block sitting in the pipeline.
+        manager.pipeline.add_from_storage(block.clone(), 200, BTreeSet::from([MOCK_WALLET_ID]));
+
+        manager.on_disconnect();
+
+        assert!(!manager.pipeline.is_complete(), "downloaded buffer must survive on_disconnect");
+        assert!(manager.filters_sync_complete);
+    }
 }

--- a/dash-spv/src/sync/blocks/pipeline.rs
+++ b/dash-spv/src/sync/blocks/pipeline.rs
@@ -191,6 +191,15 @@ impl BlocksPipeline {
     pub(super) fn handle_timeouts(&mut self) {
         self.coordinator.check_and_retry_timeouts();
     }
+
+    /// Move in-flight `getdata` requests back to pending after a peer
+    /// disconnect so the next `send_pending` reissues them to the new peer.
+    /// `pending_heights`, `downloaded`, `hash_to_height`, and `hash_to_wallets`
+    /// are preserved so already-received blocks are not re-fetched and the
+    /// per-block wallet routing stays intact.
+    pub(super) fn requeue_in_flight(&mut self) {
+        self.coordinator.requeue_in_flight();
+    }
 }
 
 #[cfg(test)]
@@ -306,6 +315,34 @@ mod tests {
         assert_eq!(pipeline.coordinator.active_count(), MAX_CONCURRENT_BLOCK_DOWNLOADS);
         assert_eq!(pipeline.coordinator.pending_count(), 1);
         assert!(!pipeline.has_pending_requests());
+    }
+
+    #[test]
+    fn test_requeue_in_flight_preserves_downloaded_and_pending_heights() {
+        let mut pipeline = BlocksPipeline::new();
+        let block_a = make_test_block(1);
+        let block_b = make_test_block(2);
+        let hash_a = block_a.block_hash();
+        let hash_b = block_b.block_hash();
+
+        // A: queued and sent — will be requeued.
+        pipeline.queue([(FilterMatchKey::new(100, hash_a), BTreeSet::from([[1u8; 32]]))]);
+        let sent = pipeline.coordinator.take_pending(1);
+        pipeline.coordinator.mark_sent(&sent);
+        assert_eq!(pipeline.coordinator.active_count(), 1);
+
+        // B: already received, sitting in `downloaded` — must survive requeue.
+        pipeline.add_from_storage(block_b.clone(), 200, BTreeSet::from([[2u8; 32]]));
+
+        pipeline.requeue_in_flight();
+
+        assert_eq!(pipeline.coordinator.active_count(), 0);
+        assert_eq!(pipeline.coordinator.pending_count(), 1);
+        assert!(pipeline.pending_heights.contains(&100));
+        assert_eq!(pipeline.hash_to_height.get(&hash_a), Some(&100));
+        assert!(pipeline.hash_to_wallets.contains_key(&hash_a));
+        assert!(pipeline.downloaded.contains_key(&200));
+        assert!(pipeline.hash_to_wallets.contains_key(&hash_b));
     }
 
     #[test]

--- a/dash-spv/src/sync/blocks/sync_manager.rs
+++ b/dash-spv/src/sync/blocks/sync_manager.rs
@@ -1,7 +1,6 @@
 use crate::error::SyncResult;
 use crate::network::{Message, MessageType, RequestSender};
 use crate::storage::{BlockHeaderStorage, BlockStorage};
-use crate::sync::blocks::pipeline::BlocksPipeline;
 use crate::sync::sync_manager::ensure_not_started;
 use crate::sync::{
     BlocksManager, ManagerIdentifier, SyncEvent, SyncManager, SyncManagerProgress, SyncState,
@@ -42,14 +41,25 @@ impl<H: BlockHeaderStorage, B: BlockStorage, W: WalletInterface + 'static> SyncM
             return Ok(vec![]);
         }
 
-        // Otherwise wait for BlocksNeeded or FiltersSyncComplete events
-        self.set_state(SyncState::WaitForEvents);
+        // If in-progress block work survived a disconnect, resume in Syncing so
+        // `process_buffered_blocks` can transition to Synced once the pipeline
+        // drains. Otherwise wait for BlocksNeeded / FiltersSyncComplete events.
+        if !self.pipeline.is_complete() {
+            self.set_state(SyncState::Syncing);
+        } else {
+            self.set_state(SyncState::WaitForEvents);
+        }
         Ok(vec![])
     }
 
-    fn clear_in_flight_state(&mut self) {
-        self.pipeline = BlocksPipeline::new();
-        self.filters_sync_complete = false;
+    /// Keep the entire pipeline (downloaded blocks, pending queue, per-block
+    /// wallet routing) and the `filters_sync_complete` flag, and move in-flight
+    /// `getdata`s back to the front of `pending` so the next `send_pending`
+    /// reissues them to the new peer immediately. Without this preservation,
+    /// `FiltersManager`'s tracker would re-track the same block hashes after a
+    /// re-scan and leak `pending_blocks` counters that never reach zero.
+    fn on_disconnect(&mut self) {
+        self.pipeline.requeue_in_flight();
     }
 
     async fn handle_message(

--- a/dash-spv/src/sync/chainlock/sync_manager.rs
+++ b/dash-spv/src/sync/chainlock/sync_manager.rs
@@ -26,7 +26,7 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for ChainLockManager
         &[MessageType::CLSig, MessageType::Inv]
     }
 
-    fn clear_in_flight_state(&mut self) {
+    fn on_disconnect(&mut self) {
         self.requested_chainlocks.clear();
         self.masternode_ready = false;
     }

--- a/dash-spv/src/sync/download_coordinator.rs
+++ b/dash-spv/src/sync/download_coordinator.rs
@@ -92,6 +92,23 @@ impl<K: Hash + Eq + Clone> DownloadCoordinator<K> {
         self.last_progress = Instant::now();
     }
 
+    /// Move all in-flight items back to the front of the pending queue.
+    ///
+    /// Used on peer disconnect: the requests went to a now-dead peer, but the
+    /// items themselves are still wanted. Retry counts are preserved so a peer
+    /// that consistently fails to deliver an item still trips the normal retry
+    /// budget. Without this hook, items would only be retried once their
+    /// timeout elapsed.
+    pub(crate) fn requeue_in_flight(&mut self) {
+        let items: Vec<K> = self.in_flight.drain().map(|(k, _)| k).collect();
+        if items.is_empty() {
+            return;
+        }
+        for item in items.into_iter().rev() {
+            self.pending.push_front(item);
+        }
+    }
+
     /// Queue items for download.
     pub(crate) fn enqueue(&mut self, items: impl IntoIterator<Item = K>) {
         for item in items {
@@ -313,6 +330,50 @@ mod tests {
         let timed_out = coord.check_timeouts();
         assert_eq!(timed_out.len(), 2);
         assert!(coord.in_flight.is_empty());
+    }
+
+    #[test]
+    fn test_requeue_in_flight_moves_items_to_pending_front() {
+        let mut coord: DownloadCoordinator<u32> = DownloadCoordinator::default();
+        coord.enqueue([10, 11]);
+        coord.mark_sent(&[1, 2, 3]);
+
+        coord.requeue_in_flight();
+
+        assert_eq!(coord.active_count(), 0);
+        // Requeued items go to the front, original pending follows.
+        let items = coord.take_pending(5);
+        assert_eq!(items.len(), 5);
+        assert_eq!(&items[3..], &[10, 11]);
+        let mut requeued = items[..3].to_vec();
+        requeued.sort();
+        assert_eq!(requeued, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_requeue_in_flight_preserves_retry_counts() {
+        let mut coord: DownloadCoordinator<u32> = DownloadCoordinator::default();
+        coord.enqueue_retry(7);
+        let items = coord.take_pending(1);
+        coord.mark_sent(&items);
+        assert_eq!(coord.retry_counts.get(&7), Some(&1));
+
+        coord.requeue_in_flight();
+
+        assert_eq!(coord.retry_counts.get(&7), Some(&1));
+        assert!(!coord.is_in_flight(&7));
+        assert_eq!(coord.pending_count(), 1);
+    }
+
+    #[test]
+    fn test_requeue_in_flight_no_op_when_empty() {
+        let mut coord: DownloadCoordinator<u32> = DownloadCoordinator::default();
+        coord.enqueue([1, 2]);
+
+        coord.requeue_in_flight();
+
+        assert_eq!(coord.pending_count(), 2);
+        assert_eq!(coord.active_count(), 0);
     }
 
     #[test]

--- a/dash-spv/src/sync/download_coordinator.rs
+++ b/dash-spv/src/sync/download_coordinator.rs
@@ -165,6 +165,18 @@ impl<K: Hash + Eq + Clone> DownloadCoordinator<K> {
         }
     }
 
+    /// Drop a key from the pending queue without touching in-flight state.
+    ///
+    /// Used when a pending item is satisfied through a side channel: a late
+    /// response from a disconnected peer can complete a batch that
+    /// `requeue_in_flight` just moved from in-flight back to pending. Without
+    /// this hook, the key would stay in `pending` with no tracker, and the
+    /// next `take_pending` would resurrect a finished batch.
+    pub(crate) fn cancel_pending(&mut self, key: &K) {
+        self.pending.retain(|k| k != key);
+        self.retry_counts.remove(key);
+    }
+
     /// Check if an item is currently in-flight.
     pub(crate) fn is_in_flight(&self, key: &K) -> bool {
         self.in_flight.contains_key(key)
@@ -374,6 +386,36 @@ mod tests {
 
         assert_eq!(coord.pending_count(), 2);
         assert_eq!(coord.active_count(), 0);
+    }
+
+    #[test]
+    fn test_cancel_pending_removes_from_pending_only() {
+        let mut coord: DownloadCoordinator<u32> = DownloadCoordinator::default();
+        coord.enqueue([1, 2, 3]);
+        coord.mark_sent(&[10]);
+        coord.enqueue_retry(2);
+        assert_eq!(coord.retry_counts.get(&2), Some(&1));
+
+        coord.cancel_pending(&2);
+
+        assert_eq!(coord.pending_count(), 2);
+        assert!(coord.is_in_flight(&10));
+        assert_eq!(coord.retry_counts.get(&2), None);
+
+        let items = coord.take_pending(2);
+        assert_eq!(items, vec![1, 3]);
+    }
+
+    #[test]
+    fn test_cancel_pending_unknown_key_is_noop() {
+        let mut coord: DownloadCoordinator<u32> = DownloadCoordinator::default();
+        coord.enqueue([1, 2]);
+        coord.mark_sent(&[5]);
+
+        coord.cancel_pending(&99);
+
+        assert_eq!(coord.pending_count(), 2);
+        assert_eq!(coord.active_count(), 1);
     }
 
     #[test]

--- a/dash-spv/src/sync/filter_headers/manager.rs
+++ b/dash-spv/src/sync/filter_headers/manager.rs
@@ -380,14 +380,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_clear_in_flight_state() {
+    async fn test_on_disconnect() {
         let mut manager = create_test_manager().await;
 
-        // Set all fields that clear_in_flight_state resets
+        // Set all fields that on_disconnect resets
         manager.block_headers_synced = true;
         manager.checkpoint_start_height = Some(500);
 
-        manager.clear_in_flight_state();
+        manager.on_disconnect();
 
         assert!(!manager.block_headers_synced);
         assert!(manager.checkpoint_start_height.is_none());

--- a/dash-spv/src/sync/filter_headers/sync_manager.rs
+++ b/dash-spv/src/sync/filter_headers/sync_manager.rs
@@ -31,7 +31,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage> SyncManager for FilterHeade
         &[MessageType::CFHeaders]
     }
 
-    fn clear_in_flight_state(&mut self) {
+    fn on_disconnect(&mut self) {
         self.pipeline = FilterHeadersPipeline::default();
         self.checkpoint_start_height = None;
         self.block_headers_synced = false;

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -126,6 +126,18 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             && self.filter_pipeline.is_idle()
     }
 
+    /// Drop all in-flight processing state so a fresh scan can begin from a
+    /// rolled-back `committed_height`. Used by the wallet-rescan trigger in
+    /// `tick` when a wallet's `synced_height` falls below the manager's
+    /// current scan progress. Distinct from `on_disconnect`, which keeps
+    /// in-progress work intact.
+    pub(super) fn reset_for_rescan(&mut self) {
+        self.active_batches.clear();
+        self.tracker.clear();
+        self.pending_batches.clear();
+        self.filter_pipeline = FiltersPipeline::new();
+    }
+
     async fn load_filters(
         &self,
         start_height: u32,
@@ -506,7 +518,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             // Drop processed-wallet records for the committed range. Below the
             // new committed_height a new wallet can only get here via the
             // `tick` rescan trigger, which already wipes the map via
-            // `clear_in_flight_state`, so older entries can never be consulted.
+            // `reset_for_rescan`, so older entries can never be consulted.
             self.tracker.prune_at_or_below(end);
             self.processing_height = end + 1;
 
@@ -883,6 +895,14 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                 }
             }
             SyncState::WaitingForConnections | SyncState::WaitForEvents => {
+                // In-progress work preserved across a disconnect cycle. Don't
+                // re-init via `start_download` — that would clobber existing
+                // batches. Instead extend the target and let the eventual
+                // `start_sync` (driven by `PeersUpdated`) resume from here.
+                if !self.active_batches.is_empty() {
+                    self.filter_pipeline.extend_target(tip_height);
+                    return Ok(vec![]);
+                }
                 return self.start_download(requests).await;
             }
             _ => {}
@@ -1584,7 +1604,7 @@ mod tests {
 
     /// `try_commit_batches` prunes `processed_blocks_per_wallet` entries at
     /// or below the new committed_height, since they cannot be reached again
-    /// without `clear_in_flight_state` wiping the map outright.
+    /// without `reset_for_rescan` wiping the map outright.
     #[tokio::test]
     async fn test_commit_prunes_processed_blocks_per_wallet() {
         let mut manager = create_test_manager().await;
@@ -1838,7 +1858,7 @@ mod tests {
         assert!(!manager.is_idle());
         manager.filter_pipeline = FiltersPipeline::new();
 
-        // Populate all fields, then clear_in_flight_state restores idleness
+        // Populate all fields, then reset_for_rescan restores idleness
         manager.active_batches.insert(0, FiltersBatch::new(0, 999, HashMap::new()));
         manager.tracker.track(&key, 0, BTreeSet::from([wallet_id]));
         manager.tracker.record_processed(100, hash, &BTreeSet::from([wallet_id]));
@@ -1846,7 +1866,7 @@ mod tests {
         manager.filter_pipeline.init(2000, 2999);
         assert!(!manager.is_idle());
 
-        manager.clear_in_flight_state();
+        manager.reset_for_rescan();
         assert!(manager.is_idle());
     }
 
@@ -2054,7 +2074,7 @@ mod tests {
         manager.progress.update_filter_header_tip_height(100);
         manager.progress.update_target_height(100);
 
-        // Pre-populate in-flight state so we can verify clear_in_flight_state runs.
+        // Pre-populate in-flight state so we can verify reset_for_rescan runs.
         manager.active_batches.insert(101, FiltersBatch::new(101, 200, HashMap::new()));
         let stale_hash = dashcore::block::Header::dummy(0).block_hash();
         let stale_key = FilterMatchKey::new(150, stale_hash);
@@ -2083,7 +2103,7 @@ mod tests {
         // Old in-flight state was cleared and a fresh batch was created at scan_start=0.
         assert!(!manager.active_batches.contains_key(&101));
         assert!(manager.active_batches.contains_key(&0));
-        // The stale pre-populated record was wiped by `clear_in_flight_state`:
+        // The stale pre-populated record was wiped by `reset_for_rescan`:
         // a fresh `track` for the same wallet now returns `NewlyTracked`.
         assert!(matches!(
             manager.tracker.track(&stale_key, 0, BTreeSet::from([MOCK_WALLET_ID])),
@@ -2178,5 +2198,51 @@ mod tests {
         assert_eq!(manager.progress.committed_height(), 100);
         assert_eq!(manager.state(), SyncState::WaitingForConnections);
         assert!(manager.active_batches.is_empty());
+    }
+
+    /// `on_disconnect` for `FiltersManager` keeps the block-match tracker,
+    /// active batches (with their `pending_blocks` counters), pending verified
+    /// batches, and per-batch filter receipts, and moves any in-flight
+    /// `getcfilters` slots back to pending so the next `send_pending` reissues
+    /// them. This keeps `FiltersManager.tracker` in lockstep with
+    /// `BlocksManager`'s preserved pipeline so already-counted matches do not
+    /// leak into a permanent non-zero `pending_blocks`.
+    #[tokio::test]
+    async fn test_on_disconnect_preserves_in_progress_work() {
+        let mut manager = create_test_manager().await;
+
+        let key = FilterMatchKey::new(100, dashcore::block::Header::dummy(0).block_hash());
+        let wallet_id = MOCK_WALLET_ID;
+
+        let mut batch = FiltersBatch::new(0, 999, HashMap::new());
+        batch.set_pending_blocks(1);
+        manager.active_batches.insert(0, batch);
+        manager.tracker.track(&key, 0, BTreeSet::from([wallet_id]));
+        manager.pending_batches.insert(FiltersBatch::new(1000, 1999, HashMap::new()));
+        manager.filter_pipeline.init(0, 1999);
+
+        manager.on_disconnect();
+
+        assert!(manager.active_batches.contains_key(&0));
+        assert_eq!(
+            manager.active_batches.get(&0).unwrap().pending_blocks(),
+            1,
+            "active batch's pending_blocks counter must not be reset"
+        );
+        assert_eq!(
+            manager.tracker.track(&key, 0, BTreeSet::from([wallet_id])),
+            BlockTrackResult::InFlight {
+                wallets: BTreeSet::from([wallet_id])
+            },
+            "tracker must still see the hash as in-flight"
+        );
+        assert_eq!(manager.pending_batches.len(), 1);
+
+        // Sanity check: the full-reset path (`reset_for_rescan`) does wipe
+        // everything — the two paths must remain distinct.
+        manager.reset_for_rescan();
+        assert!(manager.active_batches.is_empty());
+        assert!(manager.pending_batches.is_empty());
+        assert!(manager.tracker.is_empty());
     }
 }

--- a/dash-spv/src/sync/filters/pipeline.rs
+++ b/dash-spv/src/sync/filters/pipeline.rs
@@ -219,7 +219,9 @@ impl FiltersPipeline {
             self.batch_trackers.get_mut(&batch_start).map(|t| t.take_filters()).unwrap_or_default();
 
         self.batch_trackers.remove(&batch_start);
-        self.coordinator.receive(&batch_start);
+        if !self.coordinator.receive(&batch_start) {
+            self.coordinator.cancel_pending(&batch_start);
+        }
 
         tracing::info!(
             "Filter batch {}-{} complete ({} filters)",
@@ -487,6 +489,41 @@ mod tests {
         assert_eq!(tracker.received(), 1);
         assert_eq!(pipeline.filters_received, 1);
         assert_eq!(pipeline.highest_received, 50);
+    }
+
+    #[test]
+    fn test_late_filter_after_requeue_completes_batch_without_orphaning_pending() {
+        // Regression: a late `cfilter` from the disconnected peer can complete
+        // a batch after `requeue_in_flight` moved it back to pending. Without
+        // the cancel-pending hook, the key would linger in `pending` while the
+        // tracker was gone, and the next `send_pending` would error with
+        // `SyncError::InvalidState`.
+        let mut pipeline = FiltersPipeline::new();
+        pipeline.target_height = 2;
+
+        pipeline.batch_trackers.insert(0, BatchTracker::new(2));
+        pipeline.coordinator.mark_sent(&[0]);
+
+        // Two filters arrive before disconnect.
+        for h in 0..=1 {
+            let hash = Header::dummy(h).block_hash();
+            pipeline.receive_with_data(h, hash, &dummy_filter_data(h));
+        }
+
+        pipeline.requeue_in_flight();
+        assert_eq!(pipeline.coordinator.pending_count(), 1);
+        assert_eq!(pipeline.coordinator.active_count(), 0);
+
+        // Late buffered filter from old peer completes the batch.
+        let hash = Header::dummy(2).block_hash();
+        pipeline.receive_with_data(2, hash, &dummy_filter_data(2));
+
+        assert_eq!(pipeline.completed_batches.len(), 1);
+        assert!(pipeline.batch_trackers.is_empty());
+        // The orphaned pending key must be gone so `send_pending` does not
+        // resurrect a finished batch.
+        assert_eq!(pipeline.coordinator.pending_count(), 0);
+        assert_eq!(pipeline.coordinator.active_count(), 0);
     }
 
     #[test]

--- a/dash-spv/src/sync/filters/pipeline.rs
+++ b/dash-spv/src/sync/filters/pipeline.rs
@@ -251,6 +251,15 @@ impl FiltersPipeline {
             self.coordinator.enqueue_retry(start);
         }
     }
+
+    /// Move in-flight `getcfilters` requests back to pending after a peer
+    /// disconnect so the next `send_pending` reissues them to the new peer.
+    /// Per-batch trackers and any partially-received filters within them are
+    /// preserved — `BatchTracker::insert_filter` is idempotent, so duplicates
+    /// from the new peer are harmless.
+    pub(super) fn requeue_in_flight(&mut self) {
+        self.coordinator.requeue_in_flight();
+    }
 }
 
 #[cfg(test)]
@@ -453,6 +462,32 @@ mod tests {
     // =========================================================================
     // Receive Tests
     // =========================================================================
+
+    #[test]
+    fn test_requeue_in_flight_preserves_partial_batch_receipts() {
+        let mut pipeline = FiltersPipeline::new();
+        pipeline.target_height = 99;
+
+        // One batch in-flight (start_height 0). Receive a filter so the
+        // tracker has partial state.
+        pipeline.batch_trackers.insert(0, BatchTracker::new(99));
+        pipeline.coordinator.mark_sent(&[0]);
+        let hash = Header::dummy(50).block_hash();
+        pipeline.receive_with_data(50, hash, &dummy_filter_data(50));
+        assert_eq!(pipeline.filters_received, 1);
+        assert_eq!(pipeline.coordinator.active_count(), 1);
+
+        pipeline.requeue_in_flight();
+
+        // Batch is back in pending; tracker (and the partial filter inside it)
+        // is preserved so the new peer's response merges idempotently.
+        assert_eq!(pipeline.coordinator.active_count(), 0);
+        assert_eq!(pipeline.coordinator.pending_count(), 1);
+        let tracker = pipeline.batch_trackers.get(&0).expect("tracker preserved");
+        assert_eq!(tracker.received(), 1);
+        assert_eq!(pipeline.filters_received, 1);
+        assert_eq!(pipeline.highest_received, 50);
+    }
 
     #[test]
     fn test_receive_single_filter() {

--- a/dash-spv/src/sync/filters/sync_manager.rs
+++ b/dash-spv/src/sync/filters/sync_manager.rs
@@ -1,7 +1,6 @@
 use crate::error::{SyncError, SyncResult};
 use crate::network::{Message, MessageType, RequestSender};
 use crate::storage::{BlockHeaderStorage, FilterHeaderStorage, FilterStorage};
-use crate::sync::filters::pipeline::FiltersPipeline;
 use crate::sync::progress::ProgressPercentage;
 use crate::sync::sync_manager::ensure_not_started;
 use crate::sync::{
@@ -39,15 +38,29 @@ impl<
         &[MessageType::CFilter]
     }
 
-    fn clear_in_flight_state(&mut self) {
-        self.active_batches.clear();
-        self.tracker.clear();
-        self.pending_batches.clear();
-        self.filter_pipeline = FiltersPipeline::new();
+    /// Keep `active_batches`, the block-match tracker, pending verified
+    /// batches, and the filter pipeline's per-batch trackers. Move in-flight
+    /// `getcfilters` slots back to pending so the next `send_pending` reissues
+    /// them to the new peer immediately. Without this preservation, a re-scan
+    /// after reconnect would re-track the same block hashes and leak
+    /// `pending_blocks` counters that never reach zero.
+    fn on_disconnect(&mut self) {
+        self.filter_pipeline.requeue_in_flight();
     }
 
     async fn start_sync(&mut self, requests: &RequestSender) -> SyncResult<Vec<SyncEvent>> {
         ensure_not_started(self.state(), self.identifier())?;
+
+        // Resume in-progress work preserved across a disconnect cycle.
+        // `on_disconnect` keeps `active_batches`, the block-match tracker, and
+        // any pending verified batches; calling `start_download` here would
+        // insert a fresh batch at `scan_start` and clobber the existing one,
+        // leaking its `pending_blocks` counter forever.
+        if !self.active_batches.is_empty() {
+            self.filter_pipeline.send_pending(requests, &*self.header_storage.read().await).await?;
+            self.set_state(SyncState::Syncing);
+            return Ok(vec![]);
+        }
 
         // Check if there are already stored filters we need to process
         // This handles restart where filters are persisted but wallet state isn't
@@ -216,7 +229,7 @@ impl<
                     stale_min_synced,
                     committed
                 );
-                self.clear_in_flight_state();
+                self.reset_for_rescan();
                 self.progress.update_committed_height(stale_min_synced);
                 return self.start_download(requests).await;
             }

--- a/dash-spv/src/sync/instantsend/sync_manager.rs
+++ b/dash-spv/src/sync/instantsend/sync_manager.rs
@@ -25,7 +25,7 @@ impl SyncManager for InstantSendManager {
         &[MessageType::ISLock, MessageType::Inv]
     }
 
-    fn clear_in_flight_state(&mut self) {
+    fn on_disconnect(&mut self) {
         self.pending_instantlocks.clear();
     }
 

--- a/dash-spv/src/sync/masternodes/sync_manager.rs
+++ b/dash-spv/src/sync/masternodes/sync_manager.rs
@@ -225,7 +225,7 @@ impl<H: BlockHeaderStorage> SyncManager for MasternodesManager<H> {
         &[MessageType::MnListDiff, MessageType::QRInfo]
     }
 
-    fn clear_in_flight_state(&mut self) {
+    fn on_disconnect(&mut self) {
         self.sync_state.clear_pending();
         self.sync_state.qrinfo_retry_count = 0;
         self.sync_state.last_processed_qrinfo_tip = None;

--- a/dash-spv/src/sync/mempool/sync_manager.rs
+++ b/dash-spv/src/sync/mempool/sync_manager.rs
@@ -39,7 +39,7 @@ impl<W: WalletInterface + 'static> SyncManager for MempoolManager<W> {
         Ok(vec![])
     }
 
-    fn clear_in_flight_state(&mut self) {
+    fn on_disconnect(&mut self) {
         self.clear_pending();
     }
 

--- a/dash-spv/src/sync/sync_manager.rs
+++ b/dash-spv/src/sync/sync_manager.rs
@@ -117,12 +117,21 @@ pub trait SyncManager: Send + Sync + std::fmt::Debug {
     /// Called when the network manager loses its peers.
     fn stop_sync(&mut self) {
         self.set_state(SyncState::WaitingForConnections);
-        self.clear_in_flight_state();
+        self.on_disconnect();
     }
 
-    /// Clear all in-flight requests, pipelines, and retry state.
-    /// Called on disconnect when pending network requests become invalid.
-    fn clear_in_flight_state(&mut self);
+    /// Drop peer-bound in-flight state on disconnect.
+    ///
+    /// Each manager keeps as much progress as it can across a disconnect, and
+    /// only invalidates state that was tied to the now-dead peer. Anything
+    /// derivable from durable storage (block headers, filter headers, the
+    /// masternode engine) or from preserved per-batch bookkeeping should
+    /// survive so reconnect resumes instead of restarting.
+    ///
+    /// `BlocksManager` and `FiltersManager` go further and requeue their
+    /// in-flight network slots so the next `send_pending` reissues them
+    /// immediately to the new peer.
+    fn on_disconnect(&mut self);
 
     /// Handle an incoming network message.
     ///
@@ -369,7 +378,7 @@ mod tests {
             &[]
         }
 
-        fn clear_in_flight_state(&mut self) {}
+        fn on_disconnect(&mut self) {}
 
         async fn handle_message(
             &mut self,


### PR DESCRIPTION
`BlocksManager` and `FiltersManager` wiped their pipelines on every disconnect, which raced with the previous cycle's `BlockProcessed` events still in flight and left `pending_blocks` stuck above zero so `SyncComplete` never fired.

Replace the trait's `clear_in_flight_state` with a single `on_disconnect` hook. Each manager only invalidates state tied to the dead peer. `BlocksManager` and `FiltersManager` requeue their in-flight `getdata` / `getcfilters` slots so the next `send_pending` reissues them on the new peer, and `start_sync` resumes the preserved batches. The wallet-rescan path in `FiltersManager::tick` calls a manager-internal `reset_for_rescan` for the case that genuinely wants a full wipe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the disconnect lifecycle hook across sync managers for clearer lifecycle handling.

* **Improvements**
  * Download/filter/block sync now preserves in-progress work across peer disconnects and requeues in-flight requests for the next peer.
  * Introduced a distinct wallet rescan reset that fully clears rescan state without affecting disconnect-preserved progress.
  * Mempool pending state is cleared on disconnect to avoid stale requests.

* **Tests**
  * Added unit tests verifying requeue, cancel-pending, and disconnect-preserve behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->