### PR TITLE
fix(key-wallet): take the seed by reference in Wallet::from_seed_bytes

### DIFF
--- a/key-wallet/src/wallet/initialization.rs
+++ b/key-wallet/src/wallet/initialization.rs
@@ -326,16 +326,20 @@ impl Wallet {
 
     /// Create a wallet from seed bytes array
     ///
+    /// Takes the seed by reference so a caller holding it in a zeroizing buffer
+    /// can pass `&*buf` without materializing an extra un-scrubbed by-value copy
+    /// of the 64-byte master secret at the call boundary (`[u8; 64]` is `Copy`).
+    ///
     /// # Arguments
     /// * `seed_bytes` - The seed bytes array
     /// * `network` - Network to create accounts for
     /// * `account_creation_options` - Specifies which accounts to create during initialization
     pub fn from_seed_bytes(
-        seed_bytes: [u8; 64],
+        seed_bytes: &[u8; 64],
         network: Network,
         account_creation_options: WalletAccountCreationOptions,
     ) -> Result<Self> {
-        Self::from_seed(Seed::new(seed_bytes), network, account_creation_options)
+        Self::from_seed(Seed::new(*seed_bytes), network, account_creation_options)
     }
 
     /// Create a wallet from an extended private key


### PR DESCRIPTION
## What

`Wallet::from_seed_bytes` took the 64-byte seed **by value** (`[u8; 64]`). Because
`[u8; 64]` is `Copy`, a caller that holds the master secret in a zeroizing buffer
(`Zeroizing<[u8; 64]>`) has to dereference it to pass by value — materializing an
extra, un-scrubbed stack copy of the master secret at the call boundary that the
caller's zeroizing wrapper does not cover.

This changes the signature to take `&[u8; 64]`, so such a caller can pass `&*buf`
with no extra copy. The body derefs into the (already `Zeroize`-deriving) `Seed`.

## Why

Minor secret-hygiene improvement: fewer transient, un-zeroized copies of the HD
master seed on the stack. Surfaced from `dashpay/platform`'s
`create_wallet_from_seed_bytes`, which wraps the seed in `Zeroizing` but is forced
to make the by-value copy to call this function.

## Breaking change

`from_seed_bytes` now takes `&[u8; 64]`. There are **no callers within
rust-dashcore** (the FFI `wallet_create_from_seed` uses `Wallet::from_seed`, not
`from_seed_bytes`). The only known consumer is `dashpay/platform`
(`rs-platform-wallet`), which will update `from_seed_bytes(*seed)` →
`from_seed_bytes(&*seed)` when it bumps the key-wallet rev.

## Test

`cargo check -p key-wallet` clean; no internal call sites to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet seed handling by accepting seed bytes by reference, reducing unnecessary copying during wallet creation.
  * Updated wallet initialization guidance to reflect safer use of zeroized seed buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->