### PR TITLE
fix(dash-spv): rescan committed filter ranges for newly derived scripts

### DIFF
--- a/dash-spv/src/sync/filters/batch.rs
+++ b/dash-spv/src/sync/filters/batch.rs
@@ -37,6 +37,12 @@ pub(super) struct FiltersBatch {
     /// need rescan, attributed per wallet so we can rerun matching only
     /// against the wallet that produced each new script.
     collected_scripts: HashMap<WalletId, HashSet<ScriptBuf>>,
+    /// Scripts already forward-rescanned but still awaiting the one combined
+    /// backward sweep over the committed range (#846). Accumulated across
+    /// fixpoint rounds so each script crosses the stored history exactly
+    /// once, instead of the whole history being reloaded per derivation
+    /// round.
+    backward_scripts: HashMap<WalletId, HashSet<ScriptBuf>>,
 }
 
 impl FiltersBatch {
@@ -56,6 +62,7 @@ impl FiltersBatch {
             rescan_complete: false,
             scanned_wallets: BTreeMap::new(),
             collected_scripts: HashMap::new(),
+            backward_scripts: HashMap::new(),
         }
     }
     /// Start height of this batch (inclusive).
@@ -122,6 +129,21 @@ impl FiltersBatch {
     /// Take collected per-wallet scripts for rescan, leaving the map empty.
     pub(super) fn take_collected_scripts(&mut self) -> HashMap<WalletId, HashSet<ScriptBuf>> {
         std::mem::take(&mut self.collected_scripts)
+    }
+    /// Queue already forward-rescanned scripts for the deferred backward
+    /// sweep over the committed range.
+    pub(super) fn accumulate_backward_scripts(
+        &mut self,
+        scripts: HashMap<WalletId, HashSet<ScriptBuf>>,
+    ) {
+        for (wallet_id, scripts) in scripts {
+            self.backward_scripts.entry(wallet_id).or_default().extend(scripts);
+        }
+    }
+    /// Take the scripts accumulated for the backward sweep, leaving the map
+    /// empty.
+    pub(super) fn take_backward_scripts(&mut self) -> HashMap<WalletId, HashSet<ScriptBuf>> {
+        std::mem::take(&mut self.backward_scripts)
     }
     /// Record the wallets that were behind for this batch at scan time, each
     /// with its `account_generation` snapshot.

--- a/dash-spv/src/sync/filters/batch.rs
+++ b/dash-spv/src/sync/filters/batch.rs
@@ -32,6 +32,12 @@ pub(super) struct FiltersBatch {
     /// need rescan, attributed per wallet so we can rerun matching only
     /// against the wallet that produced each new script.
     collected_scripts: HashMap<WalletId, HashSet<ScriptBuf>>,
+    /// Scripts already forward-rescanned but still awaiting the one combined
+    /// backward sweep over the committed range (#846). Accumulated across
+    /// fixpoint rounds so each script crosses the stored history exactly
+    /// once, instead of the whole history being reloaded per derivation
+    /// round.
+    backward_scripts: HashMap<WalletId, HashSet<ScriptBuf>>,
 }
 
 impl FiltersBatch {
@@ -51,6 +57,7 @@ impl FiltersBatch {
             rescan_complete: false,
             scanned_wallets: BTreeSet::new(),
             collected_scripts: HashMap::new(),
+            backward_scripts: HashMap::new(),
         }
     }
     /// Start height of this batch (inclusive).
@@ -117,6 +124,21 @@ impl FiltersBatch {
     /// Take collected per-wallet scripts for rescan, leaving the map empty.
     pub(super) fn take_collected_scripts(&mut self) -> HashMap<WalletId, HashSet<ScriptBuf>> {
         std::mem::take(&mut self.collected_scripts)
+    }
+    /// Queue already forward-rescanned scripts for the deferred backward
+    /// sweep over the committed range.
+    pub(super) fn accumulate_backward_scripts(
+        &mut self,
+        scripts: HashMap<WalletId, HashSet<ScriptBuf>>,
+    ) {
+        for (wallet_id, scripts) in scripts {
+            self.backward_scripts.entry(wallet_id).or_default().extend(scripts);
+        }
+    }
+    /// Take the scripts accumulated for the backward sweep, leaving the map
+    /// empty.
+    pub(super) fn take_backward_scripts(&mut self) -> HashMap<WalletId, HashSet<ScriptBuf>> {
+        std::mem::take(&mut self.backward_scripts)
     }
     /// Record the set of wallets that were behind for this batch at scan time.
     pub(super) fn set_scanned_wallets(&mut self, wallets: BTreeSet<WalletId>) {

--- a/dash-spv/src/sync/filters/coinjoin_gap_discovery_tests.rs
+++ b/dash-spv/src/sync/filters/coinjoin_gap_discovery_tests.rs
@@ -1,0 +1,403 @@
+//! CoinJoin gap-limit discovery repros against the real filter → block →
+//! wallet pipeline (`FiltersManager` + `BlockMatchTracker` + a real
+//! `WalletManager<ManagedWalletInfo>` with a CoinJoin account).
+//!
+//! Background: a wallet with dense CoinJoin usage (dozens of consecutive
+//! external indices funded per block) historically stalled at
+//! `highest_used = 59` (initial 30-address watch window + one gap-limit
+//! extension) because a matched block was applied to a wallet exactly once —
+//! the `BlockMatchTracker` gate was keyed by `(wallet, block)`, not
+//! `(wallet, address)` — so outputs paying addresses derived *from that same
+//! block's matches* were never re-tested. PR #820 fixed the in-flight part:
+//! `rescan_batch` now re-queues already-processed blocks of ACTIVE batches
+//! against newly derived scripts, to a fixpoint.
+//!
+//! These tests pin both the fixed behaviour and the remaining hole:
+//!
+//! 1. [`coinjoin_gap_limit_dense_same_batch_recovers`] — the empirical
+//!    stall-at-59 shape (two dense blocks in one batch). GREEN since #820;
+//!    kept as a regression guard.
+//! 2. [`coinjoin_gap_limit_inversion_within_batch_recovers`] — a gap-window
+//!    output in an EARLIER block of the SAME (still-active) batch is
+//!    recovered by the commit-time rescan. GREEN since #820.
+//! 3. [`coinjoin_gap_limit_stall_across_committed_batch`] — the SAME shape
+//!    with the earlier block in an already-COMMITTED batch (#846): rescans
+//!    only reach `active_batches`, and committed batches are gone. GREEN
+//!    since `rescan_committed_range` re-tests newly derived scripts against
+//!    the STORED filters below the committing batch.
+//!
+//! Each test drives the manager exactly the way the production event loop
+//! does: `try_process_batch` → `BlocksNeeded` → (blocks-manager stand-in)
+//! `WalletInterface::process_block_for_wallets` → `BlockProcessed` (with the
+//! wallet's freshly derived scripts) → `handle_sync_event` → commit-time
+//! rescan, iterated to quiescence. Deterministic: fixed mnemonic, synthetic
+//! blocks, real BIP-158 filters, no network.
+
+use super::*;
+use crate::storage::{
+    DiskStorageManager, PersistentBlockHeaderStorage, PersistentFilterHeaderStorage,
+    PersistentFilterStorage, StorageManager,
+};
+use dashcore::{
+    Address, Block, BlockHash, Network, OutPoint, Transaction, TxIn, TxOut, Txid, Witness,
+};
+use key_wallet::account::ManagedAccountTrait;
+use key_wallet::gap_limit::DEFAULT_COINJOIN_GAP_LIMIT;
+use key_wallet::managed_account::address_pool::{AddressPool, AddressPoolType, KeySource};
+use key_wallet::wallet::initialization::WalletAccountCreationOptions;
+use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
+use key_wallet_manager::WalletManager;
+use tokio::sync::mpsc::unbounded_channel;
+
+/// Deterministic test wallet seed (standard BIP-39 test vector mnemonic).
+const TEST_MNEMONIC: &str =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+/// CoinJoin-denomination-shaped output value (0.001 DASH + per-round fee).
+/// The matcher is purely script-based; the value is for realism only.
+const DENOMINATION: u64 = 100_001;
+
+type CjFiltersManager = FiltersManager<
+    PersistentBlockHeaderStorage,
+    PersistentFilterHeaderStorage,
+    PersistentFilterStorage,
+    WalletManager<ManagedWalletInfo>,
+>;
+
+/// Real wallet manager with one seed wallet (Default accounts incl. CoinJoin
+/// account 0, external pool pre-generated to `DEFAULT_COINJOIN_GAP_LIMIT`),
+/// wired into a `FiltersManager` over temp-dir storage.
+async fn setup() -> (CjFiltersManager, Arc<RwLock<WalletManager<ManagedWalletInfo>>>, WalletId) {
+    let mut wm = WalletManager::<ManagedWalletInfo>::new(Network::Regtest);
+    let wallet_id = wm
+        .create_wallet_from_mnemonic(TEST_MNEMONIC, 0, WalletAccountCreationOptions::Default)
+        .expect("create deterministic test wallet");
+    let wallet = Arc::new(RwLock::new(wm));
+
+    let storage = DiskStorageManager::with_temp_dir().await.unwrap();
+    let mut manager = FiltersManager::new(
+        Arc::clone(&wallet),
+        storage.block_headers(),
+        storage.filter_headers(),
+        storage.filters(),
+    )
+    .await;
+    manager.set_state(SyncState::Syncing);
+    (manager, wallet, wallet_id)
+}
+
+/// Derive the wallet's first `count` CoinJoin-account-0 External addresses
+/// OFFLINE (via a standalone pool over the same xpub + base path), so test
+/// blocks can pay indices far beyond the wallet's live watch window without
+/// touching the wallet's own state.
+async fn coinjoin_external_addresses(
+    wallet: &Arc<RwLock<WalletManager<ManagedWalletInfo>>>,
+    wallet_id: &WalletId,
+    count: u32,
+) -> Vec<Address> {
+    let wm = wallet.read().await;
+    let signing_wallet = wm.get_wallet(wallet_id).expect("wallet present");
+    let xpub = signing_wallet
+        .accounts
+        .coinjoin_accounts
+        .get(&0)
+        .expect("CoinJoin account 0 (Default options)")
+        .account_xpub;
+    let info = wm.get_wallet_info(wallet_id).expect("wallet info present");
+    let live_pool = coinjoin_external_pool(info);
+    let mut pool = AddressPool::new(
+        live_pool.base_path.clone(),
+        AddressPoolType::External,
+        count,
+        Network::Regtest,
+        &KeySource::Public(xpub),
+    )
+    .expect("derive standalone CoinJoin External pool");
+    // `AddressPool::new` pre-generates `count` addresses; extend defensively
+    // in case the constructor semantics change.
+    if pool.highest_generated.map(|h| h + 1).unwrap_or(0) < count {
+        let missing = count - pool.highest_generated.map(|h| h + 1).unwrap_or(0);
+        pool.generate_addresses(missing, &KeySource::Public(xpub), true)
+            .expect("extend standalone pool");
+    }
+    (0..count).map(|i| pool.address_at_index(i).expect("address generated")).collect()
+}
+
+/// The wallet's LIVE CoinJoin-account-0 External pool.
+fn coinjoin_external_pool(info: &ManagedWalletInfo) -> &AddressPool {
+    let account =
+        info.accounts.coinjoin_accounts.get(&0).expect("CoinJoin account 0 (Default options)");
+    account
+        .managed_account_type()
+        .address_pools()
+        .into_iter()
+        .find(|p| p.pool_type == AddressPoolType::External)
+        .expect("CoinJoin External pool")
+}
+
+/// `(highest_used, highest_generated, used_count)` of the live CoinJoin
+/// External pool — the discovery frontier the assertions pin.
+async fn coinjoin_pool_state(
+    wallet: &Arc<RwLock<WalletManager<ManagedWalletInfo>>>,
+    wallet_id: &WalletId,
+) -> (Option<u32>, Option<u32>, usize) {
+    let wm = wallet.read().await;
+    let info = wm.get_wallet_info(wallet_id).expect("wallet info present");
+    let pool = coinjoin_external_pool(info);
+    (pool.highest_used, pool.highest_generated, pool.used_indices.len())
+}
+
+/// One block at `height` whose single transaction pays every address in
+/// `addresses` one denomination output. Returns the block, its real BIP-158
+/// filter, and the filter match key.
+fn block_paying(height: u32, addresses: &[Address]) -> (Block, BlockFilter, FilterMatchKey) {
+    let mut prev_txid = [0xABu8; 32];
+    prev_txid[..4].copy_from_slice(&height.to_le_bytes());
+    let tx = Transaction {
+        version: 1,
+        lock_time: 0,
+        // One non-null input so the tx is not coinbase-shaped.
+        input: vec![TxIn {
+            previous_output: OutPoint::new(Txid::from(prev_txid), 0),
+            script_sig: ScriptBuf::new(),
+            sequence: 0xffffffff,
+            witness: Witness::new(),
+        }],
+        output: addresses
+            .iter()
+            .map(|a| TxOut {
+                value: DENOMINATION,
+                script_pubkey: a.script_pubkey(),
+            })
+            .collect(),
+        special_transaction_payload: None,
+    };
+    let block = Block::dummy(height, vec![tx]);
+    let filter = BlockFilter::dummy(&block);
+    let key = FilterMatchKey::new(height, block.block_hash());
+    (block, filter, key)
+}
+
+/// Drive the production event loop to quiescence: consume `BlocksNeeded` by
+/// processing the named blocks through the real wallet (the blocks-manager's
+/// job), feed the resulting `BlockProcessed` events (carrying the wallet's
+/// freshly derived scripts) back into the filters manager, and repeat until
+/// no more blocks are requested. Blocks are processed in height order, like
+/// the real `BlocksPipeline`.
+async fn drive_to_quiescence(
+    manager: &mut CjFiltersManager,
+    wallet: &Arc<RwLock<WalletManager<ManagedWalletInfo>>>,
+    blocks: &HashMap<BlockHash, Block>,
+    initial_events: Vec<SyncEvent>,
+) {
+    let (tx, _rx) = unbounded_channel();
+    let requests = RequestSender::new(tx);
+
+    let mut events = initial_events;
+    for _round in 0..64 {
+        let mut pending: BTreeMap<(u32, BlockHash), BTreeSet<WalletId>> = BTreeMap::new();
+        for event in events.drain(..) {
+            if let SyncEvent::BlocksNeeded {
+                blocks: needed,
+            } = event
+            {
+                for (key, wallets) in needed {
+                    pending.entry((key.height(), *key.hash())).or_default().extend(wallets);
+                }
+            }
+        }
+        if pending.is_empty() {
+            return;
+        }
+
+        let mut next_events = Vec::new();
+        for ((height, block_hash), wallets) in pending {
+            let block = blocks.get(&block_hash).expect("BlocksNeeded for an unknown test block");
+            let result = wallet
+                .write()
+                .await
+                .process_block_for_wallets(block, block_hash, height, &wallets)
+                .await;
+            let confirmed_txids = result.relevant_txids().cloned().collect();
+            let event = SyncEvent::BlockProcessed {
+                block_hash,
+                height,
+                wallets,
+                new_scripts: result.new_scripts,
+                confirmed_txids,
+            };
+            next_events.extend(
+                manager.handle_sync_event(&event, &requests).await.expect("BlockProcessed"),
+            );
+        }
+        events = next_events;
+    }
+    panic!("drive_to_quiescence did not settle within 64 rounds — runaway rescan loop?");
+}
+
+/// The empirical stall-at-59 shape: block A funds CoinJoin External indices
+/// 0..=51, the NEXT block funds 52..=139, both inside one active batch.
+/// Before PR #820 the `(wallet, block)` gate stopped discovery at index 59
+/// (29 initial + one 30-wide gap extension); the commit-time fixpoint rescan
+/// now climbs the whole dense range. Regression guard for #820.
+#[tokio::test]
+async fn coinjoin_gap_limit_dense_same_batch_recovers() {
+    let (mut manager, wallet, wallet_id) = setup().await;
+    let addresses = coinjoin_external_addresses(&wallet, &wallet_id, 140).await;
+
+    let (highest_used, highest_generated, _) = coinjoin_pool_state(&wallet, &wallet_id).await;
+    assert_eq!(highest_used, None, "fresh wallet must have no used CoinJoin indices");
+    assert_eq!(
+        highest_generated,
+        Some(DEFAULT_COINJOIN_GAP_LIMIT - 1),
+        "fresh wallet must watch exactly the initial CoinJoin gap window"
+    );
+
+    let (block_a, filter_a, key_a) = block_paying(10, &addresses[0..=51]);
+    let (block_b, filter_b, key_b) = block_paying(11, &addresses[52..=139]);
+    let blocks: HashMap<BlockHash, Block> =
+        HashMap::from([(block_a.block_hash(), block_a), (block_b.block_hash(), block_b)]);
+
+    let mut batch = FiltersBatch::new(0, 99, HashMap::from([(key_a, filter_a), (key_b, filter_b)]));
+    batch.mark_verified();
+    manager.active_batches.insert(0, batch);
+    manager.progress.update_stored_height(99);
+
+    let initial_events = manager.try_process_batch().await.unwrap();
+    drive_to_quiescence(&mut manager, &wallet, &blocks, initial_events).await;
+
+    let (highest_used, _, used_count) = coinjoin_pool_state(&wallet, &wallet_id).await;
+    assert_eq!(
+        highest_used,
+        Some(139),
+        "dense same-batch CoinJoin range must be fully discovered via the commit-time \
+         fixpoint rescan (PR #820); a stall at Some(59) means the (wallet, block) \
+         once-per-block gate regressed. used_count={used_count}"
+    );
+    assert_eq!(used_count, 140, "every funded index 0..=139 must be marked used");
+}
+
+/// Height inversion INSIDE one active batch: indices 40..=51 are funded at
+/// height 10, the in-window indices 0..=29 only at height 20. The initial
+/// scan cannot see block A (nothing watched matches it), but once block B's
+/// processing derives 30..=59 the commit-time rescan re-tests block A's
+/// filter and recovers it. GREEN since #820 — contrast for the RED
+/// cross-batch test below, isolating the commit boundary as the broken seam.
+#[tokio::test]
+async fn coinjoin_gap_limit_inversion_within_batch_recovers() {
+    let (mut manager, wallet, wallet_id) = setup().await;
+    let addresses = coinjoin_external_addresses(&wallet, &wallet_id, 60).await;
+
+    let (block_a, filter_a, key_a) = block_paying(10, &addresses[40..=51]);
+    let (block_b, filter_b, key_b) = block_paying(20, &addresses[0..=29]);
+    let blocks: HashMap<BlockHash, Block> =
+        HashMap::from([(block_a.block_hash(), block_a), (block_b.block_hash(), block_b)]);
+
+    let mut batch = FiltersBatch::new(0, 99, HashMap::from([(key_a, filter_a), (key_b, filter_b)]));
+    batch.mark_verified();
+    manager.active_batches.insert(0, batch);
+    manager.progress.update_stored_height(99);
+
+    let initial_events = manager.try_process_batch().await.unwrap();
+    drive_to_quiescence(&mut manager, &wallet, &blocks, initial_events).await;
+
+    let (highest_used, _, used_count) = coinjoin_pool_state(&wallet, &wallet_id).await;
+    assert_eq!(
+        highest_used,
+        Some(51),
+        "a gap-window output in an earlier block of the SAME active batch must be \
+         recovered by the commit-time rescan (PR #820). used_count={used_count}"
+    );
+}
+
+/// Gap-window outputs in an already-COMMITTED batch (#846).
+///
+/// Same funding shape as the within-batch inversion test, but the early
+/// block (indices 40..=51, height 10) sits in batch 0..=99 while the
+/// in-window block (indices 0..=29) sits at height 110 in batch 100..=199.
+/// Batch 0 scans clean (nothing watched matches) and commits. Processing the
+/// height-110 block derives 30..=59, and those scripts DO match block 10's
+/// filter — but `rescan_batch` only reaches `active_batches`, and committed
+/// batches are gone (`try_commit_batches` removes them; the tracker prunes
+/// at-or-below the committed height). Indices 40..=51 — squarely inside the
+/// BIP-44/CoinJoin gap-limit recovery contract (40 < 29 + 1 + 30) — used to
+/// stay invisible forever, along with their funds; a fresh re-sync from
+/// genesis hit the same wall deterministically.
+///
+/// GREEN since `rescan_committed_range`: newly derived scripts are re-tested
+/// against the persisted filters below the committing batch (BIP-158 filters
+/// are address-independent, so re-matching needs no re-download), and hits
+/// flow through the `track_for_new_scripts` re-download path to the same
+/// commit-time fixpoint. `highest_used` reaches 51.
+#[tokio::test]
+async fn coinjoin_gap_limit_stall_across_committed_batch() {
+    let (mut manager, wallet, wallet_id) = setup().await;
+    let addresses = coinjoin_external_addresses(&wallet, &wallet_id, 60).await;
+
+    let (block_a, filter_a, key_a) = block_paying(10, &addresses[40..=51]);
+    let (block_b, filter_b, key_b) = block_paying(110, &addresses[0..=29]);
+
+    // Uphold the production invariant the injected batches imply: every
+    // height at or below `stored_height` has its header and filter
+    // persisted (store_and_match_batches stores a batch's filters before
+    // stored_height advances past it). The committed-range recovery path
+    // re-tests exactly this stored data, so the invariant is load-bearing
+    // here: batch 0 commits before block B's processing derives the missing
+    // scripts, and by then its in-memory filters are gone.
+    {
+        let mut header_storage = manager.header_storage.write().await;
+        let mut filter_storage = manager.filter_storage.write().await;
+        for height in 0..=99u32 {
+            let (header, filter_bytes) = if height == 10 {
+                (block_a.header, filter_a.content.clone())
+            } else {
+                let filler = Block::dummy(height, vec![]);
+                let filter = BlockFilter::dummy(&filler);
+                (filler.header, filter.content)
+            };
+            header_storage
+                .store_headers_at_height(&[header.into()], height)
+                .await
+                .expect("seed header");
+            filter_storage.store_filter(height, &filter_bytes).await.expect("seed filter");
+        }
+    }
+
+    let blocks: HashMap<BlockHash, Block> =
+        HashMap::from([(block_a.block_hash(), block_a), (block_b.block_hash(), block_b)]);
+
+    let mut batch_0 = FiltersBatch::new(0, 99, HashMap::from([(key_a, filter_a)]));
+    batch_0.mark_verified();
+    manager.active_batches.insert(0, batch_0);
+    let mut batch_1 = FiltersBatch::new(100, 199, HashMap::from([(key_b, filter_b)]));
+    batch_1.mark_verified();
+    manager.active_batches.insert(100, batch_1);
+    manager.progress.update_stored_height(199);
+
+    let initial_events = manager.try_process_batch().await.unwrap();
+    drive_to_quiescence(&mut manager, &wallet, &blocks, initial_events).await;
+
+    let (highest_used, highest_generated, used_count) =
+        coinjoin_pool_state(&wallet, &wallet_id).await;
+    // Sanity: the in-window block was found and the gap window extended past
+    // index 51, so the missed indices ARE inside the watched range by now.
+    assert!(
+        highest_generated >= Some(51),
+        "gap maintenance must have extended the watch window past index 51 \
+         (got {highest_generated:?})"
+    );
+    assert_eq!(
+        highest_used,
+        Some(51),
+        "CoinJoin External indices 40..=51 were funded at height 10 in a batch that \
+         committed before their scripts were derived, and the new-script rescan never \
+         looks below the committed boundary (rescan_batch only reaches active_batches; \
+         BlockMatchTracker/commit pruning drops the range). The addresses are within \
+         the gap-limit recovery contract and are watched now (highest_generated = \
+         {highest_generated:?}), yet their outputs stay invisible: highest_used stalls \
+         at {highest_used:?}, used_count={used_count}. Fix direction: key re-scan \
+         suppression by (wallet, address/script) instead of block/commit progress, or \
+         trigger a below-committed-height rescan for a wallet whose gap maintenance \
+         derives scripts mid-sync."
+    );
+}

--- a/dash-spv/src/sync/filters/coinjoin_gap_discovery_tests.rs
+++ b/dash-spv/src/sync/filters/coinjoin_gap_discovery_tests.rs
@@ -57,6 +57,13 @@ const TEST_MNEMONIC: &str =
 /// The matcher is purely script-based; the value is for realism only.
 const DENOMINATION: u64 = 100_001;
 
+/// The initial CoinJoin watch window is `0..G`. Every funded index range
+/// below is expressed relative to `G` so the tests keep pinning the
+/// beyond-the-window shapes they were written for even when the default gap
+/// changes (it moved 30 -> 100 in #868, which would otherwise have silently
+/// turned the cross-commit repro into a trivially-green test).
+const G: usize = DEFAULT_COINJOIN_GAP_LIMIT as usize;
+
 type CjFiltersManager = FiltersManager<
     PersistentBlockHeaderStorage,
     PersistentFilterHeaderStorage,
@@ -235,15 +242,17 @@ async fn drive_to_quiescence(
     panic!("drive_to_quiescence did not settle within 64 rounds — runaway rescan loop?");
 }
 
-/// The empirical stall-at-59 shape: block A funds CoinJoin External indices
-/// 0..=51, the NEXT block funds 52..=139, both inside one active batch.
-/// Before PR #820 the `(wallet, block)` gate stopped discovery at index 59
-/// (29 initial + one 30-wide gap extension); the commit-time fixpoint rescan
-/// now climbs the whole dense range. Regression guard for #820.
+/// The empirical dense stall shape (stall-at-59 under the original gap of
+/// 30): block A funds CoinJoin External indices 0..=51, the NEXT block funds
+/// 52..=G+39 — the tail extends a full window past the initial one, so
+/// discovery must climb through at least one gap extension. Before PR #820
+/// the `(wallet, block)` gate stopped discovery at the first extension; the
+/// commit-time fixpoint rescan now climbs the whole dense range. Regression
+/// guard for #820.
 #[tokio::test]
 async fn coinjoin_gap_limit_dense_same_batch_recovers() {
     let (mut manager, wallet, wallet_id) = setup().await;
-    let addresses = coinjoin_external_addresses(&wallet, &wallet_id, 140).await;
+    let addresses = coinjoin_external_addresses(&wallet, &wallet_id, (G + 40) as u32).await;
 
     let (highest_used, highest_generated, _) = coinjoin_pool_state(&wallet, &wallet_id).await;
     assert_eq!(highest_used, None, "fresh wallet must have no used CoinJoin indices");
@@ -254,7 +263,7 @@ async fn coinjoin_gap_limit_dense_same_batch_recovers() {
     );
 
     let (block_a, filter_a, key_a) = block_paying(10, &addresses[0..=51]);
-    let (block_b, filter_b, key_b) = block_paying(11, &addresses[52..=139]);
+    let (block_b, filter_b, key_b) = block_paying(11, &addresses[52..=(G + 39)]);
     let blocks: HashMap<BlockHash, Block> =
         HashMap::from([(block_a.block_hash(), block_a), (block_b.block_hash(), block_b)]);
 
@@ -269,26 +278,27 @@ async fn coinjoin_gap_limit_dense_same_batch_recovers() {
     let (highest_used, _, used_count) = coinjoin_pool_state(&wallet, &wallet_id).await;
     assert_eq!(
         highest_used,
-        Some(139),
+        Some((G + 39) as u32),
         "dense same-batch CoinJoin range must be fully discovered via the commit-time \
-         fixpoint rescan (PR #820); a stall at Some(59) means the (wallet, block) \
-         once-per-block gate regressed. used_count={used_count}"
+         fixpoint rescan (PR #820); a stall at the first gap extension means the \
+         (wallet, block) once-per-block gate regressed. used_count={used_count}"
     );
-    assert_eq!(used_count, 140, "every funded index 0..=139 must be marked used");
+    assert_eq!(used_count, G + 40, "every funded index 0..=G+39 must be marked used");
 }
 
-/// Height inversion INSIDE one active batch: indices 40..=51 are funded at
-/// height 10, the in-window indices 0..=29 only at height 20. The initial
-/// scan cannot see block A (nothing watched matches it), but once block B's
-/// processing derives 30..=59 the commit-time rescan re-tests block A's
-/// filter and recovers it. GREEN since #820 — contrast for the RED
-/// cross-batch test below, isolating the commit boundary as the broken seam.
+/// Height inversion INSIDE one active batch: indices G+10..=G+21 (beyond the
+/// initial watch window) are funded at height 10, in-window indices 0..=29
+/// only at height 20. The initial scan cannot see block A (nothing watched
+/// matches it), but once block B's processing extends the window past G+21
+/// the commit-time rescan re-tests block A's filter and recovers it. GREEN
+/// since #820 — contrast for the cross-batch test below, isolating the
+/// commit boundary as the broken seam.
 #[tokio::test]
 async fn coinjoin_gap_limit_inversion_within_batch_recovers() {
     let (mut manager, wallet, wallet_id) = setup().await;
-    let addresses = coinjoin_external_addresses(&wallet, &wallet_id, 60).await;
+    let addresses = coinjoin_external_addresses(&wallet, &wallet_id, (G + 22) as u32).await;
 
-    let (block_a, filter_a, key_a) = block_paying(10, &addresses[40..=51]);
+    let (block_a, filter_a, key_a) = block_paying(10, &addresses[(G + 10)..=(G + 21)]);
     let (block_b, filter_b, key_b) = block_paying(20, &addresses[0..=29]);
     let blocks: HashMap<BlockHash, Block> =
         HashMap::from([(block_a.block_hash(), block_a), (block_b.block_hash(), block_b)]);
@@ -304,7 +314,7 @@ async fn coinjoin_gap_limit_inversion_within_batch_recovers() {
     let (highest_used, _, used_count) = coinjoin_pool_state(&wallet, &wallet_id).await;
     assert_eq!(
         highest_used,
-        Some(51),
+        Some((G + 21) as u32),
         "a gap-window output in an earlier block of the SAME active batch must be \
          recovered by the commit-time rescan (PR #820). used_count={used_count}"
     );
@@ -313,28 +323,28 @@ async fn coinjoin_gap_limit_inversion_within_batch_recovers() {
 /// Gap-window outputs in an already-COMMITTED batch (#846).
 ///
 /// Same funding shape as the within-batch inversion test, but the early
-/// block (indices 40..=51, height 10) sits in batch 0..=99 while the
+/// block (indices G+10..=G+21, height 10) sits in batch 0..=99 while the
 /// in-window block (indices 0..=29) sits at height 110 in batch 100..=199.
 /// Batch 0 scans clean (nothing watched matches) and commits. Processing the
-/// height-110 block derives 30..=59, and those scripts DO match block 10's
-/// filter — but `rescan_batch` only reaches `active_batches`, and committed
-/// batches are gone (`try_commit_batches` removes them; the tracker prunes
-/// at-or-below the committed height). Indices 40..=51 — squarely inside the
-/// BIP-44/CoinJoin gap-limit recovery contract (40 < 29 + 1 + 30) — used to
-/// stay invisible forever, along with their funds; a fresh re-sync from
-/// genesis hit the same wall deterministically.
+/// height-110 block extends the window past G+21, and those scripts DO match
+/// block 10's filter — but `rescan_batch` only reaches `active_batches`, and
+/// committed batches are gone (`try_commit_batches` removes them; the
+/// tracker prunes at-or-below the committed height). Indices G+10..=G+21 —
+/// squarely inside the BIP-44/CoinJoin gap-limit recovery contract
+/// (G+21 < 29 + 1 + G) — used to stay invisible forever, along with their
+/// funds; a fresh re-sync from genesis hit the same wall deterministically.
 ///
 /// GREEN since `rescan_committed_range`: newly derived scripts are re-tested
 /// against the persisted filters below the committing batch (BIP-158 filters
 /// are address-independent, so re-matching needs no re-download), and hits
 /// flow through the `track_for_new_scripts` re-download path to the same
-/// commit-time fixpoint. `highest_used` reaches 51.
+/// commit-time fixpoint. `highest_used` reaches G+21.
 #[tokio::test]
 async fn coinjoin_gap_limit_stall_across_committed_batch() {
     let (mut manager, wallet, wallet_id) = setup().await;
-    let addresses = coinjoin_external_addresses(&wallet, &wallet_id, 60).await;
+    let addresses = coinjoin_external_addresses(&wallet, &wallet_id, (G + 22) as u32).await;
 
-    let (block_a, filter_a, key_a) = block_paying(10, &addresses[40..=51]);
+    let (block_a, filter_a, key_a) = block_paying(10, &addresses[(G + 10)..=(G + 21)]);
     let (block_b, filter_b, key_b) = block_paying(110, &addresses[0..=29]);
 
     // Uphold the production invariant the injected batches imply: every
@@ -380,16 +390,16 @@ async fn coinjoin_gap_limit_stall_across_committed_batch() {
     let (highest_used, highest_generated, used_count) =
         coinjoin_pool_state(&wallet, &wallet_id).await;
     // Sanity: the in-window block was found and the gap window extended past
-    // index 51, so the missed indices ARE inside the watched range by now.
+    // index G+21, so the missed indices ARE inside the watched range by now.
     assert!(
-        highest_generated >= Some(51),
-        "gap maintenance must have extended the watch window past index 51 \
+        highest_generated >= Some((G + 21) as u32),
+        "gap maintenance must have extended the watch window past index G+21 \
          (got {highest_generated:?})"
     );
     assert_eq!(
         highest_used,
-        Some(51),
-        "CoinJoin External indices 40..=51 were funded at height 10 in a batch that \
+        Some((G + 21) as u32),
+        "CoinJoin External indices G+10..=G+21 were funded at height 10 in a batch that \
          committed before their scripts were derived, and the new-script rescan never \
          looks below the committed boundary (rescan_batch only reaches active_batches; \
          BlockMatchTracker/commit pruning drops the range). The addresses are within \

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -588,15 +588,37 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                     // Newly derived scripts also have to reach ranges that
                     // already committed: those blocks were matched against a
                     // watch set that predates these scripts, and nothing else
-                    // ever looks below `committed_height` again (#846).
-                    // Stored filters cover that range, so re-test the new
-                    // scripts against them; hits attribute to this batch so
-                    // its commit waits for the fixpoint.
-                    events.extend(
-                        self.rescan_committed_range(batch_start, &scripts_by_wallet).await?,
-                    );
+                    // ever looks below `committed_height` again (#846). That
+                    // backward sweep walks stored history — the expensive
+                    // direction — so defer it: accumulate the scripts here
+                    // and sweep once when the forward fixpoint is quiescent,
+                    // instead of re-walking the committed range on every
+                    // derivation round.
+                    if let Some(batch) = self.active_batches.get_mut(&batch_start) {
+                        batch.accumulate_backward_scripts(scripts_by_wallet);
+                        if batch.pending_blocks() > 0 {
+                            // Forward rescan found blocks; converge the
+                            // forward direction first.
+                            break;
+                        }
+                    }
+                }
 
-                    // Check if rescan found more blocks
+                // Forward direction quiescent: one combined backward sweep
+                // over the committed range with everything accumulated. Hits
+                // attribute to this batch, so scripts their processing
+                // derives re-enter through `collected_scripts` above and
+                // only genuinely new scripts get a follow-up sweep.
+                let backward_scripts = self
+                    .active_batches
+                    .get_mut(&batch_start)
+                    .map(|b| b.take_backward_scripts())
+                    .unwrap_or_default();
+                if !backward_scripts.is_empty() {
+                    events
+                        .extend(self.rescan_committed_range(batch_start, &backward_scripts).await?);
+
+                    // Check if the backward sweep found more blocks
                     if let Some(batch) = self.active_batches.get(&batch_start) {
                         if batch.pending_blocks() > 0 {
                             // Found more blocks, can't commit yet
@@ -815,6 +837,26 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             }
         }
 
+        Ok(self.queue_new_script_matches(batch_start, block_to_wallets, "Rescan"))
+    }
+
+    /// Queue filter matches driven by newly derived scripts for
+    /// (re-)download — the shared tail of `rescan_batch` and
+    /// `rescan_committed_range`.
+    ///
+    /// These matches come from scripts that did not exist when their block
+    /// was first processed, so a processed record must not suppress the
+    /// re-download: the block has to be re-applied against the extended
+    /// pools (`track_for_new_scripts`). Genuinely new blocks are charged to
+    /// `batch_start`'s `pending_blocks` accounting so its commit waits for
+    /// them; blocks already on their way still get a fresh `BlocksNeeded`
+    /// so the pipeline merges late wallet ids into its pending wallet set.
+    fn queue_new_script_matches(
+        &mut self,
+        batch_start: u32,
+        block_to_wallets: BTreeMap<FilterMatchKey, BTreeSet<WalletId>>,
+        context: &str,
+    ) -> Vec<SyncEvent> {
         let mut events = Vec::new();
         let mut blocks_needed: BTreeMap<FilterMatchKey, BTreeSet<WalletId>> = BTreeMap::new();
         let mut new_blocks_count = 0;
@@ -823,10 +865,6 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             self.progress.add_matched(block_to_wallets.len() as u32);
         }
         for (key, wallets) in block_to_wallets {
-            // Matches here are driven by scripts that did not exist when the
-            // block was first processed, so a processed record must not
-            // suppress the re-download: the block has to be re-applied
-            // against the extended pools.
             match self.tracker.track_for_new_scripts(&key, batch_start, wallets) {
                 BlockTrackResult::NewlyTracked {
                     wallets,
@@ -837,8 +875,6 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                 BlockTrackResult::InFlight {
                     wallets,
                 } => {
-                    // Block already on its way; merge late wallet ids into the
-                    // pipeline's pending wallet set via a fresh BlocksNeeded.
                     blocks_needed.insert(key, wallets);
                 }
                 // Never returned by track_for_new_scripts.
@@ -851,7 +887,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             if let Some(batch) = self.active_batches.get_mut(&batch_start) {
                 batch.set_pending_blocks(batch.pending_blocks() + new_blocks_count);
             }
-            tracing::info!("Rescan found {} additional blocks", new_blocks_count);
+            tracing::info!("{} found {} additional blocks", context, new_blocks_count);
         }
         if !blocks_needed.is_empty() {
             events.push(SyncEvent::BlocksNeeded {
@@ -859,7 +895,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             });
         }
 
-        Ok(events)
+        events
     }
 
     /// Scan a specific batch, matching its filters against each behind-wallet's
@@ -1152,51 +1188,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             chunk_start = chunk_end + 1;
         }
 
-        let mut events = Vec::new();
-        let mut blocks_needed: BTreeMap<FilterMatchKey, BTreeSet<WalletId>> = BTreeMap::new();
-        let mut new_blocks_count = 0;
-
-        if !block_to_wallets.is_empty() {
-            self.progress.add_matched(block_to_wallets.len() as u32);
-        }
-        for (key, wallets) in block_to_wallets {
-            // As in `rescan_batch`: these matches are driven by scripts that
-            // did not exist when the block was first processed, so processed
-            // records must not suppress the re-download.
-            match self.tracker.track_for_new_scripts(&key, batch_start, wallets) {
-                BlockTrackResult::NewlyTracked {
-                    wallets,
-                } => {
-                    blocks_needed.insert(key, wallets);
-                    new_blocks_count += 1;
-                }
-                BlockTrackResult::InFlight {
-                    wallets,
-                } => {
-                    blocks_needed.insert(key, wallets);
-                }
-                // Never returned by track_for_new_scripts.
-                BlockTrackResult::AlreadyProcessed => {}
-            }
-        }
-
-        if new_blocks_count > 0 {
-            if let Some(batch) = self.active_batches.get_mut(&batch_start) {
-                batch.set_pending_blocks(batch.pending_blocks() + new_blocks_count);
-            }
-            tracing::info!(
-                "Committed-range rescan found {} blocks below height {}",
-                new_blocks_count,
-                batch_start
-            );
-        }
-        if !blocks_needed.is_empty() {
-            events.push(SyncEvent::BlocksNeeded {
-                blocks: blocks_needed,
-            });
-        }
-
-        Ok(events)
+        Ok(self.queue_new_script_matches(batch_start, block_to_wallets, "Committed-range rescan"))
     }
 
     /// Handle notification that new filter headers are available.

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -585,6 +585,17 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                         events.extend(self.rescan_batch(later_start, &scripts_by_wallet).await?);
                     }
 
+                    // Newly derived scripts also have to reach ranges that
+                    // already committed: those blocks were matched against a
+                    // watch set that predates these scripts, and nothing else
+                    // ever looks below `committed_height` again (#846).
+                    // Stored filters cover that range, so re-test the new
+                    // scripts against them; hits attribute to this batch so
+                    // its commit waits for the fixpoint.
+                    events.extend(
+                        self.rescan_committed_range(batch_start, &scripts_by_wallet).await?,
+                    );
+
                     // Check if rescan found more blocks
                     if let Some(batch) = self.active_batches.get(&batch_start) {
                         if batch.pending_blocks() > 0 {
@@ -1053,6 +1064,141 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         Ok(events)
     }
 
+    /// Re-test newly derived scriptPubKeys against the already-committed
+    /// filter range below `batch_start` (#846).
+    ///
+    /// A committed batch is gone from `active_batches` and every wallet's
+    /// `synced_height` has advanced past it, so `rescan_batch` can never
+    /// reach it again — but a script derived later by gap-limit maintenance
+    /// (CoinJoin index↔height inversions being the concrete case) may pay
+    /// out inside that range. The filters themselves are address-independent
+    /// BIP-158 commitments and are all persisted, so the committed range is
+    /// re-tested from storage — no network traffic — and only genuinely
+    /// matching blocks are re-downloaded, via the same
+    /// `track_for_new_scripts` path `rescan_batch` uses.
+    ///
+    /// Matched blocks attribute to the committing batch at `batch_start`:
+    /// its `pending_blocks` accounting defers the commit, and scripts their
+    /// processing derives collect into that batch, so the existing
+    /// commit-time fixpoint loop covers the backward direction too.
+    ///
+    /// Deliberately matches only `new_scripts` — not the wallets' bare
+    /// filter elements — since those were already watched when the range
+    /// was originally scanned; including them would re-download previously
+    /// processed blocks across the whole history.
+    pub(super) async fn rescan_committed_range(
+        &mut self,
+        batch_start: u32,
+        new_scripts: &HashMap<WalletId, HashSet<ScriptBuf>>,
+    ) -> SyncResult<Vec<SyncEvent>> {
+        let Some(range_end) = batch_start.checked_sub(1) else {
+            return Ok(vec![]);
+        };
+
+        let wallet_queries: Vec<(WalletId, Vec<ScriptBuf>)> = new_scripts
+            .iter()
+            .filter(|(_, scripts)| !scripts.is_empty())
+            .map(|(id, scripts)| (*id, scripts.iter().cloned().collect()))
+            .collect();
+        if wallet_queries.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Nothing relevant can precede the earliest wallet birth height, and
+        // nothing is loadable below the first stored filter.
+        let wallet_base = self.wallet.read().await.earliest_required_height().await;
+        let Some(filter_base) = self.filter_storage.read().await.filter_start_height().await else {
+            return Ok(vec![]);
+        };
+        let range_start = wallet_base.max(filter_base);
+        if range_start > range_end {
+            return Ok(vec![]);
+        }
+
+        tracing::info!(
+            "Rescan committed filters ({}-{}) for new scripts across {} wallets",
+            range_start,
+            range_end,
+            wallet_queries.len()
+        );
+
+        let mut block_to_wallets: BTreeMap<FilterMatchKey, BTreeSet<WalletId>> = BTreeMap::new();
+        let mut chunk_start = range_start;
+        while chunk_start <= range_end {
+            let chunk_end = (chunk_start + BATCH_PROCESSING_SIZE - 1).min(range_end);
+            // A chunk the storage cannot serve (e.g. filters pruned or never
+            // stored for a sub-range) is skipped rather than failing the
+            // commit: the sweep is best-effort recovery over whatever
+            // history is locally available.
+            let filters = match self.load_filters(chunk_start, chunk_end).await {
+                Ok(filters) => filters,
+                Err(e) => {
+                    tracing::warn!(
+                        "Committed-range rescan skipping {}-{}: {}",
+                        chunk_start,
+                        chunk_end,
+                        e
+                    );
+                    chunk_start = chunk_end + 1;
+                    continue;
+                }
+            };
+            for (wallet_id, scripts) in &wallet_queries {
+                let matches = check_compact_filters_for_elements(&filters, scripts, &[], 0);
+                for key in matches {
+                    block_to_wallets.entry(key).or_default().insert(*wallet_id);
+                }
+            }
+            chunk_start = chunk_end + 1;
+        }
+
+        let mut events = Vec::new();
+        let mut blocks_needed: BTreeMap<FilterMatchKey, BTreeSet<WalletId>> = BTreeMap::new();
+        let mut new_blocks_count = 0;
+
+        if !block_to_wallets.is_empty() {
+            self.progress.add_matched(block_to_wallets.len() as u32);
+        }
+        for (key, wallets) in block_to_wallets {
+            // As in `rescan_batch`: these matches are driven by scripts that
+            // did not exist when the block was first processed, so processed
+            // records must not suppress the re-download.
+            match self.tracker.track_for_new_scripts(&key, batch_start, wallets) {
+                BlockTrackResult::NewlyTracked {
+                    wallets,
+                } => {
+                    blocks_needed.insert(key, wallets);
+                    new_blocks_count += 1;
+                }
+                BlockTrackResult::InFlight {
+                    wallets,
+                } => {
+                    blocks_needed.insert(key, wallets);
+                }
+                // Never returned by track_for_new_scripts.
+                BlockTrackResult::AlreadyProcessed => {}
+            }
+        }
+
+        if new_blocks_count > 0 {
+            if let Some(batch) = self.active_batches.get_mut(&batch_start) {
+                batch.set_pending_blocks(batch.pending_blocks() + new_blocks_count);
+            }
+            tracing::info!(
+                "Committed-range rescan found {} blocks below height {}",
+                new_blocks_count,
+                batch_start
+            );
+        }
+        if !blocks_needed.is_empty() {
+            events.push(SyncEvent::BlocksNeeded {
+                blocks: blocks_needed,
+            });
+        }
+
+        Ok(events)
+    }
+
     /// Handle notification that new filter headers are available.
     /// Used by both FilterHeadersSyncComplete and FilterHeadersStored events.
     pub(super) async fn handle_new_filter_headers(
@@ -1125,6 +1271,10 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         f.debug_struct("FiltersManager").field("progress", &self.progress).finish()
     }
 }
+#[cfg(test)]
+#[path = "coinjoin_gap_discovery_tests.rs"]
+mod coinjoin_gap_discovery_tests;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -553,15 +553,37 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                     // Newly derived scripts also have to reach ranges that
                     // already committed: those blocks were matched against a
                     // watch set that predates these scripts, and nothing else
-                    // ever looks below `committed_height` again (#846).
-                    // Stored filters cover that range, so re-test the new
-                    // scripts against them; hits attribute to this batch so
-                    // its commit waits for the fixpoint.
-                    events.extend(
-                        self.rescan_committed_range(batch_start, &scripts_by_wallet).await?,
-                    );
+                    // ever looks below `committed_height` again (#846). That
+                    // backward sweep walks stored history — the expensive
+                    // direction — so defer it: accumulate the scripts here
+                    // and sweep once when the forward fixpoint is quiescent,
+                    // instead of re-walking the committed range on every
+                    // derivation round.
+                    if let Some(batch) = self.active_batches.get_mut(&batch_start) {
+                        batch.accumulate_backward_scripts(scripts_by_wallet);
+                        if batch.pending_blocks() > 0 {
+                            // Forward rescan found blocks; converge the
+                            // forward direction first.
+                            break;
+                        }
+                    }
+                }
 
-                    // Check if rescan found more blocks
+                // Forward direction quiescent: one combined backward sweep
+                // over the committed range with everything accumulated. Hits
+                // attribute to this batch, so scripts their processing
+                // derives re-enter through `collected_scripts` above and
+                // only genuinely new scripts get a follow-up sweep.
+                let backward_scripts = self
+                    .active_batches
+                    .get_mut(&batch_start)
+                    .map(|b| b.take_backward_scripts())
+                    .unwrap_or_default();
+                if !backward_scripts.is_empty() {
+                    events
+                        .extend(self.rescan_committed_range(batch_start, &backward_scripts).await?);
+
+                    // Check if the backward sweep found more blocks
                     if let Some(batch) = self.active_batches.get(&batch_start) {
                         if batch.pending_blocks() > 0 {
                             // Found more blocks, can't commit yet
@@ -740,6 +762,26 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             }
         }
 
+        Ok(self.queue_new_script_matches(batch_start, block_to_wallets, "Rescan"))
+    }
+
+    /// Queue filter matches driven by newly derived scripts for
+    /// (re-)download — the shared tail of `rescan_batch` and
+    /// `rescan_committed_range`.
+    ///
+    /// These matches come from scripts that did not exist when their block
+    /// was first processed, so a processed record must not suppress the
+    /// re-download: the block has to be re-applied against the extended
+    /// pools (`track_for_new_scripts`). Genuinely new blocks are charged to
+    /// `batch_start`'s `pending_blocks` accounting so its commit waits for
+    /// them; blocks already on their way still get a fresh `BlocksNeeded`
+    /// so the pipeline merges late wallet ids into its pending wallet set.
+    fn queue_new_script_matches(
+        &mut self,
+        batch_start: u32,
+        block_to_wallets: BTreeMap<FilterMatchKey, BTreeSet<WalletId>>,
+        context: &str,
+    ) -> Vec<SyncEvent> {
         let mut events = Vec::new();
         let mut blocks_needed: BTreeMap<FilterMatchKey, BTreeSet<WalletId>> = BTreeMap::new();
         let mut new_blocks_count = 0;
@@ -748,10 +790,6 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             self.progress.add_matched(block_to_wallets.len() as u32);
         }
         for (key, wallets) in block_to_wallets {
-            // Matches here are driven by scripts that did not exist when the
-            // block was first processed, so a processed record must not
-            // suppress the re-download: the block has to be re-applied
-            // against the extended pools.
             match self.tracker.track_for_new_scripts(&key, batch_start, wallets) {
                 BlockTrackResult::NewlyTracked {
                     wallets,
@@ -762,8 +800,6 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                 BlockTrackResult::InFlight {
                     wallets,
                 } => {
-                    // Block already on its way; merge late wallet ids into the
-                    // pipeline's pending wallet set via a fresh BlocksNeeded.
                     blocks_needed.insert(key, wallets);
                 }
                 // Never returned by track_for_new_scripts.
@@ -776,7 +812,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             if let Some(batch) = self.active_batches.get_mut(&batch_start) {
                 batch.set_pending_blocks(batch.pending_blocks() + new_blocks_count);
             }
-            tracing::info!("Rescan found {} additional blocks", new_blocks_count);
+            tracing::info!("{} found {} additional blocks", context, new_blocks_count);
         }
         if !blocks_needed.is_empty() {
             events.push(SyncEvent::BlocksNeeded {
@@ -784,7 +820,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             });
         }
 
-        Ok(events)
+        events
     }
 
     /// Scan a specific batch, matching its filters against each behind-wallet's
@@ -1067,51 +1103,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             chunk_start = chunk_end + 1;
         }
 
-        let mut events = Vec::new();
-        let mut blocks_needed: BTreeMap<FilterMatchKey, BTreeSet<WalletId>> = BTreeMap::new();
-        let mut new_blocks_count = 0;
-
-        if !block_to_wallets.is_empty() {
-            self.progress.add_matched(block_to_wallets.len() as u32);
-        }
-        for (key, wallets) in block_to_wallets {
-            // As in `rescan_batch`: these matches are driven by scripts that
-            // did not exist when the block was first processed, so processed
-            // records must not suppress the re-download.
-            match self.tracker.track_for_new_scripts(&key, batch_start, wallets) {
-                BlockTrackResult::NewlyTracked {
-                    wallets,
-                } => {
-                    blocks_needed.insert(key, wallets);
-                    new_blocks_count += 1;
-                }
-                BlockTrackResult::InFlight {
-                    wallets,
-                } => {
-                    blocks_needed.insert(key, wallets);
-                }
-                // Never returned by track_for_new_scripts.
-                BlockTrackResult::AlreadyProcessed => {}
-            }
-        }
-
-        if new_blocks_count > 0 {
-            if let Some(batch) = self.active_batches.get_mut(&batch_start) {
-                batch.set_pending_blocks(batch.pending_blocks() + new_blocks_count);
-            }
-            tracing::info!(
-                "Committed-range rescan found {} blocks below height {}",
-                new_blocks_count,
-                batch_start
-            );
-        }
-        if !blocks_needed.is_empty() {
-            events.push(SyncEvent::BlocksNeeded {
-                blocks: blocks_needed,
-            });
-        }
-
-        Ok(events)
+        Ok(self.queue_new_script_matches(batch_start, block_to_wallets, "Committed-range rescan"))
     }
 
     /// Handle notification that new filter headers are available.

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -550,6 +550,17 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                         events.extend(self.rescan_batch(later_start, &scripts_by_wallet).await?);
                     }
 
+                    // Newly derived scripts also have to reach ranges that
+                    // already committed: those blocks were matched against a
+                    // watch set that predates these scripts, and nothing else
+                    // ever looks below `committed_height` again (#846).
+                    // Stored filters cover that range, so re-test the new
+                    // scripts against them; hits attribute to this batch so
+                    // its commit waits for the fixpoint.
+                    events.extend(
+                        self.rescan_committed_range(batch_start, &scripts_by_wallet).await?,
+                    );
+
                     // Check if rescan found more blocks
                     if let Some(batch) = self.active_batches.get(&batch_start) {
                         if batch.pending_blocks() > 0 {
@@ -968,6 +979,141 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         Ok(events)
     }
 
+    /// Re-test newly derived scriptPubKeys against the already-committed
+    /// filter range below `batch_start` (#846).
+    ///
+    /// A committed batch is gone from `active_batches` and every wallet's
+    /// `synced_height` has advanced past it, so `rescan_batch` can never
+    /// reach it again — but a script derived later by gap-limit maintenance
+    /// (CoinJoin index↔height inversions being the concrete case) may pay
+    /// out inside that range. The filters themselves are address-independent
+    /// BIP-158 commitments and are all persisted, so the committed range is
+    /// re-tested from storage — no network traffic — and only genuinely
+    /// matching blocks are re-downloaded, via the same
+    /// `track_for_new_scripts` path `rescan_batch` uses.
+    ///
+    /// Matched blocks attribute to the committing batch at `batch_start`:
+    /// its `pending_blocks` accounting defers the commit, and scripts their
+    /// processing derives collect into that batch, so the existing
+    /// commit-time fixpoint loop covers the backward direction too.
+    ///
+    /// Deliberately matches only `new_scripts` — not the wallets' bare
+    /// filter elements — since those were already watched when the range
+    /// was originally scanned; including them would re-download previously
+    /// processed blocks across the whole history.
+    pub(super) async fn rescan_committed_range(
+        &mut self,
+        batch_start: u32,
+        new_scripts: &HashMap<WalletId, HashSet<ScriptBuf>>,
+    ) -> SyncResult<Vec<SyncEvent>> {
+        let Some(range_end) = batch_start.checked_sub(1) else {
+            return Ok(vec![]);
+        };
+
+        let wallet_queries: Vec<(WalletId, Vec<ScriptBuf>)> = new_scripts
+            .iter()
+            .filter(|(_, scripts)| !scripts.is_empty())
+            .map(|(id, scripts)| (*id, scripts.iter().cloned().collect()))
+            .collect();
+        if wallet_queries.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Nothing relevant can precede the earliest wallet birth height, and
+        // nothing is loadable below the first stored filter.
+        let wallet_base = self.wallet.read().await.earliest_required_height().await;
+        let Some(filter_base) = self.filter_storage.read().await.filter_start_height().await else {
+            return Ok(vec![]);
+        };
+        let range_start = wallet_base.max(filter_base);
+        if range_start > range_end {
+            return Ok(vec![]);
+        }
+
+        tracing::info!(
+            "Rescan committed filters ({}-{}) for new scripts across {} wallets",
+            range_start,
+            range_end,
+            wallet_queries.len()
+        );
+
+        let mut block_to_wallets: BTreeMap<FilterMatchKey, BTreeSet<WalletId>> = BTreeMap::new();
+        let mut chunk_start = range_start;
+        while chunk_start <= range_end {
+            let chunk_end = (chunk_start + BATCH_PROCESSING_SIZE - 1).min(range_end);
+            // A chunk the storage cannot serve (e.g. filters pruned or never
+            // stored for a sub-range) is skipped rather than failing the
+            // commit: the sweep is best-effort recovery over whatever
+            // history is locally available.
+            let filters = match self.load_filters(chunk_start, chunk_end).await {
+                Ok(filters) => filters,
+                Err(e) => {
+                    tracing::warn!(
+                        "Committed-range rescan skipping {}-{}: {}",
+                        chunk_start,
+                        chunk_end,
+                        e
+                    );
+                    chunk_start = chunk_end + 1;
+                    continue;
+                }
+            };
+            for (wallet_id, scripts) in &wallet_queries {
+                let matches = check_compact_filters_for_elements(&filters, scripts, &[], 0);
+                for key in matches {
+                    block_to_wallets.entry(key).or_default().insert(*wallet_id);
+                }
+            }
+            chunk_start = chunk_end + 1;
+        }
+
+        let mut events = Vec::new();
+        let mut blocks_needed: BTreeMap<FilterMatchKey, BTreeSet<WalletId>> = BTreeMap::new();
+        let mut new_blocks_count = 0;
+
+        if !block_to_wallets.is_empty() {
+            self.progress.add_matched(block_to_wallets.len() as u32);
+        }
+        for (key, wallets) in block_to_wallets {
+            // As in `rescan_batch`: these matches are driven by scripts that
+            // did not exist when the block was first processed, so processed
+            // records must not suppress the re-download.
+            match self.tracker.track_for_new_scripts(&key, batch_start, wallets) {
+                BlockTrackResult::NewlyTracked {
+                    wallets,
+                } => {
+                    blocks_needed.insert(key, wallets);
+                    new_blocks_count += 1;
+                }
+                BlockTrackResult::InFlight {
+                    wallets,
+                } => {
+                    blocks_needed.insert(key, wallets);
+                }
+                // Never returned by track_for_new_scripts.
+                BlockTrackResult::AlreadyProcessed => {}
+            }
+        }
+
+        if new_blocks_count > 0 {
+            if let Some(batch) = self.active_batches.get_mut(&batch_start) {
+                batch.set_pending_blocks(batch.pending_blocks() + new_blocks_count);
+            }
+            tracing::info!(
+                "Committed-range rescan found {} blocks below height {}",
+                new_blocks_count,
+                batch_start
+            );
+        }
+        if !blocks_needed.is_empty() {
+            events.push(SyncEvent::BlocksNeeded {
+                blocks: blocks_needed,
+            });
+        }
+
+        Ok(events)
+    }
+
     /// Handle notification that new filter headers are available.
     /// Used by both FilterHeadersSyncComplete and FilterHeadersStored events.
     pub(super) async fn handle_new_filter_headers(
@@ -1026,6 +1172,10 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         f.debug_struct("FiltersManager").field("progress", &self.progress).finish()
     }
 }
+#[cfg(test)]
+#[path = "coinjoin_gap_discovery_tests.rs"]
+mod coinjoin_gap_discovery_tests;
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What

Fixes #846: scripts derived by gap-limit maintenance mid-sync had zero backward reach across a batch-commit boundary. `rescan_batch` only reaches `active_batches`; once a batch commits it is removed, its tracker records are pruned, and the wallet's advanced `synced_height` filters those heights out of any later match. An output paying a script that didn't exist yet when its block's batch committed stayed permanently invisible — and a fresh resync from genesis hit the same wall deterministically. The concrete population is CoinJoin wallets, whose parallel mixing sessions produce index↔height inversions (the e2e ground truth in #846 shows a real one at index ~1767).

## How

BIP-158 filters are address-independent commitments and every height at or below `stored_height` has its filter persisted — so the committed range can be re-tested **from local storage, with no network traffic**. This is the structural advantage over the BIP37/bloom approach (bitcoinj/DashJ must discard and re-download blocks on filter exhaustion because a stale client-supplied filter makes peers stop sending relevant txs; a stored BIP-158 filter never goes stale, only the query side does).

`rescan_committed_range` runs at the same commit-time seam as the #820 forward rescan, whenever a committing batch has newly derived scripts:

- matches **only the new scripts** (not the wallets' bare filter elements, which were already watched when the range was first scanned) against stored filters below the committing batch, chunked at `BATCH_PROCESSING_SIZE`, best-effort per chunk (a chunk the storage can't serve is skipped with a warning rather than failing the commit);
- routes hits through the existing `track_for_new_scripts` re-download path, so previously-processed blocks are re-applied against the extended pools;
- attributes hits to the committing batch, so its `pending_blocks` accounting holds the commit open and scripts derived from re-processed backward blocks feed the next fixpoint round automatically.

The sweep is bounded below by the earliest wallet birth height and the first stored filter; the latter comes from a new `FilterStorage::filter_start_height` accessor (the underlying `SegmentCache` already tracked it).

## Testing

Adopts the cross-commit repro from `repro/pr3549-rdc` (`coinjoin_gap_discovery_tests.rs`) as the regression gate. One harness change was needed: the original test injected batches without persisting anything, but in production `stored_height` only advances after filters are written to storage — and stored filters are exactly what the recovery path reads. The test now seeds header/filter storage for the committed range to uphold that invariant. The assertion is unchanged.

Before (dev + tests only) — the seeded harness alone does **not** make it pass:

```
test coinjoin_gap_limit_stall_across_committed_batch ... FAILED
test coinjoin_gap_limit_inversion_within_batch_recovers ... ok
test coinjoin_gap_limit_dense_same_batch_recovers ... ok
  left: Some(29)   // highest_used stalls at the initial watch window
 right: Some(51)
```

After (dev + tests + fix):

```
test coinjoin_gap_limit_inversion_within_batch_recovers ... ok
test coinjoin_gap_limit_stall_across_committed_batch ... ok
test coinjoin_gap_limit_dense_same_batch_recovers ... ok
test result: ok. 3 passed; 0 failed
```

Full `dash-spv` suite: 474 unit + 7 bin tests pass; clippy clean; fmt applied. (`dashd_masternode` integration tests require `DASHD_PATH` and were not run.)

## Notes for review

- At the tip (post-sync incremental commits), a new-script derivation now sweeps the whole stored history. Correct, and it only fires when gap maintenance actually derives something, but for a mixing-heavy wallet with deep history there's a perf lever available later (bounded backward window, or a script-set bloom) if it shows up in profiles.
- A residual sibling hole is out of scope here: `new_scripts` from a `BlockProcessed` whose block isn't in the in-flight tracker (`sync_manager.rs` — tip/mempool-confirmation paths) are still dropped without triggering any rescan.

Fixes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CoinJoin wallet synchronization when transactions are discovered out of order or across batch boundaries.
  * Ensured newly discovered addresses are rescanned across previously committed filter ranges.
  * Prevented CoinJoin gap discovery from stalling at an incorrect address frontier.

* **Tests**
  * Added deterministic coverage for dense transaction batches, address-order inversions, and committed-batch boundary scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->