### PR TITLE
feat(key-wallet): gate-free provider-key derivation API (operator/platform-node at index)

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -18,6 +18,13 @@ on:
 permissions:
   contents: read
 
+# Pinned nightly: nightly-2026-07-14 (rustc daf2e5e18) ICEs while expanding the
+# libtest harness for dash-spv-ffi ("attribute is missing tokens:
+# rustc_test_entrypoint_marker" in rustc_ast/src/attr/mod.rs). Bump or restore
+# the floating `nightly` once a fixed nightly ships.
+env:
+  SANITIZER_TOOLCHAIN: nightly-2026-07-13
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -28,8 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.SANITIZER_TOOLCHAIN }}
           components: rust-src
 
       - name: Run tests with ASAN
@@ -41,11 +49,11 @@ jobs:
           SKIP_DASHD_TESTS: 1
         run: |
           # FFI crates (C interop)
-          cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu \
+          cargo "+$SANITIZER_TOOLCHAIN" test -Zbuild-std --target x86_64-unknown-linux-gnu \
             -p key-wallet-ffi -p dash-spv-ffi --lib --tests
 
           # Core crypto crates (unsafe optimizations)
-          cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu \
+          cargo "+$SANITIZER_TOOLCHAIN" test -Zbuild-std --target x86_64-unknown-linux-gnu \
             -p dashcore -p dashcore_hashes --lib --tests
 
   tsan:
@@ -53,8 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.SANITIZER_TOOLCHAIN }}
           components: rust-src
 
       - name: Run tests with TSAN
@@ -65,5 +74,5 @@ jobs:
           SKIP_DASHD_TESTS: 1
         run: |
           # Async crate with concurrent code
-          cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu \
+          cargo "+$SANITIZER_TOOLCHAIN" test -Zbuild-std --target x86_64-unknown-linux-gnu \
             -p dash-spv --lib --tests

--- a/key-wallet/src/account/bls_account.rs
+++ b/key-wallet/src/account/bls_account.rs
@@ -136,6 +136,55 @@ impl BLSAccount {
         })
     }
 
+    /// Derive the operator (masternode) BLS public key at `index` from the
+    /// stored account-level extended public key, using legacy-scheme
+    /// (`fLegacy = true`) non-hardened derivation, matching dashbls/DashSync.
+    ///
+    /// This is wallet-state-agnostic: it works on both resident accounts
+    /// (created from a mnemonic or seed) and watch-only / externally-signable
+    /// accounts, since only the account xpub is needed for the non-hardened
+    /// child step. There is no `is_watch_only` gate.
+    ///
+    /// The returned extended public key exposes both serializations of the
+    /// operator key: [`ExtendedBLSPubKey::to_bytes_legacy`] (legacy Dash
+    /// format) and [`ExtendedBLSPubKey::to_bytes`] (modern/IETF format used
+    /// in v19+ ProRegTx payloads).
+    ///
+    /// Returns an error if this account is not an
+    /// [`AccountType::ProviderOperatorKeys`] account, so a mixed-up account
+    /// lookup fails loudly instead of yielding valid-looking wrong keys.
+    pub fn operator_public_key_at(&self, index: u32) -> Result<ExtendedBLSPubKey> {
+        if self.account_type != AccountType::ProviderOperatorKeys {
+            return Err(Error::InvalidParameter(format!(
+                "operator_public_key_at requires a ProviderOperatorKeys account, got {}",
+                self.account_type
+            )));
+        }
+        let child = ChildNumber::from_normal_idx(index)?;
+        Ok(self.bls_public_key.derive_pub_legacy(child)?)
+    }
+
+    /// Derive the operator (masternode) BLS secret key at `index` directly
+    /// from a wallet seed (e.g. the 64-byte BIP39 seed).
+    ///
+    /// The full DIP-3 operator account path (`m/9'/5'/3'/3'` on mainnet,
+    /// `m/9'/1'/3'/3'` otherwise) is re-derived from the seed in the legacy
+    /// BLS scheme, then the non-hardened child `index` is applied — matching
+    /// dashbls/DashSync. Because derivation starts from the raw seed, no
+    /// account state is involved and in particular no `is_watch_only` gate
+    /// applies.
+    pub fn operator_private_key_at(
+        seed: &[u8],
+        network: Network,
+        index: u32,
+    ) -> Result<SecretKey<Bls12381G2Impl>> {
+        let master = ExtendedBLSPrivKey::new_master(network, seed)?;
+        let path = AccountType::ProviderOperatorKeys.derivation_path(network)?;
+        let account_xpriv = master.derive_path_legacy(&path)?;
+        let child = account_xpriv.derive_priv_legacy(ChildNumber::from_normal_idx(index)?)?;
+        Ok(child.private_key.clone())
+    }
+
     /// Derive a BLS key at a specific path (watch-only, non-hardened paths only)
     pub fn derive_bls_key_at_path(&self, path: &[u32]) -> Result<ExtendedBLSPubKey> {
         if self.is_watch_only {

--- a/key-wallet/src/account/eddsa_account.rs
+++ b/key-wallet/src/account/eddsa_account.rs
@@ -128,6 +128,26 @@ impl EdDSAAccount {
         })
     }
 
+    /// Derive the Platform node Ed25519 signing key at `index` directly from
+    /// a wallet seed (e.g. the 64-byte BIP39 seed).
+    ///
+    /// SLIP-0010 Ed25519 only supports hardened derivation, so the key is the
+    /// hardened child `index'` of the platform node account path
+    /// (`m/9'/5'/3'/4'` on mainnet, `m/9'/1'/3'/4'` otherwise), matching
+    /// DashSync. Because derivation starts from the raw seed, no account
+    /// state is involved and in particular no `is_watch_only` gate applies.
+    pub fn platform_node_key_at(
+        seed: &[u8],
+        network: Network,
+        index: u32,
+    ) -> Result<dashcore::ed25519_dalek::SigningKey> {
+        let master = ExtendedEd25519PrivKey::new_master(network, seed)?;
+        let path = AccountType::ProviderPlatformKeys.derivation_path(network)?;
+        let account_xpriv = master.derive_priv(&path)?;
+        let child = account_xpriv.derive_priv(&[ChildNumber::from_hardened_idx(index)?])?;
+        Ok(dashcore::ed25519_dalek::SigningKey::from_bytes(&child.private_key))
+    }
+
     /// Derive an Ed25519 key at a specific path
     /// Note: Ed25519 with SLIP-0010 only supports hardened derivation
     pub fn derive_ed25519_key_at_path(&self, path: &[u32]) -> Result<ExtendedEd25519PubKey> {

--- a/key-wallet/src/tests/provider_key_derivation_tests.rs
+++ b/key-wallet/src/tests/provider_key_derivation_tests.rs
@@ -125,6 +125,103 @@ fn ed25519_platform_node_keys_match_slip10_reference() {
     );
 }
 
+/// The gate-free provider-key entry points must work identically on resident
+/// (non-watch-only) and watch-only accounts, and must match the dashbls
+/// reference vectors. See
+/// <https://github.com/dashpay/rust-dashcore/issues/880>.
+#[cfg(feature = "bls")]
+#[test]
+fn operator_key_at_is_wallet_state_agnostic() {
+    use crate::account::bls_account::BLSAccount;
+
+    let wallet = test_wallet(Network::Mainnet);
+    let resident = wallet
+        .accounts
+        .bls_account_of_type(AccountType::ProviderOperatorKeys)
+        .expect("operator account should be auto-created for mnemonic wallets");
+    assert!(!resident.is_watch_only);
+
+    // A restored / externally-signable wallet stores the same account xpub but
+    // flags it watch-only (`BLSAccount::new` sets `is_watch_only: true`).
+    let watch_only = resident.to_watch_only();
+    assert!(watch_only.is_watch_only);
+
+    // The legacy-gated wrapper fails on the resident account — the new entry
+    // point must not.
+    assert!(resident.derive_bls_key_at_index(0).is_err());
+
+    for account in [resident, &watch_only] {
+        let key0 = account.operator_public_key_at(0).expect("gate-free derivation must succeed");
+        assert_eq!(
+            hex::encode(key0.to_bytes_legacy()),
+            "078cad04aae29eb76171937eb7101452b401b026efbc27db840f130374e6a9ec8443d917277f8921e0ba6678a7709875"
+        );
+        assert_eq!(
+            hex::encode(key0.to_bytes()),
+            "878cad04aae29eb76171937eb7101452b401b026efbc27db840f130374e6a9ec8443d917277f8921e0ba6678a7709875"
+        );
+    }
+
+    // Seed-based private derivation needs no account state at all.
+    let seed = hex::decode(TEST_SEED_HEX).unwrap();
+    let sk0 = BLSAccount::operator_private_key_at(&seed, Network::Mainnet, 0).unwrap();
+    assert_eq!(
+        hex::encode(sk0.to_be_bytes()),
+        "11122e1ad656d0610ce0f80d40da874d67ea656a3e66ed371c915ec3a488a43a"
+    );
+    let sk1 = BLSAccount::operator_private_key_at(&seed, Network::Mainnet, 1).unwrap();
+    assert_eq!(
+        hex::encode(sk1.to_be_bytes()),
+        "1a4e3318640cd4e50222184d0ea111abf8a0c18a0e5dc3ed45dad85009db4e31"
+    );
+
+    // Testnet vectors (coin type 1: m/9'/1'/3'/3').
+    let sk0_testnet = BLSAccount::operator_private_key_at(&seed, Network::Testnet, 0).unwrap();
+    assert_eq!(
+        hex::encode(sk0_testnet.to_be_bytes()),
+        "3346dfd71627f9f31cad3ee66fe7b673c32cb077b2eb38c621d7e61c30e46dbd"
+    );
+}
+
+/// `operator_public_key_at` refuses non-operator accounts so a mixed-up
+/// account lookup fails loudly instead of yielding valid-looking wrong keys.
+#[cfg(feature = "bls")]
+#[test]
+fn operator_public_key_at_rejects_non_operator_accounts() {
+    use crate::account::bls_account::BLSAccount;
+
+    let seed = hex::decode(TEST_SEED_HEX).unwrap();
+    let account =
+        BLSAccount::from_seed(None, AccountType::IdentityRegistration, &seed, Network::Mainnet)
+            .unwrap();
+    assert!(account.operator_public_key_at(0).is_err());
+}
+
+#[cfg(feature = "eddsa")]
+#[test]
+fn platform_node_key_at_is_wallet_state_agnostic() {
+    use crate::account::eddsa_account::EdDSAAccount;
+
+    // Seed-based hardened derivation, pinned to the SLIP-0010 reference
+    // vector for m/9'/5'/3'/4'/0'. No account state is involved.
+    let seed = hex::decode(TEST_SEED_HEX).unwrap();
+    let sk0 = EdDSAAccount::platform_node_key_at(&seed, Network::Mainnet, 0).unwrap();
+    assert_eq!(
+        hex::encode(sk0.to_bytes()),
+        "5fa238b12be77347abf9b5957bd902d16c6aaca28d25c4267ffacbd7458dceb1"
+    );
+
+    // Cross-check against the account stored in a resident wallet: the
+    // seed-based path must agree with the account-based path.
+    let wallet = test_wallet(Network::Mainnet);
+    let account = wallet
+        .accounts
+        .eddsa_account_of_type(AccountType::ProviderPlatformKeys)
+        .expect("platform node account should be auto-created for mnemonic wallets");
+    let via_account = account.derive_from_seed_private_key_at(&seed, 0).unwrap();
+    assert_eq!(sk0.to_bytes(), via_account.to_bytes());
+}
+
 /// Wallets created from a bare extended private key carry no seed, so
 /// DashSync-compatible BLS/Ed25519 provider keys cannot be derived for them.
 /// Default account creation must skip those accounts rather than fabricate


### PR DESCRIPTION
Closes #880.

## Problem

key-wallet's provider-key convenience wrappers are gated on `is_watch_only` in **opposite directions**:

- `BLSAccount::derive_bls_key_at_path` / `derive_bls_key_at_index` (public derivation) require `is_watch_only == true` and fail on resident accounts.
- `derive_from_seed_*_at` route through `derive_xpriv_from_master_xpriv`, which requires `is_watch_only == false` and fails on restored/external-signable (watch-only) accounts.

So no single upstream API served both wallet states, forcing downstream consumers (dashpay/platform#4120, Kotlin SDK) to re-compose derivation from low-level primitives — the duplication that caused the stale-derivation bug behind #878 / #879.

## Changes

Gate-free, wallet-state-agnostic entry points, per the API proposed in the issue:

- **`BLSAccount::operator_public_key_at(&self, index)`** — legacy-scheme (`fLegacy = true`) non-hardened public derivation off the stored account xpub. Works on resident **and** watch-only accounts; no `is_watch_only` gate. Returns `ExtendedBLSPubKey` so both serializations are obtainable (`to_bytes_legacy()` for the legacy Dash format, `to_bytes()` for the modern/IETF format used in v19+ ProRegTx payloads). Rejects non-`ProviderOperatorKeys` accounts so a mixed-up account lookup fails loudly instead of yielding valid-looking wrong keys.
- **`BLSAccount::operator_private_key_at(seed, network, index)`** — associated fn; re-derives the full DIP-3 operator path (`m/9'/5'/3'/3'` mainnet, `m/9'/1'/3'/3'` otherwise) from the raw BIP39 seed in the legacy BLS scheme, then the non-hardened child. Needs no account state at all.
- **`EdDSAAccount::platform_node_key_at(seed, network, index)`** — associated fn; SLIP-0010 hardened derivation of the platform node key (`m/9'/5'/3'/4'/i'`) from the raw seed.

This absorbs the protocol knowledge downstream currently re-encodes (legacy-scheme choice for BLS HD, hardened-leaf convention for Ed25519, account-path re-application from the raw seed) into key-wallet, next to the derivation itself. Purely additive — no existing API changed.

## Tests

- `operator_key_at_is_wallet_state_agnostic` — pins `operator_public_key_at` / `operator_private_key_at` to the existing dashbls golden vectors (mainnet + testnet) and asserts identical results on the resident account and its `to_watch_only()` counterpart, plus that the old gated wrapper still fails on the resident account (documenting the asymmetry this fixes).
- `operator_public_key_at_rejects_non_operator_accounts` — the account-type guard.
- `platform_node_key_at_is_wallet_state_agnostic` — pins to the SLIP-0010 golden vector and cross-checks against the account-based seed path.

`cargo test -p key-wallet --all-features`, `cargo fmt --check`, and `cargo clippy --all-features --all-targets -- -D warnings` all pass (one pre-existing timing-threshold flake in `performance_tests` under parallel load; passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)