### PR TITLE
refactor(key-wallet): derive `Zeroize` on `WalletType` and wipe on `drop`

### DIFF
--- a/key-wallet/src/wallet/mod.rs
+++ b/key-wallet/src/wallet/mod.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 /// Type of wallet based on how it was created
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Zeroize)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 pub enum WalletType {
@@ -152,42 +152,13 @@ impl fmt::Display for Wallet {
 // Manual implementation of Zeroize for Wallet
 impl Zeroize for Wallet {
     fn zeroize(&mut self) {
-        // Zeroize the wallet ID
-        self.wallet_id.zeroize();
+        self.wallet_type.zeroize();
+    }
+}
 
-        // Zeroize the wallet type - handle each variant's sensitive data
-        match &mut self.wallet_type {
-            WalletType::Mnemonic {
-                mnemonic,
-                root_extended_private_key,
-            } => {
-                // Zeroize the mnemonic (now possible since it implements Zeroize)
-                mnemonic.zeroize();
-                // We can't zeroize SecretKey directly, but we can zeroize the chain code
-                root_extended_private_key.zeroize();
-                // Note: root_extended_private_key.root_private_key (SecretKey) doesn't implement Zeroize
-            }
-            WalletType::Seed {
-                seed,
-                root_extended_private_key,
-            } => {
-                // We can't zeroize Seed directly as it doesn't implement Zeroize yet
-                // But we can zeroize the RootExtendedPrivKey
-                root_extended_private_key.zeroize();
-                seed.zeroize();
-            }
-            WalletType::ExtendedPrivKey(root_extended_private_key) => {
-                // Zeroize the chain code
-                root_extended_private_key.zeroize();
-                // Note: root_private_key (SecretKey) doesn't implement Zeroize
-            }
-            WalletType::ExternalSignable | WalletType::WatchOnly => {
-                // Unit variants carry no key material; nothing sensitive to zeroize.
-            }
-        }
-
-        // Clear the accounts map, only public keys here so no need to go hardcore on zeroization
-        self.accounts.clear();
+impl Drop for Wallet {
+    fn drop(&mut self) {
+        self.zeroize();
     }
 }
 

--- a/key-wallet/src/wallet/root_extended_keys.rs
+++ b/key-wallet/src/wallet/root_extended_keys.rs
@@ -13,6 +13,7 @@ use dashcore_hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine};
 use secp256k1::Secp256k1;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -21,10 +22,16 @@ pub struct RootExtendedPrivKey {
     pub root_chain_code: ChainCode,
 }
 
-impl zeroize::Zeroize for RootExtendedPrivKey {
+impl Zeroize for RootExtendedPrivKey {
     fn zeroize(&mut self) {
         self.root_private_key.non_secure_erase();
         self.root_chain_code.zeroize();
+    }
+}
+
+impl Drop for RootExtendedPrivKey {
+    fn drop(&mut self) {
+        self.zeroize();
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced secure handling of sensitive wallet data to ensure proper memory protection when wallet objects are destroyed
  * Strengthened cleanup mechanisms for cryptographic keys during wallet lifecycle operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/rust-dashcore/pull/780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->