### PR TITLE
test(dash-spv): fix `create_test_wallet` import in `tests_transaction`

### DIFF
--- a/dash-spv/tests/dashd_sync/tests_transaction.rs
+++ b/dash-spv/tests/dashd_sync/tests_transaction.rs
@@ -7,8 +7,8 @@ use tokio::sync::RwLock;
 use super::helpers::{
     wait_for_mempool_tx, wait_for_sync, wait_for_wallet_synced, EMPTY_MNEMONIC, SECONDARY_MNEMONIC,
 };
-use super::setup::{create_and_start_client, create_test_wallet, TestContext};
-use dash_spv::test_utils::TestChain;
+use super::setup::{create_and_start_client, TestContext};
+use dash_spv::test_utils::{create_test_wallet, TestChain};
 use dashcore::address::NetworkUnchecked;
 use key_wallet::account::ManagedAccountTrait;
 use key_wallet::wallet::managed_wallet_info::transaction_builder::{


### PR DESCRIPTION
CI on v0.42-dev is currently failing because #740 moved `create_test_wallet` from `dashd_sync/setup.rs` to `dash_spv::test_utils` and changed `setup.rs` to a private re-import. #748 was authored against an earlier base where `setup.rs` still defined a local `pub(super) fn create_test_wallet`, so the new tests in `tests_transaction.rs` imported it via `super::setup`.

Switch the import to `dash_spv::test_utils`, matching `tests_basic.rs`, `tests_mempool.rs`, `tests_multi_wallet.rs`, and `tests_restart.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes**

This release includes internal test infrastructure updates to reorganize module imports, with no impact on end-user functionality or features.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/rust-dashcore/pull/751)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->