### PR TITLE
ci: stop `evaluate` failing when a PR's CI is pending or red

### DIFF
--- a/.github/scripts/check_ci_status.sh
+++ b/.github/scripts/check_ci_status.sh
@@ -8,11 +8,19 @@ set -euo pipefail
 PR_NUMBER="$1"
 REPO="$2"
 
-# gh pr checks exits 8 when any check is still pending and non-zero when any
-# check fails, even with --json. Capture the JSON and ignore that exit status so
-# the jq rollup below classifies the state instead of aborting the caller under
-# set -e. Empty output means gh reported no checks at all.
-CHECKS=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,bucket 2>/dev/null) || true
+# gh pr checks signals check state through its exit code: 0 when every check
+# passed (and, with --json, also when some failed), 8 when checks are still
+# pending. Any other code is gh itself failing (auth, rate limit, network,
+# unknown PR); surface that instead of misreading it as an empty check set,
+# which would silently strip the label and hide the error. Keep stderr visible.
+set +e
+CHECKS=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,bucket)
+EXIT=$?
+set -e
+
+if [ "$EXIT" -ne 0 ] && [ "$EXIT" -ne 8 ]; then
+  exit "$EXIT"
+fi
 
 if [ -z "$CHECKS" ]; then
   echo "no_checks"

--- a/.github/scripts/check_ci_status.sh
+++ b/.github/scripts/check_ci_status.sh
@@ -8,7 +8,18 @@ set -euo pipefail
 PR_NUMBER="$1"
 REPO="$2"
 
-gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,bucket --jq '
+# gh pr checks exits 8 when any check is still pending and non-zero when any
+# check fails, even with --json. Capture the JSON and ignore that exit status so
+# the jq rollup below classifies the state instead of aborting the caller under
+# set -e. Empty output means gh reported no checks at all.
+CHECKS=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,bucket 2>/dev/null) || true
+
+if [ -z "$CHECKS" ]; then
+  echo "no_checks"
+  exit 0
+fi
+
+echo "$CHECKS" | jq -r '
   [.[] | select(.name | test("^(validate-triggers|evaluate|ready-for-review-trigger)$") | not)] |
   if length == 0 then "no_checks"
   elif all(.bucket == "pass" or .bucket == "skipping") then "all_passed"


### PR DESCRIPTION
## Problem

The `evaluate` job in the "Ready for Review Label" workflow goes red on pull requests whenever the PR's own CI is not fully green. This is highly visible on fork PRs (for example [#837](https://github.com/dashpay/rust-dashcore/pull/837)), where it shows a failing check right on the automation [#838](https://github.com/dashpay/rust-dashcore/pull/838) was meant to make work.

## Root cause

`.github/scripts/check_ci_status.sh` runs under `set -euo pipefail`, and its one real command is:

```bash
gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,bucket --jq '...'
```

`gh pr checks` reports the check rollup through its exit code, even with `--json`: it exits `8` when any check is still pending and non-zero when any check has failed. Under `set -e` the script therefore aborts before echoing its status whenever the PR's CI is pending or red. The caller assigns that output with `CI_STATUS=$(check_ci_status.sh ...)`, also under `set -e`, so the failed command substitution takes the whole `evaluate` job down with "exit code 1".

The `gh pr checks` gotcha predates [#838](https://github.com/dashpay/rust-dashcore/pull/838), but that PR's `workflow_run` relay made it surface constantly: `evaluate` now re-runs on every review and label event, routinely while CI is still pending or red, which is exactly when `gh pr checks` returns non-zero.

## Fix

Capture the JSON with `|| true` so the non-zero exit no longer aborts the caller, and treat empty output as `no_checks`. The existing `jq` rollup then classifies `pending` / `has_failures` / `all_passed` as intended, so `evaluate` exits `0` and simply removes the label while CI is unfinished, then adds it once everything is green.

No behavior change when CI is fully green. Verified the rollup still returns `all_passed`, `pending`, `has_failures`, and `no_checks` for the corresponding check states, including correctly excluding the gate jobs (`validate-triggers`, `evaluate`, `ready-for-review-trigger`) from the tally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI status handling so pending checks no longer cause the status script to stop early.
  * More reliably detects when no checks are available and classifies PR check results correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->