### PR TITLE
ci: stop caching `~/.cargo/bin`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,6 +38,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "test-${{ inputs.os }}-${{ matrix.group }}"
+          prefix-key: "v1-rust"
+          cache-bin: false
 
       - name: Install cargo-llvm-cov
         if: inputs.coverage


### PR DESCRIPTION
`Swatinem/rust-cache@v2` defaults to `cache-bin: true`, which caches `~/.cargo/bin`. On macOS aarch64 the rustup proxies are hardlinks to a single binary, and after a partial (prefix-match) cache restore `cargo` can end up pointing to the `rustup-init` installer instead of the rustup proxy, making every `cargo test` invocation fail with `error: unexpected argument 'test' found`.

Disable bin caching so the toolchain is always reinstalled by `dtolnay/rust-toolchain@stable`. Bump `prefix-key` to `v1-rust` to invalidate the existing poisoned caches, since GitHub Actions cache rejects saves to an existing key and prefix-match restore would otherwise keep pulling the bad tar.


Fixes failures like: https://github.com/dashpay/rust-dashcore/actions/runs/25866537968/job/76010036327?pr=761