### PR TITLE
test(key-wallet): cover the change-address guard

### DIFF
--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -110,6 +110,11 @@ impl TransactionBuilder {
     /// must therefore not be held across an `await` between `set_funding` and
     /// `build_signed` or `assemble_unsigned`, since suspending there reopens the
     /// read-then-reserve window for a concurrent build.
+    ///
+    /// A change address already set by [`set_change_address`](Self::set_change_address)
+    /// wins: the funding account is only asked for one when the builder has none.
+    /// Deriving unconditionally would both discard the caller's choice and burn a
+    /// pool address, since `next_change_address` advances the pool state.
     pub fn set_funding(mut self, funds_acc: &mut ManagedCoreFundsAccount, acc: &Account) -> Self {
         let reserved = funds_acc.reservations().reserved(self.current_height);
         self.inputs = funds_acc
@@ -119,7 +124,9 @@ impl TransactionBuilder {
             .cloned()
             .collect();
         self.reservations = Some(funds_acc.reservations().clone());
-        self.change_addr = funds_acc.next_change_address(Some(&acc.account_xpub), true).ok();
+        if self.change_addr.is_none() {
+            self.change_addr = funds_acc.next_change_address(Some(&acc.account_xpub), true).ok();
+        }
         self
     }
 
@@ -1204,6 +1211,33 @@ mod tests {
         let candidates: Vec<OutPoint> = builder.inputs.iter().map(|utxo| utxo.outpoint).collect();
         assert!(!candidates.contains(&reserved.outpoint));
         assert!(candidates.contains(&free.outpoint));
+    }
+
+    #[test]
+    fn set_funding_keeps_an_explicit_change_address() {
+        let ctx = TestWalletContext::new_random();
+        let account =
+            ctx.wallet.accounts.standard_bip44_accounts.get(&0).expect("BIP44 account").clone();
+
+        let mut funds = ManagedCoreFundsAccount::dummy_bip44();
+        let utxo = Utxo::dummy(0x01, 1_000_000, 100, false, true);
+        funds.utxos.insert(utxo.outpoint, utxo);
+
+        let explicit = Address::dummy(Network::Testnet, 1);
+        let builder = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_change_address(explicit.clone())
+            .set_funding(&mut funds, &account);
+
+        assert_eq!(builder.change_addr.as_ref(), Some(&explicit));
+
+        // Nor was a pool address burned to produce one that would be thrown away:
+        // `funds` still hands out the same address a pristine account would.
+        let mut control = ManagedCoreFundsAccount::dummy_bip44();
+        assert_eq!(
+            funds.next_change_address(Some(&account.account_xpub), true).expect("change address"),
+            control.next_change_address(Some(&account.account_xpub), true).expect("change address"),
+        );
     }
 
     #[tokio::test]

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -157,6 +157,11 @@ impl TransactionBuilder {
     /// must therefore not be held across an `await` between `add_funding` and
     /// `build_signed` or `assemble_unsigned`, since suspending there reopens the
     /// read-then-reserve window for a concurrent build.
+    ///
+    /// A change address already set by [`set_change_address`](Self::set_change_address)
+    /// wins: the funding account is only asked for one when the builder has none.
+    /// Deriving unconditionally would both discard the caller's choice and burn a
+    /// pool address, since `next_change_address` advances the pool state.
     pub fn add_funding(self, funds_acc: &mut ManagedCoreFundsAccount, acc: &Account) -> Self {
         self.fund_from(funds_acc, acc, true)
     }
@@ -2201,6 +2206,37 @@ mod tests {
     /// for the same outpoint, and since coin selection does not deduplicate,
     /// `SelectionStrategy::All` spends it twice — a transaction Core rejects
     /// for duplicate prevouts.
+    /// The guard in `fund_from` that keeps an explicit change address is
+    /// untested, so nothing stops it being dropped as a redundant `is_none`
+    /// check. Losing it would silently override the caller's address and, worse,
+    /// advance the change pool for an address that is then thrown away.
+    #[test]
+    fn add_funding_keeps_an_explicit_change_address() {
+        let ctx = TestWalletContext::new_random();
+        let account =
+            ctx.wallet.accounts.standard_bip44_accounts.get(&0).expect("BIP44 account").clone();
+
+        let mut funds = ManagedCoreFundsAccount::dummy_bip44();
+        let utxo = Utxo::dummy(0x01, 1_000_000, 100, false, true);
+        funds.utxos.insert(utxo.outpoint, utxo);
+
+        let explicit = Address::dummy(Network::Testnet, 1);
+        let builder = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_change_address(explicit.clone())
+            .add_funding(&mut funds, &account);
+
+        assert_eq!(builder.change_addr.as_ref(), Some(&explicit));
+
+        // Nor was a pool address burned to produce one that would be thrown away:
+        // `funds` still hands out the same address a pristine account would.
+        let mut control = ManagedCoreFundsAccount::dummy_bip44();
+        assert_eq!(
+            funds.next_change_address(Some(&account.account_xpub), true).expect("change address"),
+            control.next_change_address(Some(&account.account_xpub), true).expect("change address"),
+        );
+    }
+
     #[test]
     fn add_funding_does_not_duplicate_a_pre_seeded_input() {
         let ctx = TestWalletContext::new_random();

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -2028,12 +2028,29 @@ mod tests {
 
         funds.reservations().reserve(&[reserved.outpoint], 200, ReservationToken::next());
 
-        let builder =
-            TransactionBuilder::new().set_current_height(200).add_funding(&mut funds, &account);
+        // Set change address to test the branch that avoids it being replaced
+        // by add_funding()
+        let explicit = Address::dummy(Network::Testnet, 1);
+        let builder = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_change_address(explicit.clone())
+            .add_funding(&mut funds, &account);
 
         let candidates: Vec<OutPoint> = builder.inputs.iter().map(|utxo| utxo.outpoint).collect();
         assert!(!candidates.contains(&reserved.outpoint));
         assert!(candidates.contains(&free.outpoint));
+
+        assert_eq!(
+            builder.change_addr.as_ref(),
+            Some(&explicit),
+            "funding must not override a change address the caller chose"
+        );
+        // Nor may it burn a pool address to derive one it then discards.
+        let mut control = ManagedCoreFundsAccount::dummy_bip44();
+        assert_eq!(
+            funds.next_change_address(Some(&account.account_xpub), true).expect("change address"),
+            control.next_change_address(Some(&account.account_xpub), true).expect("change address"),
+        );
     }
 
     #[test]
@@ -2206,37 +2223,6 @@ mod tests {
     /// for the same outpoint, and since coin selection does not deduplicate,
     /// `SelectionStrategy::All` spends it twice — a transaction Core rejects
     /// for duplicate prevouts.
-    /// The guard in `fund_from` that keeps an explicit change address is
-    /// untested, so nothing stops it being dropped as a redundant `is_none`
-    /// check. Losing it would silently override the caller's address and, worse,
-    /// advance the change pool for an address that is then thrown away.
-    #[test]
-    fn add_funding_keeps_an_explicit_change_address() {
-        let ctx = TestWalletContext::new_random();
-        let account =
-            ctx.wallet.accounts.standard_bip44_accounts.get(&0).expect("BIP44 account").clone();
-
-        let mut funds = ManagedCoreFundsAccount::dummy_bip44();
-        let utxo = Utxo::dummy(0x01, 1_000_000, 100, false, true);
-        funds.utxos.insert(utxo.outpoint, utxo);
-
-        let explicit = Address::dummy(Network::Testnet, 1);
-        let builder = TransactionBuilder::new()
-            .set_current_height(200)
-            .set_change_address(explicit.clone())
-            .add_funding(&mut funds, &account);
-
-        assert_eq!(builder.change_addr.as_ref(), Some(&explicit));
-
-        // Nor was a pool address burned to produce one that would be thrown away:
-        // `funds` still hands out the same address a pristine account would.
-        let mut control = ManagedCoreFundsAccount::dummy_bip44();
-        assert_eq!(
-            funds.next_change_address(Some(&account.account_xpub), true).expect("change address"),
-            control.next_change_address(Some(&account.account_xpub), true).expect("change address"),
-        );
-    }
-
     #[test]
     fn add_funding_does_not_duplicate_a_pre_seeded_input() {
         let ctx = TestWalletContext::new_random();


### PR DESCRIPTION
This started as a fix: `set_funding` derived a change address unconditionally, discarding one the caller had set and burning a pool address to do it. #925 rewrote that path into `add_funding` / `fund_from` four days later and carried the guard with it, so the fix has been in `dev` since 7 August — which is why there is no production change left here.

  What #925 did not bring was a test. The guard reads as a redundant `is_none` next to an unconditional assignment, and every existing test funds first and sets the address after, an order that never reaches it. Removing it would compile, pass the suite, and silently override the caller's address while advancing the change pool for one that is then
  discarded.

  Folded into `set_funding_skips_reserved_utxos`, whose fixture already had what it needed, plus a note on `add_funding` stating the ordering contract. Verified by removing the guard: the new assertion fails.

  Two findings from the earlier review are deliberately not addressed; reasoning in the thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved explicitly configured change addresses during transaction funding.
  * Prevented unnecessary consumption of pooled change addresses when a change address is already set.
  * Ensured funding uses the caller’s selected change address instead of deriving a different address.

* **Documentation**
  * Clarified the priority of explicitly configured change addresses during funding.

* **Tests**
  * Added regression coverage confirming the configured address is preserved and no pooled address is consumed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->