### PR TITLE
fix(dash-spv): don't preload filters below the actually stored range on filter-download start

### DIFF
--- a/dash-spv/src/storage/filters.rs
+++ b/dash-spv/src/storage/filters.rs
@@ -21,6 +21,26 @@ pub trait FilterStorage: Send + Sync + 'static {
 
     async fn filter_tip_height(&self) -> StorageResult<u32>;
 
+    /// Lowest filter height present in storage, or `None` when no filters are
+    /// stored.
+    ///
+    /// `filter_tip_height` is a tip watermark only: storage is dense within
+    /// `[filter_start_height, filter_tip_height]`, but heights below the start
+    /// were never stored. Callers must not treat the tip as proof that storage
+    /// is contiguous from an arbitrary lower height.
+    async fn filter_start_height(&self) -> Option<u32>;
+
+    /// Drop every stored filter, leaving the storage empty.
+    ///
+    /// Used when the stored range cannot serve the current scan (e.g. filters
+    /// were previously stored from a checkpoint above a wallet's rescan
+    /// start): keeping an unreachable island of tip-region filters would leave
+    /// a permanent hole below it that the contiguous store path cannot fill.
+    ///
+    /// Like `truncate_above`, the deletion is not durable until the next
+    /// successful `persist` call.
+    async fn clear_filters(&mut self) -> StorageResult<()>;
+
     /// Drop all filters with `height > target_height`.
     ///
     /// Truncating above the current tip is a no-op, truncating below
@@ -79,6 +99,15 @@ impl FilterStorage for PersistentFilterStorage {
         Ok(self.filters.read().await.tip_height().unwrap_or(0))
     }
 
+    async fn filter_start_height(&self) -> Option<u32> {
+        self.filters.read().await.start_height()
+    }
+
+    async fn clear_filters(&mut self) -> StorageResult<()> {
+        self.filters.write().await.clear();
+        Ok(())
+    }
+
     async fn truncate_above(&mut self, target_height: u32) -> StorageResult<()> {
         self.filters.write().await.truncate_above(target_height).await
     }
@@ -106,5 +135,58 @@ mod tests {
 
         assert_eq!(storage.filter_tip_height().await.unwrap(), 2);
         assert!(storage.load_filters(3..4).await.is_err());
+    }
+
+    /// Filters stored only in a high region (as when headers previously
+    /// synced from a checkpoint): the start accessor reports the true lowest
+    /// stored height, reads below it fail loudly instead of returning
+    /// sentinels, and `clear_filters` durably empties the storage.
+    #[tokio::test]
+    async fn test_filter_start_height_and_clear_filters() {
+        let tmp_dir = TempDir::new().unwrap();
+        let mut storage = PersistentFilterStorage::open(tmp_dir.path()).await.unwrap();
+
+        assert_eq!(storage.filter_start_height().await, None);
+
+        for height in 900..=1000 {
+            storage.store_filter(height, &filter_bytes(height as u8)).await.unwrap();
+        }
+        assert_eq!(storage.filter_start_height().await, Some(900));
+        assert_eq!(storage.filter_tip_height().await.unwrap(), 1000);
+
+        // Reads that begin below the stored range must error, not hand back
+        // sentinel data zipped against real headers.
+        assert!(storage.load_filters(100..200).await.is_err());
+        assert!(storage.load_filters(850..950).await.is_err());
+        assert_eq!(storage.load_filters(900..1001).await.unwrap().len(), 101);
+
+        storage.persist(tmp_dir.path()).await.unwrap();
+        let segment_file =
+            tmp_dir.path().join(PersistentFilterStorage::FOLDER_NAME).join("segment_0000.dat");
+        assert!(segment_file.exists());
+
+        // The start height survives a reload.
+        let mut storage = PersistentFilterStorage::open(tmp_dir.path()).await.unwrap();
+        assert_eq!(storage.filter_start_height().await, Some(900));
+
+        storage.clear_filters().await.unwrap();
+        assert_eq!(storage.filter_start_height().await, None);
+        assert_eq!(storage.filter_tip_height().await.unwrap(), 0);
+        assert!(storage.load_filters(900..901).await.is_err());
+
+        storage.persist(tmp_dir.path()).await.unwrap();
+        assert!(!segment_file.exists());
+
+        // Reopen: the clear is durable, and the storage accepts a fresh
+        // contiguous range from a lower start.
+        let mut storage = PersistentFilterStorage::open(tmp_dir.path()).await.unwrap();
+        assert_eq!(storage.filter_start_height().await, None);
+        assert_eq!(storage.filter_tip_height().await.unwrap(), 0);
+
+        for height in 100..=110 {
+            storage.store_filter(height, &filter_bytes(height as u8)).await.unwrap();
+        }
+        assert_eq!(storage.filter_start_height().await, Some(100));
+        assert_eq!(storage.load_filters(100..111).await.unwrap().len(), 11);
     }
 }

--- a/dash-spv/src/storage/filters.rs
+++ b/dash-spv/src/storage/filters.rs
@@ -104,8 +104,7 @@ impl FilterStorage for PersistentFilterStorage {
     }
 
     async fn clear_filters(&mut self) -> StorageResult<()> {
-        self.filters.write().await.clear();
-        Ok(())
+        self.filters.write().await.clear()
     }
 
     async fn truncate_above(&mut self, target_height: u32) -> StorageResult<()> {

--- a/dash-spv/src/storage/mod.rs
+++ b/dash-spv/src/storage/mod.rs
@@ -375,6 +375,14 @@ impl filters::FilterStorage for DiskStorageManager {
         self.filters.read().await.filter_tip_height().await
     }
 
+    async fn filter_start_height(&self) -> Option<u32> {
+        self.filters.read().await.filter_start_height().await
+    }
+
+    async fn clear_filters(&mut self) -> StorageResult<()> {
+        self.filters.write().await.clear_filters().await
+    }
+
     async fn truncate_above(&mut self, target_height: u32) -> StorageResult<()> {
         self.filters.write().await.truncate_above(target_height).await
     }

--- a/dash-spv/src/storage/segments.rs
+++ b/dash-spv/src/storage/segments.rs
@@ -135,18 +135,18 @@ impl<I: Persistable> SegmentCache<I> {
     }
 
     /// Parse the segment id out of a segment file name of the form
-    /// `{SEGMENT_PREFIX}_{id:04}.{DATA_FILE_EXTENSION}`.
+    /// `{SEGMENT_PREFIX}_{id:04}.{DATA_FILE_EXTENSION}` (see
+    /// [`Persistable::segment_file_name`]).
+    ///
+    /// The entire remaining component between the `{prefix}_` and
+    /// `.{extension}` fixtures must parse as a `u32`, so trailing junk
+    /// (`segment_0000junk.dat`) is rejected and ids longer than the
+    /// zero-padding width (`segment_100000.dat`) are accepted, not truncated.
     fn parse_segment_id(file_name: &str) -> Option<u32> {
-        if !file_name.starts_with(I::SEGMENT_PREFIX)
-            || !file_name.ends_with(&format!(".{}", I::DATA_FILE_EXTENSION))
-        {
-            return None;
-        }
+        let separator = format!("{}_", I::SEGMENT_PREFIX);
+        let suffix = format!(".{}", I::DATA_FILE_EXTENSION);
 
-        let segment_id_start = I::SEGMENT_PREFIX.len() + 1;
-        let segment_id_end = segment_id_start + 4;
-
-        file_name.get(segment_id_start..segment_id_end)?.parse::<u32>().ok()
+        file_name.strip_prefix(&separator)?.strip_suffix(&suffix)?.parse::<u32>().ok()
     }
 
     #[inline]
@@ -455,29 +455,46 @@ impl<I: Persistable> SegmentCache<I> {
     /// `truncate_above`, the deletion is not durable until that `persist`
     /// succeeds; a crash in between leaves the old files on disk and the
     /// cache reopens with the pre-clear contents.
-    pub fn clear(&mut self) {
+    ///
+    /// The directory scan runs to completion *before* any cache state is
+    /// mutated: a failed scan must not leave the cache reporting empty while
+    /// persisted segment files survive on disk, since those would resurrect
+    /// after restart. A missing segments directory is treated as an empty
+    /// (already-cleared) cache; any other I/O error is propagated.
+    pub fn clear(&mut self) -> StorageResult<()> {
         // Queue every on-disk segment file, discovered by directory scan since
         // only up to MAX_ACTIVE_SEGMENTS of them are resident in memory.
-        if let Ok(entries) = fs::read_dir(&self.segments_dir) {
-            for entry in entries.flatten() {
-                if let Some(name) = entry.file_name().to_str() {
-                    if let Some(id) = Self::parse_segment_id(name) {
-                        self.to_delete.insert(id);
+        let mut to_delete = HashSet::new();
+        match fs::read_dir(&self.segments_dir) {
+            Ok(entries) => {
+                for entry in entries {
+                    let entry = entry?;
+                    if let Some(name) = entry.file_name().to_str() {
+                        if let Some(id) = Self::parse_segment_id(name) {
+                            to_delete.insert(id);
+                        }
                     }
                 }
             }
+            // No directory yet means nothing was ever persisted here.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(StorageError::Io(e)),
         }
 
-        // Resident and evicted segments may be dirty and not persisted yet, so
-        // the scan above cannot see them. Queue their ids too; `persist`
-        // ignores missing files.
-        self.to_delete.extend(self.segments.keys().copied());
-        self.to_delete.extend(self.evicted.keys().copied());
+        // Scan succeeded — now it is safe to mutate cache state. Resident and
+        // evicted segments may be dirty and not persisted yet, so the scan
+        // above cannot see them. Queue their ids too; `persist` ignores
+        // missing files.
+        to_delete.extend(self.segments.keys().copied());
+        to_delete.extend(self.evicted.keys().copied());
 
+        self.to_delete.extend(to_delete);
         self.segments.clear();
         self.evicted.clear();
         self.tip_height = None;
         self.start_height = None;
+
+        Ok(())
     }
 
     pub async fn persist(&mut self, segments_dir: impl Into<PathBuf>) {
@@ -1197,7 +1214,7 @@ mod tests {
 
         // Reopen (so only the min/max segments are resident) and clear.
         let mut cache = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
-        cache.clear();
+        cache.clear().unwrap();
 
         assert_eq!(cache.tip_height(), None);
         assert_eq!(cache.start_height(), None);
@@ -1238,7 +1255,7 @@ mod tests {
         // without an intervening persist.
         let more = FilterHeader::dummy_batch(100..105);
         cache.store_items_at_height(&more, 10).await.unwrap();
-        cache.clear();
+        cache.clear().unwrap();
 
         assert_eq!(cache.tip_height(), None);
         assert_eq!(cache.start_height(), None);
@@ -1249,6 +1266,45 @@ mod tests {
         let reloaded = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
         assert_eq!(reloaded.tip_height(), None);
         assert_eq!(reloaded.start_height(), None);
+    }
+
+    #[test]
+    fn test_parse_segment_id() {
+        type Cache = SegmentCache<FilterHeader>;
+
+        // Round-trips the writer's `{prefix}_{id:04}.{ext}` format for a range
+        // of ids, including ones wider than the zero-padding.
+        for id in [0u32, 1, 42, 9999, 10_000, 100_000, u32::MAX] {
+            assert_eq!(Cache::parse_segment_id(&FilterHeader::segment_file_name(id)), Some(id));
+        }
+
+        // Zero-padded low ids parse to their numeric value, not truncated.
+        assert_eq!(Cache::parse_segment_id("segment_0000.dat"), Some(0));
+        assert_eq!(Cache::parse_segment_id("segment_0005.dat"), Some(5));
+
+        // Ids wider than the padding are accepted whole, never truncated to
+        // the first four digits.
+        assert_eq!(Cache::parse_segment_id("segment_100000.dat"), Some(100_000));
+
+        // Trailing junk between the id and the extension is rejected rather
+        // than silently parsed as a prefix of the component.
+        assert_eq!(Cache::parse_segment_id("segment_0000junk.dat"), None);
+        assert_eq!(Cache::parse_segment_id("segment_12ab.dat"), None);
+
+        // Wrong prefix, wrong extension, missing separator, or a
+        // non-numeric/empty id component are all rejected.
+        assert_eq!(Cache::parse_segment_id("segment_0000.tmp"), None);
+        assert_eq!(Cache::parse_segment_id("other_0000.dat"), None);
+        assert_eq!(Cache::parse_segment_id("segment0000.dat"), None);
+        assert_eq!(Cache::parse_segment_id("segment_.dat"), None);
+        assert_eq!(Cache::parse_segment_id("segment_-1.dat"), None);
+        assert_eq!(Cache::parse_segment_id("segment_0000.dat.bak"), None);
+
+        // The filter storage's item type round-trips through the same helper.
+        assert_eq!(
+            SegmentCache::<Vec<u8>>::parse_segment_id(&<Vec<u8>>::segment_file_name(7)),
+            Some(7)
+        );
     }
 
     #[test]

--- a/dash-spv/src/storage/segments.rs
+++ b/dash-spv/src/storage/segments.rs
@@ -107,16 +107,9 @@ impl<I: Persistable> SegmentCache<I> {
 
             for entry in entries.flatten() {
                 if let Some(name) = entry.file_name().to_str() {
-                    if name.starts_with(I::SEGMENT_PREFIX)
-                        && name.ends_with(&format!(".{}", I::DATA_FILE_EXTENSION))
-                    {
-                        let segment_id_start = I::SEGMENT_PREFIX.len() + 1;
-                        let segment_id_end = segment_id_start + 4;
-
-                        if let Ok(id) = name[segment_id_start..segment_id_end].parse::<u32>() {
-                            max_seg_id = Some(max_seg_id.map_or(id, |max: u32| max.max(id)));
-                            min_seg_id = Some(min_seg_id.map_or(id, |min: u32| min.min(id)));
-                        }
+                    if let Some(id) = Self::parse_segment_id(name) {
+                        max_seg_id = Some(max_seg_id.map_or(id, |max: u32| max.max(id)));
+                        min_seg_id = Some(min_seg_id.map_or(id, |min: u32| min.min(id)));
                     }
                 }
             }
@@ -139,6 +132,21 @@ impl<I: Persistable> SegmentCache<I> {
         }
 
         Ok(cache)
+    }
+
+    /// Parse the segment id out of a segment file name of the form
+    /// `{SEGMENT_PREFIX}_{id:04}.{DATA_FILE_EXTENSION}`.
+    fn parse_segment_id(file_name: &str) -> Option<u32> {
+        if !file_name.starts_with(I::SEGMENT_PREFIX)
+            || !file_name.ends_with(&format!(".{}", I::DATA_FILE_EXTENSION))
+        {
+            return None;
+        }
+
+        let segment_id_start = I::SEGMENT_PREFIX.len() + 1;
+        let segment_id_end = segment_id_start + 4;
+
+        file_name.get(segment_id_start..segment_id_end)?.parse::<u32>().ok()
     }
 
     #[inline]
@@ -223,6 +231,17 @@ impl<I: Persistable> SegmentCache<I> {
             return Err(StorageError::InvalidArgument(format!(
                 "get_items range {height_range:?} extends above tip {:?}",
                 self.tip_height
+            )));
+        }
+
+        // Reject ranges that begin below the lowest stored height: those slots
+        // were never populated and hold only sentinels. Without this guard the
+        // read would trip the `first_valid_offset` debug assertion below in
+        // debug builds, and silently hand back sentinel data in release builds.
+        if self.start_height.is_none_or(|lowest| start < lowest) {
+            return Err(StorageError::InvalidArgument(format!(
+                "get_items range {height_range:?} begins below the lowest stored height {:?}",
+                self.start_height
             )));
         }
 
@@ -427,6 +446,38 @@ impl<I: Persistable> SegmentCache<I> {
         self.tip_height = Some(target_height);
 
         Ok(())
+    }
+
+    /// Drop every stored item, leaving the cache empty.
+    ///
+    /// All backing segment files — including segments not currently resident
+    /// in memory — are queued for deletion on the next `persist`. Like
+    /// `truncate_above`, the deletion is not durable until that `persist`
+    /// succeeds; a crash in between leaves the old files on disk and the
+    /// cache reopens with the pre-clear contents.
+    pub fn clear(&mut self) {
+        // Queue every on-disk segment file, discovered by directory scan since
+        // only up to MAX_ACTIVE_SEGMENTS of them are resident in memory.
+        if let Ok(entries) = fs::read_dir(&self.segments_dir) {
+            for entry in entries.flatten() {
+                if let Some(name) = entry.file_name().to_str() {
+                    if let Some(id) = Self::parse_segment_id(name) {
+                        self.to_delete.insert(id);
+                    }
+                }
+            }
+        }
+
+        // Resident and evicted segments may be dirty and not persisted yet, so
+        // the scan above cannot see them. Queue their ids too; `persist`
+        // ignores missing files.
+        self.to_delete.extend(self.segments.keys().copied());
+        self.to_delete.extend(self.evicted.keys().copied());
+
+        self.segments.clear();
+        self.evicted.clear();
+        self.tip_height = None;
+        self.start_height = None;
     }
 
     pub async fn persist(&mut self, segments_dir: impl Into<PathBuf>) {
@@ -1090,6 +1141,114 @@ mod tests {
             reloaded.get_items(ITEMS_PER_SEGMENT + 6..ITEMS_PER_SEGMENT + 16).await.unwrap(),
             replacement
         );
+    }
+
+    /// Ranges that begin below the lowest stored height read never-populated
+    /// sentinel slots and must fail with a typed error rather than panicking
+    /// on the `first_valid_offset` debug assertion (or silently returning
+    /// sentinels in release builds).
+    #[tokio::test]
+    async fn test_get_items_below_start_height_errors() {
+        let tmp_dir = TempDir::new().unwrap();
+
+        let items = FilterHeader::dummy_batch(0..10);
+
+        let mut cache = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
+        cache.store_items_at_height(&items, 900).await.unwrap();
+        assert_eq!(cache.start_height(), Some(900));
+
+        // Entirely below the stored range (the #892 shape: a scan start far
+        // below tip-region storage, within the same segment).
+        assert!(matches!(cache.get_items(100..200).await, Err(StorageError::InvalidArgument(_))));
+        // Straddling the lowest stored height.
+        assert!(matches!(cache.get_items(895..905).await, Err(StorageError::InvalidArgument(_))));
+        // The stored range itself is readable.
+        assert_eq!(cache.get_items(900..910).await.unwrap(), items);
+
+        // Same result when the never-populated slots live in a lower segment
+        // than the stored data.
+        const ITEMS_PER_SEGMENT: u32 = Segment::<FilterHeader>::ITEMS_PER_SEGMENT;
+        let mut cache = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
+        cache.store_items_at_height(&items, ITEMS_PER_SEGMENT + 5).await.unwrap();
+        assert!(matches!(cache.get_items(100..200).await, Err(StorageError::InvalidArgument(_))));
+
+        // An empty cache rejects every range.
+        let mut cache =
+            SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path().join("empty")).await.unwrap();
+        assert!(matches!(cache.get_items(0..1).await, Err(StorageError::InvalidArgument(_))));
+    }
+
+    #[tokio::test]
+    async fn test_segment_cache_clear() {
+        let tmp_dir = TempDir::new().unwrap();
+
+        const ITEMS_PER_SEGMENT: u32 = Segment::<FilterHeader>::ITEMS_PER_SEGMENT;
+
+        // Two segments' worth of items, persisted to disk.
+        let items = FilterHeader::dummy_batch(0..ITEMS_PER_SEGMENT + 5);
+        let mut cache = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
+        cache.store_items_at_height(&items, 0).await.unwrap();
+        cache.persist(tmp_dir.path()).await;
+
+        let file_0 = tmp_dir.path().join(FilterHeader::segment_file_name(0));
+        let file_1 = tmp_dir.path().join(FilterHeader::segment_file_name(1));
+        assert!(file_0.exists());
+        assert!(file_1.exists());
+
+        // Reopen (so only the min/max segments are resident) and clear.
+        let mut cache = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
+        cache.clear();
+
+        assert_eq!(cache.tip_height(), None);
+        assert_eq!(cache.start_height(), None);
+        assert_eq!(cache.get_item(3).await.unwrap(), None);
+        assert!(cache.get_items(0..5).await.is_err());
+
+        // The deletion becomes durable on persist.
+        cache.persist(tmp_dir.path()).await;
+        assert!(!file_0.exists());
+        assert!(!file_1.exists());
+
+        // Storing a fresh range from a lower origin after clear is sound.
+        let replacement = FilterHeader::dummy_batch(100..110);
+        cache.store_items_at_height(&replacement, 100).await.unwrap();
+        assert_eq!(cache.start_height(), Some(100));
+        assert_eq!(cache.tip_height(), Some(109));
+        assert_eq!(cache.get_items(100..110).await.unwrap(), replacement);
+
+        cache.persist(tmp_dir.path()).await;
+        let mut reloaded = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
+        assert_eq!(reloaded.start_height(), Some(100));
+        assert_eq!(reloaded.tip_height(), Some(109));
+        assert_eq!(reloaded.get_items(100..110).await.unwrap(), replacement);
+    }
+
+    /// `clear` must also drop dirty in-memory state that was never persisted,
+    /// and queue previously-persisted files of those same segments.
+    #[tokio::test]
+    async fn test_segment_cache_clear_unpersisted_state() {
+        let tmp_dir = TempDir::new().unwrap();
+
+        let items = FilterHeader::dummy_batch(0..10);
+        let mut cache = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
+        cache.store_items_at_height(&items, 0).await.unwrap();
+        cache.persist(tmp_dir.path()).await;
+
+        // Dirty the resident segment again so it differs from disk, then clear
+        // without an intervening persist.
+        let more = FilterHeader::dummy_batch(100..105);
+        cache.store_items_at_height(&more, 10).await.unwrap();
+        cache.clear();
+
+        assert_eq!(cache.tip_height(), None);
+        assert_eq!(cache.start_height(), None);
+
+        cache.persist(tmp_dir.path()).await;
+        assert!(!tmp_dir.path().join(FilterHeader::segment_file_name(0)).exists());
+
+        let reloaded = SegmentCache::<FilterHeader>::load_or_new(tmp_dir.path()).await.unwrap();
+        assert_eq!(reloaded.tip_height(), None);
+        assert_eq!(reloaded.start_height(), None);
     }
 
     #[test]

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -191,6 +191,10 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         // Get the stored filters range. `stored_filters_tip` is a tip
         // watermark only: storage is dense within `[stored_filters_start,
         // stored_filters_tip]` but holds nothing below the start.
+        // `stored_filters_start` is `None` exactly when no filters are stored;
+        // `filter_tip_height` collapses both "empty" and "only height 0
+        // stored" to 0, so the start must drive the "is anything stored?"
+        // decision.
         let (stored_filters_tip, stored_filters_start) = {
             let filter_storage = self.filter_storage.read().await;
             (filter_storage.filter_tip_height().await?, filter_storage.filter_start_height().await)
@@ -214,16 +218,20 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         // checkpoint above the wallet's birth height, only tip-region filters
         // exist: treating the tip watermark as contiguous coverage from
         // `scan_start` would preload never-populated segments (debug abort /
-        // sentinel filter data in release builds).
-        let stored_covers_scan =
-            stored_filters_tip > 0 && stored_filters_start.is_some_and(|start| start <= scan_start);
+        // sentinel filter data in release builds). Gate purely on the stored
+        // start so a genesis-only store (start = tip = 0) is recognized as
+        // covering a scan from 0 rather than being misread as empty.
+        let stored_covers_scan = stored_filters_start.is_some_and(|start| start <= scan_start);
 
         // Stored filters that don't reach down to `scan_start` cannot seed
         // this scan, and resuming the download from their tip would leave a
         // permanent hole below them that the in-order store loop can never
         // fill. Drop them and re-download from `scan_start`, exactly as if no
         // filters were stored, keeping storage dense within its stored range.
-        if stored_filters_tip > 0 && !stored_covers_scan {
+        // `is_some()` (not `tip > 0`) so this covers a lone above-scan filter
+        // stored at height 0, though that cannot arise while the start is also
+        // above `scan_start`.
+        if stored_filters_start.is_some() && !stored_covers_scan {
             tracing::warn!(
                 "Stored filters {:?}..={} do not reach scan start {}; discarding them and re-downloading",
                 stored_filters_start,
@@ -2309,6 +2317,59 @@ mod tests {
         // is already stored.
         assert_eq!(manager.next_batch_to_store, 1001);
         assert!(rx.try_recv().is_err(), "no filter request expected");
+    }
+
+    /// Genesis-only storage: a single filter at height 0, scanning from 0.
+    /// `filter_tip_height` collapses to 0 for both an empty store and this
+    /// one, so gating the preload on `tip > 0` would misread it as empty and
+    /// needlessly re-download height 0. The stored start (Some(0)) must drive
+    /// the decision: the filter is preloaded and nothing is discarded or
+    /// re-requested. Regtest can produce exactly this shape.
+    #[tokio::test]
+    async fn test_start_download_preloads_genesis_only_stored_filter() {
+        let mut manager = create_test_manager().await;
+
+        let headers = dashcore::block::Header::dummy_batch(0..1);
+        manager
+            .header_storage
+            .write()
+            .await
+            .store_headers(
+                &headers.iter().map(crate::types::HashedBlockHeader::from).collect::<Vec<_>>(),
+            )
+            .await
+            .unwrap();
+
+        // Exactly one filter stored, at height 0.
+        manager.filter_storage.write().await.store_filter(0, &[0u8; 8]).await.unwrap();
+        assert_eq!(manager.filter_storage.read().await.filter_tip_height().await.unwrap(), 0);
+        assert_eq!(manager.filter_storage.read().await.filter_start_height().await, Some(0));
+
+        // Restart shape at the genesis tip.
+        manager.progress.update_stored_height(0);
+        manager.progress.update_filter_header_tip_height(0);
+        manager.progress.update_target_height(0);
+        // Wallet at genesis: scan_start = 0.
+
+        let (tx, mut rx) = unbounded_channel();
+        manager.start_download(&RequestSender::new(tx)).await.unwrap();
+
+        // The lone filter was NOT discarded...
+        assert_eq!(manager.filter_storage.read().await.filter_tip_height().await.unwrap(), 0);
+        assert_eq!(manager.filter_storage.read().await.filter_start_height().await, Some(0));
+
+        // ...it was preloaded into the initial batch, which is verified and
+        // scanned since the whole (single-height) range is covered...
+        let batch = manager.active_batches.get(&0).expect("initial batch at scan_start");
+        assert_eq!(batch.filters().len(), 1);
+        assert!(batch.verified());
+        assert!(batch.scanned());
+        assert_eq!(manager.progress.stored_height(), 0);
+
+        // ...and the download frontier sits above the stored tip, so no
+        // filter request goes out for the already-stored genesis height.
+        assert_eq!(manager.next_batch_to_store, 1);
+        assert!(rx.try_recv().is_err(), "no filter request expected for the genesis-only store");
     }
 
     #[tokio::test]

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -188,8 +188,13 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             (wallet.earliest_required_height().await, wallet.synced_height())
         };
 
-        // Get stored filters tip
-        let stored_filters_tip = self.filter_storage.read().await.filter_tip_height().await?;
+        // Get the stored filters range. `stored_filters_tip` is a tip
+        // watermark only: storage is dense within `[stored_filters_start,
+        // stored_filters_tip]` but holds nothing below the start.
+        let (stored_filters_tip, stored_filters_start) = {
+            let filter_storage = self.filter_storage.read().await;
+            (filter_storage.filter_tip_height().await?, filter_storage.filter_start_height().await)
+        };
 
         // Get header start height (for checkpoint sync)
         let header_start_height =
@@ -204,9 +209,34 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         }
         .max(header_start_height);
 
+        // The stored range is only usable for this scan when it actually
+        // reaches down to `scan_start`. When headers previously synced from a
+        // checkpoint above the wallet's birth height, only tip-region filters
+        // exist: treating the tip watermark as contiguous coverage from
+        // `scan_start` would preload never-populated segments (debug abort /
+        // sentinel filter data in release builds).
+        let stored_covers_scan =
+            stored_filters_tip > 0 && stored_filters_start.is_some_and(|start| start <= scan_start);
+
+        // Stored filters that don't reach down to `scan_start` cannot seed
+        // this scan, and resuming the download from their tip would leave a
+        // permanent hole below them that the in-order store loop can never
+        // fill. Drop them and re-download from `scan_start`, exactly as if no
+        // filters were stored, keeping storage dense within its stored range.
+        if stored_filters_tip > 0 && !stored_covers_scan {
+            tracing::warn!(
+                "Stored filters {:?}..={} do not reach scan start {}; discarding them and re-downloading",
+                stored_filters_start,
+                stored_filters_tip,
+                scan_start
+            );
+            self.filter_storage.write().await.clear_filters().await?;
+            self.progress.update_stored_height(0);
+        }
+
         // Determine download start (where we need to download from)
         // Must be at least header_start_height for checkpoint-based sync
-        let download_start = if stored_filters_tip > 0 {
+        let download_start = if stored_covers_scan {
             (stored_filters_tip + 1).max(header_start_height)
         } else {
             scan_start
@@ -268,7 +298,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             (scan_start + BATCH_PROCESSING_SIZE - 1).min(self.progress.filter_header_tip_height());
 
         // Load any already-stored filters into the current batch, or create empty batch
-        let filters = if stored_filters_tip > 0 && scan_start <= stored_filters_tip {
+        let filters = if stored_covers_scan && scan_start <= stored_filters_tip {
             let end_height = stored_filters_tip.min(batch_end);
             tracing::info!(
                 "Loading stored filters {} to {} into current batch",
@@ -283,7 +313,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         };
 
         let mut batch = FiltersBatch::new(scan_start, batch_end, filters);
-        if stored_filters_tip >= batch_end {
+        if stored_covers_scan && stored_filters_tip >= batch_end {
             batch.mark_verified();
         }
         self.active_batches.insert(scan_start, batch);
@@ -2154,6 +2184,131 @@ mod tests {
         let batch = manager.active_batches.get(&0).expect("batch at scan_start=0");
         assert_eq!(batch.start_height(), 0);
         assert_eq!(batch.end_height(), 100);
+    }
+
+    /// Reproduces #892: filters were only ever stored near a high tip (e.g.
+    /// headers previously synced from a checkpoint), and the wallet's scan
+    /// start is far below that region. `start_download` must not treat the
+    /// stored tip watermark as contiguous coverage from `scan_start`:
+    /// preloading `load_filters(scan_start, ..)` would read never-populated
+    /// segments (debug abort in `SegmentCache::get_items`, sentinel filter
+    /// data in release builds). The unreachable tip-region filters are
+    /// discarded and the download restarts from `scan_start`.
+    #[tokio::test]
+    async fn test_start_download_discards_stored_filters_above_scan_start() {
+        let mut manager = create_test_manager().await;
+
+        // Block headers cover the whole range so send_pending can resolve stop hashes.
+        let headers = dashcore::block::Header::dummy_batch(0..1001);
+        manager
+            .header_storage
+            .write()
+            .await
+            .store_headers(
+                &headers.iter().map(crate::types::HashedBlockHeader::from).collect::<Vec<_>>(),
+            )
+            .await
+            .unwrap();
+
+        // Filters were only ever stored near the tip: 900..=1000. The heights
+        // below 900 were never populated.
+        {
+            let mut filter_storage = manager.filter_storage.write().await;
+            for height in 900..=1000u32 {
+                filter_storage.store_filter(height, &[height as u8; 8]).await.unwrap();
+            }
+        }
+        // Restart shape: `new()` seeds stored_height from the tip watermark.
+        manager.progress.update_stored_height(1000);
+        manager.progress.update_filter_header_tip_height(1000);
+        manager.progress.update_target_height(1000);
+
+        // Wallet committed far below the stored region, so scan_start = 100.
+        manager.wallet.write().await.update_wallet_synced_height(&MOCK_WALLET_ID, 99);
+
+        let (tx, mut rx) = unbounded_channel();
+        let events = manager.start_download(&RequestSender::new(tx)).await.unwrap();
+
+        assert!(events.is_empty());
+        assert_eq!(manager.state(), SyncState::Syncing);
+
+        // The unreachable tip-region filters were discarded entirely...
+        assert_eq!(manager.filter_storage.read().await.filter_tip_height().await.unwrap(), 0);
+        assert_eq!(manager.filter_storage.read().await.filter_start_height().await, None);
+
+        // ...nothing was preloaded into the initial batch...
+        let batch = manager.active_batches.get(&100).expect("initial batch at scan_start");
+        assert!(batch.filters().is_empty());
+        assert!(!batch.verified());
+        assert!(!batch.scanned());
+        assert_eq!(batch.end_height(), 1000);
+
+        // ...scan gating no longer sees the stale tip watermark...
+        assert_eq!(manager.progress.stored_height(), 0);
+
+        // ...and both the store cursor and the download restart from
+        // scan_start rather than stored_filters_tip + 1.
+        assert_eq!(manager.next_batch_to_store, 100);
+        match rx.try_recv().expect("a filter request must have been sent") {
+            NetworkRequest::SendMessage(NetworkMessage::GetCFilters(gcf)) => {
+                assert_eq!(gcf.start_height, 100);
+            }
+            other => panic!("Expected GetCFilters, got {:?}", other),
+        }
+    }
+
+    /// Counterpart to the sparse-storage case: when the stored filter range
+    /// actually reaches down to `scan_start`, the preload happens exactly as
+    /// before and nothing is discarded.
+    #[tokio::test]
+    async fn test_start_download_preloads_when_stored_filters_cover_scan_start() {
+        let mut manager = create_test_manager().await;
+
+        let headers = dashcore::block::Header::dummy_batch(0..1001);
+        manager
+            .header_storage
+            .write()
+            .await
+            .store_headers(
+                &headers.iter().map(crate::types::HashedBlockHeader::from).collect::<Vec<_>>(),
+            )
+            .await
+            .unwrap();
+
+        // Filters stored densely from genesis through the tip.
+        {
+            let mut filter_storage = manager.filter_storage.write().await;
+            for height in 0..=1000u32 {
+                filter_storage.store_filter(height, &[height as u8; 8]).await.unwrap();
+            }
+        }
+        manager.progress.update_stored_height(1000);
+        manager.progress.update_filter_header_tip_height(1000);
+        manager.progress.update_target_height(1000);
+
+        manager.wallet.write().await.update_wallet_synced_height(&MOCK_WALLET_ID, 99);
+
+        let (tx, mut rx) = unbounded_channel();
+        manager.start_download(&RequestSender::new(tx)).await.unwrap();
+
+        assert_eq!(manager.state(), SyncState::Syncing);
+
+        // Storage is untouched.
+        assert_eq!(manager.filter_storage.read().await.filter_tip_height().await.unwrap(), 1000);
+        assert_eq!(manager.filter_storage.read().await.filter_start_height().await, Some(0));
+
+        // The stored range 100..=1000 was preloaded and the batch is verified
+        // and scanned immediately.
+        let batch = manager.active_batches.get(&100).expect("initial batch at scan_start");
+        assert_eq!(batch.filters().len(), 901);
+        assert!(batch.verified());
+        assert!(batch.scanned());
+        assert_eq!(manager.progress.stored_height(), 1000);
+
+        // Nothing left to download: everything through the filter header tip
+        // is already stored.
+        assert_eq!(manager.next_batch_to_store, 1001);
+        assert!(rx.try_recv().is_err(), "no filter request expected");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes #892. `FiltersManager::start_download` treated `stored_filters_tip` (a tip watermark) as proof that filter storage is contiguous from `scan_start`. When only tip-region filters exist and the wallet's scan floor is far below (birth height « tip), the preload read never-populated segments: `SegmentCache::get_items` debug-aborts (permanent app crash-loop on relaunch, since auto-start resumes the same scan state) and release builds silently return sentinel filter data zipped against real headers.

## What was done?

- `FilterStorage` gains `filter_start_height()` (the segment cache already tracked it, it was just never exposed) and `clear_filters()`.
- `start_download` computes `stored_covers_scan = stored_filters_tip > 0 && stored_start <= scan_start`. When stored filters exist but don't reach down to `scan_start`, they are discarded (warn-logged) and the download restarts from `scan_start` — merely skipping the preload isn't enough: resuming from the stored tip would leave a permanent hole below the island that the in-order store loop can never fill, and keeping the island through a backfill risks two disjoint islands plus `Segment::insert` non-sentinel asserts. Preload and initial-batch `mark_verified` gate on `stored_covers_scan`.
- `SegmentCache::get_items` now returns a typed `InvalidArgument` for ranges beginning below the lowest stored height (replacing debug-abort / release-sentinel behavior for that case); `SegmentCache::clear()` added; `parse_segment_id` helper also fixes a latent slice-panic on short filenames in `load_or_new`.

## How Has This Been Tested?

- `test_start_download_discards_stored_filters_above_scan_start` — the exact #892 shape (filters stored 900..=1000, scan_start 100); verified it fails against the old gate at exactly the bad preload.
- `test_start_download_preloads_when_stored_filters_cover_scan_start` — regression guard for the covers case (behavior unchanged).
- Storage-layer tests: `filter_start_height` + `clear_filters` round-trip incl. persist/reopen; `get_items` below-start typed error; segment-cache clear (persisted + unpersisted).
- `cargo test -p dash-spv`: 477 passed, 0 failed (the `dashd_masternode` binary requires `DASHD_PATH`, pre-existing environmental). New tests also pass in `--release`, where the debug assertions are compiled out. fmt/clippy/`--all-features --tests`/`dash-spv-ffi --all-targets` clean.

## Breaking Changes

None. `FilterStorage` implementors gain two methods with default-free trait additions (in-repo implementors updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filter storage controls to report the earliest available filter height and clear stored filters.
  * Cleared filter data can be persisted and replaced with a new range starting at an earlier height.

* **Bug Fixes**
  * Requests below the available filter range now return a clear validation error.
  * Filter synchronization now discards incomplete stored ranges and restarts from the correct scan height.
  * Existing complete filter ranges continue to preload and scan as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->