### PR TITLE
chore: migrate from `vX.Y-dev` branching model to single `dev` branch

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -3,8 +3,8 @@ name: Merge Conflict Check
 on:
   push:
     branches:
-      - master
-      - 'v*-dev'
+      - main
+      - dev
   pull_request_target:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,8 +3,8 @@ name: Pre-commit Checks
 on:
   push:
     branches:
-      - master
-      - 'v**-dev'
+      - main
+      - dev
   pull_request:
 
 concurrency:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,8 +2,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
-      - 'v**-dev'
+      - main
+      - dev
   pull_request:
 
 name: Continuous integration

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
-      - 'v**-dev'
+      - main
+      - dev
   pull_request:
     paths:
       - 'key-wallet-ffi/**'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@
 
 ## Commit & Pull Request Guidelines
 - Prefer Conventional Commits: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`. Keep subject ≤72 chars with clear scope and rationale.
-- Target branches: feature work to `v**-dev` (development), hotfixes/docs to `master` unless directed otherwise.
+- Target branches: feature work to `dev` (development), hotfixes/docs to `main` unless directed otherwise.
 - Pre‑PR checks: `cargo fmt`, `cargo clippy`, `cargo test` (workspace). Update docs/CHANGELOG if user-facing.
 - Include in PRs: description, linked issues, test evidence (commands/output), and notes on features/FFI impacts.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,8 +182,9 @@ cargo doc --open
 - Use proptest for property-based testing where appropriate
 
 ### Git Workflow
-- Current development branch: `v0.42-dev`
-- Main branch: `master`
+- Default branch: `dev` (active development, target for new PRs)
+- Stable branch: `main` (tracks latest tagged release)
+- Release branches: `chore/release-vX.Y.Z` (short-lived, cut from `dev` per release)
 
 ## Current Status
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 **Branching model (important)**
 
-Feature work targets the active `v**-dev` branch (development). Submit hotfixes and documentation-only changes to `master` unless maintainers direct otherwise.
+Feature work targets the `dev` branch (development). Submit hotfixes and documentation-only changes to `main` unless maintainers direct otherwise.
 
 :+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
 
@@ -65,9 +65,9 @@ PR titles must use one of the following prefixes (enforced by CI):
 
 ## Preparing PRs
 
-Active development happens on `v**-dev` branches. Feature work should target the current `v**-dev`. The `master` branch is kept stable; submit hotfixes and documentation changes to `master` unless directed otherwise. All PRs must compile without errors (verified by GitHub CI).
+Active development happens on the `dev` branch. Feature work should target `dev`. The `main` branch is kept stable and tracks the latest tagged release. Submit hotfixes and documentation changes to `main` unless directed otherwise. Release branches (`chore/release-vX.Y.Z`) are cut from `dev` per release and merged back. All PRs must compile without errors (verified by GitHub CI).
 
-Prerequisites that a PR must satisfy for merging into the `master` branch:
+Prerequisites that a PR must satisfy for merging into the `main` branch:
 * each commit within a PR should compile and pass unit tests with no errors, with
   relevant feature combinations (including building fuzz tests where applicable);
 * the tip of any PR branch must also compile and pass tests with no errors on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ PR titles must use one of the following prefixes (enforced by CI):
 
 Active development happens on the `dev` branch. Feature work should target `dev`. The `main` branch is kept stable and tracks the latest tagged release. Submit hotfixes and documentation changes to `main` unless directed otherwise. Release branches (`chore/release-vX.Y.Z`) are cut from `dev` per release and merged back. All PRs must compile without errors (verified by GitHub CI).
 
-Prerequisites that a PR must satisfy for merging into the `main` branch:
+Prerequisites that a PR must satisfy for merging into the target branch:
 * each commit within a PR should compile and pass unit tests with no errors, with
   relevant feature combinations (including building fuzz tests where applicable);
 * the tip of any PR branch must also compile and pass tests with no errors on

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
   <p>
     <a href="https://crates.io/crates/dash"><img alt="Crate Info" src="https://img.shields.io/crates/v/dash.svg"/></a>
-    <a href="https://github.com/dashpay/rust-dashcore/blob/master/LICENSE"><img alt="MIT or Apache-2.0 Licensed" src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg"/></a>
+    <a href="https://github.com/dashpay/rust-dashcore/blob/main/LICENSE"><img alt="MIT or Apache-2.0 Licensed" src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg"/></a>
     <a href="https://github.com/dashpay/rust-dashcore/actions?query=workflow%3AContinuous%20integration"><img alt="CI Status" src="https://github.com/dashpay/rust-dashcore/workflows/Continuous%20integration/badge.svg"></a>
-    <a href="https://codecov.io/gh/dashpay/rust-dashcore/branch/master"><img alt="Coverage (master)" src="https://codecov.io/gh/dashpay/rust-dashcore/branch/master/graph/badge.svg"/></a>
-    <a href="https://codecov.io/gh/dashpay/rust-dashcore/branch/v0.42-dev"><img alt="Coverage (develop)" src="https://codecov.io/gh/dashpay/rust-dashcore/branch/v0.42-dev/graph/badge.svg"/></a>
+    <a href="https://codecov.io/gh/dashpay/rust-dashcore/branch/main"><img alt="Coverage (main)" src="https://codecov.io/gh/dashpay/rust-dashcore/branch/main/graph/badge.svg"/></a>
+    <a href="https://codecov.io/gh/dashpay/rust-dashcore/branch/dev"><img alt="Coverage (dev)" src="https://codecov.io/gh/dashpay/rust-dashcore/branch/dev/graph/badge.svg"/></a>
     <a href="https://docs.rs"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-rust--dashcore-green"/></a>
     <a href="#minimum-supported-rust-version-msrv"><img alt="Rustc Version 1.89+" src="https://img.shields.io/badge/rustc-1.89%2B-lightgrey.svg"/></a>
     <img alt="Lines of code" src="https://img.shields.io/tokei/lines/github/dashpay/rust-dashcore">
@@ -127,7 +127,7 @@ architectural mismatches.
 
 ## Branching Model
 
-Feature work targets the active `v**-dev` branch. Submit hotfixes and documentation-only changes to `master` unless maintainers direct otherwise.
+Feature work targets the `dev` branch. Submit hotfixes and documentation-only changes to `main` unless maintainers direct otherwise. The `main` branch tracks the latest tagged release. Release branches (`chore/release-vX.Y.Z`) are short-lived, cut from `dev` per release.
 
 ## Installing Rust
 


### PR DESCRIPTION
Switch the development model away from per-release `vX.Y-dev` branches (`v0.40-dev`, `v0.41-dev`, `v0.42-dev`, each going stale after its release) to a single permanent `dev` branch as the default for active development, with `master` renamed to `main` to track the latest tagged release. Release branches (`chore/release-vX.Y.Z`) are still cut from `dev` per release for the review window, then merged back.

Updates the file-level references that hardcode the old model:

- CI workflow triggers (`pre-commit`, `rust`, `sanitizer`, `conflict-check`) now fire on pushes to `main` / `dev` instead of `master` / `v**-dev`.
- `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, `README.md` describe the new branching model and target branches.
- README codecov badges point at `branch/main` and `branch/dev`.

The actual GitHub-side actions (rename `master` -> `main`, rename `v0.42-dev` -> `dev`, change default branch, update branch-protection rules) are repo settings and must be performed by an admin separately. Order matters: tag `v0.42.0` from `v0.42-dev` first, then perform the GitHub renames, then merge this PR against `dev`.

To fix it up locally just run:

```
git branch -m v0.42-dev dev
git fetch origin
git branch -u origin/dev dev
git remote set-head origin -a
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflows and documentation to reflect a new branching model: `main` for stable releases and hotfixes, `dev` for active feature development, replacing the previous `master` and versioned `v*-dev` branches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/rust-dashcore/pull/778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->