### PR TITLE
chore: bump version to `0.45.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["dash", "dash-network", "hashes", "internals", "fuzz", "rpc-client", 
 resolver = "2"
 
 [workspace.package]
-version = "0.43.0"
+version = "0.45.0"
 
 [patch.crates-io]
 dashcore_hashes = { path = "hashes" }


### PR DESCRIPTION
Bump the workspace version on `dev` to `0.45.0`.

`0.44.0` was cut as a back-cut release from `5c0113e7` for the platform release (tagged `v0.44.0`), so `dev` moves on to `0.45.0` rather than `0.44.0`. Using `0.44.0` again would give two different codebases the same version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the workspace version from **0.43.0** to **0.45.0** for this release. This change is versioning-only and does not alter existing features, configuration, or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
