### PR TITLE
fix(key-wallet): preserve UTXO flags across reprocessing

### DIFF
--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -202,6 +202,18 @@ impl ManagedCoreFundsAccount {
                             utxo.is_instantlocked =
                                 matches!(context, TransactionContext::InstantSend(_));
                             utxo.is_trusted = is_trusted_output;
+                            // Reprocessing (e.g. mempool→block) rebuilds this UTXO from
+                            // scratch, so carry forward flags that must not regress. An
+                            // InstantSend lock is permanent for a txid (DIP-0010) and
+                            // trust only ever settles, so both latch monotonically. A
+                            // coin reservation is orthogonal to chain context and is kept
+                            // as-is. `is_confirmed` stays freshly derived so a reorg can
+                            // still downgrade it.
+                            if let Some(prior) = self.utxos.get(&outpoint) {
+                                utxo.is_instantlocked |= prior.is_instantlocked;
+                                utxo.is_trusted |= prior.is_trusted;
+                                utxo.is_locked = prior.is_locked;
+                            }
                             self.utxos.insert(outpoint, utxo);
                             utxos_changed = true;
                         }

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -958,6 +958,8 @@ mod tests {
         assert!(ctx.transaction(&txid).is_confirmed());
         assert_eq!(ctx.transaction(&txid).height(), Some(1000));
         assert!(ctx.first_utxo().is_confirmed);
+        // The earlier IS lock must survive the mempool→block reprocess.
+        assert!(ctx.first_utxo().is_instantlocked, "IS-lock flag must not be lost on confirmation");
         assert_eq!(ctx.managed_wallet.balance.spendable(), 200_000);
 
         // Stage 4: chain-locked block (rescan with stronger context)


### PR DESCRIPTION
## Summary

`update_utxos` rebuilds each of our outputs with a fresh `Utxo::new` on every reprocess of a transaction. On the mempool→block transition this silently reset flags that had already been set on an earlier pass, in particular `is_instantlocked`: a UTXO whose transaction received an InstantSend lock while in the mempool lost the lock flag the moment the transaction was confirmed in a block.

This carries forward the flags that must not regress when an entry for the outpoint already exists:

- `is_instantlocked` and `is_trusted` latch monotonically. An InstantSend lock is permanent for a txid (DIP-0010) and trust only ever settles, so once either is true it stays true.
- `is_locked` (the coin-reservation flag, toggled only via `lock`/`unlock`) is carried through unchanged rather than being reset.
- `is_confirmed` is left freshly derived from the context so a reorg can still downgrade it.

It was latent so far because every current consumer ORs `is_instantlocked` with `is_confirmed`, and a confirmed reprocess sets `is_confirmed` true in the same pass. It is worth fixing on its own since `is_instantlocked` is now also an input to asset-lock funding selection, and a standalone consumer or a UI badge would surface the wipe.

## Testing

`test_full_confirmation_lifecycle` now asserts the IS-lock flag survives the block-confirmation stage. The assertion fails without the fix and passes with it.

Found during CodeRabbit review of #836.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved wallet UTXO lock and trust state when transactions are reprocessed, so prior status is no longer lost during updates.
  * Continued to derive confirmation status from the latest chain context so reorg changes are reflected correctly.
* **Tests**
  * Added an explicit check to ensure InstantSend lock status is retained when a transaction transitions from unconfirmed to confirmed during reprocessing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->