### PR TITLE
refactor(key-wallet): move extended_public_key out of Signer into ExtendedPubKeySigner subtrait

### DIFF
--- a/key-wallet/src/lib.rs
+++ b/key-wallet/src/lib.rs
@@ -62,7 +62,7 @@ pub use managed_account::managed_platform_account::ManagedPlatformAccount;
 pub use managed_account::platform_address::PlatformP2PKHAddress;
 pub use mnemonic::{Language, Mnemonic};
 pub use seed::Seed;
-pub use signer::{Signer, SignerMethod, TransactionCategory};
+pub use signer::{ExtendedPubKeySigner, Signer, SignerMethod, TransactionCategory};
 pub use utxo::Utxo;
 pub use wallet::{balance::WalletCoreBalance, Wallet};
 

--- a/key-wallet/src/signer.rs
+++ b/key-wallet/src/signer.rs
@@ -125,7 +125,18 @@ pub trait Signer: Send + Sync {
     /// keys) that the caller later references when signing Platform state
     /// transitions.
     async fn public_key(&self, path: &DerivationPath) -> Result<PublicKey, Self::Error>;
+}
 
+/// A [`Signer`] that can additionally export BIP-32 extended public keys.
+///
+/// Kept separate from [`Signer`] because exporting an extended public key
+/// is a key-export capability, not a signing one: a pure signing backend
+/// (an HSM or remote signing service whose policy forbids exporting chain
+/// codes, since an xpub plus any descendant non-hardened private key
+/// compromises the whole subtree) can implement [`Signer`] alone, while
+/// callers that need offline descendant derivation bound on this trait.
+#[async_trait]
+pub trait ExtendedPubKeySigner: Signer {
     /// Return the BIP-32 extended public key at `path` — the public point
     /// plus the chain code and parent fingerprint, so the caller can
     /// non-hardened-derive a whole range of descendants from a single
@@ -133,9 +144,9 @@ pub trait Signer: Send + Sync {
     /// (e.g. DashPay contact payment addresses under
     /// `m/9'/coin'/15'/account'/sender/recipient`).
     ///
-    /// Distinct from [`Self::public_key`], which returns only the leaf point
-    /// (no chain code). A signer that cannot export an extended public key at
-    /// a hardened path should return an error rather than panic.
+    /// Distinct from [`Signer::public_key`], which returns only the leaf
+    /// point (no chain code). A signer that cannot export an extended public
+    /// key at a hardened path should return an error rather than panic.
     async fn extended_public_key(
         &self,
         path: &DerivationPath,

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -488,6 +488,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn in_memory_signer_extended_public_key_matches_wallet_derivation() {
+        use std::str::FromStr;
+        let (wallet, _info) = test_wallet_and_info();
+        let root = match &wallet.wallet_type {
+            crate::wallet::WalletType::Mnemonic {
+                root_extended_private_key,
+                ..
+            } => root_extended_private_key.clone(),
+            _ => unreachable!("test_wallet_and_info produces a mnemonic wallet"),
+        };
+        let signer = InMemorySigner {
+            root,
+            network: Network::Testnet,
+        };
+        // A hardened path — only derivable with the private key, which is the
+        // whole point of exposing extended-pubkey export on the signer.
+        let path = DerivationPath::from_str("m/9'/1'/15'/0'").expect("valid path");
+        let from_signer =
+            signer.extended_public_key(&path).await.expect("signer extended_public_key");
+        let from_wallet = wallet.derive_extended_public_key(&path).expect("wallet extended pubkey");
+        assert_eq!(
+            from_signer, from_wallet,
+            "signer xpub at a hardened path must equal the wallet's own derivation"
+        );
+    }
+
+    #[tokio::test]
     async fn test_signer_empty_credit_outputs_rejected() {
         let (wallet, mut info) = test_wallet_and_info();
         let root = match &wallet.wallet_type {

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -344,7 +344,7 @@ impl ManagedWalletInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::signer::SignerMethod;
+    use crate::signer::{ExtendedPubKeySigner, SignerMethod};
     use crate::wallet::initialization::WalletAccountCreationOptions;
     use crate::Network;
     use dashcore::ScriptBuf;
@@ -469,7 +469,10 @@ mod tests {
                 .map_err(|e| e.to_string())?;
             Ok(secp256k1::PublicKey::from_secret_key(&secp, &xpriv.private_key))
         }
+    }
 
+    #[async_trait::async_trait]
+    impl ExtendedPubKeySigner for InMemorySigner {
         async fn extended_public_key(
             &self,
             path: &DerivationPath,
@@ -548,12 +551,6 @@ mod tests {
                 unreachable!("should be rejected before any signing is attempted")
             }
             async fn public_key(&self, _: &DerivationPath) -> Result<PublicKey, Self::Error> {
-                unreachable!()
-            }
-            async fn extended_public_key(
-                &self,
-                _: &DerivationPath,
-            ) -> Result<crate::bip32::ExtendedPubKey, Self::Error> {
                 unreachable!()
             }
         }

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_building.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_building.rs
@@ -387,7 +387,7 @@ mod tests {
 
     use super::super::transaction_builder::BuilderError;
     use super::super::wallet_info_interface::WalletInfoInterface;
-    use crate::signer::{Signer, SignerMethod};
+    use crate::signer::{ExtendedPubKeySigner, Signer, SignerMethod};
     use crate::wallet::initialization::WalletAccountCreationOptions;
     use crate::wallet::ManagedWalletInfo;
     use crate::DerivationPath;
@@ -447,7 +447,10 @@ mod tests {
                 .map_err(|e| e.to_string())?;
             Ok(secp256k1::PublicKey::from_secret_key(&secp, &xpriv.private_key))
         }
+    }
 
+    #[async_trait::async_trait]
+    impl ExtendedPubKeySigner for InMemorySigner {
         async fn extended_public_key(
             &self,
             path: &DerivationPath,
@@ -541,12 +544,6 @@ mod tests {
                 unreachable!("should be rejected before any signing is attempted")
             }
             async fn public_key(&self, _: &DerivationPath) -> Result<PublicKey, Self::Error> {
-                unreachable!()
-            }
-            async fn extended_public_key(
-                &self,
-                _: &DerivationPath,
-            ) -> Result<crate::bip32::ExtendedPubKey, Self::Error> {
                 unreachable!()
             }
         }


### PR DESCRIPTION
## What changed

Removes `extended_public_key` as a required method on the `Signer` trait (added in #817) and moves it, unchanged, into a new `ExtendedPubKeySigner: Signer` subtrait. `Signer` is back to its minimal signing surface: `supported_methods`, `sign_ecdsa`, `public_key`.

## Why

Exporting a BIP-32 extended public key is a key-export capability, not a signing one. Requiring it on `Signer` forced every backend to implement xpub export — including pure signing backends (HSMs, remote signing services) whose policy deliberately forbids exporting chain codes, since an xpub plus any non-hardened descendant private key compromises the whole subtree. Those backends had no honest implementation available other than stubbing an error.

The split keeps both use cases first-class:

- Pure signers implement `Signer` alone.
- Callers that need offline descendant derivation (e.g. DashPay contact payment addresses under `m/9'/coin'/15'/account'/sender/recipient` — the motivation for #817) bound on `ExtendedPubKeySigner` and keep the exact same method.

Making it a subtrait (rather than an independent trait) reuses the single associated `Error` type, so implementors and callers don't juggle two error types for one device.

## Notes for reviewers

- No production code called `Signer::extended_public_key` — only a test. The two in-repo `InMemorySigner` test signers move their impl to the new trait, and the `unreachable!()` stubs on the `NoDigestSigner` test signers are deleted outright (they no longer need the method at all, which is the concrete evidence the requirement never belonged on the base trait).
- The new trait is re-exported from `key_wallet` root alongside `Signer`.
- Downstream backports get simpler, not harder: implementors that can't export xpubs just don't implement the subtrait; implementors that can move one method body.
- Verified: full workspace `cargo check --all-targets`, all 536 key-wallet tests pass, clippy (`--all-features --all-targets -D warnings`) and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made extended public key support available as part of the wallet’s public interface.
* **Documentation**
  * Clarified how extended public key export relates to standard signing and key export behavior.
* **Tests**
  * Updated internal test signers to cover extended public key handling in wallet workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->