### PR TITLE
docs: add `0.43.0` and `0.44.0` changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.43.0 - 2026-06-01
+
+### Added
+
+- Devnet support for `dash-spv` (#784) @xdustinface
+- Consolidate devnet config into a `DevnetConfig` struct (#788) @xdustinface
+- `downgrade_to_external_signable` method on wallets (#782) @ZocoLini
+
+### Changed
+
+- **Breaking:** network-scoped wallet-id derivation, the same seed now yields different wallet IDs per network (#793) @QuantumExplorer
+- Derive `Zeroize` on `WalletType` and wipe key material on `drop` (#780) @ZocoLini
+- Avoid rebuilding `script_pubkey`s for BIP158 filter matching (#781) @xdustinface
+- Migrate from `vX.Y-dev` branching model to a single `dev` branch (#778) @xdustinface
+- Bump workspace version to `0.43.0` (#779) @xdustinface
+
+### Fixed
+
+- Handle buffered sync events during `WaitingForConnections` in `dash-spv` (#768) @xdustinface
+
 ## 0.42.0 - 2026-05-15
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.44.0 - 2026-07-01
+
+### Added
+
+- Storage truncation primitives for reorg support in `dash-spv` (#790) @xdustinface
+- Decode SML ProTx v3 entries (#797) @xdustinface
+- `normalize_phrase` and `is_word_in_language` helpers in `key-wallet` (#806) @llbartekll
+
+### Changed
+
+- **Breaking:** remove `Address::network()` and replace `Network` with `AddressPrefix` for address prefix handling (#802) @ZocoLini
+
+### Fixed
+
+- Write the compact-size count in `QuorumSnapshot` encode (#796) @xdustinface
+- Correct CoinJoin discovery in `key-wallet` (#804) @xdustinface
+
 ## 0.43.0 - 2026-06-01
 
 ### Added


### PR DESCRIPTION
Add the `0.43.0` and `0.44.0` changelog entries to `dev`.

The `0.44.0` section documents the 7 commits released in the `v0.44.0` tag, which was cut from `5c0113e7` for the platform release. The `0.43.0` section backfills the entry that never landed in the repo.
