### PR TITLE
feat(key-wallet): address pools gap limit can be externally modified runtime

### DIFF
--- a/key-wallet/src/managed_account/address_pool.rs
+++ b/key-wallet/src/managed_account/address_pool.rs
@@ -882,6 +882,19 @@ impl AddressPool {
         unused_count < self.gap_limit
     }
 
+    /// Raise the gap limit and generate the addresses the wider limit now requires.
+    ///
+    /// The new limit is capped at [`crate::gap_limit::MAX_GAP_LIMIT`]. Returns the freshly
+    /// generated [`AddressInfo`] entries
+    pub fn set_gap_limit(
+        &mut self,
+        gap_limit: u32,
+        key_source: &KeySource,
+    ) -> Result<Vec<AddressInfo>> {
+        self.gap_limit = gap_limit.clamp(1, crate::gap_limit::MAX_GAP_LIMIT);
+        self.maintain_gap_limit(key_source)
+    }
+
     /// Generate addresses to maintain the gap limit.
     ///
     /// Returns the freshly generated [`AddressInfo`] entries (in derivation
@@ -1216,6 +1229,36 @@ mod tests {
         pool.mark_used(&addr1);
         let addr3 = pool.next_unused(&key_source, true).unwrap();
         assert_ne!(addr1, addr3); // Should return different address after marking used
+    }
+
+    #[test]
+    fn test_set_gap_limit_widens_and_generates() {
+        let base_path = DerivationPath::from(vec![ChildNumber::from_normal_idx(0).unwrap()]);
+        let key_source = test_key_source();
+
+        // Start with a small gap limit (5 pre-generated addresses).
+        let mut pool = AddressPool::new(
+            base_path,
+            AddressPoolType::External,
+            5,
+            Network::Testnet,
+            &key_source,
+        )
+        .unwrap();
+        assert_eq!(pool.gap_limit, 5);
+        assert_eq!(pool.addresses.len(), 5);
+
+        // Widening generates the extra addresses up front and returns them.
+        let new = pool.set_gap_limit(20, &key_source).unwrap();
+        assert_eq!(pool.gap_limit, 20);
+        assert_eq!(new.len(), 15);
+        assert_eq!(pool.addresses.len(), 20);
+        assert_eq!(pool.highest_generated, Some(19));
+
+        // The new limit is capped at MAX_GAP_LIMIT.
+        pool.set_gap_limit(crate::gap_limit::MAX_GAP_LIMIT + 500, &key_source).unwrap();
+        assert_eq!(pool.gap_limit, crate::gap_limit::MAX_GAP_LIMIT);
+        assert_eq!(pool.addresses.len(), crate::gap_limit::MAX_GAP_LIMIT as usize);
     }
 
     #[test]

--- a/key-wallet/src/managed_account/managed_account_trait.rs
+++ b/key-wallet/src/managed_account/managed_account_trait.rs
@@ -552,6 +552,39 @@ pub trait ManagedAccountTrait {
             .sum()
     }
 
+    /// Widen the gap limit for every address pool of this account.
+    /// Returns every freshly generated address (across all pools)
+    fn set_gap_limit(
+        &mut self,
+        gap_limit: u32,
+        key_source: &address_pool::KeySource,
+    ) -> crate::error::Result<Vec<address_pool::AddressInfo>> {
+        let mut generated = Vec::new();
+        let mut first_error = None;
+
+        for pool in self.managed_account_type_mut().address_pools_mut() {
+            match pool.set_gap_limit(gap_limit, key_source) {
+                Ok(new) => generated.extend(new),
+                Err(e) => {
+                    first_error = Some(e);
+                    break;
+                }
+            }
+        }
+
+        // Bump the monitor revision if any pool actually generated addresses, even when a later
+        // pool failed — otherwise the revision would stay stale despite changed monitored state.
+        if !generated.is_empty() {
+            self.bump_monitor_revision();
+        }
+
+        if let Some(e) = first_error {
+            return Err(e);
+        }
+
+        Ok(generated)
+    }
+
     /// Get the gap limit for non-standard (single-pool) accounts
     fn gap_limit(&self) -> Option<u32> {
         match self.managed_account_type() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support to increase an account’s address gap limit, automatically regenerating and returning newly generated addresses across all pools.
  * Gap limit inputs are capped to a safe maximum and applied consistently.
* **Bug Fixes**
  * Address pools now expand reliably when the gap limit changes, with generated-range tracking kept current.
  * Monitoring revision is bumped when new addresses are generated, even if a later pool update fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->