### PR TITLE
fix(dash-spv): replaced TARGET_PEERS with already existing max_peers config fields

### DIFF
--- a/dash-spv/src/client/config.rs
+++ b/dash-spv/src/client/config.rs
@@ -86,7 +86,7 @@ impl Default for ClientConfig {
             validation_mode: ValidationMode::Full,
             enable_filters: true,
             enable_masternodes: true,
-            max_peers: 8,
+            max_peers: 3,
             user_agent: None,
             // Mempool defaults
             enable_mempool_tracking: true,

--- a/dash-spv/src/client/config_test.rs
+++ b/dash-spv/src/client/config_test.rs
@@ -23,7 +23,7 @@ mod tests {
         assert_eq!(config.validation_mode, ValidationMode::Full);
         assert!(config.enable_filters);
         assert!(config.enable_masternodes);
-        assert_eq!(config.max_peers, 8);
+        assert_eq!(config.max_peers, 3);
 
         // Mempool defaults
         assert!(config.enable_mempool_tracking);

--- a/dash-spv/src/network/constants.rs
+++ b/dash-spv/src/network/constants.rs
@@ -2,9 +2,6 @@
 
 use std::time::Duration;
 
-// Connection limits
-pub const TARGET_PEERS: usize = 3;
-
 // Timeouts
 pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);

--- a/dash-spv/src/network/manager.rs
+++ b/dash-spv/src/network/manager.rs
@@ -40,6 +40,7 @@ const DEFAULT_NETWORK_EVENT_CAPACITY: usize = 10000;
 pub struct PeerNetworkManager {
     /// Peer pool
     pool: Arc<PeerPool>,
+    max_peers: usize,
     /// DNS discovery
     discovery: Arc<DnsDiscovery>,
     /// AddrV2 handler
@@ -117,8 +118,11 @@ impl PeerNetworkManager {
         // Create request queue for outgoing messages
         let (request_tx, request_rx) = unbounded_channel();
 
+        let max_peers = config.max_peers.max(1) as usize;
+
         Ok(Self {
-            pool: Arc::new(PeerPool::new()),
+            pool: Arc::new(PeerPool::new(max_peers)),
+            max_peers,
             discovery: Arc::new(discovery),
             addrv2_handler: Arc::new(AddrV2Handler::new()),
             peer_store: Arc::new(peer_store),
@@ -194,7 +198,7 @@ impl PeerNetworkManager {
                 peer_addresses.extend(
                     dns_peers
                         .into_iter()
-                        .take(TARGET_PEERS)
+                        .take(self.max_peers)
                         .map(|addr| AddrV2Message::new(addr, ServiceFlags::NETWORK)),
                 );
                 tracing::info!(
@@ -974,10 +978,10 @@ impl PeerNetworkManager {
             self.evict_mismatched_peers().await;
             // Re-read count after potential churn so top-up sees the current pool size.
             let count = self.pool.peer_count().await;
-            if count < TARGET_PEERS {
+            if count < self.max_peers {
                 // Try known addresses first, sorted by reputation
                 let known = self.addrv2_handler.get_known_addresses().await;
-                let needed = TARGET_PEERS.saturating_sub(count);
+                let needed = self.max_peers.saturating_sub(count);
                 // Select best peers based on reputation
                 let best_peers = self.reputation_manager.select_best_peers(known, needed * 2).await;
                 let mut attempted = 0;
@@ -1039,7 +1043,7 @@ impl PeerNetworkManager {
 
     async fn dns_fallback_tick(&self) {
         let count = self.pool.peer_count().await;
-        if count >= TARGET_PEERS {
+        if count >= self.max_peers {
             return;
         }
         let dns_peers = tokio::select! {
@@ -1049,7 +1053,7 @@ impl PeerNetworkManager {
                 return
             }
         };
-        let needed = TARGET_PEERS.saturating_sub(count);
+        let needed = self.max_peers.saturating_sub(count);
         tracing::debug!("DNS fallback tick found {} addresses. Needed {}", dns_peers.len(), needed);
         let mut dns_attempted = 0;
         for addr in dns_peers.iter() {
@@ -1399,6 +1403,7 @@ impl Clone for PeerNetworkManager {
     fn clone(&self) -> Self {
         Self {
             pool: self.pool.clone(),
+            max_peers: self.max_peers,
             discovery: self.discovery.clone(),
             addrv2_handler: self.addrv2_handler.clone(),
             peer_store: self.peer_store.clone(),
@@ -1518,7 +1523,8 @@ impl PeerNetworkManager {
         let discovery = DnsDiscovery::new();
         let (request_tx, request_rx) = unbounded_channel();
         Self {
-            pool: Arc::new(PeerPool::new()),
+            pool: Arc::new(PeerPool::new(8)),
+            max_peers: 8,
             discovery: Arc::new(discovery),
             addrv2_handler: Arc::new(AddrV2Handler::new()),
             peer_store: Arc::new(peer_store),

--- a/dash-spv/src/network/pool.rs
+++ b/dash-spv/src/network/pool.rs
@@ -1,7 +1,6 @@
 //! Peer pool for managing multiple peer connections
 
 use crate::error::{NetworkError, SpvError as Error};
-use crate::network::constants::TARGET_PEERS;
 use crate::network::peer::Peer;
 use dashcore::network::constants::ServiceFlags;
 use dashcore::prelude::CoreBlockHeight;
@@ -16,14 +15,21 @@ pub struct PeerPool {
     peers: Arc<RwLock<HashMap<SocketAddr, Arc<RwLock<Peer>>>>>,
     /// Addresses currently being connected to
     connecting: Arc<RwLock<HashSet<SocketAddr>>>,
+    /// Maximum number of simultaneous peer connections (from `ClientConfig::max_peers`).
+    max_peers: usize,
 }
 
 impl PeerPool {
-    /// Create a new peer pool
-    pub fn new() -> Self {
+    /// Create a new peer pool with a connection cap.
+    pub fn new(max_peers: usize) -> Self {
+        // Assert peers are greater than 0. We may change this
+        // so 0 means 'connect to as many peers as you can'
+        debug_assert!(max_peers > 0, "max_peers must be greater than 0 for the spv client to sync");
+
         Self {
             peers: Arc::new(RwLock::new(HashMap::new())),
             connecting: Arc::new(RwLock::new(HashSet::new())),
+            max_peers,
         }
     }
 
@@ -42,10 +48,10 @@ impl PeerPool {
         connecting.remove(&addr);
 
         // Check if we're at capacity
-        if peers.len() >= TARGET_PEERS {
+        if peers.len() >= self.max_peers {
             return Err(Error::Network(NetworkError::ConnectionFailed(format!(
                 "Maximum peers ({}) reached",
-                TARGET_PEERS
+                self.max_peers
             ))));
         }
 
@@ -192,12 +198,12 @@ impl PeerPool {
 
     /// Check if we need more peers
     pub async fn needs_more_peers(&self) -> bool {
-        self.peer_count().await < TARGET_PEERS
+        self.peer_count().await < self.max_peers
     }
 
     /// Check if we can accept more peers
     pub async fn can_accept_peers(&self) -> bool {
-        self.peer_count().await < TARGET_PEERS
+        self.peer_count().await < self.max_peers
     }
 
     /// Remove unhealthy peers and return their addresses so the caller can
@@ -230,7 +236,7 @@ impl PeerPool {
 
 impl Default for PeerPool {
     fn default() -> Self {
-        Self::new()
+        Self::new(8)
     }
 }
 
@@ -249,7 +255,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_peer_pool_basic() {
-        let pool = PeerPool::new();
+        let pool = PeerPool::new(8);
 
         // Initial state
         assert_eq!(pool.peer_count().await, 0);
@@ -265,7 +271,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_service_lookup() {
-        let pool = PeerPool::new();
+        let pool = PeerPool::new(8);
         let compact_filters = ServiceFlags::COMPACT_FILTERS;
         let combined = compact_filters | ServiceFlags::NODE_HEADERS_COMPRESSED;
 

--- a/dash-spv/src/network/tests.rs
+++ b/dash-spv/src/network/tests.rs
@@ -29,12 +29,12 @@ mod pool_tests {
 
     #[tokio::test]
     async fn test_pool_limits() {
-        let pool = PeerPool::new();
+        let pool = PeerPool::new(8);
 
         // Test needs_more_peers logic
         assert!(pool.needs_more_peers().await);
 
-        // Can accept up to TARGET_PEERS
+        // Can accept up to 8 peers
         assert!(pool.can_accept_peers().await);
 
         // Test peer count

--- a/dash-spv/tests/peer_test.rs
+++ b/dash-spv/tests/peer_test.rs
@@ -177,7 +177,7 @@ mod unit_tests {
 
     #[tokio::test]
     async fn test_connection_pool_limits() {
-        let pool = PeerPool::new();
+        let pool = PeerPool::new(8);
 
         // Should start empty
         assert_eq!(pool.peer_count().await, 0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Peer connection limits are now enforced more consistently across discovery, maintenance, and DNS fallback.
  * Connection “top-up” logic now respects the same configured maximum instead of a single fixed target.
* **New Features**
  * Peer networking now supports a configurable maximum peer count per instance.
  * Client default peer limit is now **3** when not overridden (instead of **8**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->