### PR TITLE
feat(key-wallet): atomic multi-account UTXO reservations (set_funding_multi)

### DIFF
--- a/key-wallet/src/managed_account/reservation.rs
+++ b/key-wallet/src/managed_account/reservation.rs
@@ -29,7 +29,7 @@ use dashcore::blockdata::transaction::OutPoint;
 /// selection-to-processing latency (seconds): reclaiming a still-in-flight
 /// reservation too early would let coin selection re-pick the input and rebuild
 /// the very double-spend this guards against.
-const RESERVATION_TTL_BLOCKS: u32 = 24;
+pub(crate) const RESERVATION_TTL_BLOCKS: u32 = 24;
 
 /// Ephemeral, in-memory set of reserved outpoints. Cloning shares the
 /// underlying state, which is what lets a build's reservation outlive the

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -130,9 +130,9 @@ impl Reservations {
             Reservations::Single(set) => set.release(reserved.iter()),
             Reservations::Multi(ledgers) => {
                 for ledger in ledgers {
-                    ledger.set.release(reserved.iter().filter(|outpoint| {
-                        ledger.owned.contains(*outpoint)
-                    }));
+                    ledger.set.release(
+                        reserved.iter().filter(|outpoint| ledger.owned.contains(*outpoint)),
+                    );
                 }
             }
         }
@@ -1368,5 +1368,283 @@ mod tests {
         // stranding them until the TTL backstop reclaims them.
         funds.release_reservation(&tx);
         assert!(funds.reservations().reserved(200).is_empty());
+    }
+
+    // -- Multi-account funding (`set_funding_multi`) --
+
+    /// A union spend that draws an input from every one of three accounts must
+    /// reserve each input in the ledger of the account that *owns* it — never
+    /// pooled into the primary account's set. This is the core fix: a later
+    /// build issued through any owning account then observes its own coin as
+    /// taken and skips it.
+    #[test]
+    fn set_funding_multi_reserves_each_input_in_its_owning_account() {
+        let ctx = TestWalletContext::new_random();
+        let account =
+            ctx.wallet.accounts.standard_bip44_accounts.get(&0).expect("BIP44 account").clone();
+
+        let mut primary = ManagedCoreFundsAccount::dummy_bip44();
+        let up = Utxo::dummy(0x01, 1_000_000, 100, false, true);
+        primary.utxos.insert(up.outpoint, up.clone());
+
+        let mut second = ManagedCoreFundsAccount::dummy_bip44();
+        let us = Utxo::dummy(0x02, 1_000_000, 100, false, true);
+        second.utxos.insert(us.outpoint, us.clone());
+
+        let mut third = ManagedCoreFundsAccount::dummy_bip44();
+        let ut = Utxo::dummy(0x03, 1_000_000, 100, false, true);
+        third.utxos.insert(ut.outpoint, ut.clone());
+
+        let destination = Address::dummy(Network::Testnet, 0);
+        // `All` drains every candidate input across the union, so each account
+        // contributes exactly its own UTXO.
+        let (tx, _) = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_fee_rate(FeeRate::normal())
+            .set_selection_strategy(SelectionStrategy::All)
+            .set_funding_multi((&mut primary, &account), [&mut second, &mut third])
+            .add_output(&destination, 1)
+            .build_unsigned()
+            .expect("union drain builds");
+
+        // Every input was selected and reserved, but each in its own ledger.
+        assert_eq!(tx.input.len(), 3, "the drain spends all three union inputs");
+        assert_eq!(primary.reservations().reserved(200), HashSet::from([up.outpoint]));
+        assert_eq!(second.reservations().reserved(200), HashSet::from([us.outpoint]));
+        assert_eq!(third.reservations().reserved(200), HashSet::from([ut.outpoint]));
+    }
+
+    /// When coin selection leaves one account's UTXO unused, that account's
+    /// ledger stays clean — only the accounts whose coins were actually
+    /// selected reserve anything. Proves the group filter, not just the
+    /// all-or-nothing drain.
+    #[test]
+    fn set_funding_multi_reserves_only_selected_accounts() {
+        let ctx = TestWalletContext::new_random();
+        let account =
+            ctx.wallet.accounts.standard_bip44_accounts.get(&0).expect("BIP44 account").clone();
+
+        // Two small UTXOs cover the spend; the large third one is never needed.
+        let mut primary = ManagedCoreFundsAccount::dummy_bip44();
+        let up = Utxo::dummy(0x01, 300_000, 100, false, true);
+        primary.utxos.insert(up.outpoint, up.clone());
+
+        let mut second = ManagedCoreFundsAccount::dummy_bip44();
+        let us = Utxo::dummy(0x02, 300_000, 100, false, true);
+        second.utxos.insert(us.outpoint, us.clone());
+
+        let mut third = ManagedCoreFundsAccount::dummy_bip44();
+        let ut = Utxo::dummy(0x03, 900_000, 100, false, true);
+        third.utxos.insert(ut.outpoint, ut.clone());
+
+        let destination = Address::dummy(Network::Testnet, 0);
+        let (tx, _) = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_fee_rate(FeeRate::normal())
+            .set_selection_strategy(SelectionStrategy::SmallestFirst)
+            .set_funding_multi((&mut primary, &account), [&mut second, &mut third])
+            .set_change_address(Address::dummy(Network::Testnet, 1))
+            .add_output(&destination, 500_000)
+            .build_unsigned()
+            .expect("union builds from the two small inputs");
+
+        // The two small inputs were selected; the large one was not.
+        let selected: HashSet<OutPoint> =
+            tx.input.iter().map(|input| input.previous_output).collect();
+        assert!(selected.contains(&up.outpoint));
+        assert!(selected.contains(&us.outpoint));
+        assert!(!selected.contains(&ut.outpoint), "large input should be left unselected");
+
+        assert_eq!(primary.reservations().reserved(200), HashSet::from([up.outpoint]));
+        assert_eq!(second.reservations().reserved(200), HashSet::from([us.outpoint]));
+        assert!(
+            third.reservations().reserved(200).is_empty(),
+            "an account whose coin was not selected must reserve nothing"
+        );
+    }
+
+    /// A union spend that cannot be covered by any account reserves nothing
+    /// anywhere: the selection error is returned before the commit step, so no
+    /// ledger is left dirty.
+    #[test]
+    fn set_funding_multi_insufficient_funds_reserves_nothing() {
+        let ctx = TestWalletContext::new_random();
+        let account =
+            ctx.wallet.accounts.standard_bip44_accounts.get(&0).expect("BIP44 account").clone();
+
+        let mut primary = ManagedCoreFundsAccount::dummy_bip44();
+        let up = Utxo::dummy(0x01, 100_000, 100, false, true);
+        primary.utxos.insert(up.outpoint, up.clone());
+
+        let mut second = ManagedCoreFundsAccount::dummy_bip44();
+        let us = Utxo::dummy(0x02, 100_000, 100, false, true);
+        second.utxos.insert(us.outpoint, us.clone());
+
+        let destination = Address::dummy(Network::Testnet, 0);
+        let result = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_fee_rate(FeeRate::normal())
+            .set_funding_multi((&mut primary, &account), [&mut second])
+            // Far more than the union holds.
+            .set_change_address(Address::dummy(Network::Testnet, 1))
+            .add_output(&destination, 10_000_000)
+            .build_unsigned();
+
+        assert!(result.is_err(), "under-funded union must fail");
+        assert!(primary.reservations().reserved(200).is_empty());
+        assert!(second.reservations().reserved(200).is_empty());
+    }
+
+    /// A signing failure after the union has been reserved must release *every*
+    /// account's group — no owning ledger may be left with a stranded
+    /// reservation.
+    #[tokio::test]
+    async fn build_signed_multi_releases_all_ledgers_on_signing_failure() {
+        let ctx = TestWalletContext::new_random();
+        let account =
+            ctx.wallet.accounts.standard_bip44_accounts.get(&0).expect("BIP44 account").clone();
+
+        let mut primary = ManagedCoreFundsAccount::dummy_bip44();
+        let up = Utxo::dummy(0x01, 1_000_000, 100, false, true);
+        primary.utxos.insert(up.outpoint, up.clone());
+
+        let mut second = ManagedCoreFundsAccount::dummy_bip44();
+        let us = Utxo::dummy(0x02, 1_000_000, 100, false, true);
+        second.utxos.insert(us.outpoint, us.clone());
+
+        let destination = Address::dummy(Network::Testnet, 0);
+        let builder = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_fee_rate(FeeRate::normal())
+            .set_selection_strategy(SelectionStrategy::All)
+            .set_funding_multi((&mut primary, &account), [&mut second])
+            .add_output(&destination, 1);
+
+        // A resolver that never resolves a path forces signing to fail *after*
+        // both accounts' inputs have been reserved by assembly.
+        let result = builder.build_signed(&ctx.wallet, |_addr| None).await;
+        assert!(result.is_err());
+
+        // Every ledger rolled back — both accounts are clean.
+        assert!(primary.reservations().reserved(200).is_empty());
+        assert!(second.reservations().reserved(200).is_empty());
+    }
+
+    /// The per-account TTL backstop and the per-account
+    /// [`release_reservation`](ManagedCoreFundsAccount::release_reservation)
+    /// both act on the owning ledger with no multi-account machinery: releasing
+    /// through one account clears only that account's group, and the TTL sweep
+    /// reclaims each account independently.
+    #[test]
+    fn set_funding_multi_release_and_ttl_are_per_account() {
+        use crate::managed_account::reservation::RESERVATION_TTL_BLOCKS;
+
+        let ctx = TestWalletContext::new_random();
+        let account =
+            ctx.wallet.accounts.standard_bip44_accounts.get(&0).expect("BIP44 account").clone();
+
+        let mut primary = ManagedCoreFundsAccount::dummy_bip44();
+        let up = Utxo::dummy(0x01, 1_000_000, 100, false, true);
+        primary.utxos.insert(up.outpoint, up.clone());
+
+        let mut second = ManagedCoreFundsAccount::dummy_bip44();
+        let us = Utxo::dummy(0x02, 1_000_000, 100, false, true);
+        second.utxos.insert(us.outpoint, us.clone());
+
+        let destination = Address::dummy(Network::Testnet, 0);
+        let (tx, _) = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_fee_rate(FeeRate::normal())
+            .set_selection_strategy(SelectionStrategy::All)
+            .set_funding_multi((&mut primary, &account), [&mut second])
+            .add_output(&destination, 1)
+            .build_unsigned()
+            .expect("union drain builds");
+        assert_eq!(tx.input.len(), 2);
+
+        // Releasing through the primary clears only the primary's group; the
+        // second account's reservation is untouched (release is keyed on the
+        // outpoints the ledger actually holds).
+        primary.release_reservation(&tx);
+        assert!(primary.reservations().reserved(200).is_empty());
+        assert_eq!(second.reservations().reserved(200), HashSet::from([us.outpoint]));
+
+        // The second account's reservation is still reclaimed by its own TTL
+        // backstop once enough blocks elapse — no shared sweep needed.
+        assert!(second.reservations().reserved(200 + RESERVATION_TTL_BLOCKS).is_empty());
+    }
+
+    /// Two builds racing over the same union under the shared lock (the
+    /// wallet-manager lock the platform layer relies on) must never both select
+    /// the same coin: the first build's reservation is visible to the second,
+    /// which then has nothing left to fund itself with. Exercises the crate's
+    /// `Arc<Mutex>` + `thread::spawn` concurrency idiom.
+    #[test]
+    fn concurrent_multi_build_cannot_double_select() {
+        use std::collections::HashSet as StdHashSet;
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+        use std::sync::{Arc, Mutex};
+        use std::thread;
+
+        let ctx = TestWalletContext::new_random();
+        let account =
+            ctx.wallet.accounts.standard_bip44_accounts.get(&0).expect("BIP44 account").clone();
+
+        let mut primary = ManagedCoreFundsAccount::dummy_bip44();
+        let up = Utxo::dummy(0x0A, 600_000, 100, false, true);
+        primary.utxos.insert(up.outpoint, up.clone());
+
+        let mut second = ManagedCoreFundsAccount::dummy_bip44();
+        let us = Utxo::dummy(0x0B, 600_000, 100, false, true);
+        second.utxos.insert(us.outpoint, us.clone());
+
+        // The lock that serializes the two builds stands in for the
+        // wallet-manager write lock.
+        let accounts = Arc::new(Mutex::new((primary, second)));
+        let account = Arc::new(account);
+        let successes = Arc::new(AtomicUsize::new(0));
+        let all_selected = Arc::new(Mutex::new(Vec::<OutPoint>::new()));
+
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let accounts = Arc::clone(&accounts);
+            let account = Arc::clone(&account);
+            let successes = Arc::clone(&successes);
+            let all_selected = Arc::clone(&all_selected);
+            handles.push(thread::spawn(move || {
+                let mut guard = accounts.lock().expect("accounts lock");
+                let (primary, second) = &mut *guard;
+                let destination = Address::dummy(Network::Testnet, 0);
+                // Needs both 600k inputs to cover 1_000_000 + fee.
+                let result = TransactionBuilder::new()
+                    .set_current_height(200)
+                    .set_fee_rate(FeeRate::normal())
+                    .set_selection_strategy(SelectionStrategy::SmallestFirst)
+                    .set_funding_multi((primary, &account), [second])
+                    .set_change_address(Address::dummy(Network::Testnet, 1))
+                    .add_output(&destination, 1_000_000)
+                    .build_unsigned();
+                if let Ok((tx, _)) = result {
+                    successes.fetch_add(1, AtomicOrdering::SeqCst);
+                    let mut selected = all_selected.lock().expect("selected lock");
+                    selected.extend(tx.input.iter().map(|input| input.previous_output));
+                }
+            }));
+        }
+        for handle in handles {
+            handle.join().expect("thread join");
+        }
+
+        // Exactly one build could fund itself; the other observed the first's
+        // reservations and had no free inputs left.
+        assert_eq!(
+            successes.load(AtomicOrdering::SeqCst),
+            1,
+            "both builds funded themselves — the reservation window leaked"
+        );
+        // No outpoint was selected by both builds.
+        let selected = all_selected.lock().expect("selected lock");
+        let unique: StdHashSet<&OutPoint> = selected.iter().collect();
+        assert_eq!(unique.len(), selected.len(), "an outpoint was double-selected");
     }
 }

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -216,10 +216,19 @@ impl TransactionBuilder {
     /// taken and skips them.
     ///
     /// `primary` supplies both candidate UTXOs and the change address (change
-    /// always returns to the primary account). Every account in `extra`
-    /// contributes candidate UTXOs and its own reservation ledger; extra
-    /// accounts never emit change, so they need no [`Account`]. `primary` must
-    /// not also appear in `extra`.
+    /// always returns to the primary account), so it is taken by `&mut` — the
+    /// only mutation performed here is deriving the change address. Every
+    /// account in `extra` contributes candidate UTXOs and its own reservation
+    /// ledger; extra accounts are only read (their UTXOs and reservation set),
+    /// never mutated, so they are taken by *shared* reference. This lets a caller
+    /// that already holds the primary by `&mut` pass the rest by `&` out of the
+    /// same account collection without partitioning it into N exclusive borrows.
+    /// Extra accounts never emit change, so they need no [`Account`].
+    ///
+    /// `primary` must not also appear in `extra`; a duplicate would push the
+    /// same UTXOs twice and reserve them twice. This is a caller bug — it is
+    /// caught by identity comparison and the duplicate is skipped (with a
+    /// `debug_assert!` so it fails loudly in tests/debug builds).
     ///
     /// Atomicity: the reservations for all selected inputs are committed as one
     /// synchronous step at assembly time, only after coin selection has fully
@@ -240,13 +249,13 @@ impl TransactionBuilder {
         extra: E,
     ) -> Self
     where
-        E: IntoIterator<Item = &'a mut ManagedCoreFundsAccount>,
+        E: IntoIterator<Item = &'a ManagedCoreFundsAccount>,
     {
         let height = self.current_height;
         let mut inputs = Vec::new();
         let mut ledgers = Vec::new();
 
-        let mut push_account = |acc: &mut ManagedCoreFundsAccount| {
+        let mut push_account = |acc: &ManagedCoreFundsAccount| {
             let reserved = acc.reservations().reserved(height);
             let mut owned = HashSet::new();
             for utxo in acc.utxos.values() {
@@ -268,6 +277,21 @@ impl TransactionBuilder {
         self.change_addr = primary_acc.next_change_address(Some(&account.account_xpub), true).ok();
 
         for acc in extra {
+            // Enforce the documented precondition that `primary` must not also
+            // appear in `extra`. Extra accounts are shared references, so we can
+            // compare identity by pointer; a duplicate would push the same UTXOs
+            // twice and reserve them twice, so skip it. A duplicate is a caller
+            // bug, hence the debug_assert alongside the graceful skip.
+            if std::ptr::eq(acc, &*primary_acc) {
+                debug_assert!(
+                    false,
+                    "set_funding_multi: `primary` must not also appear in `extra`"
+                );
+                tracing::warn!(
+                    "set_funding_multi: skipping an `extra` account identical to `primary`"
+                );
+                continue;
+            }
             push_account(acc);
         }
 
@@ -1402,7 +1426,7 @@ mod tests {
             .set_current_height(200)
             .set_fee_rate(FeeRate::normal())
             .set_selection_strategy(SelectionStrategy::All)
-            .set_funding_multi((&mut primary, &account), [&mut second, &mut third])
+            .set_funding_multi((&mut primary, &account), [&second, &third])
             .add_output(&destination, 1)
             .build_unsigned()
             .expect("union drain builds");
@@ -1442,7 +1466,7 @@ mod tests {
             .set_current_height(200)
             .set_fee_rate(FeeRate::normal())
             .set_selection_strategy(SelectionStrategy::SmallestFirst)
-            .set_funding_multi((&mut primary, &account), [&mut second, &mut third])
+            .set_funding_multi((&mut primary, &account), [&second, &third])
             .set_change_address(Address::dummy(Network::Testnet, 1))
             .add_output(&destination, 500_000)
             .build_unsigned()
@@ -1484,7 +1508,7 @@ mod tests {
         let result = TransactionBuilder::new()
             .set_current_height(200)
             .set_fee_rate(FeeRate::normal())
-            .set_funding_multi((&mut primary, &account), [&mut second])
+            .set_funding_multi((&mut primary, &account), [&second])
             // Far more than the union holds.
             .set_change_address(Address::dummy(Network::Testnet, 1))
             .add_output(&destination, 10_000_000)
@@ -1517,7 +1541,7 @@ mod tests {
             .set_current_height(200)
             .set_fee_rate(FeeRate::normal())
             .set_selection_strategy(SelectionStrategy::All)
-            .set_funding_multi((&mut primary, &account), [&mut second])
+            .set_funding_multi((&mut primary, &account), [&second])
             .add_output(&destination, 1);
 
         // A resolver that never resolves a path forces signing to fail *after*
@@ -1556,7 +1580,7 @@ mod tests {
             .set_current_height(200)
             .set_fee_rate(FeeRate::normal())
             .set_selection_strategy(SelectionStrategy::All)
-            .set_funding_multi((&mut primary, &account), [&mut second])
+            .set_funding_multi((&mut primary, &account), [&second])
             .add_output(&destination, 1)
             .build_unsigned()
             .expect("union drain builds");
@@ -1620,7 +1644,7 @@ mod tests {
                     .set_current_height(200)
                     .set_fee_rate(FeeRate::normal())
                     .set_selection_strategy(SelectionStrategy::SmallestFirst)
-                    .set_funding_multi((primary, &account), [second])
+                    .set_funding_multi((primary, &account), [&*second])
                     .set_change_address(Address::dummy(Network::Testnet, 1))
                     .add_output(&destination, 1_000_000)
                     .build_unsigned();
@@ -1646,5 +1670,42 @@ mod tests {
         let selected = all_selected.lock().expect("selected lock");
         let unique: StdHashSet<&OutPoint> = selected.iter().collect();
         assert_eq!(unique.len(), selected.len(), "an outpoint was double-selected");
+    }
+
+    /// The documented precondition — `primary` must not also appear in `extra` —
+    /// is enforced by an identity check that skips the duplicate (so it can never
+    /// be pushed and reserved twice) and, in debug builds, trips a `debug_assert`
+    /// so the caller bug is caught loudly. Because `primary` is held by `&mut`
+    /// and `extra` by `&`, safe borrows make it impossible to present the same
+    /// account both ways; we forge the aliased shared reference through a raw
+    /// pointer purely to drive the guard.
+    #[test]
+    #[should_panic(expected = "must not also appear in `extra`")]
+    fn set_funding_multi_rejects_primary_listed_in_extra() {
+        let ctx = TestWalletContext::new_random();
+        let account =
+            ctx.wallet.accounts.standard_bip44_accounts.get(&0).expect("BIP44 account").clone();
+
+        let mut primary = ManagedCoreFundsAccount::dummy_bip44();
+        let up = Utxo::dummy(0x01, 1_000_000, 100, false, true);
+        primary.utxos.insert(up.outpoint, up.clone());
+
+        // The guard reads only the *address* of this alias (via `ptr::eq`) and
+        // panics before anything is read through it, so no data is actually
+        // accessed through both the `&mut` and this `&` at once.
+        // SAFETY: `primary` outlives the alias, and the alias is used solely to
+        // present the same account as an `extra` — the exact misuse the guard
+        // rejects. It is never dereferenced for its contents.
+        let primary_ptr: *const ManagedCoreFundsAccount = &primary;
+        let aliased: &ManagedCoreFundsAccount = unsafe { &*primary_ptr };
+
+        let destination = Address::dummy(Network::Testnet, 0);
+        let _ = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_fee_rate(FeeRate::normal())
+            .set_selection_strategy(SelectionStrategy::All)
+            .set_funding_multi((&mut primary, &account), [aliased])
+            .add_output(&destination, 1)
+            .build_unsigned();
     }
 }

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -19,6 +19,7 @@ use dashcore_hashes::Hash;
 use secp256k1::ecdsa::Signature;
 use secp256k1::{Message, PublicKey, Secp256k1};
 use std::cmp::Ordering;
+use std::collections::HashSet;
 
 /// A transaction with more inputs would exceed the relay standard-size cap (~100 KB at ~148
 /// bytes/signed input) and be rejected by the network
@@ -49,10 +50,93 @@ pub struct TransactionBuilder {
     require_final_inputs: bool,
     /// Special transaction payload for Dash-specific transactions
     special_payload: Option<TransactionPayload>,
-    /// Reservation set of the funding account, captured by `set_funding`. The
-    /// inputs chosen during assembly are reserved here so a concurrent build
-    /// skips them until the broadcast transaction is processed.
-    reservations: Option<ReservationSet>,
+    /// Where the inputs chosen during assembly are reserved so a concurrent
+    /// build skips them until the broadcast transaction is processed. Captured
+    /// by `set_funding` (single account) or `set_funding_multi` (union across
+    /// several accounts, each input reserved in its owning account's ledger).
+    reservations: Reservations,
+}
+
+/// A funding account's reservation ledger together with the candidate outpoints
+/// it owns among the builder's inputs. Used by the multi-account funding path so
+/// each selected input is reserved in its owning account, not in one shared set.
+///
+/// The `owned` sets are disjoint across ledgers because a UTXO belongs to exactly
+/// one account, which makes grouping the selected inputs by owner unambiguous.
+#[derive(Clone)]
+struct FundingLedger {
+    /// A clone (shared `Arc<Mutex<_>>` handle) of the owning account's set.
+    set: ReservationSet,
+    /// The unreserved candidate outpoints this account contributed.
+    owned: HashSet<OutPoint>,
+}
+
+/// How the builder reserves the inputs it selects.
+///
+/// Kept private: callers choose a mode through `set_funding` / `set_funding_multi`
+/// (or neither), never by naming this type.
+#[derive(Clone, Default)]
+enum Reservations {
+    /// No funding account was attached (inputs came from `add_inputs`); nothing
+    /// is reserved.
+    #[default]
+    None,
+    /// A single funding account: every selected input is reserved in this one
+    /// set. This is the historical `set_funding` behaviour, preserved exactly.
+    Single(ReservationSet),
+    /// A union of funding accounts: each selected input is reserved in the ledger
+    /// of its owning account. All groups commit together (one synchronous,
+    /// infallible step after selection succeeds) and roll back together (on a
+    /// signing failure), so there is never a window where a subset is reserved.
+    Multi(Vec<FundingLedger>),
+}
+
+impl Reservations {
+    /// Commit the reservation of every selected input. For a single funding
+    /// account all inputs go to its one set; for a union each input is reserved
+    /// in the ledger of the account that owns it. This runs as one synchronous,
+    /// infallible step (see [`ReservationSet::reserve`]) with no interior yield,
+    /// so the whole commit is atomic with respect to any correctly-locked
+    /// concurrent selector.
+    fn reserve_selected(&self, selected: &[Utxo], height: u32) {
+        match self {
+            Reservations::None => {}
+            Reservations::Single(set) => {
+                let outpoints: Vec<OutPoint> = selected.iter().map(|utxo| utxo.outpoint).collect();
+                set.reserve(&outpoints, height);
+            }
+            Reservations::Multi(ledgers) => {
+                for ledger in ledgers {
+                    let group: Vec<OutPoint> = selected
+                        .iter()
+                        .map(|utxo| utxo.outpoint)
+                        .filter(|outpoint| ledger.owned.contains(outpoint))
+                        .collect();
+                    if !group.is_empty() {
+                        ledger.set.reserve(&group, height);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Release a previously committed reservation of `reserved`, rolling back
+    /// every owning account. Idempotent: releasing an outpoint that is not (or
+    /// no longer) reserved is a no-op, so a Multi ledger only ever drops the
+    /// outpoints it actually owns.
+    fn release_selected(&self, reserved: &[OutPoint]) {
+        match self {
+            Reservations::None => {}
+            Reservations::Single(set) => set.release(reserved.iter()),
+            Reservations::Multi(ledgers) => {
+                for ledger in ledgers {
+                    ledger.set.release(reserved.iter().filter(|outpoint| {
+                        ledger.owned.contains(*outpoint)
+                    }));
+                }
+            }
+        }
+    }
 }
 
 impl Default for TransactionBuilder {
@@ -73,7 +157,7 @@ impl TransactionBuilder {
             selection_strategy: SelectionStrategy::BranchAndBound,
             require_final_inputs: false,
             special_payload: None,
-            reservations: None,
+            reservations: Reservations::None,
         }
     }
 
@@ -116,8 +200,79 @@ impl TransactionBuilder {
             .filter(|utxo| !reserved.contains(&utxo.outpoint))
             .cloned()
             .collect();
-        self.reservations = Some(funds_acc.reservations().clone());
+        self.reservations = Reservations::Single(funds_acc.reservations().clone());
         self.change_addr = funds_acc.next_change_address(Some(&acc.account_xpub), true).ok();
+        self
+    }
+
+    /// Seed the builder with a *union* of several funding accounts' spendable
+    /// UTXOs, reserving each selected input in its own owning account's ledger.
+    ///
+    /// Unlike [`set_funding`](Self::set_funding), which snapshots one account's
+    /// [`ReservationSet`] and reserves every selected input there, this reserves
+    /// each input in the account that actually owns it. That is what makes the
+    /// reservation correct when inputs are drawn from more than one account: a
+    /// later build issued through an owning account observes its own coins as
+    /// taken and skips them.
+    ///
+    /// `primary` supplies both candidate UTXOs and the change address (change
+    /// always returns to the primary account). Every account in `extra`
+    /// contributes candidate UTXOs and its own reservation ledger; extra
+    /// accounts never emit change, so they need no [`Account`]. `primary` must
+    /// not also appear in `extra`.
+    ///
+    /// Atomicity: the reservations for all selected inputs are committed as one
+    /// synchronous step at assembly time, only after coin selection has fully
+    /// succeeded. Because [`ReservationSet::reserve`] is infallible and the
+    /// commit yields to no other task, either every group is reserved or (on an
+    /// earlier selection error) none is — there is no window in which a subset
+    /// is reserved and a concurrent selector grabs the rest. A signing failure
+    /// after the commit releases every group (see
+    /// [`build_signed`](Self::build_signed)).
+    ///
+    /// Like `set_funding`, this call and the assembly that reserves the chosen
+    /// inputs must run under one uninterrupted hold of the wallet lock; the
+    /// builder must not be held across an `await` between here and
+    /// `build_signed` / `assemble_unsigned`.
+    pub fn set_funding_multi<'a, E>(
+        mut self,
+        primary: (&mut ManagedCoreFundsAccount, &Account),
+        extra: E,
+    ) -> Self
+    where
+        E: IntoIterator<Item = &'a mut ManagedCoreFundsAccount>,
+    {
+        let height = self.current_height;
+        let mut inputs = Vec::new();
+        let mut ledgers = Vec::new();
+
+        let mut push_account = |acc: &mut ManagedCoreFundsAccount| {
+            let reserved = acc.reservations().reserved(height);
+            let mut owned = HashSet::new();
+            for utxo in acc.utxos.values() {
+                if reserved.contains(&utxo.outpoint) {
+                    continue;
+                }
+                owned.insert(utxo.outpoint);
+                inputs.push(utxo.clone());
+            }
+            ledgers.push(FundingLedger {
+                set: acc.reservations().clone(),
+                owned,
+            });
+        };
+
+        let (primary_acc, account) = primary;
+        push_account(primary_acc);
+        // Change always returns to the primary (transparent) account.
+        self.change_addr = primary_acc.next_change_address(Some(&account.account_xpub), true).ok();
+
+        for acc in extra {
+            push_account(acc);
+        }
+
+        self.inputs = inputs;
+        self.reservations = Reservations::Multi(ledgers);
         self
     }
 
@@ -392,12 +547,10 @@ impl TransactionBuilder {
 
         // Reserve the chosen inputs so a concurrent build skips them until the
         // broadcast transaction is processed back into the wallet (which
-        // releases the reservation) or the TTL backstop reclaims it.
-        if let Some(reservations) = &self.reservations {
-            let outpoints: Vec<OutPoint> =
-                selected_inputs.iter().map(|utxo| utxo.outpoint).collect();
-            reservations.reserve(&outpoints, self.current_height);
-        }
+        // releases the reservation) or the TTL backstop reclaims it. Selection
+        // has fully succeeded by this point, so this commit is the last thing
+        // assembly does: on any earlier error nothing is reserved.
+        self.reservations.reserve_selected(&selected_inputs, self.current_height);
 
         return Ok((transaction, selected_inputs));
 
@@ -457,14 +610,14 @@ impl TransactionBuilder {
         // Signing never reaches the network for a local key, but an external
         // signer can fail. A failed sign means the reserved inputs are still
         // spendable, so release them now instead of stranding the funds until
-        // the TTL backstop reclaims them.
+        // the TTL backstop reclaims them. For a multi-account funding set every
+        // group rolls back together, so no owning account is left with a
+        // stranded reservation.
         let reserved: Vec<OutPoint> = inputs.iter().map(|utxo| utxo.outpoint).collect();
         let tx = match signer.sign_tx(tx, inputs, path_resolver).await {
             Ok(tx) => tx,
             Err(err) => {
-                if let Some(reservations) = &reservations {
-                    reservations.release(reserved.iter());
-                }
+                reservations.release_selected(&reserved);
                 return Err(err);
             }
         };


### PR DESCRIPTION
### What

Adds `TransactionBuilder::set_funding_multi`, a funding entry that draws a union
of UTXOs from several accounts and reserves **each selected input in the ledger
of the account that owns it**, rather than pooling every reservation into one
account's set.

### Why

This is the upstream fix for the Dash **Platform #4184** reservation blocker.
The platform asset-lock "fund from all accounts" builder seeds a primary BIP44
account via `set_funding` and appends other accounts' UTXOs via `add_inputs`.
Today the builder snapshots a single account's `ReservationSet` and reserves
**all** selected inputs there — so a CoinJoin/DashPay input gets reserved in the
**primary** account's ledger, and a later build issued through the *owning*
account can reselect that same coin before broadcast reconciliation releases it.
`ReservationSet` is `pub(crate)`, so the platform crate cannot fix this itself;
the safe fix belongs here. Platform will adopt `set_funding_multi` (replacing
its `set_funding(primary) + add_inputs(extra)` composition) at the next
key-wallet pin bump.

### How

- The builder's `reservations` field becomes a private `Reservations` enum
  (`None` / `Single` / `Multi`). `Single` is the existing `set_funding` path,
  **byte-for-byte unchanged**.
- `Multi` carries one ledger per funding account (`{ ReservationSet, owned
  outpoints }`). At assembly the selected inputs are grouped by owner and
  committed in one synchronous, infallible step — only after coin selection has
  fully succeeded.
- Signature: `primary` is `&mut` (its change address is derived here — the sole
  mutation); `extra` is an `IntoIterator` of **shared** `&ManagedCoreFundsAccount`,
  since extras are only read. Shared refs keep adoption a clean single call: the
  platform site holds the primary by `&mut` and passes the rest by `&` straight
  out of its `all_funding_accounts()` borrow, rather than partitioning that
  collection into N exclusive borrows that each also exclude the primary. The
  documented "`primary` must not appear in `extra`" precondition is enforced by
  an identity check (`std::ptr::eq`) that skips a duplicate so it can't be
  reserved twice, with a `debug_assert` to catch the caller bug in debug builds
  (a `Result` return was avoided so the fluent builder chain is preserved).
- Atomicity: `ReservationSet::reserve` cannot fail and the commit yields to no
  other task, so the union reserves entirely or (on an earlier selection error)
  not at all. A signing failure releases every group, so no owning account is
  left with a stranded reservation.
- Per-account release and the TTL backstop need **no** new machinery: each
  input lives in its owning account's existing set, so the release in
  `update_utxos` (adjacent to the spent-outpoint tracking from **#909**) and the
  TTL sweep already reclaim it in the right ledger.

Deliberately **not** ported from the internal design note: a public
`ReservationTxn`/`stage`/`commit`/`ReservationConflict` staging API. Since
`reserve` is infallible and cross-account atomicity is already provided by the
wallet-manager lock the single-account path documents, that surface is
unnecessary — this keeps the new public API to a single method.

### Known limitation (parity with the single-account path)

If the caller **panics** during signing (rather than returning an `Err`), the
already-committed reservations are not released and the coins stay reserved
until the 24-block (`RESERVATION_TTL_BLOCKS`) TTL backstop reclaims them. This
is identical to the existing single-account `set_funding` path — no `Drop`-based
panic guard is added here, so behaviour stays on par with it.

### Tests

New: atomic commit across 2–3 accounts, group filter, insufficient-funds
reserves-nothing, signing-failure rollback across all ledgers, per-account
release + TTL, a threaded no-double-select race, and a duplicate-primary guard
check. Existing single-account builder tests unchanged and green.
`cargo test`/`clippy`/`fmt` clean for `key-wallet`, `key-wallet-ffi`,
`key-wallet-manager`.
