### PR TITLE
refactor(dash-spv): drop unreachable `WouldBlock`/`TimedOut`

### DIFF
--- a/dash-spv/src/network/peer.rs
+++ b/dash-spv/src/network/peer.rs
@@ -393,12 +393,6 @@ impl Peer {
                             return Err(NetworkError::PeerDisconnected);
                         }
                         Ok(_) => {}
-                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                            return Ok(None);
-                        }
-                        Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut => {
-                            return Ok(None);
-                        }
                         Err(ref e)
                             if e.kind() == std::io::ErrorKind::ConnectionAborted
                                 || e.kind() == std::io::ErrorKind::ConnectionReset =>
@@ -455,12 +449,6 @@ impl Peer {
                                 return Err(NetworkError::PeerDisconnected);
                             }
                             Ok(_) => {}
-                            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                                return Ok(None);
-                            }
-                            Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut => {
-                                return Ok(None);
-                            }
                             Err(e) => {
                                 return Err(NetworkError::ConnectionFailed(format!(
                                     "Read failed: {}",
@@ -480,12 +468,6 @@ impl Peer {
                             return Err(NetworkError::PeerDisconnected);
                         }
                         Ok(_) => {}
-                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                            return Ok(None);
-                        }
-                        Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut => {
-                            return Ok(None);
-                        }
                         Err(e) => {
                             return Err(NetworkError::ConnectionFailed(format!(
                                 "Read failed: {}",
@@ -534,12 +516,6 @@ impl Peer {
                             return Err(NetworkError::PeerDisconnected);
                         }
                         Ok(_) => {}
-                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                            return Ok(None);
-                        }
-                        Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut => {
-                            return Ok(None);
-                        }
                         Err(e) => {
                             return Err(NetworkError::ConnectionFailed(format!(
                                 "Read failed: {}",


### PR DESCRIPTION
Tokio's `AsyncReadExt::read` consumes `WouldBlock` inside the runtime, so the future never resolves with that error kind. Read timeouts are imposed via `tokio::time::timeout(..)` and surface as `Elapsed`, not `io::Error::TimedOut`. The four `match` blocks in `Peer::receive_message`'s framing loop kept arms for both kinds, all of which were dead code.

Drop the eight unreachable arms. The remaining `Ok(0)`, `Ok(_)`, `ConnectionAborted`/`ConnectionReset`, and catch-all `Err(e)` arms continue to surface real errors, with the catch-all converting any unanticipated `io::Error` into `NetworkError::ConnectionFailed` rather than silently masking it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network error handling to properly distinguish temporary communication timeouts from actual connection failures, enhancing system reliability, error reporting accuracy, and diagnostic capabilities for peer-to-peer network operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/rust-dashcore/pull/753)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->