### PR TITLE
fix(dash-spv): prevent filter sync stalls from stale progress guards

### DIFF
--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -875,7 +875,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
 
         match self.state() {
             SyncState::Syncing | SyncState::Synced
-                if self.progress.stored_height() < self.progress.filter_header_tip_height() =>
+                if self.progress.committed_height() < self.progress.filter_header_tip_height() =>
             {
                 // Transition back to Syncing so is_synced() returns false
                 // until all new filters and matched blocks are fully processed.
@@ -884,7 +884,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                 }
 
                 self.filter_pipeline.extend_target(tip_height);
-                {
+                if self.progress.stored_height() < self.progress.filter_header_tip_height() {
                     let header_storage = self.header_storage.read().await;
                     self.filter_pipeline.send_pending(requests, &*header_storage).await?;
                 }
@@ -1961,7 +1961,7 @@ mod tests {
         let (tx, _rx) = unbounded_channel();
         let requests = RequestSender::new(tx);
 
-        // New filter headers arrive at 150: stored(100) < tip(150)
+        // New filter headers arrive at 150: committed(100) < tip(150)
         let events = manager.handle_new_filter_headers(150, &requests).await.unwrap();
 
         assert!(events.is_empty());
@@ -2244,5 +2244,66 @@ mod tests {
         assert!(manager.active_batches.is_empty());
         assert!(manager.pending_batches.is_empty());
         assert!(manager.tracker.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_handle_new_filter_headers_starts_scan_when_stored_equals_tip() {
+        let mut manager = create_test_manager().await;
+
+        let headers = dashcore::block::Header::dummy_batch(0..101);
+        manager.header_storage.write().await.store_headers(&headers).await.unwrap();
+
+        // Populate filter storage so load_filters succeeds during lookahead
+        {
+            let dummy_filter = BlockFilter::new(&[0u8; 32]);
+            let mut fs = manager.filter_storage.write().await;
+            for h in 0..=100 {
+                fs.store_filter(h, &dummy_filter.content).await.unwrap();
+            }
+        }
+
+        // Filters stored but not yet committed (restart scenario).
+        manager.set_state(SyncState::Synced);
+        manager.progress.update_filter_header_tip_height(100);
+        manager.progress.update_stored_height(100);
+        manager.progress.update_committed_height(0);
+        manager.progress.update_target_height(1000);
+        manager.filter_pipeline.init(101, 100);
+
+        let (tx, _rx) = unbounded_channel();
+        let requests = RequestSender::new(tx);
+
+        // committed(0) < tip(100) fires the guard even though stored == tip.
+        // Because stored >= tip, send_pending is skipped (no downloads needed).
+        let _events = manager.handle_new_filter_headers(100, &requests).await.unwrap();
+
+        assert_eq!(manager.state(), SyncState::Syncing);
+        assert!(
+            manager.active_batches.contains_key(&0),
+            "expected lookahead batch at processing_height=0, got keys: {:?}",
+            manager.active_batches.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_new_filter_headers_skips_when_fully_committed() {
+        let mut manager = create_test_manager().await;
+
+        // Everything committed, stored, and at tip. No work to do.
+        manager.set_state(SyncState::Synced);
+        manager.progress.update_committed_height(100);
+        manager.progress.update_stored_height(100);
+        manager.progress.update_filter_header_tip_height(100);
+        manager.progress.update_target_height(1000);
+        manager.filter_pipeline.init(101, 100);
+
+        let (tx, _rx) = unbounded_channel();
+        let requests = RequestSender::new(tx);
+
+        let events = manager.handle_new_filter_headers(100, &requests).await.unwrap();
+
+        assert_eq!(manager.state(), SyncState::Synced);
+        assert!(events.is_empty());
+        assert!(manager.active_batches.is_empty());
     }
 }

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -423,7 +423,11 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         // Phase 2: Scan any ready batches where filters are available
         events.extend(self.scan_ready_batches().await?);
 
-        // Phase 3: Create lookahead batches up to MAX_LOOKAHEAD_BATCHES
+        // Phase 3: Commit newly scanned batches that are ready
+        // (avoids a one-tick delay between scan and commit for small batches)
+        events.extend(self.try_commit_batches().await?);
+
+        // Phase 4: Create lookahead batches up to MAX_LOOKAHEAD_BATCHES
         events.extend(self.try_create_lookahead_batches().await?);
 
         // If no active batches and all filters downloaded, emit FiltersSyncComplete.
@@ -2324,5 +2328,51 @@ mod tests {
         assert_eq!(manager.state(), SyncState::Synced);
         assert!(events.is_empty());
         assert!(manager.active_batches.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_try_process_batch_commits_after_scan_in_same_call() {
+        let mut manager = create_test_manager().await;
+
+        let headers = dashcore::block::Header::dummy_batch(0..101);
+        manager.header_storage.write().await.store_headers(&headers).await.unwrap();
+        {
+            let dummy_filter = BlockFilter::new(&[0u8; 32]);
+            let mut fs = manager.filter_storage.write().await;
+            for h in 0..=100 {
+                fs.store_filter(h, &dummy_filter.content).await.unwrap();
+            }
+        }
+
+        manager.set_state(SyncState::Syncing);
+        manager.progress.update_stored_height(100);
+        manager.progress.update_filter_header_tip_height(100);
+        manager.progress.update_committed_height(0);
+        manager.progress.update_target_height(100);
+        manager.processing_height = 0;
+
+        // Create a batch that has all filters stored but is not yet scanned.
+        // Phase 1 (commit) skips it because it's not scanned.
+        // Phase 2 (scan) marks it scanned.
+        // Phase 3 (second commit) commits it immediately.
+        let mut batch = FiltersBatch::new(0, 100, manager.load_filters(0, 100).await.unwrap());
+        batch.mark_verified();
+        manager.active_batches.insert(0, batch);
+
+        let events = manager.try_process_batch().await.unwrap();
+
+        // Batch was scanned and committed in a single try_process_batch call.
+        assert!(manager.active_batches.is_empty());
+        assert_eq!(manager.progress.committed_height(), 100);
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                SyncEvent::FiltersSyncComplete {
+                    tip_height: 100
+                }
+            )),
+            "expected FiltersSyncComplete, got {:?}",
+            events
+        );
     }
 }

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -1072,6 +1072,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_filter_header_tip_height_is_monotonic() {
+        let mut manager = create_test_manager().await;
+        manager.progress.update_filter_header_tip_height(500);
+        assert_eq!(manager.progress.filter_header_tip_height(), 500);
+
+        // Lower value is rejected
+        manager.progress.update_filter_header_tip_height(200);
+        assert_eq!(manager.progress.filter_header_tip_height(), 500);
+
+        // Equal value is rejected (no spurious activity bump)
+        manager.progress.update_filter_header_tip_height(500);
+        assert_eq!(manager.progress.filter_header_tip_height(), 500);
+
+        // Higher value is accepted
+        manager.progress.update_filter_header_tip_height(600);
+        assert_eq!(manager.progress.filter_header_tip_height(), 600);
+    }
+
+    #[tokio::test]
     async fn test_max_lookahead_constant() {
         // Verify the constant is set to expected value
         assert_eq!(MAX_LOOKAHEAD_BATCHES, 3);

--- a/dash-spv/src/sync/filters/pipeline.rs
+++ b/dash-spv/src/sync/filters/pipeline.rs
@@ -153,16 +153,32 @@ impl FiltersPipeline {
                 }
             };
 
-            // Get stop hash for this batch
-            let stop_hash = storage
-                .get_header(batch_end)
-                .await?
-                .ok_or_else(|| {
-                    SyncError::Storage(format!("Missing header at height {}", batch_end))
-                })?
-                .block_hash();
+            // Get stop hash for this batch. If the header isn't available yet,
+            // re-queue for the next tick instead of losing the batch permanently.
+            let header = match storage.get_header(batch_end).await {
+                Ok(Some(h)) => h,
+                Ok(None) => {
+                    tracing::debug!(
+                        "Header at height {} not yet available, re-queuing filter batch {}",
+                        batch_end,
+                        start_height
+                    );
+                    self.coordinator.enqueue([start_height]);
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Error reading header at height {}, re-queuing filter batch {}: {}",
+                        batch_end,
+                        start_height,
+                        e
+                    );
+                    self.coordinator.enqueue([start_height]);
+                    continue;
+                }
+            };
 
-            requests.request_filters(start_height, stop_hash)?;
+            requests.request_filters(start_height, header.block_hash())?;
 
             self.coordinator.mark_sent(&[start_height]);
 
@@ -1065,5 +1081,44 @@ mod tests {
             2500,
             "deferred batch should use its original end height"
         );
+    }
+
+    #[tokio::test]
+    async fn test_send_pending_requeues_on_missing_header() {
+        // Headers 0..999 exist, but NOT 1999 (stop hash for batch 1000-1999).
+        let headers = Header::dummy_batch(0..1000);
+        let tmp_dir = TempDir::new().unwrap();
+        let mut storage = PersistentBlockHeaderStorage::open(tmp_dir.path()).await.unwrap();
+        storage.store_headers(&headers).await.unwrap();
+
+        let mut pipeline = FiltersPipeline::new();
+        pipeline.init(0, 1999);
+        assert_eq!(pipeline.coordinator.pending_count(), 2);
+
+        let (sender, mut rx) = create_test_request_sender();
+
+        // Batch 0 succeeds (header 999 exists), batch 1000 re-queued (header 1999 missing)
+        let sent = pipeline.send_pending(&sender, &storage).await.unwrap();
+        assert_eq!(sent, 1);
+        assert_eq!(pipeline.coordinator.active_count(), 1);
+        assert_eq!(pipeline.coordinator.pending_count(), 1);
+
+        let request = rx.try_recv().unwrap();
+        match request {
+            NetworkRequest::SendMessage(NetworkMessage::GetCFilters(gcf)) => {
+                assert_eq!(gcf.start_height, 0);
+            }
+            other => panic!("Expected GetCFilters, got {:?}", other),
+        }
+        assert!(rx.try_recv().is_err(), "should not have sent second request");
+
+        // Store the missing headers and retry
+        let more_headers = Header::dummy_batch(1000..2000);
+        storage.store_headers(&more_headers).await.unwrap();
+
+        let sent = pipeline.send_pending(&sender, &storage).await.unwrap();
+        assert_eq!(sent, 1);
+        assert_eq!(pipeline.coordinator.active_count(), 2);
+        assert_eq!(pipeline.coordinator.pending_count(), 0);
     }
 }

--- a/dash-spv/src/sync/filters/progress.rs
+++ b/dash-spv/src/sync/filters/progress.rs
@@ -112,9 +112,12 @@ impl FiltersProgress {
     }
 
     /// Update the filter header tip height (called when new filter headers are stored).
+    /// Only updates if the new height is greater than the current tip (monotonic increase).
     pub fn update_filter_header_tip_height(&mut self, height: u32) {
-        self.filter_header_tip_height = height;
-        self.bump_last_activity();
+        if height > self.filter_header_tip_height {
+            self.filter_header_tip_height = height;
+            self.bump_last_activity();
+        }
     }
 
     /// Add a number to the downloaded counter.


### PR DESCRIPTION
- Use `committed_height` instead of `stored_height` in the `handle_new_filter_headers` guard so the manager detects uncommitted work after restart
- Make `filter_header_tip_height` monotonic to prevent `start_sync` from regressing the tip on reconnection
- Re-queue filter batches in `send_pending` when block headers are unavailable instead of permanently losing them
- Add second `try_commit_batches` pass after scan to eliminate one-tick delay for incremental updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Filter synchronization now gracefully handles missing headers instead of halting the sync process.

* **Improvements**
  * Enhanced batch processing efficiency during filter synchronization.
  * Improved state transition logic for filter header management.

* **Tests**
  * Extended test coverage for filter synchronization behavior and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/rust-dashcore/pull/754)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->