### PR TITLE
feat(key-wallet): CoinJoin funding account + drain mode for asset-lock builds

### DIFF
--- a/key-wallet-ffi/src/transaction.rs
+++ b/key-wallet-ffi/src/transaction.rs
@@ -840,9 +840,12 @@ pub unsafe extern "C" fn wallet_build_and_sign_asset_lock_transaction(
 
             let result = unwrap_or_return!(managed_wallet.build_asset_lock(
                 wallet_ref.inner(),
-                account_index,
+                key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockFundingAccount::Bip44 {
+                    account_index,
+                },
                 fundings,
                 fee_per_kb,
+                false,
             ).await, error);
 
             // Write outputs

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -12,6 +12,7 @@ use std::fmt;
 use crate::managed_account::managed_account_trait::ManagedAccountTrait;
 use crate::managed_account::ManagedCoreKeysAccount;
 use crate::signer::Signer;
+use crate::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
 use crate::wallet::managed_wallet_info::fee::FeeRate;
 use crate::wallet::managed_wallet_info::transaction_builder::{BuilderError, TransactionBuilder};
 use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
@@ -35,6 +36,43 @@ pub enum AssetLockFundingType {
     AssetLockAddressTopUp,
     /// Asset lock shielded address top-up: m/9'/coinType'/5'/5'/index'
     AssetLockShieldedAddressTopUp,
+}
+
+/// Which wallet account supplies the funding UTXOs (and signs the inputs)
+/// of an asset lock transaction.
+///
+/// `Bip44` is the standard spendable balance — the historical behavior of
+/// the builders below. `CoinJoin` lets mixed coins fund an asset lock
+/// directly, without first sweeping them through a transparent BIP44
+/// address (which would link the mixed UTXOs to a reusable transparent
+/// address for an extra hop).
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssetLockFundingAccount {
+    /// Standard BIP44 account (`m/44'/coinType'/index'`).
+    Bip44 {
+        /// BIP44 account index.
+        account_index: u32,
+    },
+    /// CoinJoin account (`m/9'/coinType'/4'/index'`).
+    CoinJoin {
+        /// CoinJoin account index.
+        account_index: u32,
+    },
+}
+
+impl AssetLockFundingAccount {
+    /// The account index within its family.
+    pub fn account_index(&self) -> u32 {
+        match self {
+            Self::Bip44 {
+                account_index,
+            }
+            | Self::CoinJoin {
+                account_index,
+            } => *account_index,
+        }
+    }
 }
 
 /// Per-credit-output funding specification.
@@ -93,7 +131,7 @@ pub enum AssetLockError {
     SigningFailed(String),
     /// The wallet does not have a private key (watch-only).
     WatchOnlyWallet,
-    /// The specified BIP44 account was not found.
+    /// The specified funding account (BIP44 or CoinJoin, by index) was not found.
     AccountNotFound(u32),
     /// No change address available.
     NoChangeAddress,
@@ -114,7 +152,7 @@ impl fmt::Display for AssetLockError {
             Self::Signer(msg) => write!(f, "Signer error: {msg}"),
             Self::SigningFailed(msg) => write!(f, "Signing failed: {msg}"),
             Self::WatchOnlyWallet => write!(f, "Cannot sign with watch-only wallet"),
-            Self::AccountNotFound(idx) => write!(f, "BIP44 account {} not found", idx),
+            Self::AccountNotFound(idx) => write!(f, "funding account {} not found", idx),
             Self::NoChangeAddress => write!(f, "No change address available"),
             Self::Builder(e) => write!(f, "Transaction builder error: {e}"),
         }
@@ -176,12 +214,20 @@ impl ManagedWalletInfo {
     ///
     /// The transaction is built first, and keys are only derived after a successful
     /// build — so no addresses are consumed if the build fails.
+    ///
+    /// `funding_account` picks which account family supplies (and signs) the
+    /// funding UTXOs — see [`AssetLockFundingAccount`]. `drain` locks the
+    /// account's whole spendable balance: every final UTXO is consumed and
+    /// the single credit output's value is rewritten to `Σ inputs − fee`
+    /// (the caller's credit-output value is ignored; exactly one credit
+    /// output is required).
     pub async fn build_asset_lock(
         &mut self,
         wallet: &Wallet,
-        account_index: u32,
+        funding_account: AssetLockFundingAccount,
         credit_output_fundings: Vec<CreditOutputFunding>,
         fee_per_kb: u64,
+        drain: bool,
     ) -> Result<AssetLockResult, AssetLockError> {
         // Surface watch-only / no-private-key wallets here so we don't reserve
         // a change index before the build can possibly succeed.
@@ -191,27 +237,72 @@ impl ManagedWalletInfo {
         let network = self.network;
         let height = self.last_processed_height();
 
-        let acc = &wallet
-            .get_bip44_account(account_index)
-            .ok_or(AssetLockError::AccountNotFound(account_index))?;
+        let account_index = funding_account.account_index();
+        let acc = match funding_account {
+            AssetLockFundingAccount::Bip44 {
+                ..
+            } => wallet
+                .get_bip44_account(account_index)
+                .ok_or(AssetLockError::AccountNotFound(account_index))?,
+            AssetLockFundingAccount::CoinJoin {
+                ..
+            } => wallet
+                .get_coinjoin_account(account_index)
+                .ok_or(AssetLockError::AccountNotFound(account_index))?,
+        };
 
-        let funds_acc = self
-            .accounts
-            .standard_bip44_accounts
-            .get_mut(&account_index)
-            .ok_or(AssetLockError::AccountNotFound(account_index))?;
+        let funds_acc = match funding_account {
+            AssetLockFundingAccount::Bip44 {
+                ..
+            } => self
+                .accounts
+                .standard_bip44_accounts
+                .get_mut(&account_index)
+                .ok_or(AssetLockError::AccountNotFound(account_index))?,
+            AssetLockFundingAccount::CoinJoin {
+                ..
+            } => self
+                .accounts
+                .coinjoin_accounts
+                .get_mut(&account_index)
+                .ok_or(AssetLockError::AccountNotFound(account_index))?,
+        };
+
+        if drain && credit_output_fundings.len() != 1 {
+            return Err(AssetLockError::Builder(BuilderError::InvalidData(
+                "drain asset lock requires exactly one credit output".into(),
+            )));
+        }
+        if matches!(
+            funding_account,
+            AssetLockFundingAccount::CoinJoin {
+                ..
+            }
+        ) && !drain
+        {
+            // CoinJoin accounts have no change-address pool semantics for
+            // asset locks (change would need re-denomination); only the
+            // whole-balance drain is supported.
+            return Err(AssetLockError::Builder(BuilderError::InvalidData(
+                "CoinJoin-funded asset locks support drain mode only".into(),
+            )));
+        }
 
         let credit_outputs: Vec<TxOut> =
             credit_output_fundings.iter().map(|f| f.output.clone()).collect();
 
         // Build first, derive credit keys after — a build failure must not
         // consume any funding-key indices.
-        let (transaction, fee) = TransactionBuilder::new()
+        let mut builder = TransactionBuilder::new()
             .set_fee_rate(FeeRate::new(fee_per_kb))
             .set_current_height(height)
             .set_special_payload(TransactionPayload::AssetLockPayloadType(AssetLockPayload::new(
                 credit_outputs,
-            )))
+            )));
+        if drain {
+            builder = builder.set_selection_strategy(SelectionStrategy::All);
+        }
+        let (transaction, fee) = builder
             .set_funding(funds_acc, acc)
             .require_final_inputs()
             .build_signed(wallet, |addr| funds_acc.address_derivation_path(&addr))
@@ -253,36 +344,85 @@ impl ManagedWalletInfo {
     /// one per credit output in payload order. The caller uses the paths to
     /// request signatures from the same signer when later consuming the
     /// credits on Platform.
+    ///
+    /// `funding_account` / `drain` — see [`Self::build_asset_lock`].
     pub async fn build_asset_lock_with_signer<S: Signer>(
         &mut self,
         wallet: &Wallet,
-        account_index: u32,
+        funding_account: AssetLockFundingAccount,
         credit_output_fundings: Vec<CreditOutputFunding>,
         fee_per_kb: u64,
+        drain: bool,
         signer: &S,
     ) -> Result<AssetLockResult, AssetLockError> {
         let height = self.last_processed_height();
 
-        let acc = wallet
-            .get_bip44_account(account_index)
-            .ok_or(AssetLockError::AccountNotFound(account_index))?
-            .clone();
+        let account_index = funding_account.account_index();
+        let acc = match funding_account {
+            AssetLockFundingAccount::Bip44 {
+                ..
+            } => wallet
+                .get_bip44_account(account_index)
+                .ok_or(AssetLockError::AccountNotFound(account_index))?
+                .clone(),
+            AssetLockFundingAccount::CoinJoin {
+                ..
+            } => wallet
+                .get_coinjoin_account(account_index)
+                .ok_or(AssetLockError::AccountNotFound(account_index))?
+                .clone(),
+        };
 
-        let funds_acc = self
-            .accounts
-            .standard_bip44_accounts
-            .get_mut(&account_index)
-            .ok_or(AssetLockError::AccountNotFound(account_index))?;
+        let funds_acc = match funding_account {
+            AssetLockFundingAccount::Bip44 {
+                ..
+            } => self
+                .accounts
+                .standard_bip44_accounts
+                .get_mut(&account_index)
+                .ok_or(AssetLockError::AccountNotFound(account_index))?,
+            AssetLockFundingAccount::CoinJoin {
+                ..
+            } => self
+                .accounts
+                .coinjoin_accounts
+                .get_mut(&account_index)
+                .ok_or(AssetLockError::AccountNotFound(account_index))?,
+        };
+
+        if drain && credit_output_fundings.len() != 1 {
+            return Err(AssetLockError::Builder(BuilderError::InvalidData(
+                "drain asset lock requires exactly one credit output".into(),
+            )));
+        }
+        if matches!(
+            funding_account,
+            AssetLockFundingAccount::CoinJoin {
+                ..
+            }
+        ) && !drain
+        {
+            // CoinJoin accounts have no change-address pool semantics for
+            // asset locks (change would need re-denomination); only the
+            // whole-balance drain is supported.
+            return Err(AssetLockError::Builder(BuilderError::InvalidData(
+                "CoinJoin-funded asset locks support drain mode only".into(),
+            )));
+        }
 
         let credit_outputs: Vec<TxOut> =
             credit_output_fundings.iter().map(|f| f.output.clone()).collect();
 
-        let (transaction, fee) = TransactionBuilder::new()
+        let mut builder = TransactionBuilder::new()
             .set_fee_rate(FeeRate::new(fee_per_kb))
             .set_current_height(height)
             .set_special_payload(TransactionPayload::AssetLockPayloadType(AssetLockPayload::new(
                 credit_outputs,
-            )))
+            )));
+        if drain {
+            builder = builder.set_selection_strategy(SelectionStrategy::All);
+        }
+        let (transaction, fee) = builder
             .set_funding(funds_acc, &acc)
             .require_final_inputs()
             .build_signed(signer, |addr| funds_acc.address_derivation_path(&addr))
@@ -411,6 +551,149 @@ mod tests {
         outpoint
     }
 
+    /// CoinJoin-account sibling of [`insert_funded_utxo`]: fund CoinJoin
+    /// account 0 with a UTXO at a fresh receive address.
+    fn insert_funded_coinjoin_utxo(
+        info: &mut ManagedWalletInfo,
+        wallet: &Wallet,
+        txid_byte: u8,
+        value: u64,
+        is_confirmed: bool,
+    ) -> OutPoint {
+        let account_xpub = wallet.get_coinjoin_account(0).unwrap().account_xpub;
+        let account = info.accounts.coinjoin_accounts.get_mut(&0).unwrap();
+        // CoinJoin accounts have no `next_receive_address` wrapper (that is
+        // Standard-only); draw from the external (mixed-coin) pool directly.
+        let funding_address = match account.managed_account_type_mut() {
+            crate::ManagedAccountType::CoinJoin {
+                external_addresses,
+                ..
+            } => external_addresses
+                .next_unused(&crate::KeySource::Public(account_xpub), true)
+                .unwrap(),
+            _ => unreachable!("coinjoin account must carry the CoinJoin managed type"),
+        };
+        let outpoint = OutPoint {
+            txid: Txid::from_byte_array([txid_byte; 32]),
+            vout: 0,
+        };
+        let utxo = Utxo {
+            outpoint,
+            txout: TxOut {
+                value,
+                script_pubkey: funding_address.script_pubkey(),
+            },
+            address: funding_address,
+            height: 1000,
+            is_coinbase: false,
+            is_confirmed,
+            is_instantlocked: false,
+            is_locked: false,
+            is_trusted: false,
+        };
+        account.utxos.insert(outpoint, utxo);
+        outpoint
+    }
+
+    /// Drain from the CoinJoin account: every CoinJoin UTXO is consumed, the
+    /// single credit output's value is rewritten to `Σ inputs − fee`, the
+    /// on-chain burn mirrors it exactly, and there is no change output.
+    #[tokio::test]
+    async fn test_drain_coinjoin_asset_lock() {
+        let (wallet, mut info) = test_wallet_and_info();
+        insert_funded_coinjoin_utxo(&mut info, &wallet, 0x41, 400_000, true);
+        insert_funded_coinjoin_utxo(&mut info, &wallet, 0x42, 300_000, true);
+        insert_funded_coinjoin_utxo(&mut info, &wallet, 0x43, 300_000, true);
+        info.update_last_processed_height(1100);
+
+        // The caller's credit amount (0) is ignored — drain rewrites it.
+        let result = info
+            .build_asset_lock(
+                &wallet,
+                AssetLockFundingAccount::CoinJoin {
+                    account_index: 0,
+                },
+                test_credit_outputs(&[0]),
+                1000,
+                true,
+            )
+            .await
+            .expect("drain from a funded CoinJoin account should succeed");
+
+        assert_eq!(result.transaction.input.len(), 3, "drain must consume every CoinJoin UTXO");
+        assert_eq!(result.transaction.output.len(), 1, "drain emits no change output");
+        let burn = &result.transaction.output[0];
+        assert!(burn.script_pubkey.is_op_return(), "single output must be the OP_RETURN burn");
+        assert_eq!(burn.value, 1_000_000 - result.fee, "burn must carry Σ inputs − fee");
+
+        let payload = match &result.transaction.special_transaction_payload {
+            Some(TransactionPayload::AssetLockPayloadType(p)) => p,
+            other => panic!("expected asset-lock payload, got {:?}", other),
+        };
+        assert_eq!(payload.credit_outputs.len(), 1);
+        assert_eq!(
+            payload.credit_outputs[0].value, burn.value,
+            "payload credit output must mirror the burn value"
+        );
+
+        for (i, txin) in result.transaction.input.iter().enumerate() {
+            assert!(!txin.script_sig.is_empty(), "input {i} not signed");
+        }
+    }
+
+    /// A drain build requires exactly one credit output — anything else is
+    /// rejected before any wallet state is touched.
+    #[tokio::test]
+    async fn test_drain_requires_single_credit_output() {
+        let (wallet, mut info) = test_wallet_and_info();
+        insert_funded_coinjoin_utxo(&mut info, &wallet, 0x44, 500_000, true);
+        info.update_last_processed_height(1100);
+
+        let result = info
+            .build_asset_lock(
+                &wallet,
+                AssetLockFundingAccount::CoinJoin {
+                    account_index: 0,
+                },
+                test_credit_outputs(&[0, 0]),
+                1000,
+                true,
+            )
+            .await;
+        assert!(
+            matches!(result, Err(AssetLockError::Builder(BuilderError::InvalidData(_)))),
+            "two credit outputs must be rejected in drain mode, got: {:?}",
+            result.err()
+        );
+    }
+
+    /// CoinJoin funding is drain-only: a partial (non-drain) CoinJoin-funded
+    /// build is rejected before any wallet state is touched (change would
+    /// need CoinJoin re-denomination, which the builder does not do).
+    #[tokio::test]
+    async fn test_coinjoin_funding_requires_drain() {
+        let (wallet, mut info) = test_wallet_and_info();
+        insert_funded_coinjoin_utxo(&mut info, &wallet, 0x45, 1_000_000, true);
+        info.update_last_processed_height(1100);
+
+        let result = info
+            .build_asset_lock(
+                &wallet,
+                AssetLockFundingAccount::CoinJoin {
+                    account_index: 0,
+                },
+                test_credit_outputs(&[200_000]),
+                1000,
+                false,
+            )
+            .await;
+        assert!(
+            matches!(result, Err(AssetLockError::Builder(BuilderError::InvalidData(_)))),
+            "non-drain CoinJoin funding must be rejected, got: {:?}",
+            result.err()
+        );
+    }
+
     // -- Error type tests --
 
     #[test]
@@ -419,7 +702,7 @@ mod tests {
             AssetLockError::WatchOnlyWallet.to_string(),
             "Cannot sign with watch-only wallet"
         );
-        assert_eq!(AssetLockError::AccountNotFound(5).to_string(), "BIP44 account 5 not found");
+        assert_eq!(AssetLockError::AccountNotFound(5).to_string(), "funding account 5 not found");
         assert_eq!(AssetLockError::NoChangeAddress.to_string(), "No change address available");
     }
 
@@ -435,7 +718,15 @@ mod tests {
     #[tokio::test]
     async fn test_empty_credit_outputs_rejected() {
         let (wallet, mut info) = test_wallet_and_info();
-        let result = info.build_asset_lock(&wallet, 0, vec![], 1000).await;
+        let result = info.build_asset_lock(
+                &wallet,
+                AssetLockFundingAccount::Bip44 {
+                    account_index: 0,
+                },
+                vec![],
+                1000,
+                false,
+            ).await;
         assert!(matches!(result, Err(AssetLockError::Builder(BuilderError::NoOutputs))));
     }
 
@@ -443,7 +734,15 @@ mod tests {
     async fn test_invalid_account_index() {
         let (wallet, mut info) = test_wallet_and_info();
         let result =
-            info.build_asset_lock(&wallet, 99, test_credit_outputs(&[100_000]), 1000).await;
+            info.build_asset_lock(
+                &wallet,
+                AssetLockFundingAccount::Bip44 {
+                    account_index: 99,
+                },
+                test_credit_outputs(&[100_000]),
+                1000,
+                false,
+            ).await;
         assert!(matches!(result, Err(AssetLockError::AccountNotFound(99))));
     }
 
@@ -451,7 +750,15 @@ mod tests {
     async fn test_insufficient_funds() {
         // Wallet has no UTXOs, so coin selection should fail
         let (wallet, mut info) = test_wallet_and_info();
-        let result = info.build_asset_lock(&wallet, 0, test_credit_outputs(&[500_000]), 1000).await;
+        let result = info.build_asset_lock(
+                &wallet,
+                AssetLockFundingAccount::Bip44 {
+                    account_index: 0,
+                },
+                test_credit_outputs(&[500_000]),
+                1000,
+                false,
+            ).await;
         assert!(
             matches!(result, Err(AssetLockError::Builder(_))),
             "Expected Builder error for insufficient funds, got: {:?}",
@@ -469,7 +776,15 @@ mod tests {
         insert_funded_utxo(&mut info, &wallet, 0x11, 1_000_000, false);
         info.update_last_processed_height(1100);
 
-        let result = info.build_asset_lock(&wallet, 0, test_credit_outputs(&[200_000]), 1000).await;
+        let result = info.build_asset_lock(
+                &wallet,
+                AssetLockFundingAccount::Bip44 {
+                    account_index: 0,
+                },
+                test_credit_outputs(&[200_000]),
+                1000,
+                false,
+            ).await;
         assert!(
             matches!(result, Err(AssetLockError::Builder(_))),
             "asset lock must not be built on unconfirmed funds, got: {:?}",
@@ -487,7 +802,15 @@ mod tests {
         info.update_last_processed_height(1100);
 
         let result = info
-            .build_asset_lock(&wallet, 0, test_credit_outputs(&[200_000]), 1000)
+            .build_asset_lock(
+                &wallet,
+                AssetLockFundingAccount::Bip44 {
+                    account_index: 0,
+                },
+                test_credit_outputs(&[200_000]),
+                1000,
+                false,
+            )
             .await
             .expect("confirmed funds should cover the asset lock");
         assert!(!result.transaction.input.is_empty());
@@ -605,7 +928,17 @@ mod tests {
             root,
             network: Network::Testnet,
         };
-        let result = info.build_asset_lock_with_signer(&wallet, 0, vec![], 1000, &signer).await;
+        let result = info.build_asset_lock_with_signer(
+                &wallet,
+                AssetLockFundingAccount::Bip44 {
+                    account_index: 0,
+                },
+                vec![],
+                1000,
+                false,
+                &signer,
+            )
+            .await;
         assert!(matches!(result, Err(AssetLockError::Builder(BuilderError::NoOutputs))));
     }
 
@@ -626,9 +959,12 @@ mod tests {
         let result = info
             .build_asset_lock_with_signer(
                 &wallet,
-                99,
+                AssetLockFundingAccount::Bip44 {
+                    account_index: 99,
+                },
                 test_credit_outputs(&[100_000]),
                 1000,
+                false,
                 &signer,
             )
             .await;
@@ -663,9 +999,12 @@ mod tests {
         let result = info
             .build_asset_lock_with_signer(
                 &wallet,
-                0,
+                AssetLockFundingAccount::Bip44 {
+                    account_index: 0,
+                },
                 test_credit_outputs(&[100_000]),
                 1000,
+                false,
                 &NoDigestSigner,
             )
             .await;
@@ -698,7 +1037,16 @@ mod tests {
         let credit_amounts = [200_000u64, 300_000u64];
         let fundings = test_credit_outputs(&credit_amounts);
         let result = info
-            .build_asset_lock_with_signer(&wallet, 0, fundings, 1000, &signer)
+            .build_asset_lock_with_signer(
+                &wallet,
+                AssetLockFundingAccount::Bip44 {
+                    account_index: 0,
+                },
+                fundings,
+                1000,
+                false,
+                &signer,
+            )
             .await
             .expect("build_asset_lock_with_signer should succeed with funded wallet");
 
@@ -753,9 +1101,12 @@ mod tests {
         let result = info
             .build_asset_lock_with_signer(
                 &wallet,
-                0,
+                AssetLockFundingAccount::Bip44 {
+                    account_index: 0,
+                },
                 test_credit_outputs(&[500_000]),
                 1000,
+                false,
                 &signer,
             )
             .await;

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -206,6 +206,28 @@ fn resolve_funding_account(
     }
 }
 
+/// Shared guard for both asset-lock builders: a drain rewrites exactly one
+/// credit output, and CoinJoin accounts have no change-address pool semantics
+/// for asset locks (change would need re-denomination), so they only support
+/// the whole-balance drain.
+fn validate_drain_funding(
+    funding_account: AssetLockFundingAccount,
+    credit_output_count: usize,
+    drain: bool,
+) -> Result<(), AssetLockError> {
+    if drain && credit_output_count != 1 {
+        return Err(AssetLockError::Builder(BuilderError::InvalidData(
+            "drain asset lock requires exactly one credit output".into(),
+        )));
+    }
+    if matches!(funding_account, AssetLockFundingAccount::CoinJoin { .. }) && !drain {
+        return Err(AssetLockError::Builder(BuilderError::InvalidData(
+            "CoinJoin-funded asset locks support drain mode only".into(),
+        )));
+    }
+    Ok(())
+}
+
 impl ManagedWalletInfo {
     /// Build and sign an asset lock transaction.
     ///
@@ -268,25 +290,7 @@ impl ManagedWalletInfo {
                 .ok_or(AssetLockError::AccountNotFound(account_index))?,
         };
 
-        if drain && credit_output_fundings.len() != 1 {
-            return Err(AssetLockError::Builder(BuilderError::InvalidData(
-                "drain asset lock requires exactly one credit output".into(),
-            )));
-        }
-        if matches!(
-            funding_account,
-            AssetLockFundingAccount::CoinJoin {
-                ..
-            }
-        ) && !drain
-        {
-            // CoinJoin accounts have no change-address pool semantics for
-            // asset locks (change would need re-denomination); only the
-            // whole-balance drain is supported.
-            return Err(AssetLockError::Builder(BuilderError::InvalidData(
-                "CoinJoin-funded asset locks support drain mode only".into(),
-            )));
-        }
+        validate_drain_funding(funding_account, credit_output_fundings.len(), drain)?;
 
         let credit_outputs: Vec<TxOut> =
             credit_output_fundings.iter().map(|f| f.output.clone()).collect();
@@ -390,25 +394,7 @@ impl ManagedWalletInfo {
                 .ok_or(AssetLockError::AccountNotFound(account_index))?,
         };
 
-        if drain && credit_output_fundings.len() != 1 {
-            return Err(AssetLockError::Builder(BuilderError::InvalidData(
-                "drain asset lock requires exactly one credit output".into(),
-            )));
-        }
-        if matches!(
-            funding_account,
-            AssetLockFundingAccount::CoinJoin {
-                ..
-            }
-        ) && !drain
-        {
-            // CoinJoin accounts have no change-address pool semantics for
-            // asset locks (change would need re-denomination); only the
-            // whole-balance drain is supported.
-            return Err(AssetLockError::Builder(BuilderError::InvalidData(
-                "CoinJoin-funded asset locks support drain mode only".into(),
-            )));
-        }
+        validate_drain_funding(funding_account, credit_output_fundings.len(), drain)?;
 
         let credit_outputs: Vec<TxOut> =
             credit_output_fundings.iter().map(|f| f.output.clone()).collect();
@@ -718,7 +704,8 @@ mod tests {
     #[tokio::test]
     async fn test_empty_credit_outputs_rejected() {
         let (wallet, mut info) = test_wallet_and_info();
-        let result = info.build_asset_lock(
+        let result = info
+            .build_asset_lock(
                 &wallet,
                 AssetLockFundingAccount::Bip44 {
                     account_index: 0,
@@ -726,15 +713,16 @@ mod tests {
                 vec![],
                 1000,
                 false,
-            ).await;
+            )
+            .await;
         assert!(matches!(result, Err(AssetLockError::Builder(BuilderError::NoOutputs))));
     }
 
     #[tokio::test]
     async fn test_invalid_account_index() {
         let (wallet, mut info) = test_wallet_and_info();
-        let result =
-            info.build_asset_lock(
+        let result = info
+            .build_asset_lock(
                 &wallet,
                 AssetLockFundingAccount::Bip44 {
                     account_index: 99,
@@ -742,7 +730,8 @@ mod tests {
                 test_credit_outputs(&[100_000]),
                 1000,
                 false,
-            ).await;
+            )
+            .await;
         assert!(matches!(result, Err(AssetLockError::AccountNotFound(99))));
     }
 
@@ -750,7 +739,8 @@ mod tests {
     async fn test_insufficient_funds() {
         // Wallet has no UTXOs, so coin selection should fail
         let (wallet, mut info) = test_wallet_and_info();
-        let result = info.build_asset_lock(
+        let result = info
+            .build_asset_lock(
                 &wallet,
                 AssetLockFundingAccount::Bip44 {
                     account_index: 0,
@@ -758,7 +748,8 @@ mod tests {
                 test_credit_outputs(&[500_000]),
                 1000,
                 false,
-            ).await;
+            )
+            .await;
         assert!(
             matches!(result, Err(AssetLockError::Builder(_))),
             "Expected Builder error for insufficient funds, got: {:?}",
@@ -776,7 +767,8 @@ mod tests {
         insert_funded_utxo(&mut info, &wallet, 0x11, 1_000_000, false);
         info.update_last_processed_height(1100);
 
-        let result = info.build_asset_lock(
+        let result = info
+            .build_asset_lock(
                 &wallet,
                 AssetLockFundingAccount::Bip44 {
                     account_index: 0,
@@ -784,7 +776,8 @@ mod tests {
                 test_credit_outputs(&[200_000]),
                 1000,
                 false,
-            ).await;
+            )
+            .await;
         assert!(
             matches!(result, Err(AssetLockError::Builder(_))),
             "asset lock must not be built on unconfirmed funds, got: {:?}",
@@ -928,7 +921,8 @@ mod tests {
             root,
             network: Network::Testnet,
         };
-        let result = info.build_asset_lock_with_signer(
+        let result = info
+            .build_asset_lock_with_signer(
                 &wallet,
                 AssetLockFundingAccount::Bip44 {
                     account_index: 0,

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -351,6 +351,12 @@ impl TransactionBuilder {
             // Drain: the single output takes the whole balance minus fee (the caller's amount is
             // ignored); no change.
             let drained = total_input.saturating_sub(selection.estimated_fee);
+            if drained == 0 {
+                return Err(BuilderError::InsufficientFunds {
+                    available: total_input,
+                    required: selection.estimated_fee,
+                });
+            }
             let [out] = tx_outputs.as_mut_slice() else {
                 return Err(BuilderError::InvalidData(
                     "SelectionStrategy::All requires exactly one output (the destination)".into(),
@@ -370,12 +376,6 @@ impl TransactionBuilder {
                             .into(),
                     ));
                 };
-                if drained == 0 {
-                    return Err(BuilderError::InsufficientFunds {
-                        available: total_input,
-                        required: selection.estimated_fee,
-                    });
-                }
                 credit.value = drained;
             }
         } else if change_amount > 546 {

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -350,12 +350,34 @@ impl TransactionBuilder {
         if self.selection_strategy == SelectionStrategy::All {
             // Drain: the single output takes the whole balance minus fee (the caller's amount is
             // ignored); no change.
+            let drained = total_input.saturating_sub(selection.estimated_fee);
             let [out] = tx_outputs.as_mut_slice() else {
                 return Err(BuilderError::InvalidData(
                     "SelectionStrategy::All requires exactly one output (the destination)".into(),
                 ));
             };
-            out.value = total_input.saturating_sub(selection.estimated_fee);
+            out.value = drained;
+            // An asset-lock drain must also rewrite the payload's credit
+            // output: the on-chain OP_RETURN burn (`out` above) mirrors the
+            // payload credit sum, and a mismatch is consensus-invalid.
+            if let Some(TransactionPayload::AssetLockPayloadType(payload)) =
+                &mut self.special_payload
+            {
+                let [credit] = payload.credit_outputs.as_mut_slice() else {
+                    return Err(BuilderError::InvalidData(
+                        "SelectionStrategy::All with an asset-lock payload requires exactly one \
+                         credit output"
+                            .into(),
+                    ));
+                };
+                if drained == 0 {
+                    return Err(BuilderError::InsufficientFunds {
+                        available: total_input,
+                        required: selection.estimated_fee,
+                    });
+                }
+                credit.value = drained;
+            }
         } else if change_amount > 546 {
             // Add change output if above dust threshold
             let Some(change_addr) = self.change_addr else {


### PR DESCRIPTION
## What

The asset-lock builders (`build_asset_lock` / `build_asset_lock_with_signer`) previously hardcoded their funding source to standard BIP44 accounts. This adds:

- **`AssetLockFundingAccount { Bip44, CoinJoin }`** — which account family supplies (and signs) the funding UTXOs. CoinJoin funding lets mixed coins fund an asset lock directly, without first sweeping them through a transparent BIP44 address (which links the mixed UTXOs to a reusable transparent address for an extra hop).
- **Drain mode** — consume every final UTXO of the funding account and rewrite the single credit output's value to `Σ inputs − fee`. The `TransactionBuilder`'s `SelectionStrategy::All` path now also rewrites the asset-lock **payload** credit output so the payload always mirrors the on-chain OP_RETURN burn (a mismatch is consensus-invalid), and a zero-value drain is rejected with `InsufficientFunds`.
- **CoinJoin funding is drain-only** — partial spends would need CoinJoin change re-denomination, which the builder does not do; a non-drain CoinJoin build is rejected with `InvalidData`.

`key-wallet-ffi`'s `build_asset_lock` entry point keeps its exact behavior (BIP44, non-drain).

## Why

Consumed by dashpay/platform (`AssetLockFunding::DrainAccountBalance` + a `shielded_fund_from_asset_lock_coinjoin_drain` FFI) so the dashwallet-ios post-migration "move your mixed coins" flow can offer a Shielded destination that moves the whole CoinJoin balance into the shielded pool in one transaction, with no transparent intermediate hop.

## Tests

- `test_drain_coinjoin_asset_lock` — all CoinJoin UTXOs consumed, burn = `Σ − fee`, payload credit mirrors the burn, no change output, inputs signed.
- `test_drain_requires_single_credit_output`, `test_coinjoin_funding_requires_drain` — guard rejections.
- Full `key-wallet` (551) + `key-wallet-manager` (48) unit suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset-lock transactions can now be funded from either standard wallet accounts or CoinJoin accounts.
  * CoinJoin funding now supports drain-only transactions that consume all available inputs without creating change.
* **Bug Fixes**
  * Drain transactions now validate configuration and ensure credit output values match the burned amount after fees.
  * Improved checks for insufficient funds and invalid drain setups (for example, incorrect credit-output counts and non-drain CoinJoin funding).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->