### PR TITLE
fix(dash-spv-bench): report the transactions each account knows 

### DIFF
--- a/dash-spv-bench/src/main.rs
+++ b/dash-spv-bench/src/main.rs
@@ -196,16 +196,9 @@ async fn main() -> Result<()> {
         let _ = writeln!(report, "wallet_addresses:     {}", w.monitored_addresses().len());
 
         for (i, id) in wallet_ids.iter().enumerate() {
-            let txs = w
+            let txs: usize = w
                 .get_wallet_info(id)
-                .map(|info| {
-                    info.accounts()
-                        .all_accounts()
-                        .iter()
-                        .flat_map(|a| a.transactions().keys())
-                        .collect::<std::collections::BTreeSet<_>>()
-                        .len()
-                })
+                .map(|info| info.accounts().all_accounts().iter().map(|a| a.tx_count()).sum())
                 .unwrap_or(0);
 
             let (confirmed, total) =
@@ -213,7 +206,7 @@ async fn main() -> Result<()> {
 
             let _ = writeln!(
                 report,
-                "wallet[{i}] retained_records={txs} confirmed_sat={confirmed} total_sat={total}"
+                "wallet[{i}] transactions={txs} confirmed_sat={confirmed} total_sat={total}"
             );
         }
 

--- a/key-wallet/src/managed_account/managed_account_ref.rs
+++ b/key-wallet/src/managed_account/managed_account_ref.rs
@@ -109,6 +109,14 @@ impl<'a> ManagedAccountRef<'a> {
         }
     }
 
+    /// See [`ManagedAccountTrait::tx_count`].
+    pub fn tx_count(self) -> usize {
+        match self {
+            ManagedAccountRef::Funds(a) => a.tx_count(),
+            ManagedAccountRef::Keys(a) => a.tx_count(),
+        }
+    }
+
     /// Whether `txid` has been finalized (chainlocked).
     pub fn transaction_is_finalized(self, txid: &Txid) -> bool {
         match self {

--- a/key-wallet/src/managed_account/managed_account_trait.rs
+++ b/key-wallet/src/managed_account/managed_account_trait.rs
@@ -52,6 +52,10 @@ pub trait ManagedAccountTrait {
     /// (mempool → block, IS-lock arrival, chainlock, …).
     fn has_transaction(&self, txid: &Txid) -> bool;
 
+    /// Distinct transactions this account knows, including those whose records
+    /// were pruned at finalization — which [`Self::transactions`] does not.
+    fn tx_count(&self) -> usize;
+
     /// Returns `true` if `txid` has been mined in a block that is itself
     /// chainlocked — the only finality signal we treat as terminal
     /// (mirrors [`crate::transaction_checking::TransactionContext::is_chain_locked`]).

--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -1270,6 +1270,10 @@ impl ManagedAccountTrait for ManagedCoreFundsAccount {
         self.keys.has_transaction(txid)
     }
 
+    fn tx_count(&self) -> usize {
+        self.keys.tx_count()
+    }
+
     fn transaction_is_finalized(&self, txid: &Txid) -> bool {
         self.keys.transaction_is_finalized(txid)
     }

--- a/key-wallet/src/managed_account/managed_core_keys_account.rs
+++ b/key-wallet/src/managed_account/managed_core_keys_account.rs
@@ -405,6 +405,20 @@ impl ManagedAccountTrait for ManagedCoreKeysAccount {
         self.transactions.contains_key(txid) || self.finalized_txids.contains(txid)
     }
 
+    #[cfg(feature = "keep-finalized-transactions")]
+    fn tx_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    /// The two sets overlap: `drop_finalized_transaction` records the txid in
+    /// `finalized_txids` but keeps the record when it holds a provider
+    /// payload, so live entries are counted against it, not added to it.
+    #[cfg(not(feature = "keep-finalized-transactions"))]
+    fn tx_count(&self) -> usize {
+        self.finalized_txids.len()
+            + self.transactions.keys().filter(|t| !self.finalized_txids.contains(*t)).count()
+    }
+
     /// With the feature ON, finalized records live in `transactions`,
     /// so we resolve the answer purely off the live record's context.
     #[cfg(feature = "keep-finalized-transactions")]

--- a/key-wallet/src/tests/keep_finalized_transactions_tests.rs
+++ b/key-wallet/src/tests/keep_finalized_transactions_tests.rs
@@ -114,6 +114,11 @@ async fn test_chainlocked_record_dropped_when_feature_off() {
     );
     assert!(ctx.bip44_account().has_transaction(&txid));
     assert!(ctx.bip44_account().transaction_is_finalized(&txid));
+    assert_eq!(
+        ctx.bip44_account().tx_count(),
+        1,
+        "a record pruned at finalization must still be counted"
+    );
 }
 
 /// IS-lock is **not** finalization. The record must NOT be dropped when


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transaction count reporting across managed accounts.
  * Transaction counts now include finalized transactions, even after their detailed records are pruned.
  * Updated wallet reports to display the total number of transactions.

* **Bug Fixes**
  * Prevented transactions retained in multiple internal records from being counted twice.
  * Added coverage confirming finalized transactions remain included in reported totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->