### PR TITLE
ci: allow ready-for-review label mutation

### DIFF
--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -73,6 +73,10 @@ jobs:
 
   evaluate:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      checks: read
+      issues: write
     # Skip non-CodeRabbit reviews
     if: >-
       github.event_name != 'pull_request_review' ||


### PR DESCRIPTION
## Motivation

Fixes #809.

The `Ready for Review Label` workflow uses `gh pr edit --add-label` / `--remove-label` to mutate PR labels after CI and CodeRabbit checks pass. PR labels are issue labels in GitHub's API, so the workflow token needs `issues: write` in addition to the existing pull-request/check permissions.

## Changes

- Grant `issues: write` to `.github/workflows/ready-for-review.yml`.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml ok"' .github/workflows/ready-for-review.yml`
- `git diff --check origin/dev...HEAD`
- Pre-PR code review gate: ship


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow permissions to support enhanced automation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->