### PR TITLE
refactor(dash-spv): drop `description()`, use `Display` for events

### DIFF
--- a/dash-spv/src/network/event.rs
+++ b/dash-spv/src/network/event.rs
@@ -38,37 +38,25 @@ pub enum NetworkEvent {
     },
 }
 
-impl NetworkEvent {
-    /// Get a short description of this event for logging.
-    pub fn description(&self) -> String {
+impl fmt::Display for NetworkEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             NetworkEvent::PeerConnected {
                 address,
-            } => {
-                format!("PeerConnected({})", address)
-            }
+            } => write!(f, "PeerConnected({})", address),
             NetworkEvent::PeerDisconnected {
                 address,
-            } => {
-                format!("PeerDisconnected({})", address)
-            }
+            } => write!(f, "PeerDisconnected({})", address),
             NetworkEvent::PeersUpdated {
                 connected_count,
                 addresses: _,
                 best_height,
-            } => {
-                format!(
-                    "PeersUpdated(connected={}, best_height={})",
-                    connected_count,
-                    best_height.unwrap_or(0)
-                )
-            }
+            } => write!(
+                f,
+                "PeersUpdated(connected={}, best_height={})",
+                connected_count,
+                best_height.unwrap_or(0)
+            ),
         }
-    }
-}
-
-impl fmt::Display for NetworkEvent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.description())
     }
 }

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -1089,7 +1089,7 @@ impl PeerNetworkManager {
                     event = network_events.recv() => {
                         match event {
                             Ok(event) => {
-                                tracing::debug!("Network event in maintenance loop: {}", event.description());
+                                tracing::debug!("Network event in maintenance loop: {}", event);
                                 dns_interval.reset();
                                 this.maintenance_tick().await;
                             }

--- a/dash-spv/src/sync/events.rs
+++ b/dash-spv/src/sync/events.rs
@@ -178,66 +178,54 @@ pub enum SyncEvent {
     },
 }
 
-impl SyncEvent {
-    /// Get a short description of this event for logging.
-    pub fn description(&self) -> String {
+impl fmt::Display for SyncEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SyncEvent::SyncStart {
                 identifier,
-            } => {
-                format!("SyncStart(identifier={})", identifier)
-            }
+            } => write!(f, "SyncStart(identifier={})", identifier),
             SyncEvent::BlockHeadersStored {
                 tip_height,
-            } => {
-                format!("BlockHeadersStored(tip={})", tip_height)
-            }
+            } => write!(f, "BlockHeadersStored(tip={})", tip_height),
             SyncEvent::BlockHeaderSyncComplete {
                 tip_height,
-            } => {
-                format!("BlockHeaderSyncComplete(tip={})", tip_height)
-            }
+            } => write!(f, "BlockHeaderSyncComplete(tip={})", tip_height),
             SyncEvent::FilterHeadersStored {
                 start_height,
                 end_height,
                 tip_height,
-            } => {
-                format!("FilterHeadersStored({}-{}, tip={})", start_height, end_height, tip_height)
-            }
+            } => write!(
+                f,
+                "FilterHeadersStored({}-{}, tip={})",
+                start_height, end_height, tip_height
+            ),
             SyncEvent::FilterHeadersSyncComplete {
                 tip_height,
-            } => {
-                format!("FilterHeadersSyncComplete(tip={})", tip_height)
-            }
+            } => write!(f, "FilterHeadersSyncComplete(tip={})", tip_height),
             SyncEvent::FiltersStored {
                 start_height,
                 end_height,
-            } => {
-                format!("FiltersStored({}-{})", start_height, end_height)
-            }
+            } => write!(f, "FiltersStored({}-{})", start_height, end_height),
             SyncEvent::FiltersSyncComplete {
                 tip_height,
-            } => {
-                format!("FiltersSyncComplete(tip={})", tip_height)
-            }
+            } => write!(f, "FiltersSyncComplete(tip={})", tip_height),
             SyncEvent::BlocksNeeded {
                 blocks,
-            } => {
-                format!("BlocksNeeded(count={})", blocks.len())
-            }
+            } => write!(f, "BlocksNeeded(count={})", blocks.len()),
             SyncEvent::BlockProcessed {
                 height,
                 new_addresses,
                 ..
             } => {
                 let total: usize = new_addresses.values().map(|v| v.len()).sum();
-                format!("BlockProcessed(height={}, new_addrs={})", height, total)
+                write!(f, "BlockProcessed(height={}, new_addrs={})", height, total)
             }
             SyncEvent::MasternodeStateUpdated {
                 height,
                 qr_info_result,
             } => match qr_info_result {
-                Some(s) => format!(
+                Some(s) => write!(
+                    f,
                     "MasternodeStateUpdated(height={}, qr_info={{stored_cycle_height={:?}, verified={}/{}, newly_qualified={}}})",
                     height,
                     s.stored_cycle_height,
@@ -245,42 +233,33 @@ impl SyncEvent {
                     s.rotated_quorum_count,
                     s.newly_qualified_count,
                 ),
-                None => format!("MasternodeStateUpdated(height={})", height),
+                None => write!(f, "MasternodeStateUpdated(height={})", height),
             },
             SyncEvent::ManagerError {
                 manager,
                 error,
                 ..
-            } => {
-                format!("ManagerError({}, {})", manager, error)
-            }
+            } => write!(f, "ManagerError({}, {})", manager, error),
             SyncEvent::ChainLockReceived {
                 chain_lock,
                 validated,
-            } => {
-                format!(
-                    "ChainLockReceived(height={}, validated={})",
-                    chain_lock.block_height, validated
-                )
-            }
+            } => write!(
+                f,
+                "ChainLockReceived(height={}, validated={})",
+                chain_lock.block_height, validated
+            ),
             SyncEvent::InstantLockReceived {
                 instant_lock,
                 validated,
-            } => {
-                format!("InstantLockReceived(txid={}, validated={})", instant_lock.txid, validated)
-            }
+            } => write!(
+                f,
+                "InstantLockReceived(txid={}, validated={})",
+                instant_lock.txid, validated
+            ),
             SyncEvent::SyncComplete {
                 header_tip,
                 cycle,
-            } => {
-                format!("SyncComplete(tip={}, cycle={})", header_tip, cycle)
-            }
+            } => write!(f, "SyncComplete(tip={}, cycle={})", header_tip, cycle),
         }
-    }
-}
-
-impl fmt::Display for SyncEvent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.description())
     }
 }

--- a/dash-spv/src/sync/sync_manager.rs
+++ b/dash-spv/src/sync/sync_manager.rs
@@ -241,7 +241,7 @@ pub trait SyncManager: Send + Sync + std::fmt::Debug {
                         Ok(events) => {
                             if !events.is_empty() {
                                 for event in &events {
-                                    tracing::debug!("{} emitting: {}", identifier, event.description());
+                                    tracing::debug!("{} emitting: {}", identifier, event);
                                 }
                                 context.emit_sync_events(events);
                             }
@@ -261,13 +261,13 @@ pub trait SyncManager: Send + Sync + std::fmt::Debug {
                 result = sync_event_receiver.recv() => {
                     match result {
                         Ok(event) => {
-                            tracing::trace!("{} received event: {}", identifier, event.description());
+                            tracing::trace!("{} received event: {}", identifier, event);
                             let progress_before = self.progress();
                             match self.handle_sync_event(&event, &context.requests).await {
                                 Ok(events) => {
                                     if !events.is_empty() {
                                         for e in &events {
-                                            tracing::trace!("{} emitting: {}", identifier, e.description());
+                                            tracing::trace!("{} emitting: {}", identifier, e);
                                         }
                                         context.emit_sync_events(events);
                                     }
@@ -288,13 +288,13 @@ pub trait SyncManager: Send + Sync + std::fmt::Debug {
                 result = context.network_event_receiver.recv() => {
                     match result {
                         Ok(event) => {
-                            tracing::debug!("{} received network event: {}", identifier, event.description());
+                            tracing::debug!("{} received network event: {}", identifier, event);
                             let progress_before = self.progress();
                             match self.handle_network_event(&event, &context.requests).await {
                                 Ok(events) => {
                                     if !events.is_empty() {
                                         for e in &events {
-                                            tracing::debug!("{} emitting: {}", identifier, e.description());
+                                            tracing::debug!("{} emitting: {}", identifier, e);
                                         }
                                         context.emit_sync_events(events);
                                     }

--- a/dash-spv/tests/dashd_masternode/helpers.rs
+++ b/dash-spv/tests/dashd_masternode/helpers.rs
@@ -313,7 +313,7 @@ pub(super) async fn wait_for_wallet_txs_chainlocked(
                         }
                     }
                     Ok(other) => {
-                        tracing::debug!("Ignoring wallet event: {}", other.description());
+                        tracing::debug!("Ignoring wallet event: {}", other);
                     }
                     Err(err) => {
                         panic!("Wallet event receiver failed: {}", err);
@@ -376,7 +376,7 @@ pub(super) async fn wait_for_wallet_tx_chainlocked(
                             .unwrap_or_default();
                     }
                     Ok(other) => {
-                        tracing::debug!("Ignoring wallet event: {}", other.description());
+                        tracing::debug!("Ignoring wallet event: {}", other);
                         continue;
                     }
                     Err(err) => {
@@ -436,7 +436,7 @@ where
                         continue;
                     }
                     Ok(other) => {
-                        tracing::debug!("Ignoring wallet event: {}", other.description());
+                        tracing::debug!("Ignoring wallet event: {}", other);
                         continue;
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {

--- a/dash-spv/tests/dashd_sync/helpers.rs
+++ b/dash-spv/tests/dashd_sync/helpers.rs
@@ -293,7 +293,7 @@ pub(super) async fn run_disconnect_loop(
                             tracing::info!(
                                 "Disconnection {}: disconnecting peers after: {}",
                                 disconnect_count + 1,
-                                event.description()
+                                event
                             );
                             let pre_disconnect_height = current_header_height(&client_handle);
                             node.disconnect_all_peers();

--- a/dash-spv/tests/dashd_sync/tests_restart.rs
+++ b/dash-spv/tests/dashd_sync/tests_restart.rs
@@ -127,11 +127,11 @@ async fn test_sync_with_multiple_restarts() {
                         Ok(ref event) if is_progress_event(event) => {
                             events_seen += 1;
                             if events_seen % 2 == 0 {
-                                tracing::info!("Restarting on: {}", event.description());
+                                tracing::info!("Restarting on: {}", event);
                                 should_restart = true;
                                 break;
                             }
-                            tracing::info!("Skipped: {}", event.description());
+                            tracing::info!("Skipped: {}", event);
                         }
                         Ok(SyncEvent::SyncComplete { .. }) => break,
                         Ok(_) => continue,

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -332,9 +332,10 @@ impl WalletEvent {
             } => *wallet_id,
         }
     }
+}
 
-    /// Short description for logging.
-    pub fn description(&self) -> String {
+impl fmt::Display for WalletEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             WalletEvent::TransactionDetected {
                 record,
@@ -342,29 +343,27 @@ impl WalletEvent {
                 account_balances,
                 addresses_derived,
                 ..
-            } => {
-                format!(
-                    "TransactionDetected(txid={}, context={}, balance={}, account_balances={}, derived={})",
-                    record.txid,
-                    record.context,
-                    balance,
-                    format_account_balances(account_balances),
-                    addresses_derived.len(),
-                )
-            }
+            } => write!(
+                f,
+                "TransactionDetected(txid={}, context={}, balance={}, account_balances={}, derived={})",
+                record.txid,
+                record.context,
+                balance,
+                format_account_balances(account_balances),
+                addresses_derived.len(),
+            ),
             WalletEvent::TransactionInstantLocked {
                 txid,
                 balance,
                 account_balances,
                 ..
-            } => {
-                format!(
-                    "TransactionInstantLocked(txid={}, balance={}, account_balances={})",
-                    txid,
-                    balance,
-                    format_account_balances(account_balances),
-                )
-            }
+            } => write!(
+                f,
+                "TransactionInstantLocked(txid={}, balance={}, account_balances={})",
+                txid,
+                balance,
+                format_account_balances(account_balances),
+            ),
             WalletEvent::BlockProcessed {
                 height,
                 chain_lock,
@@ -375,24 +374,23 @@ impl WalletEvent {
                 account_balances,
                 addresses_derived,
                 ..
-            } => {
-                format!(
-                    "BlockProcessed(height={}, chainlocked={}, inserted={}, updated={}, matured={}, balance={}, account_balances={}, derived={})",
-                    height,
+            } => write!(
+                f,
+                "BlockProcessed(height={}, chainlocked={}, inserted={}, updated={}, matured={}, balance={}, account_balances={}, derived={})",
+                height,
                     chain_lock.is_some(),
-                    inserted.len(),
-                    updated.len(),
-                    matured.len(),
-                    balance,
-                    format_account_balances(account_balances),
-                    addresses_derived.len(),
-                )
-            }
+                inserted.len(),
+                updated.len(),
+                matured.len(),
+                balance,
+                format_account_balances(account_balances),
+                addresses_derived.len(),
+            ),
             WalletEvent::SyncHeightAdvanced {
                 height,
                 ..
             } => {
-                format!("SyncHeightAdvanced(height={})", height)
+                write!(f, "SyncHeightAdvanced(height={})", height)
             }
             WalletEvent::TransactionsChainlocked {
                 chain_lock,
@@ -400,7 +398,7 @@ impl WalletEvent {
                 ..
             } => {
                 let total_txids: usize = per_account.values().map(|v| v.len()).sum();
-                format!(
+                write!(f,
                     "TransactionsChainlocked(chainlock_height={}, accounts={}, finalized_txids={})",
                     chain_lock.block_height,
                     per_account.len(),
@@ -408,12 +406,6 @@ impl WalletEvent {
                 )
             }
         }
-    }
-}
-
-impl fmt::Display for WalletEvent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.description())
     }
 }
 


### PR DESCRIPTION
Fold the inherent `description() -> String` methods on `SyncEvent`, `NetworkEvent`, and `WalletEvent` into their `Display::fmt` bodies, and update every caller to format the event directly (`{event}` instead of `{event.description()}`). `write!` replaces the per-arm `format!` to avoid the intermediate `String` allocation.

Output is byte-for-byte identical. No new public API, just the existing `Display` impl carrying the formatting instead of a parallel inherent method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated and standardized event logging formatting across network, synchronization, and wallet management modules to improve code consistency and maintainability.
  * Refactored event rendering implementations throughout the codebase to eliminate redundancy and enhance overall code organization.
  * No functional changes or impacts to user-facing features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/rust-dashcore/pull/758)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->