### PR TITLE
feat(key-wallet): expose reserved outpoints for cross-account input selection

### DIFF
--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -121,6 +121,29 @@ impl ManagedCoreFundsAccount {
         &self.reservations
     }
 
+    /// Return the outpoints currently reserved by this account's in-flight
+    /// transaction builds, evaluated at `current_height` so stale reservations
+    /// past the TTL backstop are dropped first (see [`ReservationSet`]).
+    ///
+    /// This exposes the otherwise crate-private reservation ledger as a public,
+    /// read-only snapshot for callers that select inputs across accounts and so
+    /// cannot go through this account's own `set_funding`. A cross-account
+    /// sweep that force-adds another account's [`spendable_utxos`] bypasses that
+    /// account's coin selector and therefore its reservation awareness; reading
+    /// this set lets the caller skip inputs already committed to an in-flight
+    /// build, preventing a rebuild/retry from reselecting them into a
+    /// conflicting transaction. Prefer [`spendable_utxos_excluding_reserved`]
+    /// when the goal is simply to enumerate selectable UTXOs.
+    ///
+    /// The snapshot is a point-in-time copy: it reflects reservations taken up
+    /// to this call and is not updated as later builds reserve or release.
+    ///
+    /// [`spendable_utxos`]: Self::spendable_utxos
+    /// [`spendable_utxos_excluding_reserved`]: Self::spendable_utxos_excluding_reserved
+    pub fn reserved_outpoints(&self, current_height: u32) -> HashSet<OutPoint> {
+        self.reservations.reserved(current_height)
+    }
+
     /// Release the reservations held for `tx`'s inputs. Call this when a built
     /// transaction will not be broadcast, e.g. the user cancelled, so its inputs
     /// become selectable again immediately instead of waiting out the TTL
@@ -508,6 +531,35 @@ impl ManagedCoreFundsAccount {
     /// account-type specific.
     pub fn spendable_utxos(&self, last_processed_height: u32) -> BTreeSet<&Utxo> {
         self.utxos.values().filter(|utxo| utxo.is_spendable(last_processed_height)).collect()
+    }
+
+    /// Like [`spendable_utxos`](Self::spendable_utxos) but additionally excludes
+    /// any UTXO whose outpoint is currently reserved by an in-flight
+    /// transaction build (see [`reserved_outpoints`](Self::reserved_outpoints)).
+    ///
+    /// [`spendable_utxos`](Self::spendable_utxos) filters on spendability
+    /// (maturity, lock, and confirmation policy) only; it is unaware of
+    /// reservations because an account selecting its own inputs goes through
+    /// `set_funding`, which consults the reservation ledger directly. A caller
+    /// that force-adds another account's UTXOs into a shared selection bypasses
+    /// that path, so a broadcast that left inputs reserved could be reselected
+    /// by a rebuild/retry and produce a conflicting transaction. This variant is
+    /// the reservation-aware enumeration for exactly those cross-account sweeps.
+    ///
+    /// Reservations are evaluated at `last_processed_height`, which also drives
+    /// spendability, so a single height keeps both filters consistent and drops
+    /// reservations past the TTL backstop.
+    pub fn spendable_utxos_excluding_reserved(
+        &self,
+        last_processed_height: u32,
+    ) -> BTreeSet<&Utxo> {
+        let reserved = self.reservations.reserved(last_processed_height);
+        self.utxos
+            .values()
+            .filter(|utxo| {
+                utxo.is_spendable(last_processed_height) && !reserved.contains(&utxo.outpoint)
+            })
+            .collect()
     }
 
     /// Promote any `InBlock` records at height `<= cl_height` to

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -123,7 +123,7 @@ impl ManagedCoreFundsAccount {
 
     /// Return the outpoints currently reserved by this account's in-flight
     /// transaction builds, evaluated at `current_height` so stale reservations
-    /// past the TTL backstop are dropped first (see [`ReservationSet`]).
+    /// past the TTL backstop are dropped first (see `ReservationSet`).
     ///
     /// This exposes the otherwise crate-private reservation ledger as a public,
     /// read-only snapshot for callers that select inputs across accounts and so

--- a/key-wallet/src/tests/spent_outpoints_tests.rs
+++ b/key-wallet/src/tests/spent_outpoints_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for spent_outpoints deserialization and tracking.
 
+use std::collections::HashSet;
+
 use dashcore::blockdata::transaction::{OutPoint, Transaction};
 use dashcore::hashes::Hash;
 use dashcore::{BlockHash, TxIn, Txid};
@@ -10,6 +12,7 @@ use crate::managed_account::transaction_record::TransactionDirection;
 use crate::managed_account::ManagedCoreFundsAccount;
 use crate::test_utils::TestWalletContext;
 use crate::transaction_checking::{BlockInfo, TransactionContext, TransactionType};
+use crate::Utxo;
 
 /// Create a transaction that spends the given outpoints.
 fn spending_tx(spent: &[OutPoint]) -> Transaction {
@@ -127,6 +130,56 @@ async fn processing_a_spend_releases_its_reservation() {
 
     let account = ctx.managed_wallet.first_bip44_managed_account().expect("BIP44 account");
     assert!(!account.reservations().reserved(0).contains(&second_funded));
+}
+
+#[test]
+fn reserved_outpoints_are_excluded_from_spendable_and_reappear_on_release() {
+    // The public read API added for cross-account input selection: a caller
+    // that force-adds another account's UTXOs into a shared sweep must be able
+    // to see and skip outpoints an in-flight build already reserved, otherwise
+    // a rebuild/retry can reselect them into a conflicting transaction.
+    let height = 100;
+    let mut account = ManagedCoreFundsAccount::dummy_bip44();
+
+    // Two mature, non-coinbase UTXOs: both spendable at `height`.
+    let utxo_reserved = Utxo::dummy(0x11, 100_000, 10, false, true);
+    let utxo_free = Utxo::dummy(0x22, 200_000, 10, false, true);
+    let reserved_op = utxo_reserved.outpoint;
+    let free_op = utxo_free.outpoint;
+    account.utxos.insert(reserved_op, utxo_reserved);
+    account.utxos.insert(free_op, utxo_free);
+
+    // Nothing reserved yet: the excluding view matches plain spendable, and the
+    // reserved set is empty.
+    assert!(account.reserved_outpoints(height).is_empty());
+    let spendable: Vec<OutPoint> =
+        account.spendable_utxos(height).iter().map(|u| u.outpoint).collect();
+    assert!(spendable.contains(&reserved_op) && spendable.contains(&free_op));
+    let excluding: Vec<OutPoint> =
+        account.spendable_utxos_excluding_reserved(height).iter().map(|u| u.outpoint).collect();
+    assert!(excluding.contains(&reserved_op) && excluding.contains(&free_op));
+
+    // Reserve one outpoint as an in-flight build would.
+    account.reservations().reserve(&[reserved_op], height);
+
+    // The reserved outpoint is now visible via the public read API...
+    assert_eq!(account.reserved_outpoints(height), HashSet::from([reserved_op]));
+    // ...excluded from the reservation-aware enumeration...
+    let excluding: Vec<OutPoint> =
+        account.spendable_utxos_excluding_reserved(height).iter().map(|u| u.outpoint).collect();
+    assert_eq!(excluding, vec![free_op]);
+    // ...but still present in the reservation-unaware `spendable_utxos`, whose
+    // semantics are unchanged (the additive API must not alter it).
+    let spendable: Vec<OutPoint> =
+        account.spendable_utxos(height).iter().map(|u| u.outpoint).collect();
+    assert!(spendable.contains(&reserved_op) && spendable.contains(&free_op));
+
+    // Releasing the reservation makes the outpoint selectable again.
+    account.reservations().release([&reserved_op]);
+    assert!(account.reserved_outpoints(height).is_empty());
+    let excluding: Vec<OutPoint> =
+        account.spendable_utxos_excluding_reserved(height).iter().map(|u| u.outpoint).collect();
+    assert!(excluding.contains(&reserved_op) && excluding.contains(&free_op));
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Cross-account input sweeps in platform-wallet need to exclude UTXOs that an in-flight transaction build has already reserved, and today the reservation ledger is `pub(crate)` so they cannot.

The `ReservationSet` (added in #812) bridges the window between selecting a build's inputs and processing its broadcast back into the wallet: reserved inputs are skipped by that account's own coin selection through `set_funding`. But its read surface — `ManagedCoreFundsAccount::reservations()` and `ReservationSet::reserved()` — is crate-private.

A caller that selects inputs **across** accounts (force-adding a non-primary account's `spendable_utxos()` into a shared sweep) bypasses that account's coin selector and therefore its reservation awareness. `spendable_utxos()` filters on spendability (maturity/lock) only. So after a broadcast leaves inputs reserved, a rebuild/retry can reselect the same foreign inputs and produce a conflicting transaction.

This is the review finding on dashpay/platform#4074 (asset-lock funding from all accounts): the union sweep in `rs-platform-wallet`'s `asset_lock/build.rs` force-adds non-primary accounts' `spendable_utxos()` via `add_inputs`, bypassing reservation awareness.

## Change (additive — no existing signatures change)

Two new public read methods on `ManagedCoreFundsAccount`:

- `reserved_outpoints(current_height) -> HashSet<OutPoint>` — a read-only, TTL-swept snapshot of the outpoints currently reserved by in-flight builds.
- `spendable_utxos_excluding_reserved(last_processed_height) -> BTreeSet<&Utxo>` — the reservation-aware counterpart of `spendable_utxos`, intended for cross-account sweeps.

`spendable_utxos()` semantics are intentionally left unchanged, since other callers rely on the maturity-only behaviour; keeping the new API additive keeps the change small and unblocks the platform-wallet consumer.

## Tests

Added `reserved_outpoints_are_excluded_from_spendable_and_reappear_on_release` (in `key-wallet/src/tests/spent_outpoints_tests.rs`), proving that a reserved outpoint is:
- visible via `reserved_outpoints`,
- excluded from `spendable_utxos_excluding_reserved` while still present in the unchanged `spendable_utxos`,
- and reappears in the excluding enumeration once the reservation is released.

## Validation

```text
cargo test -p key-wallet    # 549 passed; 0 failed (+ integration suites green)
cargo clippy -p key-wallet --all-targets   # clean
cargo fmt -p key-wallet -- --check         # clean
```

## Intended consumer / follow-up

The platform-side consumption is a follow-up once this merges and the `rust-dashcore` pin advances: dashpay/platform#4074's union sweep in `packages/rs-platform-wallet/src/wallet/asset_lock/build.rs` should call `spendable_utxos_excluding_reserved(...)` (or consult `reserved_outpoints(...)`) instead of the raw `spendable_utxos()` when force-adding non-primary accounts' inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reservation-aware views that report which outpoints are currently reserved by in-progress account activity.
  * Reserved UTXOs are now excluded from spendable selection to help avoid double-spending while a transaction is being built.
  * Expired reservations are automatically omitted from reservation results.
  * Released reservations become eligible for spending again.
* **Tests**
  * Added a unit test covering the reserve/exclude/release behavior for spendable UTXOs and reserved outpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->