### PR TITLE
fix(dash-spv): count acceptance signals that arrived before the broadcast

### DIFF
--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -372,14 +372,15 @@ impl<W: WalletInterface> MempoolManager<W> {
 
         // Send self-originated transactions to the network regardless of
         // wallet relevance — the caller explicitly asked to broadcast.
+        let mut events = Vec::new();
         if is_local {
-            self.start_broadcast(&tx, requests);
+            events.extend(self.start_broadcast(&tx, requests));
         }
 
         // Skip if already tracked (e.g., locally broadcast then received from a peer)
         if self.transactions.contains_key(&txid) {
             self.seen_txids.insert(txid, Instant::now());
-            return Ok(vec![]);
+            return Ok(events);
         }
 
         self.seen_txids.insert(txid, Instant::now());
@@ -395,7 +396,7 @@ impl<W: WalletInterface> MempoolManager<W> {
         };
 
         if !result.is_relevant {
-            return Ok(vec![]);
+            return Ok(events);
         }
 
         self.progress.add_relevant(1);
@@ -414,7 +415,33 @@ impl<W: WalletInterface> MempoolManager<W> {
         self.transactions.insert(txid, unconfirmed_tx);
         self.progress.set_tracked(self.transactions.len() as u32);
 
-        Ok(vec![])
+        Ok(events)
+    }
+
+    /// Acceptance evidence gathered before this node broadcast the transaction
+    /// itself, with the label to log it under.
+    ///
+    /// The echo heuristic can only observe signals that arrive *after* the
+    /// broadcast is registered: a holdout peer announcing the txid back. When
+    /// the very same signed transaction reached the network by another route
+    /// first — a BIP70 merchant broadcasting the bytes it was just paid with,
+    /// another copy of the wallet, a rebroadcast after a restart — its
+    /// InstantSend lock or peer relay lands before `start_broadcast` runs and
+    /// is then invisible to that heuristic. No peer re-announces a transaction
+    /// it is only now being sent, so the broadcast would sit `Pending` until
+    /// the timeout and be reported as `Uncertain` while the network had in
+    /// fact accepted it seconds earlier.
+    fn preexisting_acceptance(&self, txid: &Txid) -> Option<&'static str> {
+        if self.pending_is_locks.contains_key(txid) {
+            return Some("InstantSend lock arrived before the broadcast");
+        }
+        match self.transactions.get(txid) {
+            Some(tx) if tx.is_instant_send => Some("mempool entry is already InstantSend-locked"),
+            // Present in our mempool view without a local broadcast behind it means a peer
+            // relayed it to us — the same proof of propagation the echo threshold waits for.
+            Some(_) => Some("already relayed to us by a peer"),
+            None => None,
+        }
     }
 
     /// Begin tracking a self-originated transaction and send it to the
@@ -422,11 +449,21 @@ impl<W: WalletInterface> MempoolManager<W> {
     ///
     /// Idempotent per txid: repeated local dispatches of the same transaction
     /// do not resend (the rebroadcast timer handles resends).
-    pub(super) fn start_broadcast(&mut self, tx: &Transaction, requests: &RequestSender) {
+    ///
+    /// Returns the acceptance event when the network's verdict is already
+    /// known (see [`Self::preexisting_acceptance`]); the transaction is still
+    /// sent, since knowing one peer has it says nothing about the rest.
+    pub(super) fn start_broadcast(
+        &mut self,
+        tx: &Transaction,
+        requests: &RequestSender,
+    ) -> Vec<SyncEvent> {
         let txid = tx.txid();
         if self.broadcasts.contains_key(&txid) {
-            return;
+            return Vec::new();
         }
+
+        let known_acceptance = self.preexisting_acceptance(&txid);
 
         let mut state = TxBroadcastState::new(tx.clone(), Instant::now());
         let peers: Vec<SocketAddr> = self.peers.keys().copied().collect();
@@ -459,7 +496,20 @@ impl<W: WalletInterface> MempoolManager<W> {
                 state.holdout.len()
             );
         }
+        if let Some(reason) = known_acceptance {
+            tracing::info!("Broadcast {} accepted before dispatch ({})", txid, reason);
+            state.status = BroadcastStatus::Accepted;
+            self.broadcasts.insert(txid, state);
+            return vec![SyncEvent::TransactionBroadcastResult {
+                txid,
+                result: BroadcastResult::Accepted {
+                    relayed_by: 0,
+                },
+            }];
+        }
+
         self.broadcasts.insert(txid, state);
+        Vec::new()
     }
 
     /// Transition pending broadcasts that outlived the acceptance timeout to
@@ -1908,6 +1958,106 @@ mod tests {
         assert!(
             manager.pending_requests.contains_key(&txid),
             "expired seen txid should be accepted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_seeds_acceptance_from_earlier_instant_lock() {
+        let (mut manager, requests, _rx) = create_test_manager();
+        let tx = test_transaction(40);
+        let txid = tx.txid();
+
+        // The same signed transaction reached the network by another route first (a BIP70
+        // merchant broadcasting the bytes it was just paid with), so its InstantSend lock
+        // arrives before this node dispatches its own copy.
+        manager.process_instant_send(dummy_instant_lock(txid)).await;
+        assert!(manager.pending_is_locks.contains_key(&txid));
+
+        let events = manager.start_broadcast(&tx, &requests);
+
+        assert!(
+            matches!(
+                events.as_slice(),
+                [SyncEvent::TransactionBroadcastResult {
+                    txid: seen,
+                    result: BroadcastResult::Accepted { relayed_by: 0 },
+                }] if *seen == txid
+            ),
+            "a lock that preceded the broadcast still proves acceptance, got {:?}",
+            events
+        );
+        assert_eq!(
+            manager.broadcasts.get(&txid).map(|state| state.status),
+            Some(BroadcastStatus::Accepted)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_seeds_acceptance_from_peer_relay() {
+        let (mut manager, requests, _rx) = create_test_manager();
+        let tx = test_transaction(41);
+        let txid = tx.txid();
+
+        // A peer relayed the transaction to us before we broadcast it — the same proof of
+        // propagation the echo threshold waits for, and one no later echo can repeat.
+        manager.transactions.insert(
+            txid,
+            UnconfirmedTransaction::new(tx.clone(), Amount::ZERO, false, false, vec![], 0),
+        );
+
+        let events = manager.start_broadcast(&tx, &requests);
+
+        assert!(
+            matches!(
+                events.as_slice(),
+                [SyncEvent::TransactionBroadcastResult {
+                    result: BroadcastResult::Accepted {
+                        relayed_by: 0
+                    },
+                    ..
+                }]
+            ),
+            "a peer relay that preceded the broadcast still proves acceptance, got {:?}",
+            events
+        );
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_without_prior_evidence_stays_pending() {
+        let (mut manager, requests, _rx) = create_test_manager();
+        let tx = test_transaction(42);
+        let txid = tx.txid();
+
+        let events = manager.start_broadcast(&tx, &requests);
+
+        assert!(events.is_empty(), "nothing is known yet, got {:?}", events);
+        assert_eq!(
+            manager.broadcasts.get(&txid).map(|state| state.status),
+            Some(BroadcastStatus::Pending)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_tx_reports_acceptance_proven_before_dispatch() {
+        let (mut manager, requests, _rx) = create_test_manager();
+        let tx = test_transaction(43);
+        let txid = tx.txid();
+
+        manager.process_instant_send(dummy_instant_lock(txid)).await;
+
+        let local_addr = SocketAddr::from(([0, 0, 0, 0], 0));
+        let events = manager.handle_tx(tx, local_addr, &requests).await.unwrap();
+
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                SyncEvent::TransactionBroadcastResult {
+                    txid: seen,
+                    result: BroadcastResult::Accepted { .. },
+                } if *seen == txid
+            )),
+            "handle_tx must forward the verdict, otherwise the waiter never sees it: {:?}",
+            events
         );
     }
 

--- a/dash-spv/src/sync/mempool/manager.rs
+++ b/dash-spv/src/sync/mempool/manager.rs
@@ -440,7 +440,16 @@ impl<W: WalletInterface> MempoolManager<W> {
             // Present in our mempool view without a local broadcast behind it means a peer
             // relayed it to us — the same proof of propagation the echo threshold waits for.
             Some(_) => Some("already relayed to us by a peer"),
-            None => None,
+            // `transactions` only keeps wallet-relevant entries, but relay is relay: a
+            // transaction the wallet ignored still reached us from the network. `seen_txids`
+            // records every download, and at this point it can only hold a txid some peer sent
+            // us — our own copy is inserted after `start_broadcast` runs, and a second local
+            // dispatch never reaches here (`broadcasts` short-circuits it).
+            None => self
+                .seen_txids
+                .get(txid)
+                .is_some_and(|seen| seen.elapsed() < SEEN_TXID_EXPIRY)
+                .then_some("already received from a peer"),
         }
     }
 
@@ -2018,6 +2027,35 @@ mod tests {
                 }]
             ),
             "a peer relay that preceded the broadcast still proves acceptance, got {:?}",
+            events
+        );
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_seeds_acceptance_from_irrelevant_peer_relay() {
+        let (mut manager, requests, _rx) = create_test_manager();
+        let tx = test_transaction(44);
+        let txid = tx.txid();
+
+        // A peer relayed the transaction and the wallet found it irrelevant, so it never entered
+        // `transactions` — but the network demonstrably has it.
+        manager.handle_tx(tx.clone(), test_socket_address(1), &requests).await.unwrap();
+        assert!(!manager.transactions.contains_key(&txid));
+        assert!(manager.seen_txids.contains_key(&txid));
+
+        let events = manager.start_broadcast(&tx, &requests);
+
+        assert!(
+            matches!(
+                events.as_slice(),
+                [SyncEvent::TransactionBroadcastResult {
+                    result: BroadcastResult::Accepted {
+                        relayed_by: 0
+                    },
+                    ..
+                }]
+            ),
+            "relay is relay even when the wallet ignored the transaction, got {:?}",
             events
         );
     }


### PR DESCRIPTION
## Problem

`broadcast_transaction_and_wait` reports `Uncertain` for transactions the network demonstrably accepted, whenever the acceptance evidence arrived *before* the broadcast was registered.

The acceptance heuristic in `MempoolManager` is echo-based: `start_broadcast` sends the transaction to a subset of peers, withholds it from a holdout set, and waits for a holdout peer to announce the txid back via `inv`. `process_instant_send` and the confirmation path can promote a broadcast too — but only one that is already tracked in `self.broadcasts`.

That leaves a blind spot. When the identical signed transaction reaches the network by another route first, its InstantSend lock (or its relay to us from a peer) lands before `start_broadcast` ever runs, and no later signal repeats it: a peer does not re-announce a transaction it is only now being sent. The broadcast sits `Pending` until `acceptance_timeout` and is reported `Uncertain`.

This is routine rather than exotic, because BIP70 hands the merchant the signed bytes and takes its acknowledgement *before* the wallet broadcasts. A field case from Dash Wallet iOS on mainnet:

```
20:18:57.247  New wallet transaction detected txid=e730e18f… context=mempool
20:18:57.325  InstantLock signature verified for txid e730e18f…      ← 0.7 s before our dispatch
20:18:58.019  Broadcast e730e18f… to 2/3 peers (1 withheld for acceptance detection)
20:19:58.054  Broadcast e730e18f… outcome uncertain: no acceptance signal within 60s
20:34:58      TransactionBroadcastResult(… Accepted { relayed_by: 0 })  ← only once a block confirmed it
```

The caller (rs-platform-wallet's `SpvBroadcaster`, 30 s cap) turned that into `MaybeSent`, and the wallet discarded a paid gift-card order on the strength of it — the customer paid, the merchant fulfilled the order, and the app kept no record of the card.

## Fix

`start_broadcast` now consults what is already known before registering a pending broadcast, via a new `preexisting_acceptance`:

- a lock waiting in `pending_is_locks` — the IS lock arrived before the transaction did;
- a mempool entry already flagged `is_instant_send`;
- a mempool entry at all, which at this point can only have come from a peer relaying it to us (the local injection happens after this call), i.e. the same proof of propagation the echo threshold waits for.

Any of those emits `Accepted { relayed_by: 0 }` immediately and marks the tracked state `Accepted`. The transaction is still sent to peers: knowing that one peer has it says nothing about the rest.

`start_broadcast` therefore returns `Vec<SyncEvent>` instead of `()`, and `handle_tx` forwards it — without that the waiter in `broadcast_transaction_and_wait`, which subscribes before dispatching, would never see the verdict.

## Behavior notes

- Strictly a widening of what counts as acceptance. No signal that was previously conclusive changes meaning, and `Pending`/`Uncertain`/echo handling is untouched for broadcasts with no prior evidence.
- `relayed_by: 0` already denoted "proven by something other than an echo" (IS lock, confirmation); this reuses it rather than adding a variant.
- A transaction the local node has never seen behaves exactly as before.

## Testing

Four new tests in `sync::mempool::manager`, all failing before the change:

- an IS lock processed before `start_broadcast` yields `Accepted { relayed_by: 0 }` and leaves the tracked status `Accepted`;
- a mempool entry relayed by a peer before the broadcast does the same;
- with no prior evidence the broadcast stays `Pending` and emits nothing (guards against the seed firing on our own injection);
- `handle_tx` on the local sentinel address forwards the verdict, covering the propagation path the waiter depends on.

Full `dash-spv` library suite: 567 passed, 0 failed. `cargo fmt` clean, `cargo clippy -p dash-spv --lib` reports nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction broadcast tracking and reporting.
  - Transactions with existing acceptance evidence are now recognized immediately.
  - Broadcasts remain pending when acceptance cannot yet be confirmed.
  - Acceptance events are consistently propagated, including for irrelevant or already tracked transactions.
- **Tests**
  - Added coverage for prior acceptance evidence, pending broadcasts, irrelevant peer relays, and transaction event propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->