### PR TITLE
feat(key-wallet): make gap limits configurable at account creation

### DIFF
--- a/key-wallet/src/gap_limit.rs
+++ b/key-wallet/src/gap_limit.rs
@@ -10,23 +10,57 @@ use core::cmp;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-/// Standard gap limit for external addresses (BIP44 recommendation)
-pub const DEFAULT_EXTERNAL_GAP_LIMIT: u32 = 30;
-
-/// Standard gap limit for internal (change) addresses
-pub const DEFAULT_INTERNAL_GAP_LIMIT: u32 = 30;
-
-/// Standard gap limit for CoinJoin addresses
-pub const DEFAULT_COINJOIN_GAP_LIMIT: u32 = 30;
-
-/// Standard gap limit for special purpose keys (identity, provider keys)
-pub const DEFAULT_SPECIAL_GAP_LIMIT: u32 = 5;
-
-/// Gap limit for DIP-17 platform payment addresses
-pub const DIP17_GAP_LIMIT: u32 = 20;
+/// Default gap limit applied to every address pool (BIP44 recommendation is
+/// 20, this library uses a more conservative 30). Used for external, internal,
+/// and every single-pool account type unless overridden via
+/// [`AccountGapConfig`].
+pub const DEFAULT_GAP_LIMIT: u32 = 30;
 
 /// Maximum gap limit to prevent excessive address generation
 pub const MAX_GAP_LIMIT: u32 = 1000;
+
+/// Gap limits to apply at account creation or import.
+///
+/// Decoupled from [`GapLimitManager`] (a runtime tracker with mutable usage
+/// state). This struct only carries the *configuration* the caller wants to
+/// persist on the account's address pools. Every field has a concrete value,
+/// [`Default`] populating each with [`DEFAULT_GAP_LIMIT`], so callers override
+/// only the fields they care about (e.g. via [`AccountGapConfig::standard`] or
+/// struct-update syntax over `..Default::default()`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
+pub struct AccountGapConfig {
+    /// External (receive) chain gap limit for Standard accounts.
+    pub external: u32,
+    /// Internal (change) chain gap limit for Standard accounts.
+    pub internal: u32,
+    /// Gap limit for single-pool accounts (CoinJoin, identity, provider,
+    /// asset-lock, DashPay, platform payment).
+    pub single: u32,
+}
+
+impl Default for AccountGapConfig {
+    fn default() -> Self {
+        Self {
+            external: DEFAULT_GAP_LIMIT,
+            internal: DEFAULT_GAP_LIMIT,
+            single: DEFAULT_GAP_LIMIT,
+        }
+    }
+}
+
+impl AccountGapConfig {
+    /// Build a config overriding the Standard external and internal limits,
+    /// leaving the single-pool limit at [`DEFAULT_GAP_LIMIT`].
+    pub fn standard(external: u32, internal: u32) -> Self {
+        Self {
+            external,
+            internal,
+            ..Self::default()
+        }
+    }
+}
 
 /// Stages of gap limit processing
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -261,8 +295,8 @@ impl GapLimitManager {
     /// Create a new gap limit manager with default limits
     pub fn new_default() -> Self {
         Self {
-            external: GapLimit::new(DEFAULT_EXTERNAL_GAP_LIMIT),
-            internal: GapLimit::new(DEFAULT_INTERNAL_GAP_LIMIT),
+            external: GapLimit::new(DEFAULT_GAP_LIMIT),
+            internal: GapLimit::new(DEFAULT_GAP_LIMIT),
             coinjoin: None,
         }
     }
@@ -425,6 +459,27 @@ mod tests {
         }
 
         assert!(manager.is_discovery_complete());
+    }
+
+    #[test]
+    fn test_account_gap_config_defaults_and_overrides() {
+        let default = AccountGapConfig::default();
+        assert_eq!(default.external, DEFAULT_GAP_LIMIT);
+        assert_eq!(default.internal, DEFAULT_GAP_LIMIT);
+        assert_eq!(default.single, DEFAULT_GAP_LIMIT);
+
+        let overridden = AccountGapConfig::standard(200, 50);
+        assert_eq!(overridden.external, 200);
+        assert_eq!(overridden.internal, 50);
+        // `single` stays at the default when standard() is used.
+        assert_eq!(overridden.single, DEFAULT_GAP_LIMIT);
+
+        let single_only = AccountGapConfig {
+            single: 42,
+            ..AccountGapConfig::default()
+        };
+        assert_eq!(single_only.single, 42);
+        assert_eq!(single_only.external, DEFAULT_GAP_LIMIT);
     }
 
     #[test]

--- a/key-wallet/src/managed_account/address_pool.rs
+++ b/key-wallet/src/managed_account/address_pool.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey};
 use crate::error::{Error, Result};
-use crate::gap_limit::DEFAULT_EXTERNAL_GAP_LIMIT;
+use crate::gap_limit::DEFAULT_GAP_LIMIT;
 use crate::Network;
 use dashcore::{Address, AddressType, ScriptBuf};
 
@@ -1046,7 +1046,7 @@ impl AddressPoolBuilder {
         Self {
             base_path: None,
             pool_type: AddressPoolType::External,
-            gap_limit: DEFAULT_EXTERNAL_GAP_LIMIT,
+            gap_limit: DEFAULT_GAP_LIMIT,
             network: Network::Mainnet,
             address_type: AddressType::P2pkh,
             key_source: None,

--- a/key-wallet/src/managed_account/address_pool.rs
+++ b/key-wallet/src/managed_account/address_pool.rs
@@ -1293,6 +1293,21 @@ mod tests {
         assert!(pool.is_internal());
         assert_eq!(pool.gap_limit, 10);
         assert_eq!(pool.network, Network::Testnet);
+
+        // The builder rejects an out-of-range gap limit at build time.
+        let base = DerivationPath::from(vec![ChildNumber::from_normal_idx(0).unwrap()]);
+        assert!(AddressPoolBuilder::new()
+            .base_path(base.clone())
+            .gap_limit(0)
+            .network(Network::Testnet)
+            .build()
+            .is_err());
+        assert!(AddressPoolBuilder::new()
+            .base_path(base)
+            .gap_limit(MAX_GAP_LIMIT + 1)
+            .network(Network::Testnet)
+            .build()
+            .is_err());
     }
 
     #[test]

--- a/key-wallet/src/managed_account/address_pool.rs
+++ b/key-wallet/src/managed_account/address_pool.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey};
 use crate::error::{Error, Result};
-use crate::gap_limit::DEFAULT_GAP_LIMIT;
+use crate::gap_limit::{DEFAULT_GAP_LIMIT, MAX_GAP_LIMIT};
 use crate::Network;
 use dashcore::{Address, AddressType, ScriptBuf};
 
@@ -348,6 +348,19 @@ pub struct AddressPool {
     pub address_type: AddressType,
 }
 
+/// Reject gap limits that would break pool maintenance. A `0` gap underflows
+/// the `gap_limit - 1` target computation in [`AddressPool::maintain_gap_limit`]
+/// and `prune_unused`, and a value past [`MAX_GAP_LIMIT`] would pre-generate a
+/// pathological number of addresses.
+fn validate_gap_limit(gap_limit: u32) -> Result<()> {
+    if gap_limit == 0 || gap_limit > MAX_GAP_LIMIT {
+        return Err(Error::InvalidParameter(format!(
+            "gap limit must be in 1..={MAX_GAP_LIMIT}, got {gap_limit}"
+        )));
+    }
+    Ok(())
+}
+
 impl AddressPool {
     /// Create a new address pool and generate addresses up to the gap limit
     pub fn new(
@@ -357,6 +370,7 @@ impl AddressPool {
         network: Network,
         key_source: &KeySource,
     ) -> Result<Self> {
+        validate_gap_limit(gap_limit)?;
         let mut pool = Self::new_without_generation(base_path, pool_type, gap_limit, network);
 
         // Generate addresses up to the gap limit if we have a key source
@@ -886,7 +900,7 @@ impl AddressPool {
     /// public key) for downstream persisters without re-deriving it.
     pub fn maintain_gap_limit(&mut self, key_source: &KeySource) -> Result<Vec<AddressInfo>> {
         let target = match self.highest_used {
-            None => self.gap_limit - 1,
+            None => self.gap_limit.saturating_sub(1),
             Some(highest) => highest + self.gap_limit,
         };
 
@@ -965,7 +979,7 @@ impl AddressPool {
     /// Prune unused addresses beyond the gap limit
     pub fn prune_unused(&mut self) -> u32 {
         let keep_until = match self.highest_used {
-            None => self.gap_limit - 1, // Keep indices 0 to gap_limit-1
+            None => self.gap_limit.saturating_sub(1), // Keep indices 0 to gap_limit-1
             Some(highest) => highest + self.gap_limit, // Keep up to highest + gap_limit
         };
 
@@ -1103,6 +1117,7 @@ impl AddressPoolBuilder {
     pub fn build(self) -> Result<AddressPool> {
         let base_path =
             self.base_path.ok_or(Error::InvalidParameter("base_path required".into()))?;
+        validate_gap_limit(self.gap_limit)?;
 
         let mut pool = AddressPool::new_without_generation(
             base_path,

--- a/key-wallet/src/managed_account/managed_account_collection.rs
+++ b/key-wallet/src/managed_account/managed_account_collection.rs
@@ -722,8 +722,13 @@ impl ManagedAccountCollection {
                 user_identity_id,
                 friend_identity_id,
             } => {
-                let addresses =
-                    AddressPool::new(base_path, AddressPoolType::Absent, 20, network, key_source)?;
+                let addresses = AddressPool::new(
+                    base_path,
+                    AddressPoolType::Absent,
+                    DEFAULT_GAP_LIMIT,
+                    network,
+                    key_source,
+                )?;
                 ManagedAccountType::DashpayReceivingFunds {
                     index,
                     user_identity_id,
@@ -736,8 +741,13 @@ impl ManagedAccountCollection {
                 user_identity_id,
                 friend_identity_id,
             } => {
-                let addresses =
-                    AddressPool::new(base_path, AddressPoolType::Absent, 20, network, key_source)?;
+                let addresses = AddressPool::new(
+                    base_path,
+                    AddressPoolType::Absent,
+                    DEFAULT_GAP_LIMIT,
+                    network,
+                    key_source,
+                )?;
                 ManagedAccountType::DashpayExternalAccount {
                     index,
                     user_identity_id,

--- a/key-wallet/src/managed_account/managed_account_collection.rs
+++ b/key-wallet/src/managed_account/managed_account_collection.rs
@@ -7,10 +7,7 @@ use std::collections::BTreeMap;
 
 use crate::account::account_collection::{DashpayAccountKey, PlatformPaymentAccountKey};
 use crate::account::account_type::AccountType;
-use crate::gap_limit::{
-    DEFAULT_COINJOIN_GAP_LIMIT, DEFAULT_EXTERNAL_GAP_LIMIT, DEFAULT_INTERNAL_GAP_LIMIT,
-    DEFAULT_SPECIAL_GAP_LIMIT, DIP17_GAP_LIMIT,
-};
+use crate::gap_limit::DEFAULT_GAP_LIMIT;
 use crate::managed_account::address_pool::{AddressPool, AddressPoolType};
 use crate::managed_account::managed_account_ref::{
     ManagedAccountRef, ManagedAccountRefMut, OwnedManagedCoreAccount,
@@ -558,7 +555,7 @@ impl ManagedAccountCollection {
                 let external_pool = AddressPool::new(
                     external_path,
                     AddressPoolType::External,
-                    DEFAULT_EXTERNAL_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -568,7 +565,7 @@ impl ManagedAccountCollection {
                 let internal_pool = AddressPool::new(
                     internal_path,
                     AddressPoolType::Internal,
-                    DEFAULT_INTERNAL_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -588,7 +585,7 @@ impl ManagedAccountCollection {
                 let addresses = AddressPool::new(
                     base_path,
                     AddressPoolType::Absent,
-                    DEFAULT_COINJOIN_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -601,7 +598,7 @@ impl ManagedAccountCollection {
                 let addresses = AddressPool::new(
                     base_path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -615,7 +612,7 @@ impl ManagedAccountCollection {
                 let addresses = AddressPool::new(
                     base_path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -628,7 +625,7 @@ impl ManagedAccountCollection {
                 let addresses = AddressPool::new(
                     base_path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -640,7 +637,7 @@ impl ManagedAccountCollection {
                 let addresses = AddressPool::new(
                     base_path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -652,7 +649,7 @@ impl ManagedAccountCollection {
                 let addresses = AddressPool::new(
                     base_path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -664,7 +661,7 @@ impl ManagedAccountCollection {
                 let addresses = AddressPool::new(
                     base_path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -676,7 +673,7 @@ impl ManagedAccountCollection {
                 let addresses = AddressPool::new(
                     base_path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -688,7 +685,7 @@ impl ManagedAccountCollection {
                 let addresses = AddressPool::new(
                     base_path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -700,7 +697,7 @@ impl ManagedAccountCollection {
                 let addresses = AddressPool::new(
                     base_path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -712,7 +709,7 @@ impl ManagedAccountCollection {
                 let addresses = AddressPool::new(
                     base_path,
                     AddressPoolType::AbsentHardened,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -756,7 +753,7 @@ impl ManagedAccountCollection {
                 let addresses = AddressPool::new(
                     base_path,
                     AddressPoolType::Absent,
-                    DIP17_GAP_LIMIT,
+                    DEFAULT_GAP_LIMIT,
                     network,
                     key_source,
                 )?;
@@ -789,7 +786,7 @@ impl ManagedAccountCollection {
         let addresses = AddressPool::new(
             base_path,
             AddressPoolType::Absent,
-            DIP17_GAP_LIMIT,
+            DEFAULT_GAP_LIMIT,
             account.network,
             &key_source,
         )?;

--- a/key-wallet/src/managed_account/managed_account_type.rs
+++ b/key-wallet/src/managed_account/managed_account_type.rs
@@ -1,9 +1,6 @@
 use crate::account::account_collection::{DashpayContactIdentityId, DashpayOurUserIdentityId};
 use crate::account::StandardAccountType;
-use crate::gap_limit::{
-    DEFAULT_COINJOIN_GAP_LIMIT, DEFAULT_EXTERNAL_GAP_LIMIT, DEFAULT_INTERNAL_GAP_LIMIT,
-    DEFAULT_SPECIAL_GAP_LIMIT, DIP17_GAP_LIMIT,
-};
+use crate::gap_limit::AccountGapConfig;
 
 use crate::{AccountType, AddressPool, DerivationPath};
 #[cfg(feature = "bincode")]
@@ -475,11 +472,34 @@ impl ManagedAccountType {
         }
     }
 
-    /// Create a ManagedAccountType from an AccountType with address pools
+    /// Create a [`ManagedAccountType`] from an [`AccountType`] using the per-pool
+    /// default gap limits. See [`Self::from_account_type_with_gap_config`] to
+    /// override the gap limits at creation/import time.
     pub fn from_account_type(
         account_type: AccountType,
         network: crate::Network,
         key_source: &crate::KeySource,
+    ) -> Result<Self, crate::error::Error> {
+        Self::from_account_type_with_gap_config(
+            account_type,
+            network,
+            key_source,
+            AccountGapConfig::default(),
+        )
+    }
+
+    /// Create a [`ManagedAccountType`] from an [`AccountType`] with explicit
+    /// gap limits for the underlying address pools.
+    ///
+    /// `gap_config` carries the gap limit for each pool kind: `external` /
+    /// `internal` for Standard accounts, or `single` for every other
+    /// (single-pool) account type. Use [`AccountGapConfig::default`] for the
+    /// uniform [`DEFAULT_GAP_LIMIT`](crate::gap_limit::DEFAULT_GAP_LIMIT).
+    pub fn from_account_type_with_gap_config(
+        account_type: AccountType,
+        network: crate::Network,
+        key_source: &crate::KeySource,
+        gap_config: AccountGapConfig,
     ) -> Result<Self, crate::error::Error> {
         use crate::bip32::DerivationPath;
         use crate::managed_account::address_pool::{AddressPool, AddressPoolType};
@@ -499,7 +519,7 @@ impl ManagedAccountType {
                 let external_pool = AddressPool::new(
                     external_path,
                     AddressPoolType::External,
-                    DEFAULT_EXTERNAL_GAP_LIMIT,
+                    gap_config.external,
                     network,
                     key_source,
                 )?;
@@ -509,7 +529,7 @@ impl ManagedAccountType {
                 let internal_pool = AddressPool::new(
                     internal_path,
                     AddressPoolType::Internal,
-                    DEFAULT_INTERNAL_GAP_LIMIT,
+                    gap_config.internal,
                     network,
                     key_source,
                 )?;
@@ -530,7 +550,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     AddressPoolType::Absent,
-                    DEFAULT_COINJOIN_GAP_LIMIT,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -547,7 +567,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -565,7 +585,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -582,7 +602,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -598,7 +618,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -614,7 +634,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -630,7 +650,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -646,7 +666,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -662,7 +682,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -678,7 +698,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     AddressPoolType::Absent,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -694,7 +714,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     AddressPoolType::AbsentHardened,
-                    DEFAULT_SPECIAL_GAP_LIMIT,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -714,7 +734,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     crate::managed_account::address_pool::AddressPoolType::Absent,
-                    20,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -736,7 +756,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     crate::managed_account::address_pool::AddressPoolType::Absent,
-                    20,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;
@@ -759,7 +779,7 @@ impl ManagedAccountType {
                 let pool = AddressPool::new(
                     path,
                     crate::managed_account::address_pool::AddressPoolType::Absent,
-                    DIP17_GAP_LIMIT,
+                    gap_config.single,
                     network,
                     key_source,
                 )?;

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -74,9 +74,19 @@ impl ManagedCoreFundsAccount {
         }
     }
 
-    /// Create a `ManagedCoreFundsAccount` from an [`Account`](super::super::Account).
+    /// Create a `ManagedCoreFundsAccount` from an [`Account`](super::super::Account)
+    /// using the per-pool default gap limits.
     pub fn from_account(account: &super::super::Account) -> Self {
         Self::wrap(ManagedCoreKeysAccount::from_account(account))
+    }
+
+    /// Create a `ManagedCoreFundsAccount` from an [`Account`](super::super::Account)
+    /// with caller-supplied gap limits for the underlying address pools.
+    pub fn from_account_with_gap_config(
+        account: &super::super::Account,
+        gap_config: crate::gap_limit::AccountGapConfig,
+    ) -> Self {
+        Self::wrap(ManagedCoreKeysAccount::from_account_with_gap_config(account, gap_config))
     }
 
     /// Create a `ManagedCoreFundsAccount` from a [`BLSAccount`].

--- a/key-wallet/src/managed_account/managed_core_keys_account.rs
+++ b/key-wallet/src/managed_account/managed_core_keys_account.rs
@@ -149,20 +149,32 @@ impl ManagedCoreKeysAccount {
         promoted
     }
 
-    /// Create a `ManagedCoreKeysAccount` from an [`Account`](super::super::Account).
+    /// Create a `ManagedCoreKeysAccount` from an [`Account`](super::super::Account)
+    /// using the per-pool default gap limits.
     pub fn from_account(account: &super::super::Account) -> Self {
+        Self::from_account_with_gap_config(account, crate::gap_limit::AccountGapConfig::default())
+    }
+
+    /// Create a `ManagedCoreKeysAccount` from an [`Account`](super::super::Account)
+    /// with caller-supplied gap limits for the underlying address pools.
+    pub fn from_account_with_gap_config(
+        account: &super::super::Account,
+        gap_config: crate::gap_limit::AccountGapConfig,
+    ) -> Self {
         let key_source = address_pool::KeySource::Public(account.account_xpub);
-        let managed_type = ManagedAccountType::from_account_type(
+        let managed_type = ManagedAccountType::from_account_type_with_gap_config(
             account.account_type,
             account.network,
             &key_source,
+            gap_config,
         )
         .unwrap_or_else(|_| {
             let no_key_source = address_pool::KeySource::NoKeySource;
-            ManagedAccountType::from_account_type(
+            ManagedAccountType::from_account_type_with_gap_config(
                 account.account_type,
                 account.network,
                 &no_key_source,
+                gap_config,
             )
             .expect("Should succeed with NoKeySource")
         });

--- a/key-wallet/src/tests/account_tests.rs
+++ b/key-wallet/src/tests/account_tests.rs
@@ -4,6 +4,10 @@
 
 use crate::account::{Account, AccountType, StandardAccountType};
 use crate::bip32::{ExtendedPrivKey, ExtendedPubKey};
+use crate::gap_limit::{AccountGapConfig, DEFAULT_GAP_LIMIT};
+use crate::managed_account::address_pool::AddressPoolType;
+use crate::managed_account::managed_account_trait::ManagedAccountTrait;
+use crate::managed_account::{ManagedCoreFundsAccount, ManagedCoreKeysAccount};
 use crate::mnemonic::{Language, Mnemonic};
 use crate::Network;
 use secp256k1::Secp256k1;
@@ -525,5 +529,68 @@ fn test_account_derivation_path_uniqueness() {
         assert!(!paths.contains(&path_str), "Duplicate derivation path: {}", path_str);
 
         paths.push(path_str);
+    }
+}
+
+#[test]
+fn test_configurable_gap_limit_propagates_to_pools() {
+    let network = Network::Testnet;
+    let master = create_test_extended_priv_key(network);
+    let secp = Secp256k1::new();
+
+    let make_account = |account_type: AccountType| {
+        let path = account_type.derivation_path(network).unwrap();
+        let xpriv = master.derive_priv(&secp, &path).unwrap();
+        Account::from_xpriv(Some([0u8; 32]), account_type, xpriv, network).unwrap()
+    };
+
+    let std_type = AccountType::Standard {
+        index: 0,
+        standard_account_type: StandardAccountType::BIP44Account,
+    };
+
+    // A Standard account's external and internal pools each carry their
+    // configured gap and pre-generate exactly that many addresses.
+    let managed = ManagedCoreFundsAccount::from_account_with_gap_config(
+        &make_account(std_type),
+        AccountGapConfig::standard(100, 50),
+    );
+    assert_eq!(managed.external_gap_limit(), Some(100));
+    assert_eq!(managed.internal_gap_limit(), Some(50));
+    for pool in managed.managed_account_type().address_pools() {
+        let expected = match pool.pool_type {
+            AddressPoolType::External => 100,
+            AddressPoolType::Internal => 50,
+            other => panic!("unexpected pool type for Standard account: {:?}", other),
+        };
+        assert_eq!(pool.gap_limit, expected);
+        assert_eq!(pool.addresses.len() as u32, expected);
+    }
+
+    // A single-pool account applies the `single` field to its one pool.
+    let managed = ManagedCoreFundsAccount::from_account_with_gap_config(
+        &make_account(AccountType::CoinJoin {
+            index: 0,
+        }),
+        AccountGapConfig {
+            single: 75,
+            ..AccountGapConfig::default()
+        },
+    );
+    let pools = managed.managed_account_type().address_pools();
+    assert_eq!(pools.len(), 1);
+    assert_eq!(pools[0].gap_limit, 75);
+    assert_eq!(pools[0].addresses.len() as u32, 75);
+
+    // The default constructor applies DEFAULT_GAP_LIMIT to every pool, for
+    // both Standard (external/internal) and single-pool account types.
+    let managed = ManagedCoreFundsAccount::from_account(&make_account(std_type));
+    assert_eq!(managed.external_gap_limit(), Some(DEFAULT_GAP_LIMIT));
+    assert_eq!(managed.internal_gap_limit(), Some(DEFAULT_GAP_LIMIT));
+
+    let identity =
+        ManagedCoreKeysAccount::from_account(&make_account(AccountType::IdentityRegistration));
+    for pool in identity.managed_account_type().address_pools() {
+        assert_eq!(pool.gap_limit, DEFAULT_GAP_LIMIT);
     }
 }

--- a/key-wallet/src/tests/edge_case_tests.rs
+++ b/key-wallet/src/tests/edge_case_tests.rs
@@ -4,6 +4,8 @@
 
 use crate::account::{AccountType, StandardAccountType};
 use crate::bip32::{ChildNumber, DerivationPath};
+use crate::gap_limit::MAX_GAP_LIMIT;
+use crate::managed_account::address_pool::KeySource;
 use crate::mnemonic::{Language, Mnemonic};
 use crate::wallet::Wallet;
 use crate::Network;
@@ -175,14 +177,45 @@ fn test_extreme_gap_limit() {
     // Should handle large gap limits without issues
     assert_eq!(pool.gap_limit, 10000);
 
-    // Test with zero gap limit
-    let zero_gap_pool = AddressPool::new_without_generation(
-        base_path,
+    // A zero gap limit is still constructible via the infallible
+    // `new_without_generation`, and pool maintenance on it must not underflow
+    // `gap_limit - 1`: it generates nothing rather than panicking or wrapping.
+    let mut zero_gap_pool = AddressPool::new_without_generation(
+        base_path.clone(),
         AddressPoolType::External,
         0,
         Network::Testnet,
     );
     assert_eq!(zero_gap_pool.gap_limit, 0);
+    let generated = zero_gap_pool.maintain_gap_limit(&KeySource::NoKeySource).unwrap();
+    assert!(generated.is_empty());
+    assert_eq!(zero_gap_pool.prune_unused(), 0);
+
+    // The generating constructor rejects out-of-range gap limits up front.
+    assert!(AddressPool::new(
+        base_path.clone(),
+        AddressPoolType::External,
+        0,
+        Network::Testnet,
+        &KeySource::NoKeySource,
+    )
+    .is_err());
+    assert!(AddressPool::new(
+        base_path.clone(),
+        AddressPoolType::External,
+        MAX_GAP_LIMIT + 1,
+        Network::Testnet,
+        &KeySource::NoKeySource,
+    )
+    .is_err());
+    assert!(AddressPool::new(
+        base_path,
+        AddressPoolType::External,
+        MAX_GAP_LIMIT,
+        Network::Testnet,
+        &KeySource::NoKeySource,
+    )
+    .is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Adds `AccountGapConfig { external, internal, single }` so callers can set the gap limit per pool when creating or importing an account. Every field defaults to `DEFAULT_GAP_LIMIT`, so callers override only what they need via `AccountGapConfig::standard` or struct-update over `..Default::default()`.

`from_account_type_with_gap_config` threads the config to every pool constructor. `from_account_type` and `from_account` remain thin wrappers using the default config so existing callers are unaffected, and `from_account_with_gap_config` is added on `ManagedCoreKeysAccount` and `ManagedCoreFundsAccount`.

The per-account-type gap constants are unified into a single `DEFAULT_GAP_LIMIT = 30`. This raises the default for single-pool accounts: identity, provider, and asset-lock from 5 to 30, DashPay and platform-payment from 20 to 30. The only effect is more lookahead addresses pre-generated at creation, which improves recovery coverage. CoinJoin and Standard accounts are unchanged at 30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-account configurable gap-limit settings (external, internal, single) with a single default gap limit for consistent behavior.
* **Bug Fixes**
  * Enforced gap-limit bounds and safer gap-limit maintenance to prevent invalid or off-by-one behavior; builders now reject out-of-range values.
* **Tests**
  * Added tests validating configurable gap limits, defaults, and boundary behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/rust-dashcore/pull/775?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->