### PR TITLE
fix(key-wallet): hold back catch-up receives from coin selection

### DIFF
--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -273,6 +273,12 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         self.processing_height = scan_start;
         self.next_batch_to_store = download_start;
 
+        // Arm the spend-scan gate before any block is applied. A restored
+        // wallet starts scanning from its birth height with the tip thousands
+        // of blocks above it, and every receive found in between must be held
+        // back until the scan gets there.
+        self.publish_scan_target(self.progress.filter_header_tip_height()).await;
+
         // Check if already at target (nothing to download)
         if scan_start > self.progress.filter_header_tip_height() {
             // Park the idle pipeline at the download frontier so a later
@@ -1025,6 +1031,20 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         Ok(events)
     }
 
+    /// Tell the wallets how far this scan intends to reach.
+    ///
+    /// Coin selection uses the gap between a wallet's `synced_height` and this
+    /// target to hold back outputs discovered during catch-up, which a block
+    /// above the frontier may already have spent. Publishing a target of 0
+    /// would leave that gate open, so a not-yet-known tip is skipped rather
+    /// than published as 0.
+    async fn publish_scan_target(&self, tip_height: u32) {
+        if tip_height == 0 {
+            return;
+        }
+        self.wallet.write().await.update_scan_target_height(tip_height);
+    }
+
     /// Handle notification that new filter headers are available.
     /// Used by both FilterHeadersSyncComplete and FilterHeadersStored events.
     pub(super) async fn handle_new_filter_headers(
@@ -1034,6 +1054,7 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
     ) -> SyncResult<Vec<SyncEvent>> {
         self.progress.update_filter_header_tip_height(tip_height);
         self.update_target_height(tip_height);
+        self.publish_scan_target(tip_height).await;
 
         match self.state() {
             SyncState::Syncing | SyncState::Synced

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -278,6 +278,12 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         self.wallet_infos.get(wallet_id).map(|info| info.account_generation()).unwrap_or(0)
     }
 
+    fn update_scan_target_height(&mut self, height: CoreBlockHeight) {
+        for info in self.wallet_infos.values_mut() {
+            info.update_scan_target_height(height);
+        }
+    }
+
     fn update_wallet_synced_height(&mut self, wallet_id: &WalletId, height: CoreBlockHeight) {
         if let Some(info) = self.wallet_infos.get_mut(wallet_id) {
             if height > info.synced_height() {

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -137,6 +137,18 @@ pub trait WalletInterface: Send + Sync + 'static {
     /// Return the per-wallet committed sync checkpoint, or `0` if unknown.
     fn wallet_synced_height(&self, wallet_id: &WalletId) -> CoreBlockHeight;
 
+    /// Publish the chain height the spend scan is working toward — the tip of
+    /// the filter-header chain the scanner has committed to covering. It is a
+    /// property of the chain rather than of any one wallet, so it applies to
+    /// all of them.
+    ///
+    /// Until a wallet's `synced_height` reaches this, that wallet is catching
+    /// up and cannot tell whether an output it just discovered was already
+    /// spent in a block it has not scanned yet, so such outputs are held back
+    /// from coin selection. The default is a no-op, leaving the gate open —
+    /// a scanner must call this for it to engage.
+    fn update_scan_target_height(&mut self, _height: CoreBlockHeight) {}
+
     /// Return the generation of one wallet's account set — a counter bumped
     /// whenever an account is added to that wallet (`0` if unknown). Filter
     /// sync snapshots this per wallet when scanning a range and refuses to

--- a/key-wallet/src/test_utils/wallet.rs
+++ b/key-wallet/src/test_utils/wallet.rs
@@ -37,6 +37,19 @@ impl TestWalletContext {
     /// accounts.
     pub fn new_random_with_options(options: WalletAccountCreationOptions) -> Self {
         let wallet = Wallet::new_random(Network::Testnet, options).expect("Should create wallet");
+        Self::from_wallet(wallet)
+    }
+
+    /// Creates a testnet wallet from a fixed seed, so a failing test replays
+    /// with the same keys and addresses every run.
+    pub fn new_with_seed(seed: [u8; 64]) -> Self {
+        let wallet =
+            Wallet::from_seed_bytes(seed, Network::Testnet, WalletAccountCreationOptions::Default)
+                .expect("Should create wallet");
+        Self::from_wallet(wallet)
+    }
+
+    fn from_wallet(wallet: Wallet) -> Self {
         let mut managed_wallet =
             ManagedWalletInfo::from_wallet_with_name(&wallet, "Test".to_string(), 0);
 

--- a/key-wallet/src/tests/mod.rs
+++ b/key-wallet/src/tests/mod.rs
@@ -39,3 +39,5 @@ mod spent_outpoints_tests;
 mod unit_variant_wallet_tests;
 
 mod wallet_tests;
+
+mod spend_scan_frontier_tests;

--- a/key-wallet/src/tests/spend_scan_frontier_tests.rs
+++ b/key-wallet/src/tests/spend_scan_frontier_tests.rs
@@ -1,0 +1,208 @@
+//! Tests for the spend-scan frontier gate on coin selection.
+//!
+//! A wallet catching up on history applies blocks in ascending order, so a
+//! receive it discovers says nothing about whether some higher, not-yet-scanned
+//! block already spends it. Selecting such an output builds a transaction the
+//! network settled as a double-spend long ago; peers drop it silently, with no
+//! reject message, and whatever it was funding is stranded forever.
+//!
+//! The heights here are the ones from the incident that motivated this: a
+//! restored wallet found a 1000 DASH receive in block 758983 and funded an
+//! identity top-up from it three seconds later, while the block that had
+//! already spent that outpoint — height 1510203 — was still six minutes of
+//! scanning away.
+
+use dashcore::blockdata::transaction::{OutPoint, Transaction};
+use dashcore::hashes::Hash;
+use dashcore::{BlockHash, TxIn};
+
+use crate::test_utils::TestWalletContext;
+use crate::transaction_checking::{BlockInfo, TransactionContext};
+use crate::wallet::managed_wallet_info::coin_selection::{
+    CoinSelector, SelectionError, SelectionStrategy,
+};
+use crate::wallet::managed_wallet_info::fee::FeeRate;
+use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+
+/// Heights from the incident.
+const RECEIVE_HEIGHT: u32 = 758_983;
+const SPEND_HEIGHT: u32 = 1_510_203;
+const CHAIN_TIP: u32 = 2_200_000;
+
+fn block_at(height: u32) -> TransactionContext {
+    TransactionContext::InBlock(BlockInfo::new(
+        height,
+        BlockHash::from_slice(&[(height % 251) as u8; 32]).expect("hash"),
+        1_700_000_000,
+    ))
+}
+
+/// A transaction spending `outpoint`, standing in for the wallet's own earlier
+/// asset lock that consumed the coin long before this restore.
+fn spending_tx(outpoint: OutPoint) -> Transaction {
+    Transaction {
+        version: 1,
+        lock_time: 0,
+        input: vec![TxIn {
+            previous_output: outpoint,
+            ..Default::default()
+        }],
+        output: Vec::new(),
+        special_transaction_payload: None,
+    }
+}
+
+/// Ask coin selection for `target` duffs out of the wallet's BIP44 account,
+/// exactly as the transaction builder does.
+fn select(ctx: &TestWalletContext, target: u64) -> Result<u64, SelectionError> {
+    let account = ctx.bip44_account();
+    let utxos: Vec<_> = account.utxos.values().collect();
+    CoinSelector::new(SelectionStrategy::BranchAndBound)
+        .select_coins(utxos, target, FeeRate::normal(), ctx.managed_wallet.last_processed_height())
+        .map(|selection| selection.total_value)
+}
+
+/// Put the wallet in the state a restore lands in: scanning toward the chain
+/// tip from far below it, having applied a receive at `RECEIVE_HEIGHT`.
+async fn restored_wallet_mid_catch_up(amount: u64) -> (TestWalletContext, Transaction) {
+    let mut ctx = TestWalletContext::new_random();
+    ctx.managed_wallet.update_scan_target_height(CHAIN_TIP);
+    ctx.managed_wallet.update_synced_height(RECEIVE_HEIGHT);
+    ctx.managed_wallet.update_last_processed_height(RECEIVE_HEIGHT);
+
+    let tx = Transaction::dummy(&ctx.receive_address, 0..1, &[amount]);
+    let result = ctx.check_transaction(&tx, block_at(RECEIVE_HEIGHT)).await;
+    assert!(result.is_relevant, "wallet must recognise its own receive");
+
+    (ctx, tx)
+}
+
+#[tokio::test]
+async fn receive_found_below_the_scan_target_is_tracked_but_not_selectable() {
+    let (ctx, tx) = restored_wallet_mid_catch_up(100_000_000_000).await;
+
+    let utxo = ctx.first_utxo();
+    assert_eq!(utxo.outpoint.txid, tx.txid(), "the receive is tracked");
+    assert!(utxo.is_confirmed, "and it is confirmed in a block");
+    assert!(!utxo.spend_scanned, "but the scan has not passed it yet");
+
+    assert!(
+        !ctx.managed_wallet.spend_scan_complete(),
+        "the wallet must report itself mid-catch-up"
+    );
+    assert!(
+        ctx.managed_wallet.get_spendable_utxos().is_empty(),
+        "nothing is spendable while the scan is behind"
+    );
+    assert!(
+        matches!(select(&ctx, 1_000_000), Err(SelectionError::NoUtxosAvailable)),
+        "coin selection must refuse to fund from an unscanned receive"
+    );
+}
+
+#[tokio::test]
+async fn scan_reaching_its_target_releases_the_held_back_receive() {
+    let (mut ctx, _tx) = restored_wallet_mid_catch_up(100_000_000_000).await;
+
+    // Catch-up finishes: every block up to the tip has been scanned and no
+    // spend of this outpoint turned up, so the coin is genuinely unspent.
+    ctx.managed_wallet.update_synced_height(CHAIN_TIP);
+    ctx.managed_wallet.update_last_processed_height(CHAIN_TIP);
+
+    assert!(ctx.managed_wallet.spend_scan_complete());
+    assert!(ctx.first_utxo().spend_scanned, "the scan has now covered it");
+    assert_eq!(ctx.managed_wallet.get_spendable_utxos().len(), 1, "and it becomes spendable");
+    assert_eq!(select(&ctx, 1_000_000).expect("selection succeeds"), 100_000_000_000);
+}
+
+/// The incident itself: the coin was already spent, by this wallet's own
+/// earlier transaction, in a block the restore had not reached yet.
+#[tokio::test]
+async fn coin_already_spent_above_the_frontier_is_never_selectable() {
+    let (mut ctx, tx) = restored_wallet_mid_catch_up(100_000_000_000).await;
+    let outpoint = ctx.first_utxo().outpoint;
+
+    // This is the window in which the top-up asset lock was built.
+    assert!(
+        select(&ctx, 1_000_000).is_err(),
+        "the double-spend must not be fundable during catch-up"
+    );
+
+    // The scan reaches the block that spent it.
+    ctx.managed_wallet.update_synced_height(SPEND_HEIGHT);
+    let spend = spending_tx(outpoint);
+    ctx.check_transaction(&spend, block_at(SPEND_HEIGHT)).await;
+
+    // ...and then finishes.
+    ctx.managed_wallet.update_synced_height(CHAIN_TIP);
+    ctx.managed_wallet.update_last_processed_height(CHAIN_TIP);
+
+    assert!(ctx.bip44_account().utxos.get(&outpoint).is_none(), "the spend removed the coin");
+    assert!(
+        ctx.managed_wallet.get_spendable_utxos().is_empty(),
+        "so a completed scan releases nothing"
+    );
+    assert_ne!(tx.txid(), spend.txid());
+}
+
+#[tokio::test]
+async fn receive_at_the_scan_target_is_selectable_immediately() {
+    let mut ctx = TestWalletContext::new_random();
+    ctx.managed_wallet.update_scan_target_height(CHAIN_TIP);
+    ctx.managed_wallet.update_synced_height(CHAIN_TIP);
+    ctx.managed_wallet.update_last_processed_height(CHAIN_TIP);
+
+    // A block at the tip: nothing above it exists to have spent this output,
+    // so a caught-up wallet must not be made to wait for the next batch commit.
+    let tx = Transaction::dummy(&ctx.receive_address, 0..1, &[500_000]);
+    ctx.check_transaction(&tx, block_at(CHAIN_TIP)).await;
+
+    assert!(ctx.first_utxo().spend_scanned);
+    assert_eq!(select(&ctx, 100_000).expect("selection succeeds"), 500_000);
+}
+
+#[tokio::test]
+async fn mempool_receive_during_catch_up_stays_selectable() {
+    let mut ctx = TestWalletContext::new_random();
+    ctx.managed_wallet.update_scan_target_height(CHAIN_TIP);
+    ctx.managed_wallet.update_synced_height(RECEIVE_HEIGHT);
+    ctx.managed_wallet.update_last_processed_height(RECEIVE_HEIGHT);
+
+    // A mempool transaction is at the tip by definition — no historical block
+    // can have spent an output that does not exist historically.
+    let tx = Transaction::dummy(&ctx.receive_address, 0..1, &[500_000]);
+    ctx.check_transaction(&tx, TransactionContext::Mempool).await;
+
+    assert!(ctx.first_utxo().spend_scanned);
+    assert_eq!(select(&ctx, 100_000).expect("selection succeeds"), 500_000);
+}
+
+/// Consumers with no scanner never report a target, and must keep the
+/// pre-existing unconditional behavior.
+#[tokio::test]
+async fn without_a_reported_scan_target_the_gate_stays_open() {
+    let mut ctx = TestWalletContext::new_random();
+    ctx.managed_wallet.update_last_processed_height(RECEIVE_HEIGHT);
+
+    let tx = Transaction::dummy(&ctx.receive_address, 0..1, &[500_000]);
+    ctx.check_transaction(&tx, block_at(RECEIVE_HEIGHT)).await;
+
+    assert_eq!(ctx.managed_wallet.scan_target_height(), 0);
+    assert!(ctx.managed_wallet.spend_scan_complete());
+    assert!(ctx.first_utxo().spend_scanned);
+    assert_eq!(select(&ctx, 100_000).expect("selection succeeds"), 500_000);
+}
+
+/// A UTXO deserialized from persistence written before `spend_scanned` existed
+/// must not become unspendable on upgrade.
+#[cfg(feature = "serde")]
+#[test]
+fn utxo_missing_the_field_deserializes_as_scanned() {
+    let utxo = crate::Utxo::dummy(1, 500_000, 100, false, true);
+    let mut value = serde_json::to_value(&utxo).expect("serialize");
+    value.as_object_mut().expect("object").remove("spend_scanned");
+
+    let restored: crate::Utxo = serde_json::from_value(value).expect("deserialize");
+    assert!(restored.spend_scanned, "legacy rows keep the old behavior");
+    assert!(restored.is_spendable(200));
+}

--- a/key-wallet/src/tests/spend_scan_frontier_tests.rs
+++ b/key-wallet/src/tests/spend_scan_frontier_tests.rs
@@ -137,7 +137,7 @@ async fn coin_already_spent_above_the_frontier_is_never_selectable() {
     ctx.managed_wallet.update_synced_height(CHAIN_TIP);
     ctx.managed_wallet.update_last_processed_height(CHAIN_TIP);
 
-    assert!(ctx.bip44_account().utxos.get(&outpoint).is_none(), "the spend removed the coin");
+    assert!(!ctx.bip44_account().utxos.contains_key(&outpoint), "the spend removed the coin");
     assert!(
         ctx.managed_wallet.get_spendable_utxos().is_empty(),
         "so a completed scan releases nothing"

--- a/key-wallet/src/tests/spend_scan_frontier_tests.rs
+++ b/key-wallet/src/tests/spend_scan_frontier_tests.rs
@@ -24,6 +24,9 @@ use crate::wallet::managed_wallet_info::coin_selection::{
 use crate::wallet::managed_wallet_info::fee::FeeRate;
 use crate::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 
+/// Fixed wallet seed so a failing test replays with the same keys every run.
+const SEED: [u8; 64] = [7; 64];
+
 /// Heights from the incident.
 const RECEIVE_HEIGHT: u32 = 758_983;
 const SPEND_HEIGHT: u32 = 1_510_203;
@@ -65,7 +68,7 @@ fn select(ctx: &TestWalletContext, target: u64) -> Result<u64, SelectionError> {
 /// Put the wallet in the state a restore lands in: scanning toward the chain
 /// tip from far below it, having applied a receive at `RECEIVE_HEIGHT`.
 async fn restored_wallet_mid_catch_up(amount: u64) -> (TestWalletContext, Transaction) {
-    let mut ctx = TestWalletContext::new_random();
+    let mut ctx = TestWalletContext::new_with_seed(SEED);
     ctx.managed_wallet.update_scan_target_height(CHAIN_TIP);
     ctx.managed_wallet.update_synced_height(RECEIVE_HEIGHT);
     ctx.managed_wallet.update_last_processed_height(RECEIVE_HEIGHT);
@@ -147,7 +150,7 @@ async fn coin_already_spent_above_the_frontier_is_never_selectable() {
 
 #[tokio::test]
 async fn receive_at_the_scan_target_is_selectable_immediately() {
-    let mut ctx = TestWalletContext::new_random();
+    let mut ctx = TestWalletContext::new_with_seed(SEED);
     ctx.managed_wallet.update_scan_target_height(CHAIN_TIP);
     ctx.managed_wallet.update_synced_height(CHAIN_TIP);
     ctx.managed_wallet.update_last_processed_height(CHAIN_TIP);
@@ -163,7 +166,7 @@ async fn receive_at_the_scan_target_is_selectable_immediately() {
 
 #[tokio::test]
 async fn mempool_receive_during_catch_up_stays_selectable() {
-    let mut ctx = TestWalletContext::new_random();
+    let mut ctx = TestWalletContext::new_with_seed(SEED);
     ctx.managed_wallet.update_scan_target_height(CHAIN_TIP);
     ctx.managed_wallet.update_synced_height(RECEIVE_HEIGHT);
     ctx.managed_wallet.update_last_processed_height(RECEIVE_HEIGHT);
@@ -181,7 +184,7 @@ async fn mempool_receive_during_catch_up_stays_selectable() {
 /// pre-existing unconditional behavior.
 #[tokio::test]
 async fn without_a_reported_scan_target_the_gate_stays_open() {
-    let mut ctx = TestWalletContext::new_random();
+    let mut ctx = TestWalletContext::new_with_seed(SEED);
     ctx.managed_wallet.update_last_processed_height(RECEIVE_HEIGHT);
 
     let tx = Transaction::dummy(&ctx.receive_address, 0..1, &[500_000]);

--- a/key-wallet/src/transaction_checking/wallet_checker.rs
+++ b/key-wallet/src/transaction_checking/wallet_checker.rs
@@ -258,6 +258,13 @@ impl WalletTransactionChecker for ManagedWalletInfo {
             );
         }
 
+        // Any UTXO just created from a block below the spend-scan target is
+        // only known-unspent as of that block, not as of the tip. Hold it back
+        // from coin selection until the scan proves it survived to the target.
+        if let Some(height) = block_height {
+            self.hold_back_unscanned_utxos(tx, height);
+        }
+
         if update_balance {
             self.update_balance();
         }

--- a/key-wallet/src/utxo.rs
+++ b/key-wallet/src/utxo.rs
@@ -39,6 +39,27 @@ pub struct Utxo {
     /// it is just our previously-tracked balance returning to us. Mirrors
     /// Bitcoin Core's `CWalletTx::IsTrusted` concept.
     pub is_trusted: bool,
+    /// Whether the wallet has scanned every block that could already have
+    /// spent this output.
+    ///
+    /// An output found while catching up on history is only *known* to be
+    /// unspent up to the scan frontier, which during catch-up sits far below
+    /// the chain tip. Spending it then builds a transaction the network has
+    /// long since seen double-spent, and peers drop it silently forever. So a
+    /// receive applied below the frontier starts unscanned, and is promoted in
+    /// bulk once the frontier reaches the height the scan is working toward.
+    ///
+    /// Defaults to `true` so wallets assembled by hand, and UTXOs
+    /// deserialized from persistence written before this field existed, keep
+    /// the previous unconditional behavior. Only a live scan demotes it.
+    #[cfg_attr(feature = "serde", serde(default = "spend_scanned_default"))]
+    pub spend_scanned: bool,
+}
+
+/// Serde default for [`Utxo::spend_scanned`]; see that field's docs.
+#[cfg(feature = "serde")]
+fn spend_scanned_default() -> bool {
+    true
 }
 
 impl Utxo {
@@ -60,6 +81,7 @@ impl Utxo {
             is_instantlocked: false,
             is_locked: false,
             is_trusted: false,
+            spend_scanned: true,
         }
     }
 
@@ -70,13 +92,14 @@ impl Utxo {
 
     /// Check if this UTXO can be spent at the given height.
     ///
-    /// A UTXO is spendable unless it is locked or (for coinbase)
+    /// A UTXO is spendable unless it is locked, not yet covered by the
+    /// wallet's spend scan (see [`Utxo::spend_scanned`]), or — for coinbase —
     /// immature. Mempool 0-conf outputs are spendable — callers that
     /// want to restrict to confirmed/InstantLocked UTXOs (e.g. the
     /// "spendable" balance bucket or conservative coin selection)
     /// should check `is_confirmed || is_instantlocked` themselves.
     pub fn is_spendable(&self, current_height: u32) -> bool {
-        if self.is_locked {
+        if self.is_locked || !self.spend_scanned {
             return false;
         }
         self.is_mature(current_height)

--- a/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/asset_lock_builder.rs
@@ -595,6 +595,7 @@ mod tests {
             is_instantlocked: false,
             is_locked: false,
             is_trusted: false,
+            spend_scanned: true,
         };
         account.utxos.insert(outpoint, utxo);
         outpoint
@@ -639,6 +640,7 @@ mod tests {
             is_instantlocked: false,
             is_locked: false,
             is_trusted: false,
+            spend_scanned: true,
         };
         account.utxos.insert(outpoint, utxo);
         outpoint

--- a/key-wallet/src/wallet/managed_wallet_info/mod.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/mod.rs
@@ -376,6 +376,64 @@ impl ManagedWalletInfo {
         self.observed_spent_outpoints.retain(|_, height| *height > boundary);
     }
 
+    /// Hold back the UTXOs `tx` created from coin selection, because the wallet
+    /// applied `tx` from a block below the height its spend scan is working
+    /// toward.
+    ///
+    /// Blocks are scanned in ascending order, so a receive discovered during
+    /// catch-up says nothing about whether some higher, not-yet-scanned block
+    /// already spends it. Selecting it there builds a transaction the network
+    /// settled as a double-spend long ago; peers drop it silently, with no
+    /// reject message, and the funds it was meant to move are stranded.
+    ///
+    /// No-op when no scanner has reported a target, or when `tx` came from a
+    /// block at or above it — nothing above the tip can have spent it yet.
+    /// [`Self::promote_spend_scanned_utxos`] releases what this holds back.
+    pub(crate) fn hold_back_unscanned_utxos(
+        &mut self,
+        tx: &Transaction,
+        block_height: CoreBlockHeight,
+    ) {
+        let target = self.metadata.scan_target_height;
+        if target == 0 || block_height >= target {
+            return;
+        }
+        let txid = tx.txid();
+        for account in self.accounts.all_funding_accounts_mut() {
+            for vout in 0..tx.output.len() as u32 {
+                if let Some(utxo) = account.utxos.get_mut(&OutPoint {
+                    txid,
+                    vout,
+                }) {
+                    utxo.spend_scanned = false;
+                }
+            }
+        }
+    }
+
+    /// Release every UTXO held back by [`Self::hold_back_unscanned_utxos`],
+    /// once the spend scan reaches the height it was working toward.
+    ///
+    /// At that point every block up to the target has been matched against the
+    /// wallet's scripts and every matching block body applied, so a spend of a
+    /// tracked UTXO would already have removed it. Whatever is still in the set
+    /// is genuinely unspent as of the target.
+    ///
+    /// No-op while the scan is still behind, or when no scanner has reported a
+    /// target (in which case nothing was ever held back).
+    pub(crate) fn promote_spend_scanned_utxos(&mut self) {
+        if self.metadata.scan_target_height == 0
+            || self.metadata.synced_height < self.metadata.scan_target_height
+        {
+            return;
+        }
+        for account in self.accounts.all_funding_accounts_mut() {
+            for utxo in account.utxos.values_mut() {
+                utxo.spend_scanned = true;
+            }
+        }
+    }
+
     /// Invalidate the wallet's sync certificate when an account is added.
     ///
     /// `synced_height` certifies "every filter at or below this height was

--- a/key-wallet/src/wallet/managed_wallet_info/transaction_building.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/transaction_building.rs
@@ -805,6 +805,7 @@ mod tests {
             is_instantlocked: false,
             is_locked: false,
             is_trusted: false,
+            spend_scanned: true,
         };
         info.accounts
             .standard_bip44_accounts
@@ -988,6 +989,7 @@ mod tests {
                 is_instantlocked: false,
                 is_locked: false,
                 is_trusted: false,
+                spend_scanned: true,
             },
         );
         outpoint

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -182,6 +182,25 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     /// Return the durable wallet sync checkpoint height.
     fn synced_height(&self) -> CoreBlockHeight;
 
+    /// Return the chain height the spend scan is working toward, or `0` if no
+    /// scanner has reported one. See [`WalletMetadata::scan_target_height`].
+    fn scan_target_height(&self) -> CoreBlockHeight {
+        0
+    }
+
+    /// Record the chain height the spend scan is working toward. Called by the
+    /// scanner as the filter-header chain grows.
+    fn update_scan_target_height(&mut self, _height: CoreBlockHeight) {}
+
+    /// Whether the spend scan has covered every block up to the height it is
+    /// working toward — i.e. whether the wallet's UTXO set is net of all
+    /// on-chain spends rather than mid-catch-up. Always `true` when no
+    /// scanner has reported a target.
+    fn spend_scan_complete(&self) -> bool {
+        let target = self.scan_target_height();
+        target == 0 || self.synced_height() >= target
+    }
+
     /// Return the current generation of the wallet's account set — a counter
     /// bumped on every account addition. Filter-sync layers snapshot it at
     /// scan time and refuse to certify coverage at commit time when it has
@@ -309,6 +328,17 @@ impl WalletInfoInterface for ManagedWalletInfo {
 
     fn synced_height(&self) -> CoreBlockHeight {
         self.metadata.synced_height
+    }
+
+    fn scan_target_height(&self) -> CoreBlockHeight {
+        self.metadata.scan_target_height
+    }
+
+    fn update_scan_target_height(&mut self, height: CoreBlockHeight) {
+        self.metadata.scan_target_height = height;
+        // A target the scan has already reached must not strand UTXOs that
+        // were held back under an older, higher target.
+        self.promote_spend_scanned_utxos();
     }
 
     fn account_generation(&self) -> u64 {
@@ -512,6 +542,9 @@ impl WalletInfoInterface for ManagedWalletInfo {
         // A newly committed checkpoint can lift the finality boundary when the
         // chainlock was already ahead of the old synced_height.
         self.prune_finalized_observed_spends();
+        // ...and can complete the spend scan, releasing UTXOs held back
+        // during catch-up.
+        self.promote_spend_scanned_utxos();
     }
 
     fn matured_coinbase_records(

--- a/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
+++ b/key-wallet/src/wallet/managed_wallet_info/wallet_info_interface.rs
@@ -183,7 +183,8 @@ pub trait WalletInfoInterface: Sized + WalletTransactionChecker + ManagedAccount
     fn synced_height(&self) -> CoreBlockHeight;
 
     /// Return the chain height the spend scan is working toward, or `0` if no
-    /// scanner has reported one. See [`WalletMetadata::scan_target_height`].
+    /// scanner has reported one. See
+    /// [`WalletMetadata::scan_target_height`](crate::wallet::metadata::WalletMetadata::scan_target_height).
     fn scan_target_height(&self) -> CoreBlockHeight {
         0
     }

--- a/key-wallet/src/wallet/metadata.rs
+++ b/key-wallet/src/wallet/metadata.rs
@@ -19,6 +19,21 @@ pub struct WalletMetadata {
     pub last_processed_height: CoreBlockHeight,
     /// Sync checkpoint height
     pub synced_height: CoreBlockHeight,
+    /// The chain height the spend scan is working toward — the tip of the
+    /// filter-header chain the scanner has committed to covering.
+    ///
+    /// `synced_height` is where the scan has reached; this is where it is
+    /// going. While `synced_height < scan_target_height` the wallet is
+    /// catching up and cannot know whether a freshly discovered output has
+    /// already been spent in a block it has not scanned yet, so receives
+    /// applied in that window are held back from coin selection. See
+    /// [`crate::utxo::Utxo::spend_scanned`].
+    ///
+    /// `0` means "unknown": no scanner has reported a target, and the
+    /// spend-scan gate stays open. A scanner must set this for the gate to
+    /// have any effect.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub scan_target_height: CoreBlockHeight,
     /// Highest chainlock that has been applied to this wallet,
     /// establishing the finality boundary: every block at or below
     /// `chain_lock.block_height` is final for this wallet. `None` until


### PR DESCRIPTION
## Issue being fixed or feature implemented

Coin selection can build a double-spend while a restored wallet is catching up on history.

Blocks are applied in strictly ascending order (`BlocksPipeline::take_next_ordered_block` stalls if any pending download is lower), so a receive discovered at height `H` enters the UTXO set and becomes fully selectable long before block `H' > H` — the one that spends it — has been downloaded or scanned. Nothing in the selection path consulted the scan frontier: `Utxo::is_spendable` checked only `is_locked` and coinbase maturity, and the height it was given is `last_processed_height`, a *matched-block* cursor rather than `synced_height`.

The resulting transaction is a double-spend of an outpoint the network settled long ago. Peers drop it at the mempool boundary and relay nothing back — Core has not sent BIP61 `reject` by default since 0.17 — so it never confirms and never errors.

Observed on testnet: a restore found a 1000 DASH receive in block 758983 and funded an identity top-up asset lock from it three seconds later. The block that had already spent that outpoint, 1510203, was still six minutes of scanning away.

The existing out-of-order guard in `update_utxos` only covers the mirror case (spend seen before the creating tx), so it never applied here.

## What was done?

Track where the scan is *going* alongside where it has *reached*:

- `WalletMetadata::scan_target_height` — the filter-header tip the scan has committed to covering. Published by the dash-spv filters manager in `start_download` (so the gate is armed before any block is applied) and `handle_new_filter_headers` (as the chain grows), via a new defaulted `WalletInterface::update_scan_target_height`.
- `Utxo::spend_scanned` — whether every block that could already have spent this output has been scanned. A receive applied from a block below the target is held back and excluded by `Utxo::is_spendable`.
- When the frontier reaches the target, `promote_spend_scanned_utxos` releases every survivor in one pass: at that point a spend would already have removed it, so what remains is genuinely unspent.
- `WalletInfoInterface::spend_scan_complete()` so consumers can distinguish "still syncing" from "insufficient funds".

Two deliberate choices:

**Receives at or above the target are never held back.** A wallet-level "am I caught up?" gate would block spending for the seconds after every new block while the frontier lags the header tip — roughly 3% of the time on a live chain, surfacing as a confusing insufficient-funds error. Holding back per-UTXO leaves a caught-up wallet completely unaffected, and mempool receives (at the tip by definition) stay spendable even during catch-up.

**The gate fails open until a scanner reports a target**, and `spend_scanned` serde-defaults to `true`. Consumers that never scan, and UTXOs already in persistence, keep the previous behavior exactly. Fail-closed would have made every hand-built wallet and test fixture unspendable.

Balance display is untouched: `update_balance` reads `is_mature`/`is_locked` directly, not `is_spendable`, so a mid-catch-up wallet still reports a balance. Whether the UI should say "syncing" instead is a consumer-side decision, which `spend_scan_complete()` now enables.

## How Has This Been Tested?

Seven tests in `key-wallet/src/tests/spend_scan_frontier_tests.rs`, using the incident's actual heights (758983 / 1510203): receive held back below the target, released when the scan reaches it, never selectable when a higher block spent it, immediately selectable at the target, mempool unaffected, gate open with no target reported, and a legacy row missing the serde field deserializing as scanned.

Mutation-checked rather than assumed: removing the `spend_scanned` clause from `is_spendable` makes exactly the two incident tests fail and no others.

Full `key-wallet`, `key-wallet-manager` and `dash-spv` suites pass; `cargo clippy --all-features --all-targets` and `cargo fmt --all --check` clean.

## Breaking Changes

None. New field on `Utxo` (serde-defaulted) and on `WalletMetadata`; the new `WalletInterface` method is defaulted. Behavior is unchanged for any consumer that does not publish a scan target.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet synchronization now tracks scan progress across managed wallets.
  * Newly received funds remain temporarily unavailable until scanning verifies them.
  * Funds become spendable automatically when synchronization reaches the scan target.

* **Bug Fixes**
  * Prevented unverified or later-spent funds from being selected for transactions.
  * Preserved compatibility with existing wallet data and wallets without a scan target.

* **Tests**
  * Added coverage for scan-frontier behavior, synchronization, mempool funds, and legacy wallet data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->