### PR TITLE
ci: allow ready-for-review workflow to edit labels

### DIFF
--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -14,14 +14,15 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  pull-requests: write
-  checks: read
+  contents: read
 
 jobs:
   # Ensure all pull_request-triggered workflows are monitored by workflow_run
   validate-triggers:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_run'
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -73,6 +74,11 @@ jobs:
 
   evaluate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      checks: read
     # Skip non-CodeRabbit reviews
     if: >-
       github.event_name != 'pull_request_review' ||
@@ -154,7 +160,7 @@ jobs:
             echo "CI status: $CI_STATUS"
             if [ "$CI_STATUS" = "all_passed" ]; then
               echo "All conditions met. Adding ready-for-review label."
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "ready-for-review"
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "ready-for-review" || true
             else
               echo "CI checks not all passing ($CI_STATUS). Removing label if present."
               gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "ready-for-review" || true


### PR DESCRIPTION
# Ready-for-review label permissions

## Summary

- Scope the workflow default token to `contents: read`.
- Grant `issues: write` only to the `evaluate` job that mutates PR labels.
- Keep ready-for-review label addition non-fatal, matching existing
  label-removal cleanup paths.

Fixes dashpay/rust-dashcore#809.

## Motivation

The ready-for-review workflow currently reaches:

```text
All conditions met. Adding ready-for-review label.
```

and then fails with:

```text
GraphQL: Resource not accessible by integration (addLabelsToLabelable)
```

GitHub PR labels are issue labels, so the workflow needs `issues: write` when
calling `gh pr edit --add-label` or `gh pr edit --remove-label`.

## Validation

- `python3` assertion check confirmed the workflow contains scoped
  `issues: write` permissions and non-fatal add-label handling.
- `git diff --check upstream/dev..HEAD`
- `code-review dashpay/rust-dashcore upstream/dev fork/fix-ready-for-review-permissions`
  - Result: Recommendation: ship


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to clarify permission settings and improve reliability of automated CI processes by preventing non-critical labeling failures from blocking workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->