### PR TITLE
fix(key-wallet): never offer an outpoint the builder already holds

### DIFF
--- a/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_builder.rs
@@ -148,16 +148,33 @@ impl TransactionBuilder {
     /// read-then-reserve window for a concurrent build.
     pub fn add_funding(mut self, funds_acc: &mut ManagedCoreFundsAccount, acc: &Account) -> Self {
         let reserved = funds_acc.reservations().reserved(self.current_height);
-        let candidates: Vec<Utxo> = funds_acc
-            .utxos
-            .values()
-            .filter(|utxo| !reserved.contains(&utxo.outpoint))
-            .cloned()
-            .collect();
-        self.funding.push((
-            funds_acc.reservations().clone(),
-            candidates.iter().map(|utxo| utxo.outpoint).collect(),
-        ));
+        // An outpoint the builder already holds — seeded by `add_inputs`, or
+        // offered by an earlier `add_funding` of an overlapping account — must
+        // not become a second candidate for the SAME outpoint. Coin selection
+        // does not deduplicate (and `SelectionStrategy::All` takes every
+        // candidate), so a duplicate would be spent twice in one transaction and
+        // Core rejects duplicate prevouts. This is additive funding's hazard
+        // specifically: the `set_funding` it replaced overwrote `inputs`, so a
+        // pre-seeded outpoint was silently dropped instead of duplicated.
+        let present: HashSet<OutPoint> = self.inputs.iter().map(|utxo| utxo.outpoint).collect();
+        let mut candidates: Vec<Utxo> = Vec::new();
+        // Every unreserved UTXO this account owns that ends up in the candidate
+        // pool — including one pre-seeded by `add_inputs` — so that if selection
+        // picks it, THIS account reserves it. Recording only the UTXOs added
+        // here would leave a pre-seeded input unreserved and free for a
+        // concurrent build to select.
+        let mut owned: HashSet<OutPoint> = HashSet::new();
+        for utxo in funds_acc.utxos.values() {
+            if reserved.contains(&utxo.outpoint) {
+                continue;
+            }
+            owned.insert(utxo.outpoint);
+            if present.contains(&utxo.outpoint) {
+                continue;
+            }
+            candidates.push(utxo.clone());
+        }
+        self.funding.push((funds_acc.reservations().clone(), owned));
         self.inputs.extend(candidates);
         if self.change_addr.is_none() {
             self.change_addr = funds_acc.next_change_address(Some(&acc.account_xpub), true).ok();
@@ -1773,6 +1790,58 @@ mod tests {
         let candidates: Vec<OutPoint> = builder.inputs.iter().map(|utxo| utxo.outpoint).collect();
         assert!(!candidates.contains(&reserved.outpoint));
         assert!(candidates.contains(&free.outpoint));
+    }
+
+    /// A UTXO seeded with `add_inputs` and then offered again by `add_funding`
+    /// must appear ONCE. Additive funding otherwise pushes a second candidate
+    /// for the same outpoint, and since coin selection does not deduplicate,
+    /// `SelectionStrategy::All` spends it twice — a transaction Core rejects
+    /// for duplicate prevouts.
+    #[test]
+    fn add_funding_does_not_duplicate_a_pre_seeded_input() {
+        let ctx = TestWalletContext::new_random();
+        let account =
+            ctx.wallet.accounts.standard_bip44_accounts.get(&0).expect("BIP44 account").clone();
+
+        let mut funds = ManagedCoreFundsAccount::dummy_bip44();
+        let seeded = Utxo::dummy(0x01, 500_000, 100, false, true);
+        let other = Utxo::dummy(0x02, 500_000, 100, false, true);
+        funds.utxos.insert(seeded.outpoint, seeded.clone());
+        funds.utxos.insert(other.outpoint, other.clone());
+
+        let builder = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_selection_strategy(SelectionStrategy::All)
+            .add_inputs(vec![seeded.clone()])
+            .add_funding(&mut funds, &account)
+            .add_output(&ctx.receive_address, 100_000);
+
+        let candidates: Vec<OutPoint> = builder.inputs.iter().map(|utxo| utxo.outpoint).collect();
+        assert_eq!(
+            candidates.iter().filter(|op| **op == seeded.outpoint).count(),
+            1,
+            "the pre-seeded outpoint must be offered exactly once, got {candidates:?}"
+        );
+
+        let (tx, _fee, token) = builder.build_unsigned_reserved().expect("build");
+        let mut prevouts: Vec<OutPoint> = tx.input.iter().map(|i| i.previous_output).collect();
+        prevouts.sort_by_key(|op| (op.txid.to_byte_array(), op.vout));
+        let deduped = {
+            let mut d = prevouts.clone();
+            d.dedup();
+            d
+        };
+        assert_eq!(prevouts, deduped, "transaction must not contain duplicate prevouts");
+
+        // The pre-seeded input still belongs to this account, so a drain that
+        // spends it must RESERVE it — otherwise a concurrent build would see it
+        // as free and double-spend it.
+        assert!(token.is_some(), "a funded build stamps a reservation token");
+        let reserved = funds.reservations().reserved(200);
+        assert!(
+            reserved.contains(&seeded.outpoint),
+            "the pre-seeded input must be reserved by the account that owns it"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What was fixed

`add_funding` (the additive replacement for `set_funding`, #925) appends every unreserved UTXO of a funding account to the candidate set without checking what the builder already holds. If the builder was seeded with one of those same UTXOs — `add_inputs` with a caller-chosen outpoint, or an earlier `add_funding` of an overlapping account — the outpoint became **two candidates**.

Coin selection performs no outpoint deduplication. `SelectionStrategy::All` clones every candidate, so the duplicate was *guaranteed* to reach the transaction; the ordinary strategies can select both copies and double-count them toward the target. Either way the built transaction spends one prevout twice, and Core rejects it.

This hazard is specific to additive funding: the `set_funding` it replaced did `self.inputs = …`, so a pre-seeded outpoint was silently **dropped**. Losing a caller's explicit input is a bug too, but building an invalid transaction is strictly worse, so the fix filters candidates rather than restoring the overwrite.

## Reservation correctness

The funding entry still records every unreserved outpoint the account owns that is in the candidate pool — **including one pre-seeded by `add_inputs`** — so if selection picks it, the owning account reserves it. Recording only the UTXOs this call appended would leave a pre-seeded input unreserved and free for a concurrent build to select, which is the double-spend window the reservation system exists to close.

## Testing

`add_funding_does_not_duplicate_a_pre_seeded_input` seeds a UTXO via `add_inputs`, funds the account that owns it, and drains with `SelectionStrategy::All`. It asserts the outpoint is offered exactly once, that the built transaction has no duplicate prevouts, and that the pre-seeded input *is* reserved. Verified it fails without the fix (the outpoint appears twice in the candidate list) and passes with it. Full `key-wallet` suite green (628 passed), clippy `--all-targets -D warnings` clean, `cargo fmt` clean.

## Why now

Found while reviewing [dashpay/platform#4329](https://github.com/dashpay/platform/pull/4329), which adopts multi-account funding: platform's FFI exposes `core_wallet_tx_builder_add_inputs_from_outpoints` (Swift `addInputs`), which seeds the builder with UTXOs drawn from the wallet's own account, and then finalizes through `add_funding` on that same account — exactly the sequence that duplicates. That platform PR needs a re-pin onto this fix before it can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction funding to prevent duplicate inputs when multiple funding sources overlap.
  - Ensured existing transaction inputs are correctly accounted for and reserved during funding.
  - Added safeguards to produce transactions with unique previous outputs and more reliable input selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->