### PR TITLE
feat(key-wallet): add missing DIP-15 derivation constants to dip9

### DIFF
--- a/key-wallet/src/dip9.rs
+++ b/key-wallet/src/dip9.rs
@@ -136,6 +136,13 @@ pub const FEATURE_PURPOSE_IDENTITIES_SUBFEATURE_INVITATIONS: u32 = 3;
 pub const FEATURE_PURPOSE_ASSET_LOCK_SUBFEATURE_ADDRESS_TOPUP: u32 = 4;
 pub const FEATURE_PURPOSE_ASSET_LOCK_SUBFEATURE_SHIELDED_ADDRESS_TOPUP: u32 = 5;
 pub const FEATURE_PURPOSE_DASHPAY: u32 = 15;
+/// DIP-15 auto-accept feature index: the derivation family
+/// `m/9'/coin_type'/16'/expiry'` holding the shareable, expiry-bounded
+/// bearer keys that a DashPay user embeds in an auto-accept QR (`dapk`) so a
+/// scanned contact request auto-establishes. Consumers (the platform wallet's
+/// auto-accept path builder and the FFI signer's raw-key export gate) must
+/// reference this constant rather than a local literal.
+pub const FEATURE_PURPOSE_DASHPAY_AUTO_ACCEPT: u32 = 16;
 /// DIP-17: Platform Payment Addresses feature index
 pub const FEATURE_PURPOSE_PLATFORM_PAYMENT: u32 = 17;
 pub const DASH_BIP44_PATH_MAINNET: IndexConstPath<2> = IndexConstPath {

--- a/key-wallet/src/dip9.rs
+++ b/key-wallet/src/dip9.rs
@@ -143,6 +143,14 @@ pub const FEATURE_PURPOSE_DASHPAY: u32 = 15;
 /// auto-accept path builder and the FFI signer's raw-key export gate) must
 /// reference this constant rather than a local literal.
 pub const FEATURE_PURPOSE_DASHPAY_AUTO_ACCEPT: u32 = 16;
+/// DIP-15 contactInfo `encToUserId` hardened child (`root / 65536' / index'`,
+/// where `root` is the owner's identity-authentication path): derives the
+/// AES key that encrypts the contact id in a `contactInfo` document.
+pub const DASHPAY_CONTACT_INFO_ENC_TO_USER_ID_CHILD: u32 = 1 << 16;
+/// DIP-15 contactInfo `privateData` hardened child (`root / 65537' / index'`):
+/// derives the AES key that encrypts the private-data blob in a `contactInfo`
+/// document.
+pub const DASHPAY_CONTACT_INFO_PRIVATE_DATA_CHILD: u32 = (1 << 16) + 1;
 /// DIP-17: Platform Payment Addresses feature index
 pub const FEATURE_PURPOSE_PLATFORM_PAYMENT: u32 = 17;
 pub const DASH_BIP44_PATH_MAINNET: IndexConstPath<2> = IndexConstPath {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Every other DIP-9-family feature index (identities `5'` with its sub-features, coinjoin `4'`, dashpay `15'`, platform payment `17'`) is defined in `key_wallet::dip9`, but two DIP-15 derivation families were never added:

- the **auto-accept** feature `16'` — `m/9'/coin_type'/16'/expiry'`, the expiry-bounded bearer keys behind the DashPay auto-accept QR (`dapk`);
- the **contactInfo** hardened children — `root/65536'/index'` (`encToUserId`) and `root/65537'/index'` (`privateData`) under the owner's identity-authentication path.

As a result, downstream consumers in dashpay/platform carry their own copies today: `rs-platform-wallet` (`crypto/auto_accept.rs` local const, `crypto/contact_info.rs` named consts) and `rs-sdk-ffi`'s resolver signer (raw `16`/`65536`/`65537` literals — it cannot import platform-wallet). Duplicated magic numbers for canonical derivation constants are exactly what `dip9` exists to prevent (noticed while fixing the same issue for the invitation constants in dashpay/platform#4041).

## What was done?

Added to `key-wallet/src/dip9.rs`, beside their siblings, each with a doc comment describing the derivation family:

- `FEATURE_PURPOSE_DASHPAY_AUTO_ACCEPT: u32 = 16`
- `DASHPAY_CONTACT_INFO_ENC_TO_USER_ID_CHILD: u32 = 1 << 16`
- `DASHPAY_CONTACT_INFO_PRIVATE_DATA_CHILD: u32 = (1 << 16) + 1`

No behavior change — documented constants only. The dashpay/platform call sites will switch to them on their next rust-dashcore bump.

## How Has This Been Tested?

`cargo check -p key-wallet` + `cargo fmt` clean; additive constants only, no runtime paths touched.

## Breaking Changes

None (additive).

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests (n/a — documented constants)
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)