### PR TITLE
feat(dash-spv): devnet LLMQ routing overrides (chainlocks/isd24/platform)

### DIFF
--- a/dash/src/sml/llmq_type/network.rs
+++ b/dash/src/sml/llmq_type/network.rs
@@ -75,6 +75,8 @@ impl NetworkLLMQExt for Network {
                 // Note: 400_60 and 400_85 are included but may not mine on testnet
                 LLMQType::Llmqtype25_67, // Platform consensus (smaller for testnet)
             ],
+            // Setters reject any LLMQ type outside this default list, so it
+            // already covers every possible override value — no extension needed.
             Network::Devnet => vec![
                 LLMQType::Llmqtype50_60,
                 LLMQType::Llmqtype60_75,


### PR DESCRIPTION
## Summary

Closes #785. Adds support for Dash Core's devnet LLMQ routing overrides — `-llmqchainlocks`, `-llmqinstantsenddip0024`, and `-llmqplatform` — so a `dash-spv` client can talk to small devnets that reroute these roles onto `LLMQ_DEVNET` (or another devnet quorum type).

Implementation follows PR #784's pragmatic Option B: three new process-global `OnceLock`s with idempotent setters, mirroring the established `set_llmq_devnet_params` contract.

- `dash/src/sml/llmq_type/mod.rs` — new statics `DEVNET_CHAIN_LOCKS_OVERRIDE` / `DEVNET_ISD_OVERRIDE` / `DEVNET_PLATFORM_OVERRIDE`; helpers `set_devnet_chain_locks_type` / `set_devnet_isd_type` / `set_devnet_platform_type`; getters `devnet_*_override()`; Dash-Core-name parser `devnet_llmq_type_from_name` accepting `llmq_devnet`, `llmq_devnet_dip0024`, `llmq_devnet_platform` (plus this crate's `llmq_dev_platform` spelling).
- `dash/src/sml/llmq_type/network.rs` — `NetworkLLMQExt::{chain_locks_type, isd_llmq_type, platform_type}` honor the overrides on `Devnet` only. Mainnet/testnet/regtest arms are untouched. `enabled_llmq_types` stays as the three default devnet types — setters already reject anything outside that set, so overrides are a strict subset.
- `dash-spv/src/client/config.rs` — `ClientConfig` gains `llmq_chainlocks_type` / `llmq_instantsend_dip0024_type` / `llmq_platform_type`, matching builders, `validate()` devnet-only rejection, and wiring through `apply_global_overrides()`.
- `dash-spv/src/main.rs` — new CLI flags `--llmq-chainlocks`, `--llmq-instantsend-dip0024`, `--llmq-platform`, each rejected on non-devnet networks.

## Acceptance criteria

- [x] CLI accepts the three flags; rejected on non-devnet networks
- [x] `ClientConfig` carries the overrides through to startup (`apply_global_overrides`)
- [x] `chain_locks_type` / `isd_llmq_type` / `platform_type` return the overridden values on Devnet when set
- [x] `enabled_llmq_types` covers the overridden types (already does — override domain is a subset of the default devnet list)
- [x] Unit tests cover override-set / override-unset / cross-network rejection
- [x] Existing PR #784 test `test_llmq_devnet_override_lifecycle` stays green

## Validation

- `cargo test -p dashcore --lib sml::llmq_type` — 15 passed (4 new: parser, non-devnet-type rejection, three role lifecycle tests; existing devnet-params lifecycle still green).
- `cargo test -p dash-spv --lib client::config` — 12 passed (4 new: builder coverage + three cross-network rejection tests).
- `cargo test -p dashcore --lib` — 546 passed, 0 failed, 15 ignored.
- `cargo test -p dash-spv --lib` — 441 passed, 0 failed, 2 ignored.
- `cargo fmt -p dashcore -p dash-spv --check` clean.
- `cargo clippy -p dashcore -p dash-spv --all-targets -- -D warnings` clean.
- `cargo run -p dash-spv --bin dash-spv -- --help` shows the three new flags under their Dash-Core-named forms.

## Test plan
- [ ] CI green
- [ ] Smoke against a small devnet that reroutes `-llmqinstantsenddip0024=llmq_devnet` to confirm InstantSend locks verify
- [ ] CodeRabbit review

## Notes

- The OnceLock pattern carries the same process-global limitation as PR #784: once set, the override is sticky for the lifetime of the process. Conflict re-sets error; identical re-sets are idempotent.
- Out of scope (flagged by review for a follow-up): `impl From<u8> for LLMQType` in `dash/src/sml/llmq_type/mod.rs` is missing the `107 => LlmqtypeDevnetPlatform` arm — a pre-existing decoder gap unrelated to this PR, but now relevant if Platform routing is exercised on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added devnet-specific LLMQ quorum routing overrides for ChainLocks, InstantSend DIP24, and Platform.
  * New CLI arguments allow custom quorum type configuration on devnet networks.
  * Integrated validation restricts overrides to devnet-only usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/rust-dashcore/pull/786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->