### PR TITLE
fix(key-wallet-manager): enable key-wallet/getrandom for mnemonic generation

### DIFF
--- a/key-wallet-manager/Cargo.toml
+++ b/key-wallet-manager/Cargo.toml
@@ -24,7 +24,12 @@ eddsa = ["key-wallet/eddsa"]
 keep-finalized-transactions = ["key-wallet/keep-finalized-transactions"]
 
 [dependencies]
-key-wallet = { path = "../key-wallet", default-features = false }
+# `getrandom` is required, not optional: `create_wallet_with_random_mnemonic`
+# calls `Mnemonic::generate`, which without this feature compiles to a stub that
+# always returns an error. Workspace builds and the dev-dependency below both
+# enable it via feature unification, so dropping it here fails only for external
+# consumers — and only at runtime.
+key-wallet = { path = "../key-wallet", default-features = false, features = ["getrandom"] }
 dashcore = { path = "../dash" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }

--- a/key-wallet/src/mnemonic.rs
+++ b/key-wallet/src/mnemonic.rs
@@ -465,9 +465,8 @@ mod tests {
                 assert!(
                     count > 0 && count < SAMPLES,
                     "{word_count}-word entropy bit {bit} never varied across {SAMPLES} draws \
-                     (stuck at {}) — the buffer is zero-padded, or the source carries \
-                     fewer than {bits} bits",
-                    u8::from(count > 0)
+                     ({count} ones) — the buffer is zero-padded, or the source carries \
+                     fewer than {bits} bits"
                 );
             }
         }

--- a/key-wallet/src/mnemonic.rs
+++ b/key-wallet/src/mnemonic.rs
@@ -403,25 +403,27 @@ mod tests {
         assert_eq!(mnemonic.word_count(), 12);
     }
 
-    /// Every entropy byte behind a generated phrase must be independently
-    /// random. Guards the truncation half of the weak-seed-phrase bug class
-    /// (Milk Sad / CVE-2023-39910, Trust Wallet / CVE-2023-31290), where a
-    /// full-width entropy buffer carries only 32 or 48 bits of real variation
-    /// and the rest is zero-padding or a deterministic expansion.
+    /// Regression guard against zero-padded and stuck-bit entropy: a buffer
+    /// that is the right BIP-39 width but only partly filled, with the
+    /// remainder constant across draws.
     ///
     /// Checked per supported word count: the recovered entropy is the full
     /// BIP-39 width, it round-trips back to the same phrase, no two samples
-    /// collide, and *every* bit position takes both values across samples —
-    /// a stuck bit is exactly what a narrowed source leaves behind.
+    /// collide, and every bit position takes both values across samples.
     ///
-    /// The other half of that bug class — a full-width buffer filled from a
-    /// seeded PRNG (`mt19937(time(NULL))`) rather than the OS — is not
-    /// detectable statistically at this sample size. It is held by
-    /// construction instead: [`Mnemonic::generate`] must draw straight from
-    /// `getrandom` (the OS CSPRNG) and must never route through a seeded RNG.
+    /// This says nothing about how much real entropy those bits carry, and
+    /// must not be read as verifying that it is full-width. A generator that
+    /// expands a 32- or 48-bit seed through a hash or PRNG — the actual defect
+    /// in Milk Sad (CVE-2023-39910) and Trust Wallet (CVE-2023-31290) —
+    /// produces freely varying bits and passes every assertion below. No
+    /// statistical test at this sample size would separate it from a real
+    /// CSPRNG. That property is instead held by construction, and only review
+    /// can protect it: [`Mnemonic::generate`] must fill its entropy buffer
+    /// directly from `getrandom` (the OS CSPRNG) and must never route through
+    /// a seeded RNG.
     #[test]
     #[cfg(feature = "getrandom")]
-    fn generate_draws_full_width_entropy() {
+    fn generate_entropy_has_expected_width_and_no_stuck_bits() {
         // 64 samples already makes a stuck bit a 2^-63 event; 128 is margin.
         const SAMPLES: usize = 128;
 
@@ -462,8 +464,9 @@ mod tests {
             for (bit, &count) in ones.iter().enumerate() {
                 assert!(
                     count > 0 && count < SAMPLES,
-                    "{word_count}-word entropy bit {bit} is stuck at {} across all {SAMPLES} \
-                     draws — the entropy source is narrower than {bits} bits",
+                    "{word_count}-word entropy bit {bit} never varied across {SAMPLES} draws \
+                     (stuck at {}) — the buffer is zero-padded, or the source carries \
+                     fewer than {bits} bits",
                     u8::from(count > 0)
                 );
             }

--- a/key-wallet/src/mnemonic.rs
+++ b/key-wallet/src/mnemonic.rs
@@ -403,6 +403,73 @@ mod tests {
         assert_eq!(mnemonic.word_count(), 12);
     }
 
+    /// Every entropy byte behind a generated phrase must be independently
+    /// random. Guards the truncation half of the weak-seed-phrase bug class
+    /// (Milk Sad / CVE-2023-39910, Trust Wallet / CVE-2023-31290), where a
+    /// full-width entropy buffer carries only 32 or 48 bits of real variation
+    /// and the rest is zero-padding or a deterministic expansion.
+    ///
+    /// Checked per supported word count: the recovered entropy is the full
+    /// BIP-39 width, it round-trips back to the same phrase, no two samples
+    /// collide, and *every* bit position takes both values across samples —
+    /// a stuck bit is exactly what a narrowed source leaves behind.
+    ///
+    /// The other half of that bug class — a full-width buffer filled from a
+    /// seeded PRNG (`mt19937(time(NULL))`) rather than the OS — is not
+    /// detectable statistically at this sample size. It is held by
+    /// construction instead: [`Mnemonic::generate`] must draw straight from
+    /// `getrandom` (the OS CSPRNG) and must never route through a seeded RNG.
+    #[test]
+    #[cfg(feature = "getrandom")]
+    fn generate_draws_full_width_entropy() {
+        // 64 samples already makes a stuck bit a 2^-63 event; 128 is margin.
+        const SAMPLES: usize = 128;
+
+        for (word_count, entropy_bytes) in [(12, 16), (15, 20), (18, 24), (21, 28), (24, 32)] {
+            let bits = entropy_bytes * 8;
+            let mut seen = std::collections::HashSet::new();
+            let mut ones = vec![0usize; bits];
+
+            for _ in 0..SAMPLES {
+                let mnemonic = Mnemonic::generate(word_count, Language::English).unwrap();
+                assert_eq!(mnemonic.word_count(), word_count);
+
+                let entropy = mnemonic.inner.to_entropy();
+                assert_eq!(
+                    entropy.len(),
+                    entropy_bytes,
+                    "{word_count}-word phrase must carry {entropy_bytes} entropy bytes"
+                );
+
+                // The phrase encodes exactly this entropy — nothing was
+                // dropped or padded on the way in.
+                assert_eq!(
+                    Mnemonic::from_entropy(&entropy, Language::English).unwrap().phrase(),
+                    mnemonic.phrase(),
+                    "{word_count}-word entropy must round-trip to the same phrase"
+                );
+
+                for (i, byte) in entropy.iter().enumerate() {
+                    for k in 0..8 {
+                        if byte >> (7 - k) & 1 == 1 {
+                            ones[i * 8 + k] += 1;
+                        }
+                    }
+                }
+                assert!(seen.insert(entropy), "{word_count}-word entropy repeated across draws");
+            }
+
+            for (bit, &count) in ones.iter().enumerate() {
+                assert!(
+                    count > 0 && count < SAMPLES,
+                    "{word_count}-word entropy bit {bit} is stuck at {} across all {SAMPLES} \
+                     draws — the entropy source is narrower than {bits} bits",
+                    u8::from(count > 0)
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_mnemonic_validation() {
         let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";


### PR DESCRIPTION
## Why

Prompted by an audit of seed-phrase entropy across the repo, checking for the bug class behind Milk Sad (CVE-2023-39910, Libbitcoin `bx seed` — `mt19937` seeded with 32-bit `time(NULL)`) and Trust Wallet's browser extension (CVE-2023-31290, 32-bit seed).

**The audit came back clean.** `Mnemonic::generate` is the single chokepoint every random wallet in the repo routes through, and it is correct on both halves of that bug class:

- **Width** — the entropy buffer is sized from the word count (16/20/24/28/32 bytes) and filled completely. No truncation, no zero-padding.
- **Source** — `getrandom::getrandom` goes straight to the OS CSPRNG (`getentropy` on Apple, `getrandom(2)` on Linux, `BCryptGenRandom` on Windows). No seeded PRNG anywhere in the path. `getrandom` v0.2.17 resolves with only its `default` feature — no `custom`, `js`, or `rdrand` backend, and nothing calls `register_custom_getrandom!`.

Supporting checks: `Seed::random()` fills all 64 bytes from `getrandom`; `Wallet::new_random`, `WalletManager::create_wallet_with_random_mnemonic`, and the FFI `mnemonic_generate*` entry points all delegate to `Mnemonic::generate`; no time-based seeding outside benchmarks; the only `StdRng::seed_from_u64` calls are test helpers. BIP38's 4-byte `owner_salt` is spec-mandated and drawn from a CSPRNG, not a seed.

Verified empirically as well as by reading — 20,000 generations per word count through the public API gave zero collisions, all 256 values at every byte position, and χ² on bit balance landing at the degrees of freedom (e.g. 120.2 on 128 dof for 12-word).

## What changed

### 1. `key-wallet-manager` could never generate a mnemonic (the one real defect)

`key-wallet-manager` declared `key-wallet` with `default-features = false`, which drops `getrandom`. Without it, `Mnemonic::generate` compiles to its `#[cfg(not(feature = "getrandom"))]` stub — one that always returns an error — so `create_wallet_with_random_mnemonic` could never succeed.

It was invisible in CI because workspace builds and the crate's own dev-dependency on `key-wallet` (default features on) both unify `getrandom` back on: the full test suite passed while an external consumer got a dead API. Confirmed with a crate built outside the workspace, which printed `Mnemonic generation requires getrandom feature` before the change and `OK: generated 24 words` after.

**This was fail-closed — an error, never weak entropy. Not a Milk Sad-class vulnerability.** `key-wallet-ffi` depends on `key-wallet` with default features, so iOS/Swift was never affected.

### 2. Regression guard: `generate_entropy_has_expected_width_and_no_stuck_bits`

For all five word counts, asserts the recovered entropy is the full BIP-39 width, round-trips to the same phrase, never collides across draws, and that *every* bit position takes both values. 128 samples makes a false positive a ~2^-63 event; runs in well under a second.

This catches zero-padded and stuck-bit entropy only. It does **not** establish how much real entropy those bits carry — see below.

## For reviewers

- **The test does not verify that entropy is full-width in the information-theoretic sense.** A generator expanding a 32- or 48-bit seed through a hash or PRNG — the actual defect in both CVEs — produces freely varying bits and passes every assertion. Nothing statistical at this sample size would separate it from a real CSPRNG. That property is held by construction (`generate` fills its buffer directly from `getrandom`) and only review can protect it; the test's doc comment says so explicitly. Thanks to CodeRabbit for catching that the original name and doc comment overclaimed this.
- **Not done, worth a decision:** `Mnemonic::generate` currently exists as a runtime-erroring stub when `getrandom` is off. Making it compile-time-absent would turn this whole class of misconfiguration into a build failure instead of a runtime surprise, but that's a breaking API change for `no_std` consumers who don't need generation.

## Testing

- `cargo test -p key-wallet --lib mnemonic` — 47 passed
- `cargo check -p key-wallet-manager -p key-wallet-ffi` — clean
- `cargo clippy -p key-wallet --lib --all-features` and `cargo fmt --check -p key-wallet` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled mnemonic generation for external consumers.
  * Ensured generated 12-, 15-, 18-, 21-, and 24-word phrases use the full expected entropy range.

* **Tests**
  * Added coverage verifying mnemonic round-tripping, uniqueness, and variation across all entropy bits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
