### PR TITLE
chore: bump version to `0.43.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["dash", "dash-network", "hashes", "internals", "fuzz", "rpc-client", 
 resolver = "2"
 
 [workspace.package]
-version = "0.42.0"
+version = "0.43.0"
 
 [patch.crates-io]
 dashcore_hashes = { path = "hashes" }

--- a/dash-spv/ARCHITECTURE.md
+++ b/dash-spv/ARCHITECTURE.md
@@ -1,7 +1,5 @@
 # Dash SPV Client - Comprehensive Code Guide
 
-**Version:** 0.42.0
-
 ## Table of Contents
 
 1. [Executive Summary](#executive-summary)


### PR DESCRIPTION
Open the `v0.43.0` dev cycle and remove the extra mention of the version in the `ARCHITECTURE.md` leaving us with only one number to bump on version bumps.