### PR TITLE
fix(key-wallet): cover CoinJoin/DashPay accounts for AssetLock routing

### DIFF
--- a/key-wallet/src/transaction_checking/transaction_router/mod.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/mod.rs
@@ -134,16 +134,28 @@ impl TransactionRouter {
                 AccountTypeToCheck::StandardBIP32,
                 AccountTypeToCheck::CoinJoin,
             ],
-            TransactionType::AssetLock => vec![
-                AccountTypeToCheck::StandardBIP44,
-                AccountTypeToCheck::StandardBIP32,
-                AccountTypeToCheck::IdentityRegistration,
-                AccountTypeToCheck::IdentityTopUp,
-                AccountTypeToCheck::IdentityTopUpNotBound,
-                AccountTypeToCheck::IdentityInvitation,
-                AccountTypeToCheck::AssetLockAddressTopUp,
-                AccountTypeToCheck::AssetLockShieldedAddressTopUp,
-            ],
+            TransactionType::AssetLock => {
+                // An asset lock can be funded from any fund-bearing account, and only
+                // `check_core_transaction` debits a spent UTXO — scoped to the accounts
+                // returned here. Omitting CoinJoin / DashPay meant asset locks funded from
+                // those accounts never had their inputs debited, so the spent UTXOs kept
+                // counting toward the balance indefinitely while the (BIP44) change output
+                // was still credited — the balance ended up high by exactly the
+                // CoinJoin/DashPay amount spent, both on relay and on rescan
+                // (dashpay/platform#4073, dashpay/platform#4074, dashpay/dash-wallet#1507).
+                // Discovery is membership-based like Dash Core's `IsMine`, so consulting the
+                // full fund-bearing set never yields false positives.
+                let mut accounts = Self::fund_bearing_account_types();
+                accounts.extend([
+                    AccountTypeToCheck::IdentityRegistration,
+                    AccountTypeToCheck::IdentityTopUp,
+                    AccountTypeToCheck::IdentityTopUpNotBound,
+                    AccountTypeToCheck::IdentityInvitation,
+                    AccountTypeToCheck::AssetLockAddressTopUp,
+                    AccountTypeToCheck::AssetLockShieldedAddressTopUp,
+                ]);
+                accounts
+            }
             TransactionType::AssetUnlock => {
                 vec![AccountTypeToCheck::StandardBIP44, AccountTypeToCheck::StandardBIP32]
             }

--- a/key-wallet/src/transaction_checking/transaction_router/tests/routing.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/routing.rs
@@ -432,9 +432,15 @@ fn test_asset_lock_transaction_routing() {
     let tx_type = TransactionType::AssetLock;
     let accounts = TransactionRouter::get_relevant_account_types(&tx_type);
 
-    // Should check standard accounts and all identity accounts
+    // Should check all fund-bearing accounts (an asset lock can be funded from any of them)
+    // and all identity accounts.
     assert!(accounts.contains(&AccountTypeToCheck::StandardBIP44));
     assert!(accounts.contains(&AccountTypeToCheck::StandardBIP32));
+    // Fund-bearing accounts an asset lock can spend from. Their absence let asset-lock
+    // spends of CoinJoin / DashPay UTXOs go undebited (dashpay/platform#4073, #4074).
+    assert!(accounts.contains(&AccountTypeToCheck::CoinJoin));
+    assert!(accounts.contains(&AccountTypeToCheck::DashpayReceivingFunds));
+    assert!(accounts.contains(&AccountTypeToCheck::DashpayExternalAccount));
     assert!(accounts.contains(&AccountTypeToCheck::IdentityRegistration));
     assert!(accounts.contains(&AccountTypeToCheck::IdentityTopUp));
     assert!(accounts.contains(&AccountTypeToCheck::IdentityTopUpNotBound));

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -717,6 +717,32 @@ mod tests {
                 .is_empty(),
             "spent CoinJoin UTXO must be removed"
         );
+
+        // Aggregate wallet balance — the actual regression is balance inflation.
+        // `check_core_transaction` was called with `update_balance = true`, so
+        // the cached balance now reflects the spend. If the spent CoinJoin coin
+        // were NOT debited, the wallet would still count its `funding_value`
+        // (100_000_000) on top of the new BIP44 change, reporting
+        // `funding_value + change_value`. After a correct debit only the
+        // confirmed BIP44 change UTXO remains (the asset-lock credit output is
+        // locked into Platform, never counted as a spendable wallet UTXO — see
+        // the `total_received == change_value` assertion above).
+        assert_eq!(
+            managed_wallet.balance.confirmed(),
+            change_value,
+            "confirmed balance must be only the BIP44 change; the spent CoinJoin \
+             coin must not inflate it"
+        );
+        assert_eq!(
+            managed_wallet.balance.spendable(),
+            change_value,
+            "spendable balance must fall from funding_value to change_value after the spend"
+        );
+        assert_eq!(
+            managed_wallet.balance.total(),
+            change_value,
+            "total balance must not double-count the spent CoinJoin UTXO"
+        );
     }
 
     /// Test the full coinbase maturity flow - immature to mature transition

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -565,6 +565,160 @@ mod tests {
         assert_eq!(record.net_amount, -(funding_value as i64));
     }
 
+    /// Regression: an asset-lock transaction that spends a CoinJoin UTXO must
+    /// debit that UTXO.
+    ///
+    /// `check_core_transaction` only marks a UTXO spent for the account types
+    /// returned by `TransactionRouter::get_relevant_account_types`. Before the
+    /// fix, the `AssetLock` arm omitted `CoinJoin` (and the DashPay accounts),
+    /// so an asset lock funded from a CoinJoin UTXO never had that input
+    /// debited: the spent UTXO kept counting toward the balance while the BIP44
+    /// change output was still credited, inflating the balance by exactly the
+    /// spent amount — on both relay and rescan (dashpay/platform#4073, #4074,
+    /// dashpay/dash-wallet#1507).
+    #[tokio::test]
+    async fn test_asset_lock_spending_coinjoin_utxo_is_debited() {
+        use crate::account::AccountType;
+        use crate::managed_account::managed_account_type::ManagedAccountType;
+        use dashcore::blockdata::transaction::special_transaction::asset_lock::AssetLockPayload;
+        use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
+
+        let network = Network::Testnet;
+
+        // Wallet with a BIP44 account (asset-lock change lands here) and a
+        // CoinJoin account (funds the asset lock).
+        let mut wallet = Wallet::new_random(network, WalletAccountCreationOptions::None)
+            .expect("Should create wallet");
+        wallet
+            .add_account(
+                AccountType::Standard {
+                    index: 0,
+                    standard_account_type: StandardAccountType::BIP44Account,
+                },
+                None,
+            )
+            .expect("Should add BIP44 account");
+        wallet
+            .add_account(
+                AccountType::CoinJoin {
+                    index: 0,
+                },
+                None,
+            )
+            .expect("Should add CoinJoin account");
+
+        let mut managed_wallet =
+            ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string(), 0);
+
+        // Derive a CoinJoin external address and a BIP44 change address.
+        let coinjoin_xpub =
+            wallet.accounts.coinjoin_accounts.get(&0).expect("coinjoin account").account_xpub;
+        let coinjoin_address = {
+            let managed_account =
+                managed_wallet.first_coinjoin_managed_account_mut().expect("managed coinjoin");
+            if let ManagedAccountType::CoinJoin {
+                external_addresses,
+                ..
+            } = managed_account.managed_account_type_mut()
+            {
+                external_addresses
+                    .next_unused(&KeySource::Public(coinjoin_xpub), true)
+                    .expect("coinjoin address")
+            } else {
+                panic!("Expected CoinJoin account type");
+            }
+        };
+        let bip44_xpub =
+            wallet.accounts.standard_bip44_accounts.get(&0).expect("bip44 account").account_xpub;
+        let change_address = managed_wallet
+            .first_bip44_managed_account_mut()
+            .expect("managed bip44")
+            .next_change_address(Some(&bip44_xpub), true)
+            .expect("bip44 change address");
+
+        // Fund the CoinJoin address, creating a CoinJoin UTXO.
+        let funding_value = 100_000_000u64;
+        let funding_tx = Transaction::dummy(&coinjoin_address, 0..1, &[funding_value]);
+        let funding_context = TransactionContext::InChainLockedBlock(BlockInfo::new(
+            1,
+            BlockHash::from_slice(&[7u8; 32]).expect("Should create block hash"),
+            1_650_000_000,
+        ));
+        let funding_result = managed_wallet
+            .check_core_transaction(&funding_tx, funding_context, &mut wallet, true, true)
+            .await;
+        assert!(funding_result.is_relevant, "CoinJoin funding must be relevant");
+        assert_eq!(funding_result.total_received, funding_value);
+        assert_eq!(
+            managed_wallet.first_coinjoin_managed_account().expect("coinjoin account").utxos.len(),
+            1,
+            "CoinJoin funding must create a UTXO"
+        );
+
+        // Build an asset-lock tx spending the CoinJoin UTXO, with BIP44 change.
+        let credit_value = 40_000_000u64;
+        let change_value = funding_value - credit_value - 1_000; // small fee
+        let asset_lock_tx = Transaction {
+            version: 3,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: funding_tx.txid(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: 0xffffffff,
+                witness: dashcore::Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: change_value,
+                script_pubkey: change_address.script_pubkey(),
+            }],
+            special_transaction_payload: Some(TransactionPayload::AssetLockPayloadType(
+                AssetLockPayload {
+                    version: 1,
+                    credit_outputs: vec![TxOut {
+                        value: credit_value,
+                        script_pubkey: change_address.script_pubkey(),
+                    }],
+                },
+            )),
+        };
+        assert_eq!(
+            TransactionRouter::classify_transaction(&asset_lock_tx),
+            TransactionType::AssetLock,
+            "tx must classify as AssetLock so it routes through the AssetLock arm"
+        );
+
+        let spend_context = TransactionContext::InChainLockedBlock(BlockInfo::new(
+            2,
+            BlockHash::from_slice(&[8u8; 32]).expect("Should create block hash"),
+            1_650_000_100,
+        ));
+        let spend_result = managed_wallet
+            .check_core_transaction(&asset_lock_tx, spend_context, &mut wallet, true, true)
+            .await;
+
+        assert!(spend_result.is_relevant, "asset lock spending our UTXO must be relevant");
+        // The load-bearing assertion: the CoinJoin input must be debited.
+        assert_eq!(
+            spend_result.total_sent, funding_value,
+            "asset lock must debit the CoinJoin UTXO it spends"
+        );
+        assert_eq!(
+            spend_result.total_received, change_value,
+            "BIP44 change output must be credited"
+        );
+        assert!(
+            managed_wallet
+                .first_coinjoin_managed_account()
+                .expect("coinjoin account")
+                .utxos
+                .is_empty(),
+            "spent CoinJoin UTXO must be removed"
+        );
+    }
+
     /// Test the full coinbase maturity flow - immature to mature transition
     #[tokio::test]
     async fn test_wallet_checker_immature_transaction_flow() {


### PR DESCRIPTION
## Summary

`TransactionRouter::get_relevant_account_types(TransactionType::AssetLock)` omitted the
CoinJoin and DashPay fund-bearing account types. Because **only `check_core_transaction`
marks a UTXO spent, and it scopes spend detection to the account types this router
returns**, an asset-lock transaction funded from a CoinJoin, DashpayReceivingFunds, or
DashpayExternalAccount UTXO never had its input debited. The spent UTXO kept counting
toward the balance indefinitely, while the (BIP44) change output *was* credited — so the
reported balance ended up high by **exactly** the CoinJoin/DashPay amount spent, on both
initial relay and full rescan.

This is the rust-dashcore half of the fix tracked in dashpay/platform#4073 /
dashpay/platform#4074 (Kotlin SDK) and dashpay/dash-wallet#1507 (Android wallet).

## The defect

`check_core_transaction` (`key-wallet/src/transaction_checking/wallet_checker.rs`) does:

```rust
let tx_type = TransactionRouter::classify_transaction(tx);
let relevant_types = TransactionRouter::get_relevant_account_types(&tx_type);
let mut result = self.accounts.check_transaction(tx, &relevant_types);
```

`check_transaction` is what matches a transaction's inputs against account UTXOs and marks
them spent. If an account type is not in `relevant_types`, its UTXOs are never considered
for spend detection for that transaction. The `AssetLock` arm returned only:

```
StandardBIP44, StandardBIP32, IdentityRegistration, IdentityTopUp,
IdentityTopUpNotBound, IdentityInvitation, AssetLockAddressTopUp,
AssetLockShieldedAddressTopUp
```

An asset lock is a normal funded transaction: its inputs can come from *any* fund-bearing
account. A heavy-mixing wallet naturally funds identity top-ups from mixed (CoinJoin)
coins. When it did, the CoinJoin input outpoint was never matched, `total_sent` stayed 0
for that input, and the UTXO was left in the CoinJoin account as if unspent.

## Field evidence

Android SDK wallet (dashpay/dash-wallet#1507). We reconciled the SDK's tracked UTXO set
against the dashj reference wallet by outpoint diff. The SDK balance was high by exactly
the summed value of CoinJoin outpoints that had been spent by asset-lock (identity
top-up) transactions but were still present in the SDK's CoinJoin account UTXO set. Every
missing debit corresponded to an `AssetLock`-classified transaction whose input pointed at
a CoinJoin UTXO. The mismatch reproduced on a from-birth rescan, ruling out a transient
relay-ordering artifact — consistent with a routing omission rather than a sync gap.

## The fix

Route `AssetLock` through the full fund-bearing account set before the identity/asset-lock
accounts. On the current `dev` branch this set is already factored out as
`fund_bearing_account_types()` (BIP44, BIP32, CoinJoin, DashpayReceivingFunds,
DashpayExternalAccount) and is already used by the `Standard | CoinJoin` arm, so the fix
reuses it:

```rust
TransactionType::AssetLock => {
    let mut accounts = Self::fund_bearing_account_types();
    accounts.extend([
        AccountTypeToCheck::IdentityRegistration,
        AccountTypeToCheck::IdentityTopUp,
        AccountTypeToCheck::IdentityTopUpNotBound,
        AccountTypeToCheck::IdentityInvitation,
        AccountTypeToCheck::AssetLockAddressTopUp,
        AccountTypeToCheck::AssetLockShieldedAddressTopUp,
    ]);
    accounts
}
```

Discovery is membership-based, exactly like Dash Core's `IsMine` — an account only matches
when a scriptPubKey or spent-UTXO outpoint actually belongs to it — so consulting the
extra accounts can never produce a false positive. It only closes the case where the input
genuinely does belong to a CoinJoin/DashPay account.

> Note on porting: the original change (in the platform-vendored copy pinned at
> `1860089e`) listed the five fund-bearing accounts inline, because that revision predates
> the `fund_bearing_account_types()` helper. `dev` introduced that helper, so this PR ports
> the same change by reusing it. Functionally identical; happy to inline it instead if you
> prefer.

## Test

Adds an end-to-end regression test,
`wallet_checker::tests::test_asset_lock_spending_coinjoin_utxo_is_debited`, that:

1. builds a wallet with a BIP44 account and a CoinJoin account,
2. funds a real CoinJoin external address (creating a CoinJoin UTXO),
3. spends that UTXO with an `AssetLockPayload` transaction that has BIP44 change,
4. processes it through `check_core_transaction`, and
5. asserts the CoinJoin UTXO is debited (`total_sent == funding_value`) and removed, and
   the BIP44 change is credited.

Verified it fails on the old routing (`total_sent` is `0`, UTXO not removed) and passes
with the fix. The existing `routing::test_asset_lock_transaction_routing` unit test is
also extended to assert CoinJoin/DashPay coverage.

## Verification

- `cargo test -p key-wallet` — 548 passed, 0 failed
- `cargo clippy -p key-wallet --all-features --all-targets -- -D warnings` — clean
- `cargo fmt -p key-wallet -- --check` — clean

cc @HashEngineering @QuantumExplorer — this is the AssetLock-routing PR requested on
dashpay/platform#4074 ("If rust-dashcore changes are required, then submit PRs to that
repo").


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing for asset-lock transactions to include all supported fund-bearing account types (including CoinJoin and DashPay-related accounts), ensuring the correct accounts are considered.
  * Fixed wallet accounting when an asset-lock spends a CoinJoin UTXO, including correct totals and removal of the spent UTXO without inflating balances.
* **Tests**
  * Added a regression test covering asset-lock spending of a CoinJoin UTXO and verifying routing and wallet balance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->