### PR TITLE
feat(dash-spv-bench): multi-scenario sync benchmark framework

### DIFF
--- a/.github/ci-groups.yml
+++ b/.github/ci-groups.yml
@@ -29,4 +29,5 @@ excluded:
   - integration_test  # Requires live Dash node
   - dash-fuzz  # Honggfuzz binary targets, tested by fuzz.yml
   - masternode-seeds-fetcher  # Tooling binary; needs live dashd RPC, exercised by update-masternode-seeds.yml
+  - dash-spv-bench  # Benchmarking binary
   - git-state  # Compile-time proc-macro with no tests, exercised via dash-spv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["dash", "dash-network", "hashes", "internals", "fuzz", "rpc-client", "rpc-json", "rpc-integration-test", "key-wallet", "key-wallet-manager", "key-wallet-ffi", "dash-spv", "dash-spv-ffi", "git-state", "dash-network-seeds", "masternode-seeds-fetcher"]
+members = ["dash", "dash-network", "hashes", "internals", "fuzz", "rpc-client", "rpc-json", "rpc-integration-test", "key-wallet", "key-wallet-manager", "key-wallet-ffi", "dash-spv", "dash-spv-ffi", "git-state", "dash-network-seeds", "masternode-seeds-fetcher", "dash-spv-bench"]
 resolver = "2"
 
 [workspace.package]

--- a/dash-spv-bench/.gitignore
+++ b/dash-spv-bench/.gitignore
@@ -1,0 +1,24 @@
+bench-results/
+bench-storage/
+profiles/
+
+*.lock
+
+# Persistent testnet chain snapshot grown by snapshot-chain.sh (multi-GB; never committed).
+chain-data/
+
+# Transient per-peer CoW clones created by run.sh + the file that remembers their dir.
+.bench-clones.*
+.clonedir
+
+# Scenario matrix outputs (bench-scenarios.sh): generated reports/logs/compose, and the
+# bootstrapped yq binary. Reports are meant to be copied out, not committed.
+.scenario.*.yml
+results/
+.bin/
+
+# FlameGraph tooling clone (run.sh --flame), fetched on demand.
+.flamegraph/
+
+# Wallet mnemonics (one BIP39 phrase per line) — secrets, never committed.
+wallets.txt

--- a/dash-spv-bench/Cargo.toml
+++ b/dash-spv-bench/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "dash-spv-bench"
+version = { workspace = true }
+edition = "2021"
+license = "MIT"
+publish = false
+
+[dependencies]
+dash-spv = { path = "../dash-spv" }
+dashcore = { path = "../dash", features = ["serde", "core-block-hash-use-x11", "message_verification", "bls", "quorum_validation"] }
+key-wallet = { path = "../key-wallet" }
+key-wallet-manager = { path = "../key-wallet-manager", features = ["parallel-filters"] }
+
+tokio = { version = "1.0", features = ["full"] }
+
+anyhow = "1.0"
+tempfile = "3.0"
+
+tracing = "0.1"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+indicatif = "0.18"
+
+[[bin]]
+name = "dash-spv-bench"
+path = "src/main.rs"

--- a/dash-spv-bench/Dockerfile
+++ b/dash-spv-bench/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:bookworm-slim
+
+ARG DASHVERSION=23.1.7
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download the Linux dashd matching the host CPU arch (amd64 -> x86_64, arm64 -> aarch64).
+# The version is pinned so benchmark numbers stay comparable; run.sh and snapshot-chain.sh tag the
+# image with it and pass it back as --build-arg, so bumping it there rebuilds instead of reusing.
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) dlarch=x86_64 ;; \
+      arm64) dlarch=aarch64 ;; \
+      *) echo "unsupported arch $arch" >&2; exit 1 ;; \
+    esac; \
+    url="https://github.com/dashpay/dash/releases/download/v${DASHVERSION}/dashcore-${DASHVERSION}-${dlarch}-linux-gnu.tar.gz"; \
+    curl -fsSL "$url" -o /tmp/dashcore.tgz; \
+    tar -xzf /tmp/dashcore.tgz -C /tmp; \
+    cp "/tmp/dashcore-${DASHVERSION}/bin/dashd" /usr/local/bin/dashd; \
+    rm -rf /tmp/dashcore*; \
+    dashd --version | head -1

--- a/dash-spv-bench/bench-scenarios.sh
+++ b/dash-spv-bench/bench-scenarios.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# dash-spv-bench scenario matrix (LOCAL mode only).
+#
+#   ./bench-scenarios.sh [-d scenarios]
+#
+# Thin loop over scenario files: for each scenarios/*.yml it calls `run.sh scenario <file>`
+# once per its `repeats:` count, captures the timings run.sh prints, and writes an organized
+# Markdown report (median over repeats). All the real work — compose generation, bring-up,
+# CPU pinning, teardown — lives in run.sh; this only orchestrates and aggregates.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${SCRIPT_DIR}"
+
+SCN_DIR="${SCRIPT_DIR}/scenarios"
+RUN_CMD="${RUN_CMD:-${SCRIPT_DIR}/run.sh}"   # overridable for testing the loop without docker
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -d | --dir) SCN_DIR="$2"; shift 2 ;;
+    -h | --help) sed -n '3,10p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+shopt -s nullglob
+FILES=("${SCN_DIR}"/*.yml)
+[ "${#FILES[@]}" -gt 0 ] || { echo "Error: no scenarios (*.yml) in ${SCN_DIR}" >&2; exit 1; }
+
+RUN_TS="$(date +%Y%m%d-%H%M%S)"
+OUT_DIR="${SCRIPT_DIR}/results/${RUN_TS}"
+mkdir -p "${OUT_DIR}"
+REPORT="${OUT_DIR}/report.md"
+TSV="${OUT_DIR}/results.tsv"
+: >"${TSV}"
+
+metric() { awk -F':[[:space:]]*' -v k="$2" '$1==k {gsub(/[[:space:]]+$/,"",$2); print $2; exit}' "$1"; }
+median() { sort -n | awk '{a[NR]=$1} END{if(NR==0){print"-";exit} print (NR%2)?a[(NR+1)/2]:int((a[NR/2]+a[NR/2+1])/2)}'; }
+
+for f in "${FILES[@]}"; do
+  name="$(basename "${f}" .yml)"
+  repeats="$(awk '/^repeats:/{print $2; exit}' "${f}")"; repeats="${repeats:-1}"
+  echo "===== scenario '${name}' × ${repeats} ====="
+  for r in $(seq 1 "${repeats}"); do
+    echo "-- ${name} repeat ${r}/${repeats}"
+    log="${OUT_DIR}/${name}.r${r}.log"
+    "${RUN_CMD}" "${f}" >"${log}" 2>&1 || echo "   (run.sh exited non-zero; see ${log})"
+
+    # Scenario metadata comes straight from run.sh's own echo lines, so we never re-parse the YAML.
+    meta="$(grep -m1 "==> scenario '" "${log}" || true)"
+    cpus="$(sed -n "s/.*cpus=\([^,]*\),.*/\1/p" <<<"${meta}")"
+    blocks="$(sed -n "s/.*blocks=\([0-9]*\).*/\1/p" <<<"${meta}")"
+    peers="$(sed -n "s/.*\[\(.*\)\], cpus=.*/\1/p" <<<"${meta}")"
+    desc="$(grep -m1 "==> description:" "${log}" | sed 's/.*==> description: //' || true)"
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "${name}" "${cpus}" "${blocks}" "${peers}" "${r}" \
+      "$(metric "${log}" completed)" "$(metric "${log}" total_ms)" \
+      "$(metric "${log}" block_headers_ms)" "$(metric "${log}" filter_headers_ms)" \
+      "$(metric "${log}" filters_ms)" "$(metric "${log}" filter_hdr_lag_ms)" "${desc}" \
+      >>"${TSV}"
+  done
+done
+
+# --- report ---------------------------------------------------------------------------------
+{
+  echo "# dash-spv-bench scenario report"
+  echo
+  echo "- **Date:** $(date -u '+%Y-%m-%d %H:%M:%SZ')"
+  echo "- **Host:** $(nproc) cores — $(grep -m1 'model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2 | sed 's/^ //' || uname -m)"
+  echo "- **git:** $(git -C "${REPO_ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null)@$(git -C "${REPO_ROOT}" rev-parse --short HEAD 2>/dev/null)"
+  echo "- **Scenarios:** \`$(basename "${SCN_DIR}")/\` (${#FILES[@]} files)"
+  echo
+  echo "Timings are the **median** over each scenario's repeats (ms)."
+  echo
+  echo "| scenario | description | cpus | blocks | peers | completed | total | block_hdrs | filter_hdrs | filters | fh_lag |"
+  echo "|---|---|---|---|---|---|---|---|---|---|---|"
+  for name in $(cut -f1 "${TSV}" | awk '!seen[$0]++'); do
+    row() { awk -F'\t' -v n="${name}" '$1==n{print $'"$1"'; exit}' "${TSV}"; }
+    med() { awk -F'\t' -v n="${name}" '$1==n && $'"$1"'!="" && $'"$1"'!="-"{print $'"$1"'}' "${TSV}" | median; }
+    echo "| ${name} | $(row 12) | $(row 2) | $(row 3) | $(row 4) | $(row 6) | $(med 7) | $(med 8) | $(med 9) | $(med 10) | $(med 11) |"
+  done
+  echo
+  echo "Raw per-repeat data: \`results.tsv\`; per-run logs alongside this report."
+} >"${REPORT}"
+
+echo "==> wrote ${REPORT}"

--- a/dash-spv-bench/run.sh
+++ b/dash-spv-bench/run.sh
@@ -1,0 +1,339 @@
+#!/bin/bash
+#
+# dash-spv benchmark driver — runs ONE scenario end to end (build, bring up peers, sync, report).
+#
+# Usage:
+#   ./run.sh <scenario.yml>            Run the scenario
+#   ./run.sh <scenario.yml> --flame    Same, under the sampler (perf on Linux, sample on macOS)
+#                                       -> profiles/flamegraph.svg
+#   --wallets <file>                   Wallets for this run: a file with one BIP39 mnemonic per
+#                                      line. No file => the run has no wallet.
+#
+# RUST_LOG can be set to tweak logging, e.g.  RUST_LOG=info ./run.sh scenarios/ideal-1-peer.yml
+# It is the tracing filter for BOTH log sinks and overrides the defaults, which are
+#   terminal = "warn,dash_spv_bench=info"  (kept light so the live bars stay readable)
+#   file     = "warn,dash_spv=debug,dash_spv_bench=debug"  (debug, for offline analysis)
+#
+# Outputs land in bench-storage/ (gitignored, wiped at the start of each run):
+#   run.log      full trace of the sync (debug by default) for offline analysis
+#   summary.txt  metrics + per-wallet tx/balance fingerprint (also printed to stdout)
+#   plus the SPV storage the run produced (block_headers/, filters/, ...)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMPOSE_FILE=""            # local mode generates one here; deleted on exit
+DASH_VERSION="23.1.7"
+IMAGE="dash-spv-bench/dashd:${DASH_VERSION}"
+PROJECT="spv-bench"
+STATE="${SCRIPT_DIR}/.clonedir"
+FLAME_SVG="${SCRIPT_DIR}/profiles/flamegraph.svg"
+FLAMEGRAPH_DIR="${SCRIPT_DIR}/.flamegraph"   # FlameGraph tooling clone (gitignored, inside the package)
+CHAIN_DIR="${SCRIPT_DIR}/chain-data"
+
+INVOCATION_DIR="${PWD}"
+abspath() { case "$1" in /*) printf '%s\n' "$1" ;; *) printf '%s\n' "${INVOCATION_DIR%/}/$1" ;; esac; }
+
+cd "${SCRIPT_DIR}"
+
+FLAME=0
+SCN_FILE=""
+WALLETS_ARG=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --flame) FLAME=1; shift ;;
+    --wallets) WALLETS_ARG="${2:?--wallets needs a file path}"; shift 2 ;;
+    -h | --help) sed -n '3,20p' "$0"; exit 0 ;;
+    -*) echo "unknown flag: $1" >&2; exit 1 ;;
+    *) SCN_FILE="$1"; shift ;;
+  esac
+done
+[ -n "${SCN_FILE}" ] || { echo "usage: $0 <scenario.yml> [--flame] [--wallets <file>]" >&2; exit 1; }
+SCN_FILE="$(abspath "${SCN_FILE}")"
+[ -f "${SCN_FILE}" ] || { echo "Error: scenario file not found: ${SCN_FILE}" >&2; exit 1; }
+
+YQ_VERSION="v4.44.6"
+ensure_yq() {
+  if command -v yq >/dev/null 2>&1; then YQ=yq; return 0; fi
+  local bin="${SCRIPT_DIR}/.bin/yq"
+  if [ ! -x "${bin}" ]; then
+    mkdir -p "${SCRIPT_DIR}/.bin"
+    local os arch
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"; arch="$(uname -m)"
+    case "${arch}" in x86_64 | amd64) arch=amd64 ;; aarch64 | arm64) arch=arm64 ;; esac
+    echo "==> fetching yq ${YQ_VERSION} (${os}/${arch}) into .bin/yq"
+    curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_${os}_${arch}" \
+      -o "${bin}" || { echo "Error: could not download yq; install it manually." >&2; exit 1; }
+    chmod +x "${bin}"
+  fi
+  YQ="${bin}"
+}
+ensure_yq
+scn() { "${YQ}" "$1" "${SCN_FILE}"; }   # evaluate a yq expression against the scenario file
+
+_peer_group() {
+  "${YQ}" ".peers[$1] | [.count, .latency_ms // 0, .jitter_ms // 0, .loss_pct // 0, .rate_kbit // 0, .corrupt_pct // 0, .reorder_pct // 0] | @tsv" "${SCN_FILE}"
+}
+
+build_netem() {
+  local lat="$1" jit="$2" loss="$3" rate="$4" corrupt="$5" reorder="$6" a=""
+  [ "${lat}" != 0 ] && { a="delay ${lat}ms"; [ "${jit}" != 0 ] && a="${a} ${jit}ms"; }
+  [ "${loss}" != 0 ] && a="${a} loss ${loss}%"
+  [ "${rate}" != 0 ] && a="${a} rate ${rate}kbit"
+  [ "${corrupt}" != 0 ] && a="${a} corrupt ${corrupt}%"
+  [ "${reorder}" != 0 ] && a="${a} reorder ${reorder}%"
+  echo "${a# }"
+}
+
+peers_summary() {
+  local ng g count lat jit loss rate corrupt reorder tag out=""
+  ng="$(scn '.peers | length')"
+  for g in $(seq 0 $((ng - 1))); do
+    read -r count lat jit loss rate corrupt reorder <<<"$(_peer_group "${g}")"
+    tag="${lat}ms"
+    [ "${jit}" != 0 ] && tag="${tag}±${jit}"
+    [ "${loss}" != 0 ] && tag="${tag}/${loss}%loss"
+    [ "${rate}" != 0 ] && tag="${tag}/${rate}kbit"
+    out="${out}, ${count}×${tag}"
+  done
+  echo "${out#, }"
+}
+
+emit_compose() {
+  local out="$1" peer_cpus="$2"
+  cat >"${out}" <<HEADER
+# GENERATED for a bench scenario — do not edit; regenerated and deleted each run.
+x-dashd-peer: &dashd-peer
+  image: ${IMAGE}
+HEADER
+  cat >>"${out}" <<'ANCHOR'
+  build:
+    context: .
+    dockerfile: Dockerfile
+  cap_add: [NET_ADMIN]
+  entrypoint: ["/bin/sh", "-ec"]
+  command:
+    - |
+      if [ -n "$${NETEM_ARGS:-}" ]; then
+        tc qdisc add dev eth0 root netem $${NETEM_ARGS} \
+          && echo "netem: $${NETEM_ARGS}" || echo "WARNING: netem failed (NET_ADMIN/sch_netem?)"
+      fi
+      exec dashd -testnet -datadir=/data -port=19400 -rpcport=19500 -server=1 -daemon=0 \
+        -connect=0 -bind=0.0.0.0 -listen=1 -rpcbind=0.0.0.0 -rpcallowip=0.0.0.0/0 \
+        -whitelist=0.0.0.0/0 -disablewallet=1 -peerbloomfilters=1 \
+        -dbcache=64 -fallbackfee=0.00001 -txindex=0 -addressindex=0 $${FILTER_FLAGS}
+
+services:
+ANCHOR
+  local ng g count lat jit loss rate corrupt reorder netem n peer=0
+  ng="$(scn '.peers | length')"
+  for g in $(seq 0 $((ng - 1))); do
+    read -r count lat jit loss rate corrupt reorder <<<"$(_peer_group "${g}")"
+    netem="$(build_netem "${lat}" "${jit}" "${loss}" "${rate}" "${corrupt}" "${reorder}")"
+    for n in $(seq 1 "${count}"); do
+      peer=$((peer + 1))
+      cat >>"${out}" <<SERVICE
+  dashd${peer}:
+    <<: *dashd-peer
+    container_name: spv-bench-dashd${peer}
+    cpuset: "${peer_cpus}"
+    environment:
+      NETEM_ARGS: "${netem}"
+      FILTER_FLAGS: "-blockfilterindex=1 -peerblockfilters=1"
+    volumes: ["\${CLONE_DIR}/peer${peer}:/data"]
+    ports: ["127.0.0.1:$((19400 + peer)):19400"]
+SERVICE
+    done
+  done
+  echo "${peer}"
+}
+
+MODE="$(scn '.mode // "local"')"
+case "${MODE}" in local | testnet | mainnet) ;; *) echo "Error: mode must be 'local', 'testnet' or 'mainnet' (got '${MODE}')" >&2; exit 1 ;; esac
+export BENCH_MODE="${MODE}"
+export CLONE_DIR="${CLONE_DIR:-/nonexistent}"
+
+BENCH_CPUS="$(scn '.cpus // ""')"
+BENCH_MAX_PEERS="$(scn '.max_peers // ""')"   # only if set; else the ClientConfig default
+export BENCH_MAX_PEERS
+
+BENCH_WALLET_FILE="${SCRIPT_DIR}/wallets.txt"
+[ -n "${WALLETS_ARG}" ] && BENCH_WALLET_FILE="$(abspath "${WALLETS_ARG}")"
+export BENCH_WALLET_FILE
+export BENCH_STORAGE_DIR="${SCRIPT_DIR}/bench-storage"
+
+DESC="$(scn '.description // ""')"
+[ -n "${DESC}" ] && echo "==> description: ${DESC}"
+
+BLOCKS=""
+if [ "${MODE}" = local ]; then
+  BLOCKS="$(scn '.blocks // 1000000')"
+  export BENCH_HEIGHT="${BLOCKS}"
+  unset BENCH_START_HEIGHT   # local always syncs from genesis
+else
+  BENCH_PEERS="$(scn '.peers // [] | join(",")')"
+  export BENCH_PEERS
+  sh="$(scn '.start_height // ""')"; [ -n "${sh}" ] && export BENCH_START_HEIGHT="${sh}"
+fi
+
+expand_cpus() {
+  local part lo hi
+  local IFS=,
+  for part in $1; do
+    case "${part}" in
+      *-*) lo="${part%-*}"; hi="${part#*-}"; seq "${lo}" "${hi}" ;;
+      *)   echo "${part}" ;;
+    esac
+  done
+}
+
+CPU_PREFIX=()
+if [ -n "${BENCH_CPUS}" ]; then
+  ncpu="$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 0)"
+  bench_cores="$(expand_cpus "${BENCH_CPUS}" | sort -nu)"
+  if [ "${ncpu}" -gt 0 ]; then
+    peer_cores=""
+    for i in $(seq 0 $((ncpu - 1))); do
+      grep -qxF "${i}" <<<"${bench_cores}" || peer_cores="${peer_cores},${i}"
+    done
+    BENCH_PEER_CPUS="${peer_cores#,}"
+  fi
+
+  if command -v taskset >/dev/null 2>&1; then
+    CPU_PREFIX=(taskset -c "${BENCH_CPUS}")
+    echo "==> pinning the measured run to CPUs ${BENCH_CPUS}${BENCH_PEER_CPUS:+; docker peers to ${BENCH_PEER_CPUS}}"
+  else
+    echo "==> note: 'taskset' not found (e.g. macOS); running the measured binary UNPINNED${BENCH_PEER_CPUS:+ (docker peers still pinned to ${BENCH_PEER_CPUS})}" >&2
+  fi
+fi
+
+if [ "${MODE}" = local ]; then
+  COMPOSE_FILE="$(mktemp "${SCRIPT_DIR}/.scenario.XXXXXX")"
+  mv "${COMPOSE_FILE}" "${COMPOSE_FILE}.yml"
+  COMPOSE_FILE="${COMPOSE_FILE}.yml"
+  npeers="$(emit_compose "${COMPOSE_FILE}" "${BENCH_PEER_CPUS:-}")"
+  echo "==> scenario '$(basename "${SCN_FILE}" .yml)': ${npeers} peers [$(peers_summary)], cpus=${BENCH_CPUS:-<none>}, blocks=${BLOCKS}"
+fi
+
+compose() { docker compose -p "${PROJECT}" -f "${COMPOSE_FILE}" "$@"; }
+
+wait_loaded() {
+  local c logs
+  for _ in $(seq 1 400); do
+    local all=1
+    for c in "$@"; do
+      logs="$(docker logs "${c}" 2>&1)" || { all=0; break; }
+      case "${logs}" in *"init message: Done loading"*) ;; *) all=0; break ;; esac
+    done
+    [ "${all}" -eq 1 ] && return 0
+    echo -n "."; sleep 3
+  done
+  return 1
+}
+
+teardown() {
+  [ -n "${COMPOSE_FILE}" ] && compose down --remove-orphans >/dev/null 2>&1 || true
+  [ -f "${STATE}" ] && { rm -rf "$(cat "${STATE}")" 2>/dev/null || true; rm -f "${STATE}"; }
+  rm -rf "${SCRIPT_DIR}"/.bench-clones.* 2>/dev/null || true
+}
+
+arm_teardown() {
+  # On exit: tear down, THEN delete the generated compose (down needs it to still exist).
+  trap 'teardown; [ -n "${COMPOSE_FILE}" ] && rm -f "${COMPOSE_FILE}"' EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  trap 'exit 129' HUP
+}
+
+bring_up() {
+  echo "==> ensuring a clean network"
+  teardown
+  docker image inspect "${IMAGE}" >/dev/null 2>&1 || { echo "==> building peer image"; compose build; }
+
+  local services; services="$(compose config --services)"
+  local n; n="$(echo ${services} | wc -w | tr -d ' ')"
+  # BENCH_PEERS is derived from the generated peers (host ports 19401..).
+  local peers_csv=""
+  for svc in ${services}; do peers_csv="${peers_csv},127.0.0.1:$((19400 + ${svc#dashd}))"; done
+  export BENCH_PEERS="${peers_csv#,}"
+
+  echo "==> CoW-cloning ${CHAIN_DIR} for ${n} peers (instant)"
+  local clone_dir; clone_dir="$(mktemp -d "${SCRIPT_DIR}/.bench-clones.XXXXXX")"
+  echo "${clone_dir}" > "${STATE}"
+  for svc in ${services}; do
+    local dst="${clone_dir}/peer${svc#dashd}"
+    cp -c -R "${CHAIN_DIR}" "${dst}" 2>/dev/null \
+      || cp --reflink=auto -R "${CHAIN_DIR}" "${dst}" 2>/dev/null \
+      || cp -R "${CHAIN_DIR}" "${dst}"
+  done
+
+  local batch=4
+  echo "==> starting ${n} peers in batches of ${batch}"
+  local started="" count=0
+  for svc in ${services}; do
+    CLONE_DIR="${clone_dir}" compose up -d "${svc}" >/dev/null 2>&1
+    started="${started} spv-bench-${svc}"; count=$((count + 1))
+    if [ $((count % batch)) -eq 0 ]; then
+      echo -n "  loaded ${count}/${n} "
+      wait_loaded ${started} || { echo " timeout loading batch" >&2; exit 1; }
+      echo " ok"
+    fi
+  done
+  if [ $((count % batch)) -ne 0 ]; then   # wait on the trailing partial batch too
+    echo -n "  loaded ${count}/${n} "
+    wait_loaded ${started} || { echo " timeout loading batch" >&2; exit 1; }
+    echo " ok"
+  fi
+
+  echo "==> ${n} peers started"
+}
+
+build_bin() {
+  echo "==> building bench binary (release + line-table symbols)"
+  ( cd "${REPO_ROOT}" && CARGO_PROFILE_RELEASE_DEBUG=line-tables-only \
+      cargo build --release -p dash-spv-bench )
+  BIN="${REPO_ROOT}/target/release/dash-spv-bench"
+}
+
+FLAME_TOOL=""
+if [ "${FLAME}" -eq 1 ]; then       # fail fast on missing profiler deps, before building
+  if command -v perf >/dev/null; then FLAME_TOOL=perf                  # Linux
+  elif command -v /usr/bin/sample >/dev/null; then FLAME_TOOL=sample   # macOS
+  else echo "flame mode needs 'perf' (Linux) or '/usr/bin/sample' (macOS)" >&2; exit 1; fi
+  [ -f "${FLAMEGRAPH_DIR}/flamegraph.pl" ] || \
+    git clone --depth 1 https://github.com/brendangregg/FlameGraph "${FLAMEGRAPH_DIR}"
+fi
+
+build_bin
+
+if [ "${MODE}" = local ]; then
+  arm_teardown
+  bash "${SCRIPT_DIR}/snapshot-chain.sh"   # builds ./chain-data to BENCH_HEIGHT via docker
+  bring_up
+else
+  echo "==> testnet mode, peers: ${BENCH_PEERS:-<DNS discovery>}"
+fi
+
+if [ "${FLAME}" -eq 0 ]; then
+  echo "==> running sync"
+  "${CPU_PREFIX[@]+"${CPU_PREFIX[@]}"}" "${BIN}"
+elif [ "${FLAME_TOOL}" = perf ]; then
+  echo "==> running sync under perf"
+  mkdir -p "$(dirname "${FLAME_SVG}")"
+  perf record -F 499 -g -o /tmp/bench-perf.data -- "${CPU_PREFIX[@]+"${CPU_PREFIX[@]}"}" "${BIN}"
+  perf script -i /tmp/bench-perf.data \
+    | "${FLAMEGRAPH_DIR}/stackcollapse-perf.pl" \
+    | "${FLAMEGRAPH_DIR}/flamegraph.pl" --title "dash-spv sync" --colors hot > "${FLAME_SVG}"
+  echo "==> wrote ${FLAME_SVG}"
+else
+  echo "==> running sync under the sampler"
+  "${CPU_PREFIX[@]+"${CPU_PREFIX[@]}"}" "${BIN}" & bpid=$!
+  sleep 3
+  /usr/bin/sample "${bpid}" 2000 1 -file /tmp/bench.sample.txt -mayDie >/dev/null 2>&1 || true
+  wait "${bpid}" 2>/dev/null || true
+  mkdir -p "$(dirname "${FLAME_SVG}")"
+  "${FLAMEGRAPH_DIR}/stackcollapse-sample.awk" /tmp/bench.sample.txt \
+    | sed -E 's/^Thread_[^;]*;//' \
+    | "${FLAMEGRAPH_DIR}/flamegraph.pl" --title "dash-spv sync" --colors hot > "${FLAME_SVG}"
+  echo "==> wrote ${FLAME_SVG}"
+fi

--- a/dash-spv-bench/scenario.example.yml
+++ b/dash-spv-bench/scenario.example.yml
@@ -1,0 +1,38 @@
+description: "One-line summary of this scenario"   # optional; shown in the report table.
+
+mode: local            # "local" (docker peers you control), "testnet" or "mainnet" (real network). Default: local.
+
+cpus: "0-3"            # optional. taskset CPU list pinning the MEASURED client (here cores 0,1,2,3).
+                       # In local mode the docker peers get every OTHER core. Omit => no pinning.
+
+max_peers: 3           # optional. Max simultaneous peers. Omit => the ClientConfig default.
+
+
+# ---------------------------------------------------------------------------------------------
+# LOCAL mode (mode: local) — docker dashd peers serving the frozen ./chain-data snapshot
+# ---------------------------------------------------------------------------------------------
+blocks: 1000000            # optional (default 1000000). The target HEIGHT: snapshot-chain.sh builds
+                           # ./chain-data up to here (via docker) and the client syncs the full
+                           # range genesis..blocks. Lower it for a shorter run.
+
+# Peer groups: one entry per group; each becomes `count` dashd containers sharing a connection
+# quality (via `tc netem`). List several groups to mix good and bad peers in one network.
+peers:
+  - count: 3               # required: how many peers in this group
+    latency_ms: 50         # optional: added one-way delay (netem delay)
+    jitter_ms: 0           # optional: delay jitter (netem delay <lat> <jitter>)
+    loss_pct: 0            # optional: packet loss %  (netem loss)
+    rate_kbit: 0           # optional: bandwidth cap in kbit (netem rate)
+    corrupt_pct: 0         # optional: bit corruption %  (netem corrupt)
+    reorder_pct: 0         # optional: packet reordering % (netem reorder)
+  # A second, degraded group ("bad peers"):
+  # - { count: 1, latency_ms: 800, loss_pct: 8, rate_kbit: 500 }
+
+# ---------------------------------------------------------------------------------------------
+# TESTNET / MAINNET mode — connect to the real Dash network instead of docker peers.
+# Set `mode: testnet` or `mode: mainnet` above, then use these instead of blocks/peers:
+# ---------------------------------------------------------------------------------------------
+# peers:                   # explicit nodes as "host:port" strings; omit for DNS discovery.
+#   - "1.2.3.4:9999"       # (testnet uses :19999, mainnet :9999)
+#   - "5.6.7.8:9999"
+# start_height: 2000000    # optional checkpoint: skip genesis..start and sync a bounded range.

--- a/dash-spv-bench/scenarios/congested-2core.yml
+++ b/dash-spv-bench/scenarios/congested-2core.yml
@@ -1,0 +1,5 @@
+description: "CPU-starved client (2 cores), 5 peers on a jittery 300ms link."
+cpus: "0-1"
+repeats: 3
+peers:
+  - { count: 5, latency_ms: 300, jitter_ms: 100 }

--- a/dash-spv-bench/scenarios/ideal-1-peer.yml
+++ b/dash-spv-bench/scenarios/ideal-1-peer.yml
@@ -1,0 +1,5 @@
+description: "Ideal link, single peer: 4 CPUs, 1 peer @ 50ms, full 1M sync."
+cpus: "0-3"
+repeats: 3
+peers:
+  - { count: 1, latency_ms: 50 }

--- a/dash-spv-bench/scenarios/ideal-3-peers.yml
+++ b/dash-spv-bench/scenarios/ideal-3-peers.yml
@@ -1,0 +1,5 @@
+description: "Ideal link: 4 CPUs, 3 peers @ 50ms, full 1M sync."
+cpus: "0-3"
+repeats: 3
+peers:
+  - { count: 3, latency_ms: 50 }

--- a/dash-spv-bench/scenarios/ideal-5-peers.yml
+++ b/dash-spv-bench/scenarios/ideal-5-peers.yml
@@ -1,0 +1,5 @@
+description: "Ideal link, more peers: 4 CPUs, 5 peers @ 50ms, full 1M sync."
+cpus: "0-3"
+repeats: 3
+peers:
+  - { count: 5, latency_ms: 50 }

--- a/dash-spv-bench/scenarios/no-lag-ideal-1-peer.yml
+++ b/dash-spv-bench/scenarios/no-lag-ideal-1-peer.yml
@@ -1,0 +1,5 @@
+description: "No-lag ideal, single peer: 12 CPUs, 1 peer @ 0ms, full 1M sync."
+cpus: "0-11"
+repeats: 3
+peers:
+  - { count: 1, latency_ms: 0 }

--- a/dash-spv-bench/scenarios/no-lag-ideal-3-peers.yml
+++ b/dash-spv-bench/scenarios/no-lag-ideal-3-peers.yml
@@ -1,0 +1,5 @@
+description: "No-lag ideal: 12 CPUs, 3 peers @ 0ms, full 1M sync."
+cpus: "0-11"
+repeats: 3
+peers:
+  - { count: 3, latency_ms: 0 }

--- a/dash-spv-bench/scenarios/no-lag-ideal-5-peers.yml
+++ b/dash-spv-bench/scenarios/no-lag-ideal-5-peers.yml
@@ -1,0 +1,5 @@
+description: "No-lag ideal, more peers: 12 CPUs, 5 peers @ 0ms, full 1M sync."
+cpus: "0-11"
+repeats: 3
+peers:
+  - { count: 5, latency_ms: 0 }

--- a/dash-spv-bench/scenarios/one-bad-peer.yml
+++ b/dash-spv-bench/scenarios/one-bad-peer.yml
@@ -1,0 +1,6 @@
+description: "Two good peers plus one slow/lossy/capped peer (a bad peer in the set)."
+cpus: "0-3"
+repeats: 3
+peers:
+  - { count: 2, latency_ms: 50 }
+  - { count: 1, latency_ms: 800, loss_pct: 8, rate_kbit: 500 }

--- a/dash-spv-bench/scenarios/real-mainnet.yml
+++ b/dash-spv-bench/scenarios/real-mainnet.yml
@@ -1,0 +1,3 @@
+description: "Mainnet sync from genesis via DNS peer discovery."
+max_peers: 3
+mode: mainnet

--- a/dash-spv-bench/scenarios/real-testnet.yml
+++ b/dash-spv-bench/scenarios/real-testnet.yml
@@ -1,0 +1,3 @@
+description: "Testnet sync from genesis via DNS peer discovery."
+max_peers: 3
+mode: testnet

--- a/dash-spv-bench/scenarios/slow-many-peers.yml
+++ b/dash-spv-bench/scenarios/slow-many-peers.yml
@@ -1,0 +1,11 @@
+description: "Many slow peers: 8 peers @ 300ms/30ms jitter, 8 Mbit each, full 1M sync. Stresses per-peer cap growth — saturating a high-latency rate-capped link needs several in-flight requests per peer, so caps must climb well above the floor."
+mode: local
+cpus: "0-5"
+max_peers: 8
+repeats: 2
+blocks: 1000000
+peers:
+  - count: 8
+    latency_ms: 300
+    jitter_ms: 30
+    rate_kbit: 8000

--- a/dash-spv-bench/snapshot-chain.sh
+++ b/dash-spv-bench/snapshot-chain.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHAIN_DIR="${SCRIPT_DIR}/chain-data"
+SUBDIR="testnet3"
+DASH_VERSION="23.1.7"      # keep in sync with run.sh
+IMAGE="dash-spv-bench/dashd:${DASH_VERSION}"
+
+cd "${SCRIPT_DIR}"
+
+: "${BENCH_HEIGHT:?BENCH_HEIGHT must be set — run.sh exports it from the scenario blocks}"
+command -v docker >/dev/null 2>&1 || { echo "Error: docker is required to build the snapshot." >&2; exit 1; }
+
+docker image inspect "${IMAGE}" >/dev/null 2>&1 \
+  || { echo "==> building peer image"
+       docker build --build-arg "DASHVERSION=${DASH_VERSION}" \
+         -t "${IMAGE}" -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"; }
+
+mkdir -p "${CHAIN_DIR}"
+
+echo "==> extending snapshot to height ${BENCH_HEIGHT} via docker (downloads only the missing blocks)..."
+
+docker run --rm --user "$(id -u):$(id -g)" -v "${CHAIN_DIR}:/data" "${IMAGE}" \
+  dashd -testnet -datadir=/data -daemon=0 -server=1 \
+  -blockfilterindex=1 -peerblockfilters=1 -stopatheight="${BENCH_HEIGHT}" \
+  -txindex=0 -prune=0 -disablewallet=1
+
+echo "==> done. Snapshot is at ${CHAIN_DIR}/${SUBDIR} (height ${BENCH_HEIGHT})."

--- a/dash-spv-bench/src/dashboard.rs
+++ b/dash-spv-bench/src/dashboard.rs
@@ -1,0 +1,217 @@
+use std::io::{self, IsTerminal, Write};
+
+use dash_spv::sync::{ProgressPercentage, SyncProgress};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
+use tracing_subscriber::fmt::MakeWriter;
+
+const REDRAW_HZ: u8 = 10;
+const BAR_WIDTH: usize = 32;
+const NOT_ENABLED: &str = "not enabled";
+
+pub struct Dashboard {
+    multi: MultiProgress,
+    block_headers: ProgressBar,
+    filter_headers: ProgressBar,
+    filters: ProgressBar,
+    masternodes: ProgressBar,
+    blocks: ProgressBar,
+    chainlocks: ProgressBar,
+    instantsend: ProgressBar,
+    mempool: ProgressBar,
+}
+
+impl Dashboard {
+    pub fn new() -> Self {
+        let target = if io::stderr().is_terminal() {
+            ProgressDrawTarget::stderr_with_hz(REDRAW_HZ)
+        } else {
+            ProgressDrawTarget::hidden()
+        };
+        let multi = MultiProgress::with_draw_target(target);
+
+        let bar_style = ProgressStyle::with_template(&format!(
+            "  {{prefix:<15}} [{{bar:{BAR_WIDTH}}}] {{percent:>3}}%  {{msg}}"
+        ))
+        .expect("static template")
+        .progress_chars("=> ");
+
+        let info_style = ProgressStyle::with_template(&format!(
+            "  {{prefix:<15}}  {:BAR_WIDTH$}    {{msg}}",
+            ""
+        ))
+        .expect("static template");
+
+        let mk = |label: &'static str, style: &ProgressStyle| {
+            let pb = multi.add(ProgressBar::new(1));
+            pb.set_style(style.clone());
+            pb.set_prefix(label);
+            pb.set_message(NOT_ENABLED);
+            pb
+        };
+
+        Self {
+            block_headers: mk("block headers", &bar_style),
+            filter_headers: mk("filter headers", &bar_style),
+            filters: mk("filters", &bar_style),
+            masternodes: mk("masternodes", &bar_style),
+            blocks: mk("matched blocks", &bar_style),
+            chainlocks: mk("chainlocks", &info_style),
+            instantsend: mk("instantsend", &info_style),
+            mempool: mk("mempool", &info_style),
+            multi,
+        }
+    }
+
+    pub fn log_writer(&self) -> BarWriter {
+        BarWriter(self.multi.clone())
+    }
+
+    pub fn render(&self, progress: &SyncProgress) {
+        fn set(pb: &ProgressBar, p: &impl ProgressPercentage) {
+            let (current, target) = (p.current_height(), p.target_height());
+            pb.set_length(target.max(1) as u64);
+            pb.set_position(current.min(target) as u64);
+            pb.set_message(format!("{} / {}", current, target));
+        }
+
+        if let Ok(p) = progress.headers() {
+            set(&self.block_headers, p);
+        }
+        if let Ok(p) = progress.filter_headers() {
+            let (current, target) = (p.current_height(), p.target_height());
+            self.filter_headers.set_length(target.max(1) as u64);
+            self.filter_headers.set_position(current.min(target) as u64);
+            self.filter_headers.set_message(format!(
+                "{} / {}  (verified {})",
+                current,
+                target,
+                p.current_height()
+            ));
+        }
+        if let Ok(p) = progress.filters() {
+            set(&self.filters, p);
+        }
+        if let Ok(p) = progress.masternodes() {
+            let (current, target) = (p.current_height(), p.target_height());
+            self.masternodes.set_length(target.max(1) as u64);
+            self.masternodes.set_position(current.min(target) as u64);
+            self.masternodes.set_message(format!(
+                "{} / {}  ({} diffs, {} cycles)",
+                current,
+                target,
+                p.diffs_processed(),
+                p.validated_cycles()
+            ));
+        }
+        if let Ok(p) = progress.blocks() {
+            let tip = progress.headers().map(|h| h.target_height()).unwrap_or(0);
+            let done = p.last_processed();
+            self.blocks.set_length(tip.max(1) as u64);
+            self.blocks.set_position(done.min(tip) as u64);
+            self.blocks.set_message(format!(
+                "{} / {}  ({} blocks, {} txs)",
+                done,
+                tip,
+                p.processed(),
+                p.transactions()
+            ));
+        }
+        if let Ok(p) = progress.chainlocks() {
+            self.chainlocks.set_message(format!(
+                "{:?}  best {}  ({} valid, {} invalid)",
+                p.state(),
+                p.best_validated_height(),
+                p.valid(),
+                p.invalid()
+            ));
+        }
+        if let Ok(p) = progress.instantsend() {
+            self.instantsend.set_message(format!(
+                "{:?}  {} valid, {} invalid, {} pending",
+                p.state(),
+                p.valid(),
+                p.invalid(),
+                p.pending()
+            ));
+        }
+        if let Ok(p) = progress.mempool() {
+            self.mempool.set_message(format!(
+                "{:?}  {} tracked ({} relevant of {} seen)",
+                p.state(),
+                p.tracked(),
+                p.relevant(),
+                p.received()
+            ));
+        }
+    }
+
+    pub fn finish(&self) {
+        for pb in [
+            &self.block_headers,
+            &self.filter_headers,
+            &self.filters,
+            &self.masternodes,
+            &self.blocks,
+            &self.chainlocks,
+            &self.instantsend,
+            &self.mempool,
+        ] {
+            if pb.message() == NOT_ENABLED {
+                pb.abandon();
+            } else {
+                pb.finish();
+            }
+        }
+    }
+}
+
+impl Default for Dashboard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone)]
+pub struct BarWriter(MultiProgress);
+
+impl<'a> MakeWriter<'a> for BarWriter {
+    type Writer = BarWriterGuard;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        BarWriterGuard {
+            multi: self.0.clone(),
+            buf: Vec::new(),
+        }
+    }
+}
+
+pub struct BarWriterGuard {
+    multi: MultiProgress,
+    buf: Vec<u8>,
+}
+
+impl Write for BarWriterGuard {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if self.buf.is_empty() {
+            return Ok(());
+        }
+        let line = std::mem::take(&mut self.buf);
+        self.multi.suspend(|| {
+            let mut err = io::stderr().lock();
+            let _ = err.write_all(&line);
+            let _ = err.flush();
+        });
+        Ok(())
+    }
+}
+
+impl Drop for BarWriterGuard {
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
+}

--- a/dash-spv-bench/src/main.rs
+++ b/dash-spv-bench/src/main.rs
@@ -1,0 +1,239 @@
+mod dashboard;
+mod metrics;
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use dash_spv::storage::DiskStorageManager;
+use dash_spv::{ClientConfig, DashSpvClient, EventHandler};
+use dashcore::Network;
+use key_wallet::wallet::initialization::WalletAccountCreationOptions;
+use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+use key_wallet::wallet::ManagedWalletInfo;
+use key_wallet_manager::WalletManager;
+use std::collections::BTreeSet;
+use tokio::sync::RwLock;
+use tracing_subscriber::prelude::*;
+
+use crate::dashboard::Dashboard;
+use crate::metrics::BenchEventHandler;
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+fn load_mnemonics() -> Vec<String> {
+    std::env::var("BENCH_WALLET_FILE")
+        .ok()
+        .filter(|p| !p.trim().is_empty())
+        .and_then(|path| std::fs::read_to_string(&path).ok())
+        .map(|contents| {
+            contents
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty() && !line.starts_with('#'))
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let dashboard = Arc::new(Dashboard::new());
+
+    let (output_dir, _tempdir_guard): (PathBuf, Option<tempfile::TempDir>) =
+        match std::env::var("BENCH_STORAGE_DIR") {
+            Ok(dir) if !dir.trim().is_empty() => {
+                let path = PathBuf::from(dir.trim());
+                let _ = std::fs::remove_dir_all(&path);
+                std::fs::create_dir_all(&path).context("create bench storage dir")?;
+                (path, None)
+            }
+            _ => {
+                let td = tempfile::tempdir().context("temp storage dir")?;
+                (td.path().to_path_buf(), Some(td))
+            }
+        };
+
+    let log_file = std::fs::File::create(output_dir.join("run.log")).context("create run.log")?;
+    let terminal_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn,dash_spv_bench=info"));
+    let file_filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        tracing_subscriber::EnvFilter::new("warn,dash_spv=debug,dash_spv_bench=debug")
+    });
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(dashboard.log_writer())
+                .with_filter(terminal_filter),
+        )
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(std::sync::Mutex::new(log_file))
+                .with_filter(file_filter),
+        )
+        .init();
+
+    let mode = env_or("BENCH_MODE", "local").trim().to_ascii_lowercase();
+    let (network, remote) = match mode.as_str() {
+        "local" => (Network::Testnet, false),
+        "testnet" => (Network::Testnet, true),
+        "mainnet" => (Network::Mainnet, true),
+        other => {
+            return Err(anyhow!(
+                "BENCH_MODE must be 'local', 'testnet' or 'mainnet', got '{other}'"
+            ))
+        }
+    };
+
+    let peers: Vec<SocketAddr> = std::env::var("BENCH_PEERS")
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|p| p.parse::<SocketAddr>().with_context(|| format!("bad peer {p}")))
+        .collect::<Result<_>>()?;
+
+    if !remote && peers.is_empty() {
+        return Err(anyhow!("BENCH_MODE=local requires BENCH_PEERS (the docker peer addresses)"));
+    }
+
+    let dns_mode = remote && peers.is_empty();
+
+    let start_height: Option<u32> =
+        std::env::var("BENCH_START_HEIGHT").ok().and_then(|v| v.trim().parse().ok());
+
+    let mnemonics = load_mnemonics();
+    let timeout = Duration::from_secs(1800);
+
+    tracing::info!(
+        "dash-spv-bench: mode={} ({}) on {:?}, wallets={}",
+        mode,
+        if dns_mode {
+            "DNS discovery".to_string()
+        } else {
+            format!("{} peers", peers.len())
+        },
+        network,
+        mnemonics.len(),
+    );
+
+    let mut config = ClientConfig::new(network).with_storage_path(output_dir.clone());
+    config.start_from_height = start_height;
+    config.restrict_to_configured_peers = !dns_mode;
+    if let Ok(v) = std::env::var("BENCH_MAX_PEERS") {
+        if let Ok(n) = v.trim().parse() {
+            config.max_peers = n;
+        }
+    }
+    for addr in &peers {
+        config.add_peer(*addr);
+    }
+
+    let storage_manager =
+        DiskStorageManager::new(&config).await.map_err(|e| anyhow!("storage manager: {e}"))?;
+
+    // Wallets: one BIP44 account 0 per mnemonic, so filter matches drive block download.
+    let mut wallet_manager = WalletManager::<ManagedWalletInfo>::new(network);
+    let birth_height = start_height.unwrap_or(0);
+    let mut wallet_ids = Vec::with_capacity(mnemonics.len());
+    for mnemonic in &mnemonics {
+        let id = wallet_manager
+            .create_wallet_from_mnemonic(mnemonic, birth_height, account_creation_options())
+            .map_err(|e| anyhow!("wallet from mnemonic: {e}"))?;
+        wallet_ids.push(id);
+    }
+    let wallet = Arc::new(RwLock::new(wallet_manager));
+    let wallet_probe = wallet.clone();
+
+    let handler = Arc::new(BenchEventHandler::new(dashboard.clone()));
+    let network = dash_spv::network::PeerNetworkManager::new(&config)
+        .await
+        .map_err(|e| anyhow!("network new: {e}"))?;
+
+    let client = DashSpvClient::new(
+        config,
+        network,
+        storage_manager,
+        wallet,
+        vec![handler.clone() as Arc<dyn EventHandler>],
+    )
+    .await
+    .map_err(|e| anyhow!("client new: {e}"))?;
+
+    let run_client = client.clone();
+    let run_handle = tokio::spawn(async move {
+        if let Err(e) = run_client.run().await {
+            tracing::error!("client run() exited with error: {e}");
+        }
+    });
+
+    tokio::select! {
+        _ = handler.wait_done() => {}
+        _ = tokio::time::sleep(timeout) => {}
+        _ = tokio::signal::ctrl_c() => eprintln!("ctrl-c received, shutting down..."),
+    }
+    let m = handler.snapshot();
+
+    let _ = client.shutdown().await;
+    run_handle.abort();
+    let _ = run_handle.await;
+
+    use std::fmt::Write as _;
+    let mut report = format!("{m}\n");
+
+    if !wallet_ids.is_empty() {
+        use key_wallet_manager::WalletInterface;
+        let w = wallet_probe.read().await;
+        let _ = writeln!(report, "wallet_synced_height: {}", w.synced_height());
+        let _ = writeln!(report, "wallet_addresses:     {}", w.monitored_addresses().len());
+
+        for (i, id) in wallet_ids.iter().enumerate() {
+            let txs = w
+                .get_wallet_info(id)
+                .map(|info| {
+                    info.accounts()
+                        .all_accounts()
+                        .iter()
+                        .flat_map(|a| a.transactions().keys())
+                        .collect::<std::collections::BTreeSet<_>>()
+                        .len()
+                })
+                .unwrap_or(0);
+
+            let (confirmed, total) =
+                w.get_wallet_balance(id).map(|b| (b.confirmed(), b.total())).unwrap_or((0, 0));
+
+            let _ = writeln!(
+                report,
+                "wallet[{i}] txs={txs} confirmed_sat={confirmed} total_sat={total}"
+            );
+        }
+
+        let _ = writeln!(report, "wallet_describe:\n{}", w.describe().await);
+    }
+
+    print!("\n{report}");
+    if let Err(e) = std::fs::write(output_dir.join("summary.txt"), &report) {
+        tracing::warn!("could not write summary.txt: {e}");
+    }
+    tracing::info!("run outputs written to {}", output_dir.display());
+
+    Ok(())
+}
+
+fn account_creation_options() -> WalletAccountCreationOptions {
+    WalletAccountCreationOptions::SpecificAccounts(
+        BTreeSet::from([0]),
+        BTreeSet::new(),
+        BTreeSet::new(),
+        BTreeSet::new(),
+        BTreeSet::new(),
+        None,
+    )
+}

--- a/dash-spv-bench/src/metrics.rs
+++ b/dash-spv-bench/src/metrics.rs
@@ -1,0 +1,154 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use dash_spv::sync::{SyncEvent, SyncProgress};
+use dash_spv::EventHandler;
+use tokio::sync::Notify;
+
+use crate::dashboard::Dashboard;
+
+pub const MILESTONE_BLOCK_HEADERS: &str = "block_headers_complete";
+pub const MILESTONE_FILTER_HEADERS: &str = "filter_headers_complete";
+pub const MILESTONE_FILTERS: &str = "filters_complete";
+pub const MILESTONE_SYNC: &str = "sync_complete";
+
+#[derive(Debug)]
+pub struct RunMetrics {
+    total_ms: u64,
+    completed: bool,
+    block_headers_ms: Option<u64>,
+    filter_headers_ms: Option<u64>,
+    filters_ms: Option<u64>,
+    error: Option<String>,
+}
+
+impl fmt::Display for RunMetrics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ms = |o: Option<u64>| o.map(|v| v.to_string()).unwrap_or_else(|| "-".to_string());
+
+        writeln!(f, "=== dash-spv sync ===")?;
+        writeln!(
+            f,
+            "completed:         {}{}",
+            self.completed,
+            if self.completed {
+                ""
+            } else {
+                " (TIMED OUT)"
+            }
+        )?;
+        writeln!(f, "total_ms:          {}", self.total_ms)?;
+        writeln!(f, "block_headers_ms:  {}", ms(self.block_headers_ms))?;
+        writeln!(f, "filter_headers_ms: {}", ms(self.filter_headers_ms))?;
+        write!(f, "filters_ms:        {}", ms(self.filters_ms))?;
+        if let Some(e) = &self.error {
+            write!(f, "\nerror:             {e}")?;
+        }
+
+        Ok(())
+    }
+}
+
+pub struct BenchEventHandler {
+    start: Instant,
+    inner: Mutex<Inner>,
+    done: Notify,
+    dashboard: Arc<Dashboard>,
+}
+
+struct Inner {
+    milestones: BTreeMap<&'static str, u64>,
+    error: Option<String>,
+    completed: bool,
+}
+
+impl BenchEventHandler {
+    pub fn new(dashboard: Arc<Dashboard>) -> Self {
+        Self {
+            start: Instant::now(),
+            inner: Mutex::new(Inner {
+                milestones: BTreeMap::new(),
+                error: None,
+                completed: false,
+            }),
+            done: Notify::new(),
+            dashboard,
+        }
+    }
+
+    fn record(&self, label: &'static str) {
+        let elapsed = self.start.elapsed().as_millis() as u64;
+        let mut inner = self.inner.lock().unwrap();
+        inner.milestones.entry(label).or_insert(elapsed);
+    }
+
+    pub async fn wait_done(&self) {
+        let notified = self.done.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        if self.inner.lock().unwrap().completed {
+            return;
+        }
+
+        notified.await;
+    }
+
+    pub fn snapshot(&self) -> RunMetrics {
+        let inner = self.inner.lock().unwrap();
+        let bh = inner.milestones.get(MILESTONE_BLOCK_HEADERS).copied();
+        let fh = inner.milestones.get(MILESTONE_FILTER_HEADERS).copied();
+        let fl = inner.milestones.get(MILESTONE_FILTERS).copied();
+        let sc = inner.milestones.get(MILESTONE_SYNC).copied();
+
+        RunMetrics {
+            total_ms: sc.unwrap_or_else(|| self.start.elapsed().as_millis() as u64),
+            completed: inner.completed,
+            block_headers_ms: bh,
+            filter_headers_ms: fh,
+            filters_ms: fl,
+            error: inner.error.clone(),
+        }
+    }
+}
+
+impl EventHandler for BenchEventHandler {
+    fn on_sync_event(&self, event: &SyncEvent) {
+        match event {
+            SyncEvent::BlockHeaderSyncComplete {
+                ..
+            } => self.record(MILESTONE_BLOCK_HEADERS),
+            SyncEvent::FilterHeadersSyncComplete {
+                ..
+            } => self.record(MILESTONE_FILTER_HEADERS),
+            SyncEvent::FiltersSyncComplete {
+                ..
+            } => self.record(MILESTONE_FILTERS),
+            SyncEvent::SyncComplete {
+                ..
+            } => {
+                self.record(MILESTONE_SYNC);
+                self.dashboard.finish();
+                let mut inner = self.inner.lock().unwrap();
+                inner.completed = true;
+                drop(inner);
+                self.done.notify_waiters();
+            }
+            _ => {}
+        }
+    }
+
+    /// Every progress change repaints the bars (throttled inside).
+    fn on_progress(&self, progress: &SyncProgress) {
+        self.dashboard.render(progress);
+    }
+
+    fn on_error(&self, error: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.error.is_none() {
+            inner.error = Some(error.to_string());
+        }
+    }
+}


### PR DESCRIPTION
A docker-driven benchmark that syncs the SPV client against a frozen chain snapshot (local peers via tc netem) or the real testnet/mainnet, reporting sync time and a live dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a Dash SPV benchmarking tool with repeatable scenario runs and generated TSV/Markdown reports.
  * Introduced a live terminal dashboard showing sync progress, plus per-run milestone timing and completion status.
* **Documentation**
  * Added a benchmark scenario template and several ready-to-run example scenarios.
* **Chores / CI**
  * Added container-based dashd setup and automated chain snapshot helpers.
  * Updated CI and workspace config so the benchmark binary is excluded from CI test-group assignment; improved git ignores for benchmark outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->