### PR TITLE
fix(ffi): validate account seed lengths

### DIFF
--- a/key-wallet-ffi/src/account_derivation.rs
+++ b/key-wallet-ffi/src/account_derivation.rs
@@ -16,6 +16,26 @@ use std::ptr;
 
 // No extra FFI enum for chain selection; account semantics decide path.
 
+fn validate_bls_seed_len(seed_len: usize, error: *mut FFIError) -> bool {
+    if !(16..=64).contains(&seed_len) {
+        unsafe {
+            (*error).set(FFIErrorCode::InvalidInput, "Seed length must be between 16 and 64 bytes");
+        }
+        return false;
+    }
+    true
+}
+
+fn validate_eddsa_seed_len(seed_len: usize, error: *mut FFIError) -> bool {
+    if seed_len < 16 {
+        unsafe {
+            (*error).set(FFIErrorCode::InvalidInput, "Seed length must be at least 16 bytes");
+        }
+        return false;
+    }
+    true
+}
+
 /// Derive an extended private key from an account at a given index, using the provided master xpriv.
 ///
 /// Returns an opaque FFIExtendedPrivKey pointer that must be freed with `extended_private_key_free`.
@@ -65,7 +85,7 @@ pub unsafe extern "C" fn account_derive_extended_private_key_at(
 ///
 /// # Safety
 /// - `account` must be a valid, non-null pointer to an `FFIBLSAccount` (only when `bls` feature is enabled).
-/// - `seed` must point to a readable buffer of length `seed_len` (1..=64 bytes expected).
+/// - `seed` must point to a readable buffer of length `seed_len` (16..=64 bytes expected).
 /// - `error` must be a valid pointer to an FFIError.
 /// - Returned string must be freed with `string_free`.
 #[cfg(feature = "bls")]
@@ -79,8 +99,7 @@ pub unsafe extern "C" fn bls_account_derive_private_key_from_seed(
 ) -> *mut c_char {
     let account = deref_ptr!(account, error);
     check_ptr!(seed, error);
-    if seed_len == 0 || seed_len > 64 {
-        (*error).set(FFIErrorCode::InvalidInput, "Seed length must be between 1 and 64 bytes");
+    if !validate_bls_seed_len(seed_len, error) {
         return ptr::null_mut();
     }
     let seed_slice = std::slice::from_raw_parts(seed, seed_len);
@@ -147,7 +166,7 @@ pub unsafe extern "C" fn bls_account_derive_private_key_from_mnemonic(
 ///
 /// # Safety
 /// - `account` must be a valid, non-null pointer to an `FFIEdDSAAccount` (only when `eddsa` feature is enabled).
-/// - `seed` must point to a readable buffer of length `seed_len` (1..=64 bytes expected).
+/// - `seed` must point to a readable buffer of length `seed_len` (at least 16 bytes expected).
 /// - `error` must be a valid pointer to an FFIError.
 /// - Returned string must be freed with `string_free`.
 #[cfg(feature = "eddsa")]
@@ -161,6 +180,9 @@ pub unsafe extern "C" fn eddsa_account_derive_private_key_from_seed(
 ) -> *mut c_char {
     let account = deref_ptr!(account, error);
     check_ptr!(seed, error);
+    if !validate_eddsa_seed_len(seed_len, error) {
+        return ptr::null_mut();
+    }
     let seed_slice = std::slice::from_raw_parts(seed, seed_len);
     let sk = unwrap_or_return!(
         account.inner().derive_from_seed_private_key_at(seed_slice, index),

--- a/key-wallet-ffi/src/account_derivation_tests.rs
+++ b/key-wallet-ffi/src/account_derivation_tests.rs
@@ -10,9 +10,10 @@ mod tests {
     use crate::types::FFIAccountKind;
     use crate::wallet;
     use dash_network::ffi::FFINetwork;
+    #[cfg(feature = "bls")]
+    use key_wallet::account::{AccountType, BLSAccount};
 
-    const MNEMONIC: &str =
-        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
     #[test]
     fn test_account_derive_private_key_at_receive_index() {
@@ -325,5 +326,73 @@ mod tests {
             crate::account_collection::account_collection_free(collection);
             wallet::wallet_free(wallet);
         }
+    }
+
+    #[cfg(feature = "bls")]
+    #[test]
+    fn test_bls_seed_helper_rejects_invalid_seed_lengths() {
+        let mut error = FFIError::default();
+        let account = BLSAccount::from_seed(
+            None,
+            AccountType::ProviderOperatorKeys,
+            &[1u8; 32],
+            dashcore::Network::Testnet,
+        )
+        .unwrap();
+        let ffi_account = crate::account::FFIBLSAccount::new(&account);
+        let short_seed = [0u8; 15];
+        let long_seed = [0u8; 65];
+
+        let too_short = unsafe {
+            bls_account_derive_private_key_from_seed(
+                &ffi_account,
+                short_seed.as_ptr(),
+                short_seed.len(),
+                0,
+                &mut error,
+            )
+        };
+        assert!(too_short.is_null());
+        assert_eq!(error.code, FFIErrorCode::InvalidInput);
+
+        error = FFIError::default();
+        let too_long = unsafe {
+            bls_account_derive_private_key_from_seed(
+                &ffi_account,
+                long_seed.as_ptr(),
+                long_seed.len(),
+                0,
+                &mut error,
+            )
+        };
+        assert!(too_long.is_null());
+        assert_eq!(error.code, FFIErrorCode::InvalidInput);
+    }
+
+    #[cfg(feature = "eddsa")]
+    #[test]
+    fn test_eddsa_seed_helper_rejects_invalid_seed_lengths() {
+        let mut error = FFIError::default();
+        let account = key_wallet::account::EdDSAAccount::from_seed(
+            None,
+            FFIAccountKind::ProviderPlatformKeys.to_account_type(0),
+            &[1u8; 32],
+            FFINetwork::Testnet.into(),
+        )
+        .unwrap();
+        let ffi_account = crate::account::FFIEdDSAAccount::new(&account);
+        let short_seed = [0u8; 15];
+
+        let too_short = unsafe {
+            eddsa_account_derive_private_key_from_seed(
+                &ffi_account,
+                short_seed.as_ptr(),
+                short_seed.len(),
+                0,
+                &mut error,
+            )
+        };
+        assert!(too_short.is_null());
+        assert_eq!(error.code, FFIErrorCode::InvalidInput);
     }
 }


### PR DESCRIPTION
# FFI account seed-length validation

## Summary

- Add FFI-side seed-length validation for BLS seed derivation helpers before
  slicing or deriving.
- Add EdDSA seed-length validation at the FFI boundary to mirror the underlying
  SLIP-10 contract.
- Cover invalid BLS and EdDSA seed lengths with focused regression tests while
  leaving generic secp256k1 account seed behavior unchanged.

## Validation

- `cargo fmt -- key-wallet-ffi/src/account_derivation.rs \
  key-wallet-ffi/src/account_derivation_tests.rs`
- `cargo test -p key-wallet-ffi --features eddsa,bls account_derivation -- \
  --nocapture` — 6 passed
- `code-review dashpay/rust-dashcore upstream/v0.42-dev \
  fix-ffi-seed-length-validation "Validate key-wallet FFI BLS/EdDSA account \
  seed lengths before slicing/deriving while preserving secp256k1 generic \
  account seed behavior"` — no significant issues found; recommendation:
  ship

## Notes

Draft until human review marks it ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account derivation input validation. BLS derivation now accepts seeds from 16 to 64 bytes, while EdDSA derivation requires at least 16 bytes.
  * Invalid seed lengths now fail safely with an invalid-input error instead of producing an account.

* **Tests**
  * Added coverage confirming invalid seed lengths are rejected for both BLS and EdDSA account derivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->