### PR TITLE
fix(dash-spv): degrade gracefully when advisory file locking is unsupported (Android)

### DIFF
--- a/dash-spv/src/storage/lockfile.rs
+++ b/dash-spv/src/storage/lockfile.rs
@@ -22,24 +22,52 @@ impl LockFile {
             .open(&path)
             .map_err(|e| StorageError::WriteFailed(format!("Failed to create lock file: {}", e)))?;
 
-        file.try_lock().map_err(|e| match e {
-            std::fs::TryLockError::WouldBlock => StorageError::DirectoryLocked(format!(
-                "Data directory '{}' is already in use by another process",
-                path.parent().map(|p| p.display().to_string()).unwrap_or_default()
-            )),
-            std::fs::TryLockError::Error(io_err) => {
-                StorageError::WriteFailed(format!("Failed to acquire lock: {}", io_err))
+        if classify_lock_result(file.try_lock(), &path)? {
+            if let Err(e) = writeln!(file, "{}", std::process::id()) {
+                tracing::warn!("Failed to write PID to lock file: {}", e);
             }
-        })?;
-
-        if let Err(e) = writeln!(file, "{}", std::process::id()) {
-            tracing::warn!("Failed to write PID to lock file: {}", e);
         }
 
         Ok(Self {
             path,
             _file: file,
         })
+    }
+}
+
+/// Interprets the result of [`File::try_lock`] for an advisory data-directory lock.
+///
+/// Returns `Ok(true)` when the lock was acquired, `Ok(false)` when advisory
+/// locking is unsupported on the platform (so the caller should proceed without
+/// it), and `Err(..)` when the directory is already locked or a genuine I/O
+/// error occurred.
+fn classify_lock_result(
+    result: Result<(), std::fs::TryLockError>,
+    path: &std::path::Path,
+) -> StorageResult<bool> {
+    match result {
+        Ok(()) => Ok(true),
+        Err(std::fs::TryLockError::WouldBlock) => Err(StorageError::DirectoryLocked(format!(
+            "Data directory '{}' is already in use by another process",
+            path.parent().map(|p| p.display().to_string()).unwrap_or_default()
+        ))),
+        // Some platforms (e.g. Android) do not implement advisory file locking
+        // and return `ErrorKind::Unsupported` at the std layer. The lock is only
+        // a best-effort guard against multiple processes sharing one data
+        // directory; on such single-process platforms its absence is safe, so
+        // degrade gracefully instead of failing init.
+        Err(std::fs::TryLockError::Error(io_err))
+            if io_err.kind() == std::io::ErrorKind::Unsupported =>
+        {
+            tracing::warn!(
+                "advisory file lock not supported on this platform ({io_err}); \
+                 continuing without multi-process protection"
+            );
+            Ok(false)
+        }
+        Err(std::fs::TryLockError::Error(io_err)) => {
+            Err(StorageError::WriteFailed(format!("Failed to acquire lock: {io_err}")))
+        }
     }
 }
 
@@ -121,6 +149,48 @@ mod tests {
         // Should be able to acquire lock again
         let lock2 = LockFile::new(lock_path.clone());
         assert!(lock2.is_ok(), "Should acquire lock after previous one dropped");
+    }
+
+    #[test]
+    fn test_classify_lock_result_acquired() {
+        let path = PathBuf::from("/tmp/data/.lock");
+        assert!(classify_lock_result(Ok(()), &path).expect("acquired lock should be Ok"));
+    }
+
+    #[test]
+    fn test_classify_lock_result_would_block() {
+        let path = PathBuf::from("/tmp/data/.lock");
+        let result = classify_lock_result(Err(std::fs::TryLockError::WouldBlock), &path);
+        match result {
+            Err(StorageError::DirectoryLocked(msg)) => {
+                assert!(msg.contains("already in use"), "unexpected message: {msg}");
+            }
+            other => panic!("Expected DirectoryLocked error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_lock_result_unsupported_is_non_fatal() {
+        // Platforms such as Android return `ErrorKind::Unsupported` from
+        // `try_lock`; this must degrade gracefully rather than fail init.
+        let path = PathBuf::from("/tmp/data/.lock");
+        let io_err =
+            std::io::Error::new(std::io::ErrorKind::Unsupported, "try_lock() not supported");
+        let result = classify_lock_result(Err(std::fs::TryLockError::Error(io_err)), &path);
+        assert!(!result.expect("unsupported lock should be Ok(false)"));
+    }
+
+    #[test]
+    fn test_classify_lock_result_genuine_io_error_is_fatal() {
+        let path = PathBuf::from("/tmp/data/.lock");
+        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        let result = classify_lock_result(Err(std::fs::TryLockError::Error(io_err)), &path);
+        match result {
+            Err(StorageError::WriteFailed(msg)) => {
+                assert!(msg.contains("Failed to acquire lock"), "unexpected message: {msg}");
+            }
+            other => panic!("Expected WriteFailed error, got: {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #840.

On **Android** (`target_os = "android"`) the Rust standard library does not implement `flock`-based advisory file locking — `File::try_lock()` is a compile-time stub that unconditionally returns `ErrorKind::Unsupported`. `LockFile::new()` treated any `TryLockError::Error` as fatal, so `dash-spv` storage init always failed with:

```
SPV error: Write failed: Failed to acquire lock: try_lock() not supported
```

This blocked the **entire Core/SPV layer on Android** — no header/filter sync, no balances, no L1 send. iOS, macOS, and Linux desktop were unaffected (their targets implement `flock`).

## Fix

The lock file is only a best-effort guard against multiple processes sharing one data directory. On single-process platforms that lack advisory locking, proceeding without it is safe. This PR treats `ErrorKind::Unsupported` as **non-fatal**: skip the advisory lock with a `tracing::warn!` and continue.

- `WouldBlock` (directory already in use) → still fatal (`DirectoryLocked`).
- Genuine I/O errors → still fatal (`WriteFailed`).
- `Unsupported` → warn and continue without the cross-process guard.
- The fast path on desktop/iOS is unchanged.

Handling `ErrorKind::Unsupported` generically (rather than `#[cfg(target_os = "android")]`-gating) is more robust: it covers any non-`flock` target without special-casing.

## Testing

The classification logic is extracted into a small `classify_lock_result` helper so the degradation path can be unit-tested with a synthesized `Unsupported` error — this never occurs naturally on Linux/macOS CI. Added tests cover all four outcomes:

- lock acquired → `Ok(true)`
- `WouldBlock` → `DirectoryLocked`
- `Unsupported` → `Ok(false)` (non-fatal, skip)
- genuine I/O error → `WriteFailed`

All existing lockfile tests continue to pass:

```
running 9 tests ... test result: ok. 9 passed; 0 failed
```

`cargo fmt --check` and `cargo clippy -p dash-spv --all-targets --all-features` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)