### PR TITLE
refactor(dash-spv): inline event logging into monitor tasks

### DIFF
--- a/dash-spv/src/client/event_handler.rs
+++ b/dash-spv/src/client/event_handler.rs
@@ -4,6 +4,7 @@
 //! consumers override to receive push-based event notifications. The monitoring
 //! infrastructure subscribes to internal channels and dispatches to the handler.
 
+use std::fmt::Display;
 use std::sync::Arc;
 
 use tokio::sync::{broadcast, mpsc, watch};
@@ -34,37 +35,13 @@ pub trait EventHandler: Send + Sync + 'static {
 /// No-op implementation for consumers that don't need event notifications.
 impl EventHandler for () {}
 
-/// Built-in handler that mirrors all events into `tracing` so consumers get
-/// log output once they install a tracing subscriber (e.g., via `init_logging`).
-///
-/// Attached automatically by `DashSpvClient::new` ahead of consumer-supplied
-/// handlers. To silence event logs without affecting other subscribers, set a
-/// per-target filter such as `dash_spv::client::event_handler=warn`.
-pub(crate) struct LoggingEventHandler;
-
-impl EventHandler for LoggingEventHandler {
-    fn on_sync_event(&self, event: &SyncEvent) {
-        tracing::info!("SyncEvent: {}", event.description());
-    }
-
-    fn on_network_event(&self, event: &NetworkEvent) {
-        tracing::info!("NetworkEvent: {}", event.description());
-    }
-
-    fn on_progress(&self, progress: &SyncProgress) {
-        tracing::info!("SyncProgress: {}", progress);
-    }
-
-    fn on_wallet_event(&self, event: &WalletEvent) {
-        tracing::info!("WalletEvent: {}", event.description());
-    }
-
-    fn on_error(&self, error: &str) {
-        tracing::error!("{}", error);
-    }
-}
-
 /// Spawns a task that monitors a broadcast channel and dispatches events to the handler.
+///
+/// Every received event is mirrored into `tracing::info!` as `"<name>: <event>"`
+/// before consumer handlers run, so installing a tracing subscriber is enough to
+/// get event log output. To silence event logs without affecting other
+/// subscribers, set a per-target filter such as
+/// `dash_spv::client::event_handler=warn`.
 ///
 /// On failure, the error message is sent via `on_failure` so the coordinator can report
 /// it as the single source of error handling.
@@ -77,7 +54,7 @@ pub(crate) fn spawn_broadcast_monitor<E, F>(
     dispatch_fn: F,
 ) -> JoinHandle<()>
 where
-    E: Clone + Send + 'static,
+    E: Clone + Display + Send + 'static,
     F: Fn(&dyn EventHandler, &E) + Send + 'static,
 {
     tokio::spawn(async move {
@@ -87,6 +64,7 @@ where
                 result = receiver.recv() => {
                     match result {
                         Ok(event) => {
+                            tracing::info!("{}: {}", name, event);
                             for handler in handlers.iter() {
                                 dispatch_fn(handler.as_ref(), &event);
                             }
@@ -116,7 +94,9 @@ where
 
 /// Spawns a task that monitors a watch channel for progress updates.
 ///
-/// Sends the initial progress value, then monitors for changes.
+/// Sends the initial progress value, then monitors for changes. Every value is
+/// mirrored into `tracing::info!` before consumer handlers run, matching
+/// `spawn_broadcast_monitor`'s behavior.
 pub(crate) fn spawn_progress_monitor(
     mut receiver: watch::Receiver<SyncProgress>,
     handlers: Arc<Vec<Arc<dyn EventHandler>>>,
@@ -126,8 +106,13 @@ pub(crate) fn spawn_progress_monitor(
     tokio::spawn(async move {
         tracing::debug!("Progress monitoring task started");
 
-        for handler in handlers.iter() {
-            handler.on_progress(&receiver.borrow_and_update());
+        {
+            let guard = receiver.borrow_and_update();
+            let progress: &SyncProgress = &guard;
+            tracing::info!("SyncProgress: {}", progress);
+            for handler in handlers.iter() {
+                handler.on_progress(progress);
+            }
         }
 
         loop {
@@ -135,8 +120,11 @@ pub(crate) fn spawn_progress_monitor(
                 result = receiver.changed() => {
                     match result {
                         Ok(()) => {
+                            let guard = receiver.borrow_and_update();
+                            let progress: &SyncProgress = &guard;
+                            tracing::info!("SyncProgress: {}", progress);
                             for handler in handlers.iter() {
-                                handler.on_progress(&receiver.borrow_and_update());
+                                handler.on_progress(progress);
                             }
                         }
                         Err(_) if shutdown.is_cancelled() => break,

--- a/dash-spv/src/client/lifecycle.rs
+++ b/dash-spv/src/client/lifecycle.rs
@@ -8,7 +8,6 @@
 //! - Genesis block initialization
 //! - Wallet data loading
 
-use super::event_handler::LoggingEventHandler;
 use super::{ClientConfig, DashSpvClient, EventHandler};
 use crate::chain::checkpoints::{mainnet_checkpoints, testnet_checkpoints, CheckpointManager};
 use crate::error::{Result, SpvError};
@@ -37,10 +36,6 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         wallet: Arc<RwLock<W>>,
         event_handlers: Vec<Arc<dyn EventHandler>>,
     ) -> Result<Self> {
-        let event_handlers: Vec<Arc<dyn EventHandler>> =
-            std::iter::once(Arc::new(LoggingEventHandler) as Arc<dyn EventHandler>)
-                .chain(event_handlers)
-                .collect();
         // Validate configuration
         config.validate().map_err(SpvError::Config)?;
 

--- a/dash-spv/src/client/mod.rs
+++ b/dash-spv/src/client/mod.rs
@@ -76,28 +76,4 @@ mod tests {
         let wallet_ref = client.wallet();
         let _wallet_guard = wallet_ref.read().await;
     }
-
-    #[tokio::test]
-    async fn client_attaches_builtin_logging_handler() {
-        let config = ClientConfig::mainnet()
-            .without_filters()
-            .without_masternodes()
-            .with_mempool_tracking(MempoolStrategy::FetchAll)
-            .with_storage_path(TempDir::new().unwrap().path());
-
-        let network_manager = MockNetworkManager::new();
-        let storage =
-            DiskStorageManager::with_temp_dir().await.expect("Failed to create tmp storage");
-        let wallet = Arc::new(RwLock::new(WalletManager::<ManagedWalletInfo>::new(config.network)));
-
-        let client = DashSpvClient::new(config, network_manager, storage, wallet, Vec::new())
-            .await
-            .expect("client construction must succeed");
-
-        assert_eq!(
-            client.event_handlers.len(),
-            1,
-            "constructor should auto-attach the built-in logging handler",
-        );
-    }
 }

--- a/dash-spv/src/client/sync_coordinator.rs
+++ b/dash-spv/src/client/sync_coordinator.rs
@@ -40,7 +40,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         let wallet_event_rx = self.wallet.read().await.subscribe_events();
 
         let sync_task = spawn_broadcast_monitor(
-            "Sync event",
+            "SyncEvent",
             sync_event_rx,
             handlers.clone(),
             monitor_shutdown.clone(),
@@ -49,7 +49,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         );
 
         let network_task = spawn_broadcast_monitor(
-            "Network event",
+            "NetworkEvent",
             network_event_rx,
             handlers.clone(),
             monitor_shutdown.clone(),
@@ -58,7 +58,7 @@ impl<W: WalletInterface, N: NetworkManager, S: StorageManager> DashSpvClient<W, 
         );
 
         let wallet_task = spawn_broadcast_monitor(
-            "Wallet event",
+            "WalletEvent",
             wallet_event_rx,
             handlers.clone(),
             monitor_shutdown.clone(),

--- a/dash-spv/src/network/event.rs
+++ b/dash-spv/src/network/event.rs
@@ -4,6 +4,7 @@
 //! need to react to, such as peer connections and disconnections.
 
 use dashcore::prelude::CoreBlockHeight;
+use std::fmt;
 use std::net::SocketAddr;
 
 /// Events emitted by the network layer.
@@ -63,5 +64,11 @@ impl NetworkEvent {
                 )
             }
         }
+    }
+}
+
+impl fmt::Display for NetworkEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.description())
     }
 }

--- a/dash-spv/src/sync/events.rs
+++ b/dash-spv/src/sync/events.rs
@@ -5,6 +5,7 @@ use dashcore::sml::masternode_list_engine::QRInfoFeedResult;
 use dashcore::{Address, BlockHash, Txid};
 use key_wallet_manager::{FilterMatchKey, WalletId};
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 
 /// Events that managers can emit and subscribe to.
 ///
@@ -275,5 +276,11 @@ impl SyncEvent {
                 format!("SyncComplete(tip={}, cycle={})", header_tip, cycle)
             }
         }
+    }
+}
+
+impl fmt::Display for SyncEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.description())
     }
 }

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -5,6 +5,7 @@
 //! persist the transaction(s) and balance atomically off a single event.
 
 use std::collections::BTreeMap;
+use std::fmt;
 
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::prelude::CoreBlockHeight;
@@ -349,6 +350,12 @@ impl WalletEvent {
                 format!("SyncHeightAdvanced(height={})", height)
             }
         }
+    }
+}
+
+impl fmt::Display for WalletEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.description())
     }
 }
 


### PR DESCRIPTION
Drop `LoggingEventHandler` and the auto-prepend in `DashSpvClient::new`. Instead, have `spawn_broadcast_monitor` log every received event via `tracing::info!("{}: {}", name, event)` before consumer handlers run, and have `spawn_progress_monitor` log progress directly alongside its `on_progress` dispatch. Add `Display` impls on `SyncEvent`, `NetworkEvent`, and `WalletEvent` that delegate to their existing `description()` so the helper can format generically with an `E: Display` bound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Built-in event logging integrated directly into monitoring services for sync, network, and wallet activities, improving consistency and performance.
  * Event display formatting standardized across all event types for more uniform logging output.
  * Monitor labels enhanced for improved clarity in system diagnostics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/rust-dashcore/pull/757)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->