### PR TITLE
fix(dash-spv): resume on the invariant start_download asserts

### DIFF
--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -139,7 +139,11 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
     }
 
     /// Returns true if there is no in-flight processing state.
-    fn is_idle(&self) -> bool {
+    ///
+    /// `pub(super)` so the resume decision in `start_sync` can be taken on the
+    /// same predicate `start_download` asserts. Checking a subset there is how
+    /// a disconnect/reconnect cycle used to reach that assert.
+    pub(super) fn is_idle(&self) -> bool {
         self.active_batches.is_empty()
             && self.tracker.is_empty()
             && self.pending_batches.is_empty()
@@ -3075,6 +3079,39 @@ mod tests {
         manager.handle_new_filter_headers(101, &requests).await.unwrap();
         assert!(!manager.active_batches.contains_key(&0));
         assert_eq!(manager.active_batches.keys().next(), Some(&101));
+    }
+
+    /// A verified batch waiting in `pending_batches` outlives the last active
+    /// one, so a reconnect used to fall through the resume guard — which asked
+    /// only about `active_batches` — into `start_download`, whose
+    /// `debug_assert!(is_idle())` then aborted the process. It is reachable in
+    /// the field: `on_disconnect` preserves this state by design, and a build
+    /// with debug assertions on turns the mismatch into a crash rather than a
+    /// log line.
+    #[tokio::test]
+    async fn test_start_sync_resumes_when_only_pending_batches_survive() {
+        let (mut manager, _headers, _filter) = setup_synced_manager_at_tip().await;
+
+        // What a disconnect leaves behind after the last active batch finished
+        // downloading but before its verified output was processed.
+        manager.pending_batches.insert(FiltersBatch::new(0, 99, HashMap::new()));
+        assert!(manager.active_batches.is_empty(), "the guard's old predicate says idle");
+        assert!(!manager.is_idle(), "the invariant start_download asserts says otherwise");
+
+        manager.set_state(SyncState::WaitingForConnections);
+        let (tx, _rx) = unbounded_channel();
+        let requests = RequestSender::new(tx);
+
+        // Must resume rather than start a fresh download over the top of it.
+        let events = manager.start_sync(&requests).await.unwrap();
+
+        assert!(events.is_empty(), "resuming emits no SyncStart");
+        assert_eq!(manager.state(), SyncState::Syncing);
+        assert_eq!(
+            manager.pending_batches.len(),
+            1,
+            "the surviving batch must not be discarded by the resume"
+        );
     }
 
     /// A fully synced node that reconnects and then sees one new block must

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -1080,7 +1080,21 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                 // re-init via `start_download` — that would clobber existing
                 // batches. Instead extend the target and let the eventual
                 // `start_sync` (driven by `PeersUpdated`) resume from here.
-                if !self.active_batches.is_empty() {
+                //
+                // `is_idle()` for the same reason `start_sync` uses it: this is
+                // the second route into `start_download`, and it asserts all
+                // four conditions. `active_batches` alone is a strict subset —
+                // a batch that finished downloading leaves it while its
+                // verified output waits in `pending_batches` and its blocks
+                // wait in the tracker, and `on_disconnect` moves the pipeline's
+                // in-flight slots to pending rather than clearing them.
+                //
+                // Extending the target is the right answer for all four, not
+                // just for active batches: `handle_message` keeps running
+                // regardless of state (filters always want `CFilter`), so
+                // `store_and_match_batches` drains the leftovers, and the next
+                // filter-header event re-enters here once genuinely idle.
+                if !self.is_idle() {
                     self.filter_pipeline.extend_target(tip_height);
                     return Ok(vec![]);
                 }
@@ -3079,6 +3093,32 @@ mod tests {
         manager.handle_new_filter_headers(101, &requests).await.unwrap();
         assert!(!manager.active_batches.contains_key(&0));
         assert_eq!(manager.active_batches.keys().next(), Some(&101));
+    }
+
+    /// The same predicate mismatch on the OTHER route into `start_download`.
+    ///
+    /// A filter-header event arriving while the manager sits in `WaitForEvents`
+    /// takes `handle_new_filter_headers`, not `start_sync` — and that arm asked
+    /// the same subset question. A verified batch waiting in `pending_batches`
+    /// with `active_batches` already empty therefore fell through to
+    /// `start_download` and its `debug_assert!(is_idle())`.
+    #[tokio::test]
+    async fn test_new_filter_headers_resumes_when_only_pending_batches_survive() {
+        let (mut manager, _headers, _filter) = setup_synced_manager_at_tip().await;
+
+        manager.pending_batches.insert(FiltersBatch::new(0, 99, HashMap::new()));
+        assert!(manager.active_batches.is_empty(), "the old predicate says idle");
+        assert!(!manager.is_idle(), "the invariant start_download asserts says otherwise");
+
+        manager.set_state(SyncState::WaitForEvents);
+        let (tx, _rx) = unbounded_channel();
+        let requests = RequestSender::new(tx);
+
+        // Must extend the target and leave the surviving work alone.
+        let events = manager.handle_new_filter_headers(200, &requests).await.unwrap();
+
+        assert!(events.is_empty(), "extending the target emits nothing");
+        assert_eq!(manager.pending_batches.len(), 1, "the surviving batch must not be discarded");
     }
 
     /// A verified batch waiting in `pending_batches` outlives the last active

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -3118,6 +3118,21 @@ mod tests {
         let events = manager.handle_new_filter_headers(200, &requests).await.unwrap();
 
         assert!(events.is_empty(), "extending the target emits nothing");
+        // `pending_batches` alone does not prove the guard held: `start_download`
+        // preserves it too, so a broken guard would reinitialize the pipeline and
+        // still leave this at 1. The state and the absence of a fresh active
+        // batch are what tell resuming from restarting — and unlike the
+        // `debug_assert` inside `start_download`, they still hold in a release
+        // build, where that assert is compiled out.
+        assert_eq!(
+            manager.state(),
+            SyncState::WaitForEvents,
+            "the arm must return without changing state"
+        );
+        assert!(
+            manager.active_batches.is_empty(),
+            "must not start a fresh download over the surviving work"
+        );
         assert_eq!(manager.pending_batches.len(), 1, "the surviving batch must not be discarded");
     }
 
@@ -3147,6 +3162,13 @@ mod tests {
 
         assert!(events.is_empty(), "resuming emits no SyncStart");
         assert_eq!(manager.state(), SyncState::Syncing);
+        // See the sibling test: `start_download` keeps `pending_batches`, so only
+        // the absence of a new active batch proves this resumed rather than
+        // restarted, and it proves it without relying on a debug assertion.
+        assert!(
+            manager.active_batches.is_empty(),
+            "must not start a fresh download over the surviving work"
+        );
         assert_eq!(
             manager.pending_batches.len(),
             1,

--- a/dash-spv/src/sync/filters/sync_manager.rs
+++ b/dash-spv/src/sync/filters/sync_manager.rs
@@ -59,7 +59,22 @@ impl<
         // any pending verified batches; calling `start_download` here would
         // insert a fresh batch at `scan_start` and clobber the existing one,
         // leaking its `pending_blocks` counter forever.
-        if !self.active_batches.is_empty() {
+        //
+        // The condition is `is_idle()` — the whole invariant `start_download`
+        // asserts — and not `active_batches` alone. They are not the same
+        // question: `on_disconnect` calls `requeue_in_flight`, which moves the
+        // pipeline's in-flight slots to *pending*, and a batch that finished
+        // downloading leaves `active_batches` while its verified output waits
+        // in `pending_batches` and its blocks wait in the tracker. Any of those
+        // three outlasting the last active batch used to fall through to
+        // `start_download` and trip its `debug_assert!(is_idle())` — an abort
+        // in any build with debug assertions on.
+        //
+        // Resuming is safe for all of them: this path sets `Syncing`, and
+        // `tick` in that state runs `send_pending`, `store_and_match_batches`
+        // and `try_process_batch` unconditionally. `send_pending` is a no-op
+        // when the pipeline has nothing queued.
+        if !self.is_idle() {
             self.filter_pipeline.send_pending(requests, &*self.header_storage.read().await).await?;
             self.set_state(SyncState::Syncing);
             return Ok(vec![]);


### PR DESCRIPTION
## The bug

`FiltersManager::start_sync` decides whether in-flight work survived a disconnect by asking one question:

```rust
if !self.active_batches.is_empty() {
    // resume
}
```

`start_download`, which the other branch falls into, asserts a stricter one:

```rust
debug_assert!(self.is_idle(), "manager should have no in-flight state on start");
```

and `is_idle()` is **four** conditions — `active_batches`, `tracker`, `pending_batches` and `filter_pipeline` all empty. The guard checked one of them.

They come apart routinely:

- `on_disconnect` deliberately preserves the first three (its own doc says so) and calls `requeue_in_flight()`, which moves the pipeline's in-flight slots to *pending* — making the pipeline **non**-idle rather than restoring it.
- A batch that finished downloading leaves `active_batches` while its verified output waits in `pending_batches` and its blocks wait in the tracker.

Any of those outlasting the last active batch sends a reconnect through the guard and straight into the assert.

## Why it matters

In a build with debug assertions on this aborts the host process. `debug_assert!` is not a no-op there, and the iOS profile pairs it with `panic = "abort"`, so there is no unwinding either.

It has already happened in the field. A TestFlight build of the Dash iOS wallet (9.0.0/25, iPhone17,2, iOS 26.6) died with `SIGABRT` in exactly this frame:

```
Thread 9 Crashed:
  abort ← rust_panic ← core::panicking::panic_fmt
  ← FiltersManager::start_download::{{closure}}            (manager.rs:182)
  ← filters::sync_manager::…::start_sync                   (sync_manager.rs:89)
  ← SyncManager::handle_network_event                      (sync_manager.rs:193)
  ← SyncManager::run                                       (sync_manager.rs:293)
```

The app had been running 33 minutes with `Role: Non UI` — backgrounded, where iOS tearing down and restoring networking makes the disconnect/reconnect cycle routine rather than exotic.

## The fix

The guard now asks `is_idle()` — the same predicate the assert states. `is_idle` becomes `pub(super)` so the decision and the assertion cannot drift apart again.

Resuming is safe for all four cases, not just the one the guard covered: the resume path sets `Syncing`, and `tick` in that state runs `send_pending`, `store_and_match_batches` and `try_process_batch` unconditionally. `send_pending` returns `Ok(0)` when the pipeline has nothing queued, so a manager whose only surviving state is a pending batch or a tracked block still gets drained by the ticker instead of being wedged.

Deliberately **not** `reset_for_rescan()` before `start_download`: that would also clear the state `on_disconnect` documents itself as preserving, throwing away verified batches and forcing a re-download of work already done.

## Test

`test_start_sync_resumes_when_only_pending_batches_survive` puts a verified batch in `pending_batches` with `active_batches` empty, asserts the two predicates disagree at that moment, and drives `start_sync`.

It **fails without the guard change**, panicking at the assert — the production crash reproduced as a unit test.

```
cargo test -p dash-spv --lib                 # 538 passed
cargo clippy -p dash-spv --all-targets       # clean
cargo fmt --check                            # clean
```

## Note for reviewers

`tick` has the same narrow predicate in `let has_pending_work = !self.active_batches.is_empty();`, used to decide whether to tick while `Synced`. It cannot abort — the worst case is that a surviving pending batch waits for a state change instead of being drained — so I left it alone rather than widen the diff. Worth a look by someone who knows whether that path can strand work.

Also: #921 and #902 both change `start_download`'s signature (`requests` → `network`). Neither touches this guard, but whichever lands first will make the other a trivial conflict here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization recovery after disconnects and reconnects.
  * Preserved pending verified work instead of restarting synchronization from scratch.
  * Prevented duplicate downloads while resuming existing synchronization activity.
  * Added coverage for recovery scenarios involving pending batches and filter headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->