### PR TITLE
test: return chainlock height from `wait_for_wallet_tx_chainlocked`

### DIFF
--- a/dash-spv/tests/dashd_masternode/helpers.rs
+++ b/dash-spv/tests/dashd_masternode/helpers.rs
@@ -358,22 +358,17 @@ pub(super) async fn wait_for_wallet_tx_chainlocked(
                         return chain_lock.block_height;
                     }
                     Ok(WalletEvent::BlockProcessed {
-                        chain_lock: Some(_),
+                        chain_lock: Some(cl),
                         inserted,
                         updated,
                         ..
                     }) if inserted.iter().chain(updated.iter()).any(|r| r.txid == txid) =>
                     {
                         tracing::info!(
-                            "Wallet BlockProcessed(chainlocked, txid={})",
-                            txid
+                            "Wallet BlockProcessed(chainlock_height={}, txid={})",
+                            cl.block_height, txid
                         );
-                        return inserted
-                            .iter()
-                            .chain(updated.iter())
-                            .find(|r| r.txid == txid)
-                            .and_then(|r| r.context.block_info().map(|i| i.height()))
-                            .unwrap_or_default();
+                        return cl.block_height;
                     }
                     Ok(other) => {
                         tracing::debug!("Ignoring wallet event: {}", other.description());


### PR DESCRIPTION
The helper's `BlockProcessed { chain_lock: Some(_), .. }` branch returned the tx's own block height instead of the chainlock's height, which broke `test_chainlock_promotes_in_block_tx` whenever the SPV client processed the tx's block after the chainlock had already arrived (the common ordering when filter sync runs ahead of block delivery). In that case the wallet emits `BlockProcessed` with the chainlock attached, the helper returned the tx block height, and the test's `promoted_at >= cl_height` assertion failed even though the tx was correctly chainlocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved wallet transaction chain lock verification in test infrastructure for enhanced reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/rust-dashcore/pull/766)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->