### PR TITLE
fix(rpc-json)!: resolve Core 23 nested platform addresses (breaking field/accessor renames)

### DIFF
--- a/rpc-json/src/lib.rs
+++ b/rpc-json/src/lib.rs
@@ -2079,13 +2079,17 @@ impl MasternodeAddresses {
 
 /// Splits a `"host:port"` string into `(host, port)` with a non-fabricated host.
 ///
-/// Uses [`str::rsplit_once`] so only the final `:port` segment is parsed, which
-/// keeps IPv4 and unbracketed IPv6 hosts intact. The port is parsed through
-/// [`u16`] then widened to `u32`, rejecting values outside the TCP/UDP port range
-/// (e.g. `"host:70000"`). Returns `None` when no colon is present or the suffix is
-/// not a valid `u16`.
+/// Supports IPv4 (`1.2.3.4:9999`) and bracketed IPv6 (`[2001:db8::1]:9999`). The
+/// final `:port` segment is parsed through [`u16`] then widened to `u32`, rejecting
+/// values outside the TCP/UDP port range (e.g. `"host:70000"`). Unbracketed
+/// multi-colon hosts (bare IPv6) are rejected rather than silently mangled. Returns
+/// `None` when no colon is present, the host is ambiguous, or the suffix is not a
+/// valid `u16`.
 fn parse_host_port(addr: &str) -> Option<(String, u32)> {
     let (host, port) = addr.rsplit_once(':')?;
+    if host.contains(':') && !(host.starts_with('[') && host.ends_with(']')) {
+        return None;
+    }
     let port = port.parse::<u16>().ok()?;
     Some((host.to_string(), u32::from(port)))
 }
@@ -2118,8 +2122,10 @@ pub struct DMNState {
         rename = "platformNodeID"
     )]
     pub platform_node_id: Option<[u8; 20]>,
+    #[deprecated(note = "Core 23+ nested addresses.platform_p2p should be used instead")]
     #[serde(default, rename = "platformP2PPort")]
     pub legacy_platform_p2p_port: Option<u32>,
+    #[deprecated(note = "Core 23+ nested addresses.platform_https should be used instead")]
     #[serde(default, rename = "platformHTTPPort")]
     pub legacy_platform_http_port: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2134,6 +2140,7 @@ impl DMNState {
     /// `platformP2PPort`, pairing it with the node IP from [`service`](Self::service)
     /// because Dash deploys platform services on the masternode's core IP. Returns
     /// `None` when no source yields a non-zero in-range port.
+    #[allow(deprecated)]
     pub fn platform_p2p_address(&self) -> Option<(String, u32)> {
         self.addresses
             .as_ref()
@@ -2148,6 +2155,7 @@ impl DMNState {
     /// `platformHTTPPort`, pairing it with the node IP from [`service`](Self::service)
     /// because Dash deploys platform services on the masternode's core IP. Returns
     /// `None` when no source yields a non-zero in-range port.
+    #[allow(deprecated)]
     pub fn platform_http_address(&self) -> Option<(String, u32)> {
         self.addresses
             .as_ref()
@@ -2155,9 +2163,12 @@ impl DMNState {
             .or_else(|| self.legacy_platform_address(self.legacy_platform_http_port))
     }
 
-    /// Pairs a legacy platform port with the node IP, dropping zero/absent ports.
+    /// Pairs a legacy platform port with the node IP, dropping zero, absent, and
+    /// out-of-`u16`-range ports so the result honors the TCP/UDP port range.
     fn legacy_platform_address(&self, port: Option<u32>) -> Option<(String, u32)> {
-        port.filter(|&p| p != 0).map(|p| (self.service.ip().to_string(), p))
+        port.and_then(|p| u16::try_from(p).ok())
+            .filter(|&p| p != 0)
+            .map(|p| (self.service.ip().to_string(), u32::from(p)))
     }
 }
 
@@ -2465,10 +2476,12 @@ impl DMNState {
             self.platform_node_id = Some(platform_node_id);
         }
 
+        #[allow(deprecated)]
         if let Some(legacy_platform_p2p_port) = legacy_platform_p2p_port {
             self.legacy_platform_p2p_port = Some(legacy_platform_p2p_port);
         }
 
+        #[allow(deprecated)]
         if let Some(legacy_platform_http_port) = legacy_platform_http_port {
             self.legacy_platform_http_port = Some(legacy_platform_http_port);
         }
@@ -3407,7 +3420,7 @@ mod tests {
 
     use crate::{
         DMNState, DMNStateDiff, ExtendedQuorumListResult, MasternodeAddresses, MasternodeListDiff,
-        MnSyncStatus, QuorumType, deserialize_u32_opt,
+        MnSyncStatus, QuorumType, deserialize_u32_opt, parse_host_port,
     };
 
     #[test]
@@ -3585,6 +3598,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn dmn_state_core23_addresses_resolve_platform_ports() {
         // Core 23 entry: legacy platformP2PPort/platformHTTPPort absent, ports live
         // in the nested `addresses` object. Raw fields stay None; accessors resolve.
@@ -3677,6 +3691,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn dmn_state_zero_legacy_port_resolves_to_addresses() {
         // Transitional entry: legacy port present but zero -> addresses wins (new-first).
         let json = r#"{
@@ -3703,6 +3718,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn dmn_state_zero_legacy_port_no_addresses_resolves_to_none() {
         // Legacy port present but zero and no `addresses` -> accessor returns None,
         // never `(host, 0)`.
@@ -3740,6 +3756,25 @@ mod tests {
         }"#;
         let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
         assert_eq!(state.platform_p2p_address(), None, "out-of-range port rejected");
+    }
+
+    #[test]
+    fn dmn_state_legacy_out_of_range_port_rejected() {
+        // A legacy port above the u16 range must be rejected, matching the addresses
+        // path, so the accessor honors its documented in-range invariant.
+        let json = r#"{
+            "service": "192.0.2.1:9999",
+            "registeredHeight": 123456,
+            "revocationReason": 0,
+            "ownerAddress": "yPBWCdMRY5PsS3hJzs7csbdWQVRR85yxUz",
+            "votingAddress": "ySM11LUD65Bi4p1gm68XLkdWc65TBKRzvQ",
+            "payoutAddress": "yX4Ve7Q8Y4jscV4LZJD8HVCHKyePzR3MhA",
+            "pubKeyOperator": "8ed3f0c208efbcfc815cbfb94490dc68cf2e29d44dd9f8a91e20e06057aa110d7062c8ab7ccc85a9ff0c88760157f563",
+            "platformNodeID": "f2dbd9b0a1f541a7c44d34a58674d0262f5feca5",
+            "platformP2PPort": 70000
+        }"#;
+        let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
+        assert_eq!(state.platform_p2p_address(), None, "out-of-range legacy port rejected");
     }
 
     #[test]
@@ -3835,6 +3870,35 @@ mod tests {
         let mut applied = newer;
         applied.apply_diff(diff);
         assert!(applied.addresses.is_none(), "Some(None) diff clears stored addresses");
+    }
+
+    #[test]
+    fn dmn_state_diff_addresses_null_wire_clears() {
+        // Wire-level three-state: `null` -> Some(None) (clear), absent -> None
+        // (unchanged). Exercises `deserialize_addresses_2opt` through the intermediate.
+        let diff: DMNStateDiff =
+            serde_json::from_str(r#"{"addresses": null}"#).expect("expected to deserialize json");
+        assert_eq!(diff.addresses, Some(None), "null wire -> Some(None) (clear)");
+
+        let diff: DMNStateDiff =
+            serde_json::from_str(r#"{}"#).expect("expected to deserialize json");
+        assert_eq!(diff.addresses, None, "absent wire -> None (unchanged)");
+    }
+
+    #[test]
+    fn parse_host_port_ipv6() {
+        // Bracketed IPv6 keeps host intact; unbracketed (ambiguous) is rejected.
+        assert_eq!(
+            parse_host_port("[2001:db8::1]:9999"),
+            Some(("[2001:db8::1]".to_string(), 9999)),
+            "bracketed IPv6 parses host + port"
+        );
+        assert_eq!(parse_host_port("2001:db8::1"), None, "unbracketed IPv6 rejected");
+        assert_eq!(
+            parse_host_port("192.0.2.1:9999"),
+            Some(("192.0.2.1".to_string(), 9999)),
+            "IPv4 still parses"
+        );
     }
 
     #[test]

--- a/rpc-json/src/lib.rs
+++ b/rpc-json/src/lib.rs
@@ -2082,11 +2082,14 @@ impl MasternodeAddresses {
 /// Supports IPv4 (`1.2.3.4:9999`) and bracketed IPv6 (`[2001:db8::1]:9999`). The
 /// final `:port` segment is parsed through [`u16`] then widened to `u32`, rejecting
 /// values outside the TCP/UDP port range (e.g. `"host:70000"`). Unbracketed
-/// multi-colon hosts (bare IPv6) are rejected rather than silently mangled. Returns
-/// `None` when no colon is present, the host is ambiguous, or the suffix is not a
-/// valid `u16`.
+/// multi-colon hosts (bare IPv6) are rejected rather than silently mangled. An empty
+/// host (e.g. `":36656"`) is also rejected. Returns `None` when no colon is present,
+/// the host is empty or ambiguous, or the suffix is not a valid `u16`.
 fn parse_host_port(addr: &str) -> Option<(String, u32)> {
     let (host, port) = addr.rsplit_once(':')?;
+    if host.is_empty() {
+        return None;
+    }
     if host.contains(':') && !(host.starts_with('[') && host.ends_with(']')) {
         return None;
     }
@@ -2201,6 +2204,7 @@ pub struct DMNStateDiff {
 impl TryFrom<DMNStateDiffIntermediate> for DMNStateDiff {
     type Error = encode::Error;
 
+    #[allow(deprecated)]
     fn try_from(value: DMNStateDiffIntermediate) -> Result<Self, Self::Error> {
         let DMNStateDiffIntermediate {
             service,
@@ -3029,8 +3033,10 @@ pub struct DMNStateDiffIntermediate {
     pub voting_address: Option<String>,
     #[serde(default, rename = "platformNodeID")]
     pub platform_node_id: Option<String>,
+    #[deprecated(note = "Core 23+ nested addresses.platform_p2p should be used instead")]
     #[serde(default, rename = "platformP2PPort")]
     pub legacy_platform_p2p_port: Option<u32>,
+    #[deprecated(note = "Core 23+ nested addresses.platform_https should be used instead")]
     #[serde(default, rename = "platformHTTPPort")]
     pub legacy_platform_http_port: Option<u32>,
     #[serde(default)]
@@ -3899,6 +3905,9 @@ mod tests {
             Some(("192.0.2.1".to_string(), 9999)),
             "IPv4 still parses"
         );
+        // Empty host must be rejected.
+        assert_eq!(parse_host_port(":36656"), None, "empty host rejected");
+        assert_eq!(parse_host_port(":443"), None, "empty host rejected");
     }
 
     #[test]

--- a/rpc-json/src/lib.rs
+++ b/rpc-json/src/lib.rs
@@ -2067,6 +2067,13 @@ pub struct MasternodeAddresses {
     pub platform_https: Vec<String>,
 }
 
+impl MasternodeAddresses {
+    /// First valid (non-zero, parseable) port from a `"host:port"` array, if any.
+    fn first_valid_port(addrs: &[String]) -> Option<u32> {
+        addrs.iter().filter_map(|a| parse_port(a)).find(|&p| p != 0)
+    }
+}
+
 /// Extracts the trailing `:port` from a `"host:port"` string as a `u32`.
 ///
 /// Uses [`str::rsplit_once`] so it works for IPv4 and unbracketed IPv6 hosts —
@@ -2076,18 +2083,9 @@ fn parse_port(addr: &str) -> Option<u32> {
     addr.rsplit_once(':').and_then(|(_, port)| port.parse().ok())
 }
 
-/// Backfills a legacy port field from the matching `addresses` array.
-///
-/// Keeps a non-zero legacy port as-is; otherwise takes the port of the first entry
-/// in `addrs`. This preserves pre-23 behavior exactly while reading Core 23 entries.
-fn backfill_port(legacy: Option<u32>, addrs: &[String]) -> Option<u32> {
-    legacy.filter(|&p| p != 0).or_else(|| addrs.first().and_then(|a| parse_port(a)))
-}
-
 #[serde_as]
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[serde(from = "DMNStateIntermediate")]
 pub struct DMNState {
     #[serde_as(as = "DisplayFromStr")]
     pub service: SocketAddr,
@@ -2121,85 +2119,29 @@ pub struct DMNState {
     pub addresses: Option<MasternodeAddresses>,
 }
 
-#[serde_as]
-#[derive(Clone, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct DMNStateIntermediate {
-    #[serde_as(as = "DisplayFromStr")]
-    service: SocketAddr,
-    registered_height: u32,
-    #[serde(default, rename = "PoSeRevivedHeight", deserialize_with = "deserialize_u32_opt")]
-    pose_revived_height: Option<u32>,
-    #[serde(default, rename = "PoSeBanHeight", deserialize_with = "deserialize_u32_opt")]
-    pose_ban_height: Option<u32>,
-    revocation_reason: u32,
-    #[serde(deserialize_with = "deserialize_address")]
-    owner_address: [u8; 20],
-    #[serde(deserialize_with = "deserialize_address")]
-    voting_address: [u8; 20],
-    #[serde(deserialize_with = "deserialize_address")]
-    payout_address: [u8; 20],
-    #[serde(with = "hex")]
-    pub_key_operator: Vec<u8>,
-    #[serde(default, deserialize_with = "deserialize_address_optional")]
-    operator_payout_address: Option<[u8; 20]>,
-    #[serde(
-        default,
-        deserialize_with = "deserialize_hex_to_address_optional",
-        rename = "platformNodeID"
-    )]
-    platform_node_id: Option<[u8; 20]>,
-    #[serde(default, rename = "platformP2PPort")]
-    platform_p2p_port: Option<u32>,
-    #[serde(default, rename = "platformHTTPPort")]
-    platform_http_port: Option<u32>,
-    #[serde(default)]
-    addresses: Option<MasternodeAddresses>,
-}
+impl DMNState {
+    /// Resolved platform P2P port.
+    ///
+    /// Prefers the Core 23+ nested `addresses.platform_p2p` port; falls back to the
+    /// deprecated top-level `platformP2PPort`. Read this instead of the raw
+    /// `platform_p2p_port` field, which is `0`/absent on Core 23+ entries.
+    pub fn resolved_platform_p2p_port(&self) -> Option<u32> {
+        self.addresses
+            .as_ref()
+            .and_then(|a| MasternodeAddresses::first_valid_port(&a.platform_p2p))
+            .or(self.platform_p2p_port)
+    }
 
-impl From<DMNStateIntermediate> for DMNState {
-    fn from(value: DMNStateIntermediate) -> Self {
-        let DMNStateIntermediate {
-            service,
-            registered_height,
-            pose_revived_height,
-            pose_ban_height,
-            revocation_reason,
-            owner_address,
-            voting_address,
-            payout_address,
-            pub_key_operator,
-            operator_payout_address,
-            platform_node_id,
-            platform_p2p_port,
-            platform_http_port,
-            addresses,
-        } = value;
-
-        let (platform_p2p_port, platform_http_port) = match &addresses {
-            Some(addr) => (
-                backfill_port(platform_p2p_port, &addr.platform_p2p),
-                backfill_port(platform_http_port, &addr.platform_https),
-            ),
-            None => (platform_p2p_port, platform_http_port),
-        };
-
-        DMNState {
-            service,
-            registered_height,
-            pose_revived_height,
-            pose_ban_height,
-            revocation_reason,
-            owner_address,
-            voting_address,
-            payout_address,
-            pub_key_operator,
-            operator_payout_address,
-            platform_node_id,
-            platform_p2p_port,
-            platform_http_port,
-            addresses,
-        }
+    /// Resolved platform HTTPS port.
+    ///
+    /// Prefers the Core 23+ nested `addresses.platform_https` port; falls back to the
+    /// deprecated top-level `platformHTTPPort`. Read this instead of the raw
+    /// `platform_http_port` field, which is `0`/absent on Core 23+ entries.
+    pub fn resolved_platform_http_port(&self) -> Option<u32> {
+        self.addresses
+            .as_ref()
+            .and_then(|a| MasternodeAddresses::first_valid_port(&a.platform_https))
+            .or(self.platform_http_port)
     }
 }
 
@@ -2247,14 +2189,6 @@ impl TryFrom<DMNStateDiffIntermediate> for DMNStateDiff {
             pub_key_operator,
             addresses,
         } = value;
-
-        let (platform_p2p_port, platform_http_port) = match &addresses {
-            Some(addr) => (
-                backfill_port(platform_p2p_port, &addr.platform_p2p),
-                backfill_port(platform_http_port, &addr.platform_https),
-            ),
-            None => (platform_p2p_port, platform_http_port),
-        };
 
         let owner_address = owner_address
             .map(|address| {
@@ -2319,6 +2253,32 @@ impl TryFrom<DMNStateDiffIntermediate> for DMNStateDiff {
             platform_http_port,
             addresses,
         })
+    }
+}
+
+impl DMNStateDiff {
+    /// Resolved platform P2P port carried by this diff, if any.
+    ///
+    /// Prefers the Core 23+ nested `addresses.platform_p2p` port; falls back to the
+    /// deprecated top-level `platformP2PPort`. Read this instead of the raw
+    /// `platform_p2p_port` field, which is `0`/absent on Core 23+ diffs.
+    pub fn resolved_platform_p2p_port(&self) -> Option<u32> {
+        self.addresses
+            .as_ref()
+            .and_then(|a| MasternodeAddresses::first_valid_port(&a.platform_p2p))
+            .or(self.platform_p2p_port)
+    }
+
+    /// Resolved platform HTTPS port carried by this diff, if any.
+    ///
+    /// Prefers the Core 23+ nested `addresses.platform_https` port; falls back to the
+    /// deprecated top-level `platformHTTPPort`. Read this instead of the raw
+    /// `platform_http_port` field, which is `0`/absent on Core 23+ diffs.
+    pub fn resolved_platform_http_port(&self) -> Option<u32> {
+        self.addresses
+            .as_ref()
+            .and_then(|a| MasternodeAddresses::first_valid_port(&a.platform_https))
+            .or(self.platform_http_port)
     }
 }
 
@@ -2440,6 +2400,7 @@ impl DMNState {
             platform_node_id,
             platform_p2p_port,
             platform_http_port,
+            addresses,
             ..
         } = diff;
         self.pose_revived_height = pose_revived_height;
@@ -2478,6 +2439,10 @@ impl DMNState {
 
         if let Some(platform_http_port) = platform_http_port {
             self.platform_http_port = Some(platform_http_port);
+        }
+
+        if addresses.is_some() {
+            self.addresses = addresses;
         }
     }
 }
@@ -3573,9 +3538,9 @@ mod tests {
     }
 
     #[test]
-    fn dmn_state_core23_addresses_backfills_platform_ports() {
-        // Core 23 simplified entry: platformP2PPort/platformHTTPPort removed,
-        // ports now live in the nested `addresses` object as "host:port" arrays.
+    fn dmn_state_core23_addresses_resolve_platform_ports() {
+        // Core 23 entry: legacy platformP2PPort/platformHTTPPort absent, ports live
+        // in the nested `addresses` object. Raw fields stay None; accessors resolve.
         let json = r#"{
             "service": "192.0.2.1:9999",
             "registeredHeight": 123456,
@@ -3592,12 +3557,14 @@ mod tests {
             }
         }"#;
         let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
-        assert_eq!(state.platform_p2p_port, Some(36656), "platform_p2p_port from addresses");
-        assert_eq!(state.platform_http_port, Some(443), "platform_http_port from addresses");
+        assert_eq!(state.platform_p2p_port, None, "raw legacy field deserialized as-is");
+        assert_eq!(state.platform_http_port, None, "raw legacy field deserialized as-is");
+        assert_eq!(state.resolved_platform_p2p_port(), Some(36656), "p2p resolved from addresses");
+        assert_eq!(state.resolved_platform_http_port(), Some(443), "http resolved from addresses");
     }
 
     #[test]
-    fn dmn_state_diff_core23_addresses_backfills_platform_ports() {
+    fn dmn_state_diff_core23_addresses_resolve_platform_ports() {
         // updatedMNs entry carrying only the new `addresses` object.
         let json = r#"{
             "addresses": {
@@ -3606,13 +3573,23 @@ mod tests {
             }
         }"#;
         let diff: DMNStateDiff = serde_json::from_str(json).expect("expected to deserialize json");
-        assert_eq!(diff.platform_p2p_port, Some(36656), "diff platform_p2p_port from addresses");
-        assert_eq!(diff.platform_http_port, Some(443), "diff platform_http_port from addresses");
+        assert_eq!(diff.platform_p2p_port, None, "raw legacy diff field deserialized as-is");
+        assert_eq!(diff.platform_http_port, None, "raw legacy diff field deserialized as-is");
+        assert_eq!(
+            diff.resolved_platform_p2p_port(),
+            Some(36656),
+            "diff p2p resolved from addresses"
+        );
+        assert_eq!(
+            diff.resolved_platform_http_port(),
+            Some(443),
+            "diff http resolved from addresses"
+        );
     }
 
     #[test]
-    fn dmn_state_legacy_platform_ports_preserved() {
-        // Pre-23 entry: legacy top-level keys, no `addresses`. Behavior must not change.
+    fn dmn_state_legacy_platform_ports_resolve_to_legacy() {
+        // Pre-23 entry: legacy top-level keys, no `addresses`. Accessors fall back to legacy.
         let json = r#"{
             "service": "192.0.2.1:9999",
             "registeredHeight": 123456,
@@ -3626,13 +3603,14 @@ mod tests {
             "platformHTTPPort": 443
         }"#;
         let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
-        assert_eq!(state.platform_p2p_port, Some(26656), "legacy platform_p2p_port preserved");
-        assert_eq!(state.platform_http_port, Some(443), "legacy platform_http_port preserved");
+        assert!(state.addresses.is_none(), "no addresses object present");
+        assert_eq!(state.resolved_platform_p2p_port(), Some(26656), "p2p resolved from legacy");
+        assert_eq!(state.resolved_platform_http_port(), Some(443), "http resolved from legacy");
     }
 
     #[test]
-    fn dmn_state_zero_legacy_port_yields_to_addresses() {
-        // Transitional entry: legacy port present but zero -> addresses wins.
+    fn dmn_state_zero_legacy_port_resolves_to_addresses() {
+        // Transitional entry: legacy port present but zero -> addresses wins (new-first).
         let json = r#"{
             "service": "192.0.2.1:9999",
             "registeredHeight": 123456,
@@ -3648,7 +3626,30 @@ mod tests {
             }
         }"#;
         let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
-        assert_eq!(state.platform_p2p_port, Some(36656), "zero legacy port replaced by addresses");
+        assert_eq!(state.platform_p2p_port, Some(0), "raw legacy zero deserialized as-is");
+        assert_eq!(
+            state.resolved_platform_p2p_port(),
+            Some(36656),
+            "zero legacy yields to addresses"
+        );
+    }
+
+    #[test]
+    fn dmn_state_no_ports_resolve_to_none() {
+        // No addresses and no legacy ports -> accessors return None.
+        let json = r#"{
+            "service": "192.0.2.1:9999",
+            "registeredHeight": 123456,
+            "revocationReason": 0,
+            "ownerAddress": "yPBWCdMRY5PsS3hJzs7csbdWQVRR85yxUz",
+            "votingAddress": "ySM11LUD65Bi4p1gm68XLkdWc65TBKRzvQ",
+            "payoutAddress": "yX4Ve7Q8Y4jscV4LZJD8HVCHKyePzR3MhA",
+            "pubKeyOperator": "8ed3f0c208efbcfc815cbfb94490dc68cf2e29d44dd9f8a91e20e06057aa110d7062c8ab7ccc85a9ff0c88760157f563",
+            "platformNodeID": "f2dbd9b0a1f541a7c44d34a58674d0262f5feca5"
+        }"#;
+        let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
+        assert_eq!(state.resolved_platform_p2p_port(), None, "no source -> None");
+        assert_eq!(state.resolved_platform_http_port(), None, "no source -> None");
     }
 
     #[test]

--- a/rpc-json/src/lib.rs
+++ b/rpc-json/src/lib.rs
@@ -2068,19 +2068,26 @@ pub struct MasternodeAddresses {
 }
 
 impl MasternodeAddresses {
-    /// First valid (non-zero, parseable) port from a `"host:port"` array, if any.
-    fn first_valid_port(addrs: &[String]) -> Option<u32> {
-        addrs.iter().filter_map(|a| parse_port(a)).find(|&p| p != 0)
+    /// First valid `(host, port)` from a `"host:port"` array, if any.
+    ///
+    /// "Valid" means parseable and with a non-zero in-range port; zero ports are
+    /// skipped because Dash Core uses `0` as a "not set" sentinel.
+    fn first_valid_host_port(addrs: &[String]) -> Option<(String, u32)> {
+        addrs.iter().filter_map(|a| parse_host_port(a)).find(|(_, p)| *p != 0)
     }
 }
 
-/// Extracts the trailing `:port` from a `"host:port"` string as a `u32`.
+/// Splits a `"host:port"` string into `(host, port)` with a non-fabricated host.
 ///
-/// Uses [`str::rsplit_once`] so it works for IPv4 and unbracketed IPv6 hosts —
-/// only the final port segment is parsed. Returns `None` when no colon is present
-/// or the suffix is not a valid `u32`.
-fn parse_port(addr: &str) -> Option<u32> {
-    addr.rsplit_once(':').and_then(|(_, port)| port.parse().ok())
+/// Uses [`str::rsplit_once`] so only the final `:port` segment is parsed, which
+/// keeps IPv4 and unbracketed IPv6 hosts intact. The port is parsed through
+/// [`u16`] then widened to `u32`, rejecting values outside the TCP/UDP port range
+/// (e.g. `"host:70000"`). Returns `None` when no colon is present or the suffix is
+/// not a valid `u16`.
+fn parse_host_port(addr: &str) -> Option<(String, u32)> {
+    let (host, port) = addr.rsplit_once(':')?;
+    let port = port.parse::<u16>().ok()?;
+    Some((host.to_string(), u32::from(port)))
 }
 
 #[serde_as]
@@ -2112,36 +2119,45 @@ pub struct DMNState {
     )]
     pub platform_node_id: Option<[u8; 20]>,
     #[serde(default, rename = "platformP2PPort")]
-    pub platform_p2p_port: Option<u32>,
+    pub legacy_platform_p2p_port: Option<u32>,
     #[serde(default, rename = "platformHTTPPort")]
-    pub platform_http_port: Option<u32>,
+    pub legacy_platform_http_port: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub addresses: Option<MasternodeAddresses>,
 }
 
 impl DMNState {
-    /// Resolved platform P2P port.
+    /// Resolved platform P2P `(host, port)`.
     ///
-    /// Prefers the Core 23+ nested `addresses.platform_p2p` port; falls back to the
-    /// deprecated top-level `platformP2PPort`. Read this instead of the raw
-    /// `platform_p2p_port` field, which is `0`/absent on Core 23+ entries.
-    pub fn resolved_platform_p2p_port(&self) -> Option<u32> {
+    /// Prefers the Core 23+ nested `addresses.platform_p2p` entry, returning its
+    /// host and port verbatim. Falls back to the deprecated top-level
+    /// `platformP2PPort`, pairing it with the node IP from [`service`](Self::service)
+    /// because Dash deploys platform services on the masternode's core IP. Returns
+    /// `None` when no source yields a non-zero in-range port.
+    pub fn platform_p2p_address(&self) -> Option<(String, u32)> {
         self.addresses
             .as_ref()
-            .and_then(|a| MasternodeAddresses::first_valid_port(&a.platform_p2p))
-            .or(self.platform_p2p_port)
+            .and_then(|a| MasternodeAddresses::first_valid_host_port(&a.platform_p2p))
+            .or_else(|| self.legacy_platform_address(self.legacy_platform_p2p_port))
     }
 
-    /// Resolved platform HTTPS port.
+    /// Resolved platform HTTPS `(host, port)`.
     ///
-    /// Prefers the Core 23+ nested `addresses.platform_https` port; falls back to the
-    /// deprecated top-level `platformHTTPPort`. Read this instead of the raw
-    /// `platform_http_port` field, which is `0`/absent on Core 23+ entries.
-    pub fn resolved_platform_http_port(&self) -> Option<u32> {
+    /// Prefers the Core 23+ nested `addresses.platform_https` entry, returning its
+    /// host and port verbatim. Falls back to the deprecated top-level
+    /// `platformHTTPPort`, pairing it with the node IP from [`service`](Self::service)
+    /// because Dash deploys platform services on the masternode's core IP. Returns
+    /// `None` when no source yields a non-zero in-range port.
+    pub fn platform_http_address(&self) -> Option<(String, u32)> {
         self.addresses
             .as_ref()
-            .and_then(|a| MasternodeAddresses::first_valid_port(&a.platform_https))
-            .or(self.platform_http_port)
+            .and_then(|a| MasternodeAddresses::first_valid_host_port(&a.platform_https))
+            .or_else(|| self.legacy_platform_address(self.legacy_platform_http_port))
+    }
+
+    /// Pairs a legacy platform port with the node IP, dropping zero/absent ports.
+    fn legacy_platform_address(&self, port: Option<u32>) -> Option<(String, u32)> {
+        port.filter(|&p| p != 0).map(|p| (self.service.ip().to_string(), p))
     }
 }
 
@@ -2162,9 +2178,11 @@ pub struct DMNStateDiff {
     pub pub_key_operator: Option<Vec<u8>>,
     pub operator_payout_address: Option<Option<[u8; 20]>>,
     pub platform_node_id: Option<[u8; 20]>,
-    pub platform_p2p_port: Option<u32>,
-    pub platform_http_port: Option<u32>,
-    pub addresses: Option<MasternodeAddresses>,
+    pub legacy_platform_p2p_port: Option<u32>,
+    pub legacy_platform_http_port: Option<u32>,
+    /// Three-state nested addresses: `None` = unchanged, `Some(None)` = cleared,
+    /// `Some(Some(_))` = set. Mirrors [`pose_ban_height`](Self::pose_ban_height).
+    pub addresses: Option<Option<MasternodeAddresses>>,
 }
 
 impl TryFrom<DMNStateDiffIntermediate> for DMNStateDiff {
@@ -2183,8 +2201,8 @@ impl TryFrom<DMNStateDiffIntermediate> for DMNStateDiff {
             owner_address,
             voting_address,
             platform_node_id,
-            platform_p2p_port,
-            platform_http_port,
+            legacy_platform_p2p_port,
+            legacy_platform_http_port,
             payout_address,
             pub_key_operator,
             addresses,
@@ -2249,36 +2267,38 @@ impl TryFrom<DMNStateDiffIntermediate> for DMNStateDiff {
             pub_key_operator,
             operator_payout_address,
             platform_node_id,
-            platform_p2p_port,
-            platform_http_port,
+            legacy_platform_p2p_port,
+            legacy_platform_http_port,
             addresses,
         })
     }
 }
 
 impl DMNStateDiff {
-    /// Resolved platform P2P port carried by this diff, if any.
+    /// Resolved platform P2P `(host, port)` carried by this diff, if any.
     ///
-    /// Prefers the Core 23+ nested `addresses.platform_p2p` port; falls back to the
-    /// deprecated top-level `platformP2PPort`. Read this instead of the raw
-    /// `platform_p2p_port` field, which is `0`/absent on Core 23+ diffs.
-    pub fn resolved_platform_p2p_port(&self) -> Option<u32> {
+    /// Returns the host and port from the Core 23+ nested `addresses.platform_p2p`
+    /// entry. The legacy top-level `platformP2PPort` is not resolved here: a diff
+    /// carries no node IP to pair it with, so a host would have to be fabricated.
+    /// Read the legacy port via [`legacy_platform_p2p_port`](Self::legacy_platform_p2p_port).
+    pub fn platform_p2p_address(&self) -> Option<(String, u32)> {
         self.addresses
             .as_ref()
-            .and_then(|a| MasternodeAddresses::first_valid_port(&a.platform_p2p))
-            .or(self.platform_p2p_port)
+            .and_then(|a| a.as_ref())
+            .and_then(|a| MasternodeAddresses::first_valid_host_port(&a.platform_p2p))
     }
 
-    /// Resolved platform HTTPS port carried by this diff, if any.
+    /// Resolved platform HTTPS `(host, port)` carried by this diff, if any.
     ///
-    /// Prefers the Core 23+ nested `addresses.platform_https` port; falls back to the
-    /// deprecated top-level `platformHTTPPort`. Read this instead of the raw
-    /// `platform_http_port` field, which is `0`/absent on Core 23+ diffs.
-    pub fn resolved_platform_http_port(&self) -> Option<u32> {
+    /// Returns the host and port from the Core 23+ nested `addresses.platform_https`
+    /// entry. The legacy top-level `platformHTTPPort` is not resolved here: a diff
+    /// carries no node IP to pair it with, so a host would have to be fabricated.
+    /// Read the legacy port via [`legacy_platform_http_port`](Self::legacy_platform_http_port).
+    pub fn platform_http_address(&self) -> Option<(String, u32)> {
         self.addresses
             .as_ref()
-            .and_then(|a| MasternodeAddresses::first_valid_port(&a.platform_https))
-            .or(self.platform_http_port)
+            .and_then(|a| a.as_ref())
+            .and_then(|a| MasternodeAddresses::first_valid_host_port(&a.platform_https))
     }
 }
 
@@ -2360,21 +2380,25 @@ impl DMNState {
             } else {
                 None
             },
-            platform_p2p_port: if self.platform_p2p_port != newer.platform_p2p_port {
+            legacy_platform_p2p_port: if self.legacy_platform_p2p_port
+                != newer.legacy_platform_p2p_port
+            {
                 has_diff = true;
-                newer.platform_p2p_port
+                newer.legacy_platform_p2p_port
             } else {
                 None
             },
-            platform_http_port: if self.platform_http_port != newer.platform_http_port {
+            legacy_platform_http_port: if self.legacy_platform_http_port
+                != newer.legacy_platform_http_port
+            {
                 has_diff = true;
-                newer.platform_http_port
+                newer.legacy_platform_http_port
             } else {
                 None
             },
             addresses: if self.addresses != newer.addresses {
                 has_diff = true;
-                newer.addresses.clone()
+                Some(newer.addresses.clone())
             } else {
                 None
             },
@@ -2398,8 +2422,8 @@ impl DMNState {
             pub_key_operator,
             operator_payout_address,
             platform_node_id,
-            platform_p2p_port,
-            platform_http_port,
+            legacy_platform_p2p_port,
+            legacy_platform_http_port,
             addresses,
             ..
         } = diff;
@@ -2433,15 +2457,15 @@ impl DMNState {
             self.platform_node_id = Some(platform_node_id);
         }
 
-        if let Some(platform_p2p_port) = platform_p2p_port {
-            self.platform_p2p_port = Some(platform_p2p_port);
+        if let Some(legacy_platform_p2p_port) = legacy_platform_p2p_port {
+            self.legacy_platform_p2p_port = Some(legacy_platform_p2p_port);
         }
 
-        if let Some(platform_http_port) = platform_http_port {
-            self.platform_http_port = Some(platform_http_port);
+        if let Some(legacy_platform_http_port) = legacy_platform_http_port {
+            self.legacy_platform_http_port = Some(legacy_platform_http_port);
         }
 
-        if addresses.is_some() {
+        if let Some(addresses) = addresses {
             self.addresses = addresses;
         }
     }
@@ -2985,15 +3009,16 @@ pub struct DMNStateDiffIntermediate {
     #[serde(default, rename = "platformNodeID")]
     pub platform_node_id: Option<String>,
     #[serde(default, rename = "platformP2PPort")]
-    pub platform_p2p_port: Option<u32>,
+    pub legacy_platform_p2p_port: Option<u32>,
     #[serde(default, rename = "platformHTTPPort")]
-    pub platform_http_port: Option<u32>,
+    pub legacy_platform_http_port: Option<u32>,
     #[serde(default)]
     pub payout_address: Option<String>,
     #[serde(default, deserialize_with = "deserialize_hex_opt")]
     pub pub_key_operator: Option<Vec<u8>>,
-    #[serde(default)]
-    pub addresses: Option<MasternodeAddresses>,
+    // Three-state: missing field = None, `null` = Some(None), object = Some(Some(_)).
+    #[serde(default, deserialize_with = "deserialize_addresses_2opt")]
+    pub addresses: Option<Option<MasternodeAddresses>>,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize)]
@@ -3352,6 +3377,20 @@ where
     Ok(Some(Some(val as u32)))
 }
 
+/// Deserializes the present-but-clearable nested `addresses` object.
+///
+/// Paired with `#[serde(default)]`, the field absence yields `None` (unchanged),
+/// a JSON `null` yields `Some(None)` (cleared), and an object yields
+/// `Some(Some(_))` (set) — the canonical serde double-`Option` pattern.
+fn deserialize_addresses_2opt<'de, D>(
+    deserializer: D,
+) -> Result<Option<Option<MasternodeAddresses>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Some(Option::<MasternodeAddresses>::deserialize(deserializer)?))
+}
+
 #[cfg(test)]
 mod tests {
     use dashcore::hashes::Hash;
@@ -3359,8 +3398,8 @@ mod tests {
     use serde_json::json;
 
     use crate::{
-        DMNState, DMNStateDiff, ExtendedQuorumListResult, MasternodeListDiff, MnSyncStatus,
-        QuorumType, deserialize_u32_opt,
+        DMNState, DMNStateDiff, ExtendedQuorumListResult, MasternodeAddresses, MasternodeListDiff,
+        MnSyncStatus, QuorumType, deserialize_u32_opt,
     };
 
     #[test]
@@ -3557,10 +3596,18 @@ mod tests {
             }
         }"#;
         let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
-        assert_eq!(state.platform_p2p_port, None, "raw legacy field deserialized as-is");
-        assert_eq!(state.platform_http_port, None, "raw legacy field deserialized as-is");
-        assert_eq!(state.resolved_platform_p2p_port(), Some(36656), "p2p resolved from addresses");
-        assert_eq!(state.resolved_platform_http_port(), Some(443), "http resolved from addresses");
+        assert_eq!(state.legacy_platform_p2p_port, None, "raw legacy field deserialized as-is");
+        assert_eq!(state.legacy_platform_http_port, None, "raw legacy field deserialized as-is");
+        assert_eq!(
+            state.platform_p2p_address(),
+            Some(("192.0.2.2".to_string(), 36656)),
+            "p2p resolved from addresses"
+        );
+        assert_eq!(
+            state.platform_http_address(),
+            Some(("192.0.2.2".to_string(), 443)),
+            "http resolved from addresses"
+        );
     }
 
     #[test]
@@ -3573,23 +3620,27 @@ mod tests {
             }
         }"#;
         let diff: DMNStateDiff = serde_json::from_str(json).expect("expected to deserialize json");
-        assert_eq!(diff.platform_p2p_port, None, "raw legacy diff field deserialized as-is");
-        assert_eq!(diff.platform_http_port, None, "raw legacy diff field deserialized as-is");
+        assert_eq!(diff.legacy_platform_p2p_port, None, "raw legacy diff field deserialized as-is");
         assert_eq!(
-            diff.resolved_platform_p2p_port(),
-            Some(36656),
+            diff.legacy_platform_http_port, None,
+            "raw legacy diff field deserialized as-is"
+        );
+        assert_eq!(
+            diff.platform_p2p_address(),
+            Some(("192.0.2.2".to_string(), 36656)),
             "diff p2p resolved from addresses"
         );
         assert_eq!(
-            diff.resolved_platform_http_port(),
-            Some(443),
+            diff.platform_http_address(),
+            Some(("192.0.2.2".to_string(), 443)),
             "diff http resolved from addresses"
         );
     }
 
     #[test]
-    fn dmn_state_legacy_platform_ports_resolve_to_legacy() {
-        // Pre-23 entry: legacy top-level keys, no `addresses`. Accessors fall back to legacy.
+    fn dmn_state_legacy_platform_ports_resolve_to_node_ip() {
+        // Pre-23 entry: legacy top-level keys, no `addresses`. Accessors fall back to
+        // the legacy port paired with the node IP from `service`.
         let json = r#"{
             "service": "192.0.2.1:9999",
             "registeredHeight": 123456,
@@ -3604,8 +3655,16 @@ mod tests {
         }"#;
         let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
         assert!(state.addresses.is_none(), "no addresses object present");
-        assert_eq!(state.resolved_platform_p2p_port(), Some(26656), "p2p resolved from legacy");
-        assert_eq!(state.resolved_platform_http_port(), Some(443), "http resolved from legacy");
+        assert_eq!(
+            state.platform_p2p_address(),
+            Some(("192.0.2.1".to_string(), 26656)),
+            "p2p resolved from legacy paired with node IP"
+        );
+        assert_eq!(
+            state.platform_http_address(),
+            Some(("192.0.2.1".to_string(), 443)),
+            "http resolved from legacy paired with node IP"
+        );
     }
 
     #[test]
@@ -3626,12 +3685,52 @@ mod tests {
             }
         }"#;
         let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
-        assert_eq!(state.platform_p2p_port, Some(0), "raw legacy zero deserialized as-is");
+        assert_eq!(state.legacy_platform_p2p_port, Some(0), "raw legacy zero deserialized as-is");
         assert_eq!(
-            state.resolved_platform_p2p_port(),
-            Some(36656),
+            state.platform_p2p_address(),
+            Some(("192.0.2.2".to_string(), 36656)),
             "zero legacy yields to addresses"
         );
+    }
+
+    #[test]
+    fn dmn_state_zero_legacy_port_no_addresses_resolves_to_none() {
+        // Legacy port present but zero and no `addresses` -> accessor returns None,
+        // never `(host, 0)`.
+        let json = r#"{
+            "service": "192.0.2.1:9999",
+            "registeredHeight": 123456,
+            "revocationReason": 0,
+            "ownerAddress": "yPBWCdMRY5PsS3hJzs7csbdWQVRR85yxUz",
+            "votingAddress": "ySM11LUD65Bi4p1gm68XLkdWc65TBKRzvQ",
+            "payoutAddress": "yX4Ve7Q8Y4jscV4LZJD8HVCHKyePzR3MhA",
+            "pubKeyOperator": "8ed3f0c208efbcfc815cbfb94490dc68cf2e29d44dd9f8a91e20e06057aa110d7062c8ab7ccc85a9ff0c88760157f563",
+            "platformNodeID": "f2dbd9b0a1f541a7c44d34a58674d0262f5feca5",
+            "platformP2PPort": 0
+        }"#;
+        let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
+        assert_eq!(state.legacy_platform_p2p_port, Some(0), "raw legacy zero deserialized as-is");
+        assert_eq!(state.platform_p2p_address(), None, "zero legacy with no addresses -> None");
+    }
+
+    #[test]
+    fn dmn_state_out_of_range_port_rejected() {
+        // A port above the u16 range must be rejected rather than truncated/accepted.
+        let json = r#"{
+            "service": "192.0.2.1:9999",
+            "registeredHeight": 123456,
+            "revocationReason": 0,
+            "ownerAddress": "yPBWCdMRY5PsS3hJzs7csbdWQVRR85yxUz",
+            "votingAddress": "ySM11LUD65Bi4p1gm68XLkdWc65TBKRzvQ",
+            "payoutAddress": "yX4Ve7Q8Y4jscV4LZJD8HVCHKyePzR3MhA",
+            "pubKeyOperator": "8ed3f0c208efbcfc815cbfb94490dc68cf2e29d44dd9f8a91e20e06057aa110d7062c8ab7ccc85a9ff0c88760157f563",
+            "platformNodeID": "f2dbd9b0a1f541a7c44d34a58674d0262f5feca5",
+            "addresses": {
+                "platform_p2p": ["192.0.2.2:70000"]
+            }
+        }"#;
+        let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
+        assert_eq!(state.platform_p2p_address(), None, "out-of-range port rejected");
     }
 
     #[test]
@@ -3648,8 +3747,83 @@ mod tests {
             "platformNodeID": "f2dbd9b0a1f541a7c44d34a58674d0262f5feca5"
         }"#;
         let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
-        assert_eq!(state.resolved_platform_p2p_port(), None, "no source -> None");
-        assert_eq!(state.resolved_platform_http_port(), None, "no source -> None");
+        assert_eq!(state.platform_p2p_address(), None, "no source -> None");
+        assert_eq!(state.platform_http_address(), None, "no source -> None");
+    }
+
+    fn dmn_state_with_legacy_p2p_zero() -> DMNState {
+        let json = r#"{
+            "service": "192.0.2.1:9999",
+            "registeredHeight": 123456,
+            "revocationReason": 0,
+            "ownerAddress": "yPBWCdMRY5PsS3hJzs7csbdWQVRR85yxUz",
+            "votingAddress": "ySM11LUD65Bi4p1gm68XLkdWc65TBKRzvQ",
+            "payoutAddress": "yX4Ve7Q8Y4jscV4LZJD8HVCHKyePzR3MhA",
+            "pubKeyOperator": "8ed3f0c208efbcfc815cbfb94490dc68cf2e29d44dd9f8a91e20e06057aa110d7062c8ab7ccc85a9ff0c88760157f563",
+            "platformNodeID": "f2dbd9b0a1f541a7c44d34a58674d0262f5feca5",
+            "platformP2PPort": 0
+        }"#;
+        serde_json::from_str(json).expect("expected to deserialize json")
+    }
+
+    #[test]
+    fn dmn_state_apply_diff_propagates_addresses() {
+        // Stored entry has a zero legacy port and no addresses; a diff carrying a
+        // nested `addresses` object must make the merged state resolvable.
+        let mut state = dmn_state_with_legacy_p2p_zero();
+        assert_eq!(state.platform_p2p_address(), None, "unresolvable before diff");
+
+        let diff = DMNStateDiff {
+            service: None,
+            registered_height: None,
+            last_paid_height: None,
+            consecutive_payments: None,
+            pose_penalty: None,
+            pose_revived_height: None,
+            pose_ban_height: None,
+            revocation_reason: None,
+            owner_address: None,
+            voting_address: None,
+            payout_address: None,
+            pub_key_operator: None,
+            operator_payout_address: None,
+            platform_node_id: None,
+            legacy_platform_p2p_port: None,
+            legacy_platform_http_port: None,
+            addresses: Some(Some(MasternodeAddresses {
+                core_p2p: vec![],
+                platform_p2p: vec!["192.0.2.2:36656".to_string()],
+                platform_https: vec![],
+            })),
+        };
+
+        state.apply_diff(diff);
+        assert_eq!(
+            state.platform_p2p_address(),
+            Some(("192.0.2.2".to_string(), 36656)),
+            "diff addresses propagated and resolvable"
+        );
+    }
+
+    #[test]
+    fn dmn_state_diff_clears_addresses() {
+        // A Some -> None transition must survive the compare/apply round-trip: the
+        // diff carries `Some(None)` and applying it clears the stored addresses.
+        let mut newer = dmn_state_with_legacy_p2p_zero();
+        newer.addresses = Some(MasternodeAddresses {
+            core_p2p: vec![],
+            platform_p2p: vec!["192.0.2.2:36656".to_string()],
+            platform_https: vec![],
+        });
+        let older = dmn_state_with_legacy_p2p_zero();
+
+        let diff =
+            newer.compare_to_newer_dmn_state(&older).expect("addresses change yields a diff");
+        assert_eq!(diff.addresses, Some(None), "clear is encoded as Some(None)");
+
+        let mut applied = newer;
+        applied.apply_diff(diff);
+        assert!(applied.addresses.is_none(), "Some(None) diff clears stored addresses");
     }
 
     #[test]

--- a/rpc-json/src/lib.rs
+++ b/rpc-json/src/lib.rs
@@ -2052,9 +2052,42 @@ pub struct GetMasternodePaymentsResult {
     pub masternodes: Vec<MasternodePayment>,
 }
 
+/// Nested `addresses` object on Core 23+ masternode entries.
+///
+/// Each purpose maps to an array of `"host:port"` strings. Dash Core 23 moved the
+/// platform ports here, away from the deprecated top-level `platformP2PPort`/
+/// `platformHTTPPort` keys. Unknown purposes are ignored.
+#[derive(Clone, PartialEq, Eq, Debug, Default, Deserialize, Serialize)]
+pub struct MasternodeAddresses {
+    #[serde(default)]
+    pub core_p2p: Vec<String>,
+    #[serde(default)]
+    pub platform_p2p: Vec<String>,
+    #[serde(default)]
+    pub platform_https: Vec<String>,
+}
+
+/// Extracts the trailing `:port` from a `"host:port"` string as a `u32`.
+///
+/// Uses [`str::rsplit_once`] so it works for IPv4 and unbracketed IPv6 hosts —
+/// only the final port segment is parsed. Returns `None` when no colon is present
+/// or the suffix is not a valid `u32`.
+fn parse_port(addr: &str) -> Option<u32> {
+    addr.rsplit_once(':').and_then(|(_, port)| port.parse().ok())
+}
+
+/// Backfills a legacy port field from the matching `addresses` array.
+///
+/// Keeps a non-zero legacy port as-is; otherwise takes the port of the first entry
+/// in `addrs`. This preserves pre-23 behavior exactly while reading Core 23 entries.
+fn backfill_port(legacy: Option<u32>, addrs: &[String]) -> Option<u32> {
+    legacy.filter(|&p| p != 0).or_else(|| addrs.first().and_then(|a| parse_port(a)))
+}
+
 #[serde_as]
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(from = "DMNStateIntermediate")]
 pub struct DMNState {
     #[serde_as(as = "DisplayFromStr")]
     pub service: SocketAddr,
@@ -2084,6 +2117,90 @@ pub struct DMNState {
     pub platform_p2p_port: Option<u32>,
     #[serde(default, rename = "platformHTTPPort")]
     pub platform_http_port: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub addresses: Option<MasternodeAddresses>,
+}
+
+#[serde_as]
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DMNStateIntermediate {
+    #[serde_as(as = "DisplayFromStr")]
+    service: SocketAddr,
+    registered_height: u32,
+    #[serde(default, rename = "PoSeRevivedHeight", deserialize_with = "deserialize_u32_opt")]
+    pose_revived_height: Option<u32>,
+    #[serde(default, rename = "PoSeBanHeight", deserialize_with = "deserialize_u32_opt")]
+    pose_ban_height: Option<u32>,
+    revocation_reason: u32,
+    #[serde(deserialize_with = "deserialize_address")]
+    owner_address: [u8; 20],
+    #[serde(deserialize_with = "deserialize_address")]
+    voting_address: [u8; 20],
+    #[serde(deserialize_with = "deserialize_address")]
+    payout_address: [u8; 20],
+    #[serde(with = "hex")]
+    pub_key_operator: Vec<u8>,
+    #[serde(default, deserialize_with = "deserialize_address_optional")]
+    operator_payout_address: Option<[u8; 20]>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_hex_to_address_optional",
+        rename = "platformNodeID"
+    )]
+    platform_node_id: Option<[u8; 20]>,
+    #[serde(default, rename = "platformP2PPort")]
+    platform_p2p_port: Option<u32>,
+    #[serde(default, rename = "platformHTTPPort")]
+    platform_http_port: Option<u32>,
+    #[serde(default)]
+    addresses: Option<MasternodeAddresses>,
+}
+
+impl From<DMNStateIntermediate> for DMNState {
+    fn from(value: DMNStateIntermediate) -> Self {
+        let DMNStateIntermediate {
+            service,
+            registered_height,
+            pose_revived_height,
+            pose_ban_height,
+            revocation_reason,
+            owner_address,
+            voting_address,
+            payout_address,
+            pub_key_operator,
+            operator_payout_address,
+            platform_node_id,
+            platform_p2p_port,
+            platform_http_port,
+            addresses,
+        } = value;
+
+        let (platform_p2p_port, platform_http_port) = match &addresses {
+            Some(addr) => (
+                backfill_port(platform_p2p_port, &addr.platform_p2p),
+                backfill_port(platform_http_port, &addr.platform_https),
+            ),
+            None => (platform_p2p_port, platform_http_port),
+        };
+
+        DMNState {
+            service,
+            registered_height,
+            pose_revived_height,
+            pose_ban_height,
+            revocation_reason,
+            owner_address,
+            voting_address,
+            payout_address,
+            pub_key_operator,
+            operator_payout_address,
+            platform_node_id,
+            platform_p2p_port,
+            platform_http_port,
+            addresses,
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
@@ -2105,6 +2222,7 @@ pub struct DMNStateDiff {
     pub platform_node_id: Option<[u8; 20]>,
     pub platform_p2p_port: Option<u32>,
     pub platform_http_port: Option<u32>,
+    pub addresses: Option<MasternodeAddresses>,
 }
 
 impl TryFrom<DMNStateDiffIntermediate> for DMNStateDiff {
@@ -2127,7 +2245,16 @@ impl TryFrom<DMNStateDiffIntermediate> for DMNStateDiff {
             platform_http_port,
             payout_address,
             pub_key_operator,
+            addresses,
         } = value;
+
+        let (platform_p2p_port, platform_http_port) = match &addresses {
+            Some(addr) => (
+                backfill_port(platform_p2p_port, &addr.platform_p2p),
+                backfill_port(platform_http_port, &addr.platform_https),
+            ),
+            None => (platform_p2p_port, platform_http_port),
+        };
 
         let owner_address = owner_address
             .map(|address| {
@@ -2190,6 +2317,7 @@ impl TryFrom<DMNStateDiffIntermediate> for DMNStateDiff {
             platform_node_id,
             platform_p2p_port,
             platform_http_port,
+            addresses,
         })
     }
 }
@@ -2281,6 +2409,12 @@ impl DMNState {
             platform_http_port: if self.platform_http_port != newer.platform_http_port {
                 has_diff = true;
                 newer.platform_http_port
+            } else {
+                None
+            },
+            addresses: if self.addresses != newer.addresses {
+                has_diff = true;
+                newer.addresses.clone()
             } else {
                 None
             },
@@ -2893,6 +3027,8 @@ pub struct DMNStateDiffIntermediate {
     pub payout_address: Option<String>,
     #[serde(default, deserialize_with = "deserialize_hex_opt")]
     pub pub_key_operator: Option<Vec<u8>>,
+    #[serde(default)]
+    pub addresses: Option<MasternodeAddresses>,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize)]
@@ -3258,7 +3394,8 @@ mod tests {
     use serde_json::json;
 
     use crate::{
-        ExtendedQuorumListResult, MasternodeListDiff, MnSyncStatus, QuorumType, deserialize_u32_opt,
+        DMNState, DMNStateDiff, ExtendedQuorumListResult, MasternodeListDiff, MnSyncStatus,
+        QuorumType, deserialize_u32_opt,
     };
 
     #[test]
@@ -3433,6 +3570,85 @@ mod tests {
             hex::encode(result.added_mns[0].state.pub_key_operator.clone()),
             "invalid pub_key_operator"
         );
+    }
+
+    #[test]
+    fn dmn_state_core23_addresses_backfills_platform_ports() {
+        // Core 23 simplified entry: platformP2PPort/platformHTTPPort removed,
+        // ports now live in the nested `addresses` object as "host:port" arrays.
+        let json = r#"{
+            "service": "192.0.2.1:9999",
+            "registeredHeight": 123456,
+            "revocationReason": 0,
+            "ownerAddress": "yPBWCdMRY5PsS3hJzs7csbdWQVRR85yxUz",
+            "votingAddress": "ySM11LUD65Bi4p1gm68XLkdWc65TBKRzvQ",
+            "payoutAddress": "yX4Ve7Q8Y4jscV4LZJD8HVCHKyePzR3MhA",
+            "pubKeyOperator": "8ed3f0c208efbcfc815cbfb94490dc68cf2e29d44dd9f8a91e20e06057aa110d7062c8ab7ccc85a9ff0c88760157f563",
+            "platformNodeID": "f2dbd9b0a1f541a7c44d34a58674d0262f5feca5",
+            "addresses": {
+                "core_p2p": ["192.0.2.1:9999"],
+                "platform_p2p": ["192.0.2.2:36656"],
+                "platform_https": ["192.0.2.2:443"]
+            }
+        }"#;
+        let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
+        assert_eq!(state.platform_p2p_port, Some(36656), "platform_p2p_port from addresses");
+        assert_eq!(state.platform_http_port, Some(443), "platform_http_port from addresses");
+    }
+
+    #[test]
+    fn dmn_state_diff_core23_addresses_backfills_platform_ports() {
+        // updatedMNs entry carrying only the new `addresses` object.
+        let json = r#"{
+            "addresses": {
+                "platform_p2p": ["192.0.2.2:36656"],
+                "platform_https": ["192.0.2.2:443"]
+            }
+        }"#;
+        let diff: DMNStateDiff = serde_json::from_str(json).expect("expected to deserialize json");
+        assert_eq!(diff.platform_p2p_port, Some(36656), "diff platform_p2p_port from addresses");
+        assert_eq!(diff.platform_http_port, Some(443), "diff platform_http_port from addresses");
+    }
+
+    #[test]
+    fn dmn_state_legacy_platform_ports_preserved() {
+        // Pre-23 entry: legacy top-level keys, no `addresses`. Behavior must not change.
+        let json = r#"{
+            "service": "192.0.2.1:9999",
+            "registeredHeight": 123456,
+            "revocationReason": 0,
+            "ownerAddress": "yPBWCdMRY5PsS3hJzs7csbdWQVRR85yxUz",
+            "votingAddress": "ySM11LUD65Bi4p1gm68XLkdWc65TBKRzvQ",
+            "payoutAddress": "yX4Ve7Q8Y4jscV4LZJD8HVCHKyePzR3MhA",
+            "pubKeyOperator": "8ed3f0c208efbcfc815cbfb94490dc68cf2e29d44dd9f8a91e20e06057aa110d7062c8ab7ccc85a9ff0c88760157f563",
+            "platformNodeID": "f2dbd9b0a1f541a7c44d34a58674d0262f5feca5",
+            "platformP2PPort": 26656,
+            "platformHTTPPort": 443
+        }"#;
+        let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
+        assert_eq!(state.platform_p2p_port, Some(26656), "legacy platform_p2p_port preserved");
+        assert_eq!(state.platform_http_port, Some(443), "legacy platform_http_port preserved");
+    }
+
+    #[test]
+    fn dmn_state_zero_legacy_port_yields_to_addresses() {
+        // Transitional entry: legacy port present but zero -> addresses wins.
+        let json = r#"{
+            "service": "192.0.2.1:9999",
+            "registeredHeight": 123456,
+            "revocationReason": 0,
+            "ownerAddress": "yPBWCdMRY5PsS3hJzs7csbdWQVRR85yxUz",
+            "votingAddress": "ySM11LUD65Bi4p1gm68XLkdWc65TBKRzvQ",
+            "payoutAddress": "yX4Ve7Q8Y4jscV4LZJD8HVCHKyePzR3MhA",
+            "pubKeyOperator": "8ed3f0c208efbcfc815cbfb94490dc68cf2e29d44dd9f8a91e20e06057aa110d7062c8ab7ccc85a9ff0c88760157f563",
+            "platformNodeID": "f2dbd9b0a1f541a7c44d34a58674d0262f5feca5",
+            "platformP2PPort": 0,
+            "addresses": {
+                "platform_p2p": ["192.0.2.2:36656"]
+            }
+        }"#;
+        let state: DMNState = serde_json::from_str(json).expect("expected to deserialize json");
+        assert_eq!(state.platform_p2p_port, Some(36656), "zero legacy port replaced by addresses");
     }
 
     #[test]

--- a/rpc-json/src/lib.rs
+++ b/rpc-json/src/lib.rs
@@ -2178,7 +2178,9 @@ pub struct DMNStateDiff {
     pub pub_key_operator: Option<Vec<u8>>,
     pub operator_payout_address: Option<Option<[u8; 20]>>,
     pub platform_node_id: Option<[u8; 20]>,
+    #[deprecated(note = "Core 23+ nested addresses.platform_p2p should be used instead")]
     pub legacy_platform_p2p_port: Option<u32>,
+    #[deprecated(note = "Core 23+ nested addresses.platform_https should be used instead")]
     pub legacy_platform_http_port: Option<u32>,
     /// Three-state nested addresses: `None` = unchanged, `Some(None)` = cleared,
     /// `Some(Some(_))` = set. Mirrors [`pose_ban_height`](Self::pose_ban_height).
@@ -2267,7 +2269,9 @@ impl TryFrom<DMNStateDiffIntermediate> for DMNStateDiff {
             pub_key_operator,
             operator_payout_address,
             platform_node_id,
+            #[allow(deprecated)]
             legacy_platform_p2p_port,
+            #[allow(deprecated)]
             legacy_platform_http_port,
             addresses,
         })
@@ -2380,6 +2384,7 @@ impl DMNState {
             } else {
                 None
             },
+            #[allow(deprecated)]
             legacy_platform_p2p_port: if self.legacy_platform_p2p_port
                 != newer.legacy_platform_p2p_port
             {
@@ -2388,6 +2393,7 @@ impl DMNState {
             } else {
                 None
             },
+            #[allow(deprecated)]
             legacy_platform_http_port: if self.legacy_platform_http_port
                 != newer.legacy_platform_http_port
             {
@@ -2422,7 +2428,9 @@ impl DMNState {
             pub_key_operator,
             operator_payout_address,
             platform_node_id,
+            #[allow(deprecated)]
             legacy_platform_p2p_port,
+            #[allow(deprecated)]
             legacy_platform_http_port,
             addresses,
             ..
@@ -3611,6 +3619,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn dmn_state_diff_core23_addresses_resolve_platform_ports() {
         // updatedMNs entry carrying only the new `addresses` object.
         let json = r#"{
@@ -3788,7 +3797,9 @@ mod tests {
             pub_key_operator: None,
             operator_payout_address: None,
             platform_node_id: None,
+            #[allow(deprecated)]
             legacy_platform_p2p_port: None,
+            #[allow(deprecated)]
             legacy_platform_http_port: None,
             addresses: Some(Some(MasternodeAddresses {
                 core_p2p: vec![],


### PR DESCRIPTION
> [!WARNING]
> **Breaking change.** Public `rpc-json` API changes on `DMNState` / `DMNStateDiff`: the raw `platform_p2p_port` / `platform_http_port` fields are renamed `legacy_platform_p2p_port` / `legacy_platform_http_port`; the resolver accessors are renamed and now return `(host, port)` (`platform_p2p_address()` / `platform_http_address() -> Option<(String, u32)>`); a new public `addresses` field is added to both structs. See [Breaking changes](#breaking-changes) for the consumer migration.

## Why this PR exists

- **Problem**: `rpc-json`'s `DMNState` / `DMNStateDiff` model only the deprecated top-level `platformP2PPort` / `platformHTTPPort` keys. With `DEPLOYMENT_V24` active, Dash Core 23.1.x returns **ProTx version-3** masternodes whose `protx listdiff` **diff** entries (`updatedMNs`) carry legacy `platformP2PPort: 0` / `platformHTTPPort: 0`, while the real ports live **only** in the new nested `addresses` object (`core_p2p` / `platform_p2p` / `platform_https`, each an array of `"host:port"`). `rpc-json` ignores `addresses` and so reports the port as `0`.

- **What breaks — confirmed live on devnet**: `drive-abci` builds its masternode list by applying these diffs incrementally; the legacy `0` overwrites the stored port → the masternode's `platform_p2p_port` becomes `0` → it is captured into the validator at quorum creation (`platform_types/validator/v0/mod.rs` — a validator is dropped only on `None`, **not** on `0`, so the `0` survives and is cast to `u16 0`) → the validator is advertised to Tenderdash with port `0` → validator-set divergence / consensus connectivity failure. Reproduced on devnet **paloma** (Core **23.1.3**):

  ```
  proTxHash:        63aa0d6fcbe1229ce844a91f74e913f56b9a700ca281948cd303195e2e05757c
  version:          3
  platformP2PPort:  0          ← legacy top-level, zeroed
  platformHTTPPort: 0          ← legacy top-level, zeroed
  addresses.platform_p2p:   ["68.67.122.87:36656"]   ← real port, present
  addresses.platform_https: ["68.67.122.87:1443"]    ← real port, present
  ```

  The bad value first enters via a state **diff** (e.g. a PoSe-revival update); the full-state `addedMNs` entry still reconstructs the legacy port correctly, which is why only the incremental diff path is affected.

- **Impact by network**:
  - **Affected now**: any platform network with `DEPLOYMENT_V24` active — i.e. devnets (paloma, active since 2025-07-01). The development line (`v3.1-dev`, rust-dashcore pin `dev`) is actively broken there. The `v3.0.2` release (pin `v0.41.0`) is byte-identical in the DMN region — equally code-vulnerable.
  - **Mainnet — latent, not yet triggerable**: Core hard-codes mainnet (and testnet) `DEPLOYMENT_V24.nStartTime = NEVER_ACTIVE` (verified in `chainparams.cpp` for v23.0.0 and v23.1.3), so no mainnet masternode can be `version: 3`. Verified empirically: a mainnet `protx listdiff` version histogram is `{v1: 1789, v2: 1152, v3: 0}`, all 350 Evo nodes carrying correct non-zero ports. This fix must be live in the mainnet release **before** a future Core schedules a real mainnet V24 activation, or the first v3 masternode upgrade will start corrupting validator ports.

## What was done

This crate keeps RPC structs as a plain data-mapping layer, so deserialization stays a bare `#[derive(Deserialize)]` with **no logic in the deserialize path** — the legacy fields and the new `addresses` object land raw — and the legacy-vs-new resolution lives in explicit **accessor methods**:

- New `MasternodeAddresses { core_p2p, platform_p2p, platform_https: Vec<String> }` (serde-default per field; tolerant of unknown purposes), exposed as `addresses` on both `DMNState` and `DMNStateDiff`.
- The deprecated raw fields are renamed `legacy_platform_p2p_port` / `legacy_platform_http_port` (serde wire renames `platformP2PPort` / `platformHTTPPort` intact) so callers reach for the accessors instead of the deprecated fields.
- New accessors return a full `(host, port)` pair, new-first / legacy-fallback:
  - `DMNState::platform_p2p_address(&self) -> Option<(String, u32)>`
  - `DMNState::platform_http_address(&self) -> Option<(String, u32)>`
  - `DMNStateDiff::platform_p2p_address(&self) -> Option<(String, u32)>`
  - `DMNStateDiff::platform_http_address(&self) -> Option<(String, u32)>`
  - Rule: prefer the `addresses` entry (host + port verbatim) when its port is valid (non-zero, in-range); otherwise, on `DMNState`, fall back to the legacy port paired with the node IP from `service` (Dash deploys platform services on the masternode's core IP). A diff carries no node IP, so its accessors do not resolve the legacy port — read it via `legacy_platform_*_port`.
- Zero ports never surface: `0` is dropped in both the `addresses` path and the legacy fallback.
- Ports parse through `u16` then widen to `u32`, rejecting out-of-range values (e.g. `"host:70000"`). IPv4/IPv6-safe (`rsplit_once(':')`). Serialize output unchanged.
- `DMNStateDiff::addresses` is `Option<Option<MasternodeAddresses>>` (mirrors `pose_ban_height`): `None` = unchanged, `Some(None)` = cleared, `Some(Some(_))` = set. `compare_to_newer_dmn_state` encodes a clear as `Some(None)` and `apply_diff` applies the inner value, so a `Some → None` transition survives the compare→apply round-trip. A custom serde helper distinguishes absent / `null` / object on the wire.

## Testing

- RED-first TDD, assertions go through the accessors: legacy-only → legacy port paired with node IP; legacy `0` + `addresses` → addresses port (the exact devnet failure shape); legacy `0` + no `addresses` → `None`; out-of-range port → `None`; `apply_diff` propagates `addresses` into a stored `DMNState`; `Some → None` `addresses` clear survives the round-trip; raw fields remain the untouched wire values.
- `13/13` rpc-json lib tests green. `cargo fmt` + `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.

## Breaking changes

- Adds a public `addresses` field to `DMNState` (`Option<MasternodeAddresses>`) and `DMNStateDiff` (`Option<Option<MasternodeAddresses>>`). Downstream struct literals must add the field or use `..`. No wire/serialize change; legacy deserialization is unchanged.
- The raw fields `platform_p2p_port` / `platform_http_port` are renamed `legacy_platform_p2p_port` / `legacy_platform_http_port` on both `DMNState` and `DMNStateDiff` (serde wire names unchanged).
- The resolver accessors are renamed and now return an address pair: `resolved_platform_p2p_port()` / `resolved_platform_http_port()` → `platform_p2p_address()` / `platform_http_address()` returning `Option<(String, u32)>`.
- **Consumer action required**: to get the correct port (or full address) for Core-23 (ProTx v3) entries, callers must use the new `platform_p2p_address()` / `platform_http_address()` accessors instead of reading the raw `legacy_platform_*_port` fields. The raw fields intentionally still reflect the wire value (which is `0` for v3 entries).

## Checklist

- [x] RED→GREEN tests, `fmt`, `clippy -D warnings` clean
- [x] Backward-compatible deserialization (legacy wire fields unchanged; plain derive)
- [x] Root cause confirmed against live devnet data (Core 23.1.3, paloma)
- [x] Self-review + bot-review comments addressed (accessors return `(host, port)`; clearable nested-`addresses` diff; zero-port → `None`; port-range hardening; `apply_diff` regression test)
- [ ] Reviewer confirmation

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Dash Core 23+ nested address format for masternode platform service endpoints
  * Introduced new address resolution helpers for platform peer-to-peer and HTTP services
  * Preserved backward compatibility by automatically falling back to legacy port fields when needed
* **Bug Fixes**
  * Improved address/port parsing to reject ambiguous IPv6 and enforce valid port ranges
  * Updated diff handling so address updates and clears behave consistently
* **Tests**
  * Added coverage for nested-address resolution, fallback behavior, clearing semantics, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->