### PR TITLE
fix(dash-spv): derive storage lockfile path from full directory name

### DIFF
--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use dashcore::hash_types::FilterHeader;
 use dashcore::prelude::CoreBlockHeight;
 use std::ops::Range;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -99,16 +99,34 @@ pub struct DiskStorageManager {
     _lock_file: LockFile,
 }
 
+/// Derives the lockfile path for a storage directory by appending `.lock` to
+/// the directory's full name. `Path::set_extension` is unsuitable here: it
+/// replaces everything after the last dot, so directory names containing dots
+/// (e.g. `95.183.53.19-9999` and `95.183.53.20-9999`) would collide on the
+/// same lockfile.
+fn lock_file_path(storage_path: &Path) -> PathBuf {
+    match storage_path.file_name() {
+        Some(name) => {
+            let mut lock_name = name.to_os_string();
+            lock_name.push(".lock");
+            storage_path.with_file_name(lock_name)
+        }
+        // Paths without a final component (e.g. `/` or `..`); keep the
+        // previous `set_extension` behavior.
+        None => {
+            let mut lock_file = storage_path.to_path_buf();
+            lock_file.set_extension("lock");
+            lock_file
+        }
+    }
+}
+
 impl DiskStorageManager {
     pub async fn new(config: &ClientConfig) -> StorageResult<Self> {
         use std::fs;
 
         let storage_path = config.storage_path.clone();
-        let lock_file = {
-            let mut lock_file = storage_path.clone();
-            lock_file.set_extension("lock");
-            lock_file
-        };
+        let lock_file = lock_file_path(&storage_path);
 
         fs::create_dir_all(&storage_path)?;
 
@@ -415,6 +433,41 @@ mod tests {
 
     fn hashed_batch(r: std::ops::Range<u32>) -> Vec<HashedBlockHeader> {
         BlockHeader::dummy_batch(r).into_iter().map(HashedBlockHeader::from).collect()
+    }
+
+    #[test]
+    fn test_lock_file_path_appends_to_full_name() {
+        // Dot-free directory names keep the historical behavior.
+        assert_eq!(
+            lock_file_path(Path::new("data/discovery")),
+            PathBuf::from("data/discovery.lock")
+        );
+
+        // Dotted directory names must not have their "extension" replaced:
+        // distinct sibling directories need distinct lockfiles.
+        let a = lock_file_path(Path::new("probes/95.183.53.19-9999"));
+        let b = lock_file_path(Path::new("probes/95.183.53.20-9999"));
+        assert_eq!(a, PathBuf::from("probes/95.183.53.19-9999.lock"));
+        assert_eq!(b, PathBuf::from("probes/95.183.53.20-9999.lock"));
+        assert_ne!(a, b);
+    }
+
+    #[tokio::test]
+    async fn test_dotted_sibling_dirs_do_not_share_lock() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp_dir = TempDir::new()?;
+        let path_a = temp_dir.path().join("95.183.53.19-9999");
+        let path_b = temp_dir.path().join("95.183.53.20-9999");
+
+        let config_a = ClientConfig::testnet().with_storage_path(&path_a);
+        let config_b = ClientConfig::testnet().with_storage_path(&path_b);
+
+        let _storage_a = DiskStorageManager::new(&config_a).await?;
+        // Before the fix this failed with "Data directory ... is already in
+        // use by another process" because both paths derived the same lockfile.
+        let _storage_b = DiskStorageManager::new(&config_b).await?;
+
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`DiskStorageManager::new` derived its data-directory lockfile with `storage_path.set_extension("lock")`. When the storage path's final component contains a dot (e.g. `probes/95.183.53.19-9999`), `set_extension` replaces everything after the last dot — so `probes/95.183.53.19-9999` and `probes/95.183.53.20-9999` both derived `probes/95.183.53.lock`, and distinct data directories spuriously failed with `Data directory ... is already in use by another process`.

Discovered via the spv-network-health probe tool, which uses per-peer `ip-port` directory names.

## Fix

Build the lock path by appending `.lock` to the full final path component (via `OsString::push` + `with_file_name`, since `Path::add_extension` is unstable on the pinned toolchain). Dot-free paths behave exactly as before (`discovery` → `discovery.lock`). Paths with no final component keep the previous `set_extension` behavior.

## Tests

- Unit test asserting dotted sibling directory names produce distinct lock paths, and that dot-free names are unchanged.
- Async test opening two `DiskStorageManager`s on dotted sibling directories — failed with the spurious lock conflict before the fix.

`cargo test -p dash-spv --lib storage` (58 passed), `cargo clippy -p dash-spv --all-targets --all-features -- -D warnings`, and `cargo fmt --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)