### PR TITLE
feat(key-wallet,key-wallet-manager): add serde derives for AssetLockFundingType and DerivedAddress

### DIFF
--- a/key-wallet-manager/Cargo.toml
+++ b/key-wallet-manager/Cargo.toml
@@ -10,6 +10,7 @@ license = "CC0-1.0"
 [features]
 default = []
 parallel-filters = ["dep:rayon"]
+serde = ["dep:serde", "key-wallet/serde", "dashcore/serde"]
 bincode = ["key-wallet/bincode", "dep:bincode"]
 test-utils = ["key-wallet/test-utils"]
 bls = ["key-wallet/bls"]
@@ -31,6 +32,7 @@ tracing = "0.1"
 zeroize = { version = "1.8", features = ["derive"] }
 rayon = { version = "1.11", optional = true }
 bincode = { version = "2.0.1", optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 key-wallet = { path = "../key-wallet", features = ["test-utils", "bincode"] }

--- a/key-wallet-manager/src/events.rs
+++ b/key-wallet-manager/src/events.rs
@@ -29,6 +29,7 @@ use crate::WalletId;
 /// stand-alone event) is what lets consumers store
 /// `Wallet → Account → CoreAddress → Txo` without breaking the
 /// `CoreAddress` link for UTXOs landing on freshly derived addresses.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DerivedAddress {
     /// The account that derived this address.

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -20,6 +20,7 @@ use crate::wallet::Wallet;
 use crate::DerivationPath;
 
 /// Which funding account to derive the one-time key from.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssetLockFundingType {
     /// Identity registration: m/9'/coinType'/5'/0'/index'


### PR DESCRIPTION
## What this PR does

Adds optional serde derives behind a `serde` feature gate on two types:

- `key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockFundingType` (enum)
- `key_wallet_manager::DerivedAddress` (struct)

`key-wallet` already had a `serde` feature — just the derive line was added. `key-wallet-manager` had no `serde` feature, so this PR also adds one: optional `serde` dep, `[features] serde = ["dep:serde", "key-wallet/serde", "dashcore/serde"]`.

`DerivedAddress::public_key: [u8; 33]` needs a tiny local `with =` adapter (`serde_pubkey33`) because `serde` only ships built-in array impls up to length 32. The adapter writes a flat 33-element byte sequence — same shape `serde` would have produced for `[u8; 32]` — and the new `derived_address_serde_json_roundtrip` test locks that in.

## Why

Downstream consumers in `dashpay/platform` (specifically PR #3637 — `rs-platform-wallet` serde support) currently work around these missing derives:

1. A custom `serde_adapters::asset_lock_funding_type` module re-implements derive-equivalent serialization with a stable `u8` wire-tag. Once this PR lands, the adapter becomes deletable (with one caveat the platform PR will resolve: wire-tag stability for pre-serde on-disk blobs).
2. The `PlatformAddressChangeSet::addresses_derived` field is `#[serde(skip)]` because `DerivedAddress` can't be serialized through. Once this PR lands, the skip can be removed and the field can round-trip normally.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo check -p key-wallet --no-default-features` and `--features serde` both pass
- `cargo check -p key-wallet-manager --no-default-features` and `--features serde` both pass
- `cargo clippy -p key-wallet -p key-wallet-manager --tests --all-features --no-deps -- -D warnings` clean
- `cargo test -p key-wallet -p key-wallet-manager --features serde` — 557 tests pass (includes the new round-trip)

## Companion PR

dashpay/platform#3637 will pick up these derives once this lands; the platform PR is currently working around their absence.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional serialization support for wallet data structures via a new feature.

* **Tests**
  * Added JSON serialization/deserialization round-trip tests.

* **Chores**
  * Introduced feature wiring and development dependency updates to support optional serialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/rust-dashcore/pull/761)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->