### PR TITLE
fix(key-wallet): actionable error when add_account(_, None) hits a keyless wallet

### DIFF
--- a/key-wallet-ffi/src/error.rs
+++ b/key-wallet-ffi/src/error.rs
@@ -250,9 +250,12 @@ impl From<key_wallet::Error> for FFIError {
             Error::InvalidNetwork => FFIErrorCode::InvalidNetwork,
             Error::InvalidAddress(_) => FFIErrorCode::InvalidAddress,
             Error::Serialization(_) => FFIErrorCode::SerializationError,
-            Error::WatchOnly | Error::CoinJoinNotEnabled | Error::NoKeySource => {
-                FFIErrorCode::InvalidState
-            }
+            Error::WatchOnly
+            | Error::CoinJoinNotEnabled
+            | Error::NoKeySource
+            | Error::KeylessWalletRequiresAccountKey {
+                ..
+            } => FFIErrorCode::InvalidState,
             Error::Bip32(_)
             | Error::Slip10(_)
             | Error::BLS(_)

--- a/key-wallet/src/error.rs
+++ b/key-wallet/src/error.rs
@@ -41,6 +41,16 @@ pub enum Error {
     WatchOnly,
     /// No key source available for address derivation
     NoKeySource,
+    /// A keyless wallet (watch-only or external-signable) was asked to derive an
+    /// account from an in-wallet private key it does not hold. The caller must
+    /// instead supply the account's key material via the `Some(..)` argument of
+    /// the relevant `add_*account` method.
+    KeylessWalletRequiresAccountKey {
+        /// The account type the caller was trying to add.
+        account_type: crate::account::AccountType,
+        /// What must be supplied instead, e.g. `"extended public key (xpub)"`.
+        required_key: &'static str,
+    },
 }
 
 impl fmt::Display for Error {
@@ -63,6 +73,16 @@ impl fmt::Display for Error {
             Error::InvalidParameter(s) => write!(f, "Invalid parameter: {}", s),
             Error::WatchOnly => write!(f, "Watch-only wallet: private keys not available"),
             Error::NoKeySource => write!(f, "No key source available for address derivation"),
+            Error::KeylessWalletRequiresAccountKey {
+                account_type,
+                required_key,
+            } => write!(
+                f,
+                "Wallet has no in-wallet private key (watch-only / external-signable): cannot \
+                 derive the {} account from a root key. Supply the account's {} via the \
+                 Some(..) argument of the add_*account method.",
+                account_type, required_key
+            ),
         }
     }
 }

--- a/key-wallet/src/tests/unit_variant_wallet_tests.rs
+++ b/key-wallet/src/tests/unit_variant_wallet_tests.rs
@@ -6,6 +6,8 @@
 //! the host to track addresses or route signing requests to an external device.
 
 use crate::account::account_collection::AccountCollection;
+use crate::account::{AccountType, StandardAccountType};
+use crate::error::Error;
 use crate::mnemonic::{Language, Mnemonic};
 use crate::wallet::initialization::WalletAccountCreationOptions;
 use crate::wallet::{Wallet, WalletType};
@@ -159,6 +161,73 @@ fn derive_extended_public_key_error_points_to_per_account_xpub() {
     // Hardened path: the existing "no private key" error shape is preserved.
     let hardened: DerivationPath = "m/44'/1'/0'".parse().unwrap();
     assert!(watch.derive_extended_public_key(&hardened).is_err());
+}
+
+// -------- add_*account(_, None) is actionable on keyless wallets -------
+
+#[test]
+fn add_account_none_on_keyless_wallet_returns_typed_error() {
+    let full = built_full_wallet();
+    let account_type = AccountType::Standard {
+        index: 0,
+        standard_account_type: StandardAccountType::BIP44Account,
+    };
+
+    for mut wallet in [
+        Wallet::new_watch_only(Network::Testnet, full.wallet_id, AccountCollection::new()),
+        Wallet::new_external_signable(Network::Testnet, full.wallet_id, AccountCollection::new()),
+    ] {
+        let err = wallet.add_account(account_type, None).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                Error::KeylessWalletRequiresAccountKey { account_type: at, .. } if at == account_type
+            ),
+            "expected KeylessWalletRequiresAccountKey, got: {err:?}"
+        );
+        // The message must name its own remedy: the Some(..) argument.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Some(") && msg.contains("private key"),
+            "error should name the Some(..) remedy; got: {msg}"
+        );
+    }
+}
+
+#[cfg(feature = "bls")]
+#[test]
+fn add_bls_account_none_on_keyless_wallet_returns_typed_error() {
+    let full = built_full_wallet();
+    let account_type = AccountType::ProviderOperatorKeys;
+    let mut wallet =
+        Wallet::new_external_signable(Network::Testnet, full.wallet_id, AccountCollection::new());
+
+    let err = wallet.add_bls_account(account_type, None).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            Error::KeylessWalletRequiresAccountKey { account_type: at, .. } if at == account_type
+        ),
+        "expected KeylessWalletRequiresAccountKey, got: {err:?}"
+    );
+}
+
+#[cfg(feature = "eddsa")]
+#[test]
+fn add_eddsa_account_none_on_keyless_wallet_returns_typed_error() {
+    let full = built_full_wallet();
+    let account_type = AccountType::ProviderPlatformKeys;
+    let mut wallet =
+        Wallet::new_watch_only(Network::Testnet, full.wallet_id, AccountCollection::new());
+
+    let err = wallet.add_eddsa_account(account_type, None).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            Error::KeylessWalletRequiresAccountKey { account_type: at, .. } if at == account_type
+        ),
+        "expected KeylessWalletRequiresAccountKey, got: {err:?}"
+    );
 }
 
 // -------- bincode round-trip -------------------------------------------

--- a/key-wallet/src/wallet/accounts.rs
+++ b/key-wallet/src/wallet/accounts.rs
@@ -18,13 +18,15 @@ impl Wallet {
     /// # Arguments
     /// * `account_type` - The type of account to create
     /// * `account_xpub` - Optional extended public key for the account. If not provided,
-    ///   the account will be derived from the wallet's private key.
-    ///   This will fail if the wallet doesn't have a private key
-    ///   (watch-only wallets or externally managed wallets where
-    ///   the private key is stored securely outside of the SDK).
+    ///   the account is derived from the wallet's in-wallet private key.
     ///
     /// # Returns
     /// Ok(()) if the account was successfully added
+    ///
+    /// # Errors
+    /// Returns [`Error::KeylessWalletRequiresAccountKey`] when `account_xpub` is
+    /// `None` on a keyless wallet (watch-only / external-signable): such wallets
+    /// hold no in-wallet private key, so pass the account's xpub via `Some(..)`.
     pub fn add_account(
         &mut self,
         account_type: AccountType,
@@ -41,8 +43,12 @@ impl Wallet {
             // Derive from wallet's private key
             let derivation_path = account_type.derivation_path(self.network)?;
 
-            // This will fail if the wallet doesn't have a private key (watch-only or externally managed)
-            let root_key = self.root_extended_priv_key()?;
+            let root_key = self.root_extended_priv_key().map_err(|_| {
+                Error::KeylessWalletRequiresAccountKey {
+                    account_type,
+                    required_key: "extended public key (xpub)",
+                }
+            })?;
             let master_key = root_key.to_extended_priv_key(self.network);
             let secp = Secp256k1::new();
             let account_xpriv =
@@ -70,10 +76,14 @@ impl Wallet {
     /// # Arguments
     /// * `account_type` - The type of account (must be ProviderOperatorKeys)
     /// * `bls_seed` - Optional 32-byte seed for BLS key generation. If not provided,
-    ///   the account will be derived from the wallet's private key.
+    ///   the account is derived from the wallet's in-wallet private key.
     ///
     /// # Returns
     /// Ok(()) if the account was successfully added
+    ///
+    /// # Errors
+    /// Returns [`Error::KeylessWalletRequiresAccountKey`] when `bls_seed` is `None`
+    /// on a keyless wallet (watch-only / external-signable): pass the seed via `Some(..)`.
     #[cfg(feature = "bls")]
     pub fn add_bls_account(
         &mut self,
@@ -98,8 +108,12 @@ impl Wallet {
             // Derive from wallet's private key
             let derivation_path = account_type.derivation_path(self.network)?;
 
-            // This will fail if the wallet doesn't have a private key
-            let root_key = self.root_extended_priv_key()?;
+            let root_key = self.root_extended_priv_key().map_err(|_| {
+                Error::KeylessWalletRequiresAccountKey {
+                    account_type,
+                    required_key: "32-byte BLS seed",
+                }
+            })?;
             let master_key = root_key.to_extended_priv_key(self.network);
             let secp = Secp256k1::new();
             let account_xpriv =
@@ -131,10 +145,14 @@ impl Wallet {
     /// # Arguments
     /// * `account_type` - The type of account (must be ProviderPlatformKeys)
     /// * `ed25519_seed` - Optional 32-byte seed for Ed25519 key generation. If not provided,
-    ///   the account will be derived from the wallet's private key.
+    ///   the account is derived from the wallet's in-wallet private key.
     ///
     /// # Returns
     /// Ok(()) if the account was successfully added
+    ///
+    /// # Errors
+    /// Returns [`Error::KeylessWalletRequiresAccountKey`] when `ed25519_seed` is `None`
+    /// on a keyless wallet (watch-only / external-signable): pass the seed via `Some(..)`.
     #[cfg(feature = "eddsa")]
     pub fn add_eddsa_account(
         &mut self,
@@ -159,8 +177,12 @@ impl Wallet {
             // Derive from wallet's private key
             let derivation_path = account_type.derivation_path(self.network)?;
 
-            // This will fail if the wallet doesn't have a private key
-            let root_key = self.root_extended_priv_key()?;
+            let root_key = self.root_extended_priv_key().map_err(|_| {
+                Error::KeylessWalletRequiresAccountKey {
+                    account_type,
+                    required_key: "32-byte Ed25519 seed",
+                }
+            })?;
             let master_key = root_key.to_extended_priv_key(self.network);
             let secp = Secp256k1::new();
             let account_xpriv =


### PR DESCRIPTION
## Why this PR exists
- **Problem**: On an external-signable / watch-only wallet (one with no in-wallet private key), `add_account(account_type, None)` — and its BLS/EdDSA siblings — fail deep inside `root_extended_priv_key()` with a bare, non-actionable string: `"External signable wallet has no private key"`. The message says *what* broke, never *what to do*.
- **What breaks without it**: This cryptic error caused a downstream Dash Platform finding (Found-031) to be misdiagnosed **three separate times** as a production defect — when the correct usage is simply `add_account(_, Some(xpub))`. A keyless-wallet caller gets no signal pointing them at the right overload; the failure reads like a missing capability rather than an API misuse.

## What was done
- Added a typed error variant `Error::KeylessWalletRequiresAccountKey { account_type, required_key }` (manual-`Display`, matching the crate's existing hand-rolled `Error`; fully pattern-matchable).
- In the derive-from-root branch of `add_account` (xpub), `add_bls_account` (32-byte BLS seed) and `add_eddsa_account` (32-byte Ed25519 seed), the keyless-wallet failure now maps to this variant, whose message names the remedy: supply the account's key material via the `Some(..)` argument.
- Maps **only** the keyless failure — `root_extended_priv_key()` errors solely on keyless wallets, so the `Some(..)` path, all derivation logic, and every other error path are untouched. The `None` API shape (the legitimate hot-wallet convenience path) is preserved.

## Testing
- New unit tests: `add_account(_, None)` on watch-only + external-signable wallets returns the new variant and its message names the `Some(..)` remedy (all three siblings, feature-gated for BLS/EdDSA). 11/11 in-module pass.
- `cargo build -p key-wallet` clean · `cargo clippy -p key-wallet --all-targets -- -D warnings` clean · `cargo fmt` applied.
- Verified no exhaustive external `match` on `Error` breaks (all have `_ =>` arms).

## Breaking changes
None — additive `Error` variant only.

## Checklist
- [x] Code compiles; clippy clean (`-D warnings`); `cargo fmt` applied
- [x] Tests added for the new behaviour
- [x] No secrets; additive change

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet account creation now returns a clearer, typed error when a keyless wallet can’t create accounts without an in-wallet private key.
  * The error message now specifies which account key is required and how to provide it when adding the account.
  * Added matching behavior for standard, BLS, and Ed25519 account creation in watch-only and external-signable wallets.
  * Updated the FFI error mapping so the same condition is reported with the correct error code.
* **Tests**
  * Expanded unit test coverage to validate the new keyless-wallet error behavior across supported wallet types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->