### PR TITLE
fix(dash-spv): handle buffered sync events during `WaitingForConnections`

### DIFF
--- a/dash-spv/src/sync/chainlock/manager.rs
+++ b/dash-spv/src/sync/chainlock/manager.rs
@@ -336,6 +336,31 @@ mod tests {
         assert_eq!(manager.wanted_message_types(), vec![MessageType::CLSig, MessageType::Inv]);
     }
 
+    /// Buffered `MasternodeStateUpdated` events delivered during
+    /// `WaitingForConnections` must not force a `Synced` transition.
+    /// `MasternodesManager` re-emits the event once it completes its next
+    /// sync cycle after reconnect, so dropping it here is safe.
+    #[tokio::test]
+    async fn test_handle_sync_event_drops_masternode_state_updated_in_waiting_for_connections() {
+        use crate::network::RequestSender;
+        use crate::sync::SyncEvent;
+        use tokio::sync::mpsc::unbounded_channel;
+
+        let mut manager = create_test_manager().await;
+        manager.set_state(SyncState::WaitingForConnections);
+
+        let event = SyncEvent::MasternodeStateUpdated {
+            height: 100,
+            qr_info_result: None,
+        };
+        let (tx, _rx) = unbounded_channel();
+        let events = manager.handle_sync_event(&event, &RequestSender::new(tx)).await.unwrap();
+
+        assert!(events.is_empty());
+        assert_eq!(manager.state(), SyncState::WaitingForConnections);
+        assert!(!manager.masternode_ready);
+    }
+
     #[tokio::test]
     async fn test_chainlock_skips_validation_before_masternode_ready() {
         let mut manager = create_test_manager().await;

--- a/dash-spv/src/sync/chainlock/sync_manager.rs
+++ b/dash-spv/src/sync/chainlock/sync_manager.rs
@@ -80,8 +80,15 @@ impl<H: BlockHeaderStorage, M: MetadataStorage> SyncManager for ChainLockManager
     ) -> SyncResult<Vec<SyncEvent>> {
         // `MasternodeStateUpdated` fires on every MnListDiff / QRInfo
         // update; the work below is strictly one-shot startup work, so
-        // gate the entire branch on the not-ready transition.
-        if !matches!(event, SyncEvent::MasternodeStateUpdated { .. }) || self.masternode_ready {
+        // gate the entire branch on the not-ready transition. Also drop
+        // buffered events that arrive between `stop_sync` and the next
+        // `start_sync`, otherwise the one-shot would force `Synced` while
+        // peerless. `MasternodeStateUpdated` re-fires once `MasternodesManager`
+        // completes a sync cycle after reconnect.
+        if !matches!(event, SyncEvent::MasternodeStateUpdated { .. })
+            || self.masternode_ready
+            || self.state() == SyncState::WaitingForConnections
+        {
             return Ok(vec![]);
         }
 

--- a/dash-spv/src/sync/instantsend/manager.rs
+++ b/dash-spv/src/sync/instantsend/manager.rs
@@ -316,6 +316,30 @@ mod tests {
         assert_eq!(manager.wanted_message_types(), vec![MessageType::ISLock, MessageType::Inv]);
     }
 
+    /// Buffered `MasternodeStateUpdated` events delivered during
+    /// `WaitingForConnections` must not run validation or transition state.
+    /// `pending_instantlocks` is cleared on disconnect and
+    /// `MasternodesManager` re-emits the event after reconnect.
+    #[tokio::test]
+    async fn test_handle_sync_event_drops_masternode_state_updated_in_waiting_for_connections() {
+        use crate::network::RequestSender;
+        use crate::sync::SyncEvent;
+        use tokio::sync::mpsc::unbounded_channel;
+
+        let mut manager = create_test_manager();
+        manager.set_state(SyncState::WaitingForConnections);
+
+        let event = SyncEvent::MasternodeStateUpdated {
+            height: 100,
+            qr_info_result: None,
+        };
+        let (tx, _rx) = unbounded_channel();
+        let events = manager.handle_sync_event(&event, &RequestSender::new(tx)).await.unwrap();
+
+        assert!(events.is_empty());
+        assert_eq!(manager.state(), SyncState::WaitingForConnections);
+    }
+
     #[tokio::test]
     async fn test_instantsend_duplicate_handling() {
         let mut manager = create_test_manager();

--- a/dash-spv/src/sync/instantsend/sync_manager.rs
+++ b/dash-spv/src/sync/instantsend/sync_manager.rs
@@ -62,6 +62,14 @@ impl SyncManager for InstantSendManager {
         event: &SyncEvent,
         _requests: &RequestSender,
     ) -> SyncResult<Vec<SyncEvent>> {
+        // Drop buffered events that arrive between `stop_sync` and the next
+        // `start_sync`. `pending_instantlocks` is cleared on disconnect, and
+        // `MasternodesManager` re-emits `MasternodeStateUpdated` once it
+        // completes a sync cycle after reconnect.
+        if self.state() == SyncState::WaitingForConnections {
+            return Ok(vec![]);
+        }
+
         // Validate pending InstantLocks when masternode state is updated
         if let SyncEvent::MasternodeStateUpdated {
             ..

--- a/dash-spv/src/sync/masternodes/manager.rs
+++ b/dash-spv/src/sync/masternodes/manager.rs
@@ -528,11 +528,6 @@ impl<H: BlockHeaderStorage> MasternodesManager<H> {
             return Ok(vec![]);
         }
 
-        // Only transition to Syncing if not already Synced (incremental updates stay Synced)
-        if self.state() != SyncState::Synced {
-            self.set_state(SyncState::Syncing);
-        }
-
         let base_hashes = {
             let engine = self.engine.read().await;
             match compute_qrinfo_anchor_hash(&engine, self.network, tip_height) {
@@ -546,11 +541,19 @@ impl<H: BlockHeaderStorage> MasternodesManager<H> {
             tip_height,
             base_hashes.len()
         );
+        // Send before mutating state. If the request errors (e.g. no peers
+        // connected during a reconnect race), the `?` propagates and we leave
+        // `WaitingForConnections` intact instead of stranding the manager in
+        // `Syncing` with `qrinfo_in_flight = None`, which `tick` cannot recover.
         requests.request_qr_info(base_hashes, tip_block_hash, true)?;
         self.progress.add_qr_infos_requested(1);
         self.sync_state.record_qrinfo_attempt(tip_height);
-
         self.sync_state.start_waiting_for_qrinfo(tip_block_hash);
+
+        // Only transition to Syncing if not already Synced (incremental updates stay Synced)
+        if self.state() != SyncState::Synced {
+            self.set_state(SyncState::Syncing);
+        }
 
         Ok(vec![])
     }
@@ -956,6 +959,28 @@ mod tests {
             "the queued request must be a `GetQRInfo`, got {:?}",
             queued
         );
+    }
+
+    /// `send_qrinfo_for_tip` must not strand the manager in `Syncing` when
+    /// the network send fails. A buffered `BlockHeaderSyncComplete` consumed
+    /// during `WaitingForConnections` reaches `send_qrinfo_for_tip` while no
+    /// peers are connected. If state transitions before the failing send,
+    /// `tick` cannot recover because it gates on `qrinfo_in_flight.is_some()`.
+    #[tokio::test]
+    async fn test_send_qrinfo_for_tip_preserves_state_when_send_fails() {
+        let (mut manager, requests, rx) = make_synced_incremental_manager(70).await;
+        manager.set_state(SyncState::WaitingForConnections);
+        drop(rx);
+
+        let err = manager
+            .send_qrinfo_for_tip(&requests)
+            .await
+            .expect_err("send must fail when the receiver is dropped");
+        assert!(matches!(err, SyncError::Network(_)), "expected Network error, got {:?}", err);
+
+        assert_eq!(manager.state(), SyncState::WaitingForConnections);
+        assert!(manager.sync_state.qrinfo_in_flight.is_none());
+        assert_eq!(manager.progress.qr_infos_requested(), 0);
     }
 
     /// When the cycle gate picks `Incremental` after an `Incremental`


### PR DESCRIPTION
Three independent fixes for a class of races where sync events buffered in the broadcast channel get delivered to a manager while it sits in `SyncState::WaitingForConnections` (between `stop_sync` and the next `start_sync`).

- `MasternodesManager::send_qrinfo_for_tip` no longer mutates state before the network send. On `Err("No connected peers")` the manager stays in `WaitingForConnections` instead of getting stranded in `Syncing` with `qrinfo_in_flight = None` (which `tick` cannot recover).
- `ChainLockManager::handle_sync_event` drops buffered `MasternodeStateUpdated` events while in `WaitingForConnections`. Prevents a peerless `Synced` transition. The event re-fires after reconnect via `verify_and_complete` / `complete_incremental_pipeline`.
- `InstantSendManager::handle_sync_event` drops events the same way. Avoids running `validate_pending` against state that `on_disconnect` already cleared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization state management when establishing connections to prevent invalid state transitions.
  * Fixed handling of buffered sync events that could cause the manager to enter incorrect states between connection cycles.
  * Enhanced error recovery in network requests to maintain proper sync state when operations fail.

* **Tests**
  * Added tests verifying correct sync behavior during connection establishment phases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/rust-dashcore/pull/768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->