### PR TITLE
fix(dash-spv): coinbase maturity clock

### DIFF
--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -214,6 +214,21 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
     ) -> SyncResult<Vec<SyncEvent>> {
         debug_assert!(self.is_idle(), "manager should have no in-flight state on start");
 
+        // Coverage certified before this process is certified maturity too, so
+        // lift each wallet's clock to its own checkpoint. A boot that is already
+        // at the tip commits no batch, and nothing else would move it
+        // (dashpay/rust-dashcore#995).
+        {
+            let mut wallet = self.wallet.write().await;
+            // Every wallet the manager holds: none can sit at `u32::MAX`.
+            for wallet_id in wallet.wallets_behind(u32::MAX) {
+                let synced = wallet.wallet_synced_height(&wallet_id);
+                if synced > 0 {
+                    wallet.update_wallet_last_processed_height(&wallet_id, synced);
+                }
+            }
+        }
+
         // Use synced_height for restart recovery instead of
         // last_processed_height, which advances per-block and may exceed committed scan progress.
         let (wallet_birth_height, wallet_committed_height) = {
@@ -1716,6 +1731,10 @@ mod tests {
         assert_eq!(manager.wallet.read().await.wallet_synced_height(&MOCK_WALLET_ID), 0);
     }
 
+    async fn last_processed(multi: &Arc<RwLock<MultiMockWallet>>, id: &WalletId) -> u32 {
+        multi.write().await.wallet_mut(id).last_processed_height
+    }
+
     #[tokio::test]
     async fn test_batch_commit_advances_only_scanned_wallets() {
         let mut manager = create_test_manager().await;
@@ -1733,6 +1752,7 @@ mod tests {
         manager.try_commit_batches().await.unwrap();
         assert_eq!(manager.progress.committed_height(), 4999);
         assert_eq!(manager.wallet.read().await.wallet_synced_height(&MOCK_WALLET_ID), 4999);
+        assert_eq!(manager.wallet.read().await.last_processed_height(), 4999);
 
         // Second batch leaves scanned_wallets empty (nothing to scan in this
         // range), so the per-wallet synced_height stays put even though the
@@ -1746,6 +1766,7 @@ mod tests {
         manager.try_commit_batches().await.unwrap();
         assert_eq!(manager.progress.committed_height(), 9999);
         assert_eq!(manager.wallet.read().await.wallet_synced_height(&MOCK_WALLET_ID), 4999);
+        assert_eq!(manager.wallet.read().await.last_processed_height(), 4999);
     }
 
     /// Two wallets in the same batch: only the wallet recorded in
@@ -1776,6 +1797,8 @@ mod tests {
         assert_eq!(manager.progress.committed_height(), 4999);
         assert_eq!(multi.read().await.wallet_synced_height(&wallet_a), 4999);
         assert_eq!(multi.read().await.wallet_synced_height(&wallet_b), 0);
+        assert_eq!(last_processed(&multi, &wallet_a).await, 4999);
+        assert_eq!(last_processed(&multi, &wallet_b).await, 0);
     }
 
     /// Contiguity guard (dashpay/rust-dashcore#649): a batch scanned before an
@@ -1822,6 +1845,11 @@ mod tests {
             49,
             "the rewound checkpoint must survive commit — the batch is non-contiguous with it"
         );
+        assert_eq!(
+            last_processed(&multi, &wallet_a).await,
+            0,
+            "a batch that cannot certify coverage cannot certify maturity either"
+        );
         // The wallet is still behind, so the next tick rescans it.
         assert!(
             multi.read().await.wallets_behind(9999).contains(&wallet_a),
@@ -1851,6 +1879,7 @@ mod tests {
             0,
             "heights 200000..204999 are reachable and were never scanned, so the batch cannot certify"
         );
+        assert_eq!(last_processed(&multi, &wallet_b).await, 0);
     }
 
     /// The contiguity guard is transparent in normal operation: contiguous
@@ -1997,6 +2026,11 @@ mod tests {
             7499,
             "a rewind INSIDE the batch range must survive commit: 7500..=9999 were \
              scanned without the new account's scripts"
+        );
+        assert_eq!(
+            last_processed(&multi, &wallet_a).await,
+            0,
+            "scripts the scan never tested cannot certify maturity"
         );
         assert!(
             multi.read().await.wallets_behind(9999).contains(&wallet_a),
@@ -3442,6 +3476,25 @@ mod tests {
         assert_eq!(manager.state(), SyncState::Synced);
         assert!(manager.active_batches.is_empty());
         assert!(manager.next_batch_to_store > 100);
+    }
+
+    /// A wallet whose stored maturity clock lags its own certified checkpoint —
+    /// state written by a build that never advanced it — must be lifted at
+    /// startup. An already-synced boot commits no batch, so nothing else would
+    /// (dashpay/rust-dashcore#995).
+    #[tokio::test]
+    async fn test_synced_boot_lifts_the_maturity_clock_to_certified_coverage() {
+        let (mut manager, _headers, _filter) = setup_synced_manager_at_tip().await;
+        assert_eq!(manager.wallet.read().await.wallet_synced_height(&MOCK_WALLET_ID), 100);
+        assert_eq!(manager.wallet.read().await.last_processed_height(), 0);
+
+        manager.set_state(SyncState::WaitingForConnections);
+        let (tx, _rx) = unbounded_channel();
+        let requests = RequestSender::new(tx);
+        manager.start_sync(&requests).await.unwrap();
+
+        assert_eq!(manager.state(), SyncState::Synced);
+        assert_eq!(manager.wallet.read().await.last_processed_height(), 100);
     }
 
     /// A node that boots already synced (default `WaitForEvents` state, which

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -716,6 +716,12 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                             .max(scan_floor.saturating_sub(1));
                         if effective_synced.saturating_add(1) >= batch_start {
                             wallet.update_wallet_synced_height(wallet_id, end);
+                            // A committed batch certifies the whole range for
+                            // this wallet, so it is also the wallet's maturity
+                            // clock: filters have no false negatives and every
+                            // matched block below `end` is already applied
+                            // (dashpay/rust-dashcore#995).
+                            wallet.update_wallet_last_processed_height(wallet_id, end);
                         }
                     }
                 }

--- a/dash-spv/tests/dashd_sync/tests_transaction.rs
+++ b/dash-spv/tests/dashd_sync/tests_transaction.rs
@@ -9,7 +9,7 @@ use super::helpers::{
     count_wallet_transactions, get_spendable_balance, wait_for_mempool_tx, wait_for_sync,
     wait_for_wallet_synced, EMPTY_MNEMONIC, SECONDARY_MNEMONIC,
 };
-use super::setup::{create_and_start_client, TestContext};
+use super::setup::{create_and_start_client, ClientHandle, TestContext};
 use dash_spv::test_utils::{create_test_wallet, TestChain};
 use dashcore::address::NetworkUnchecked;
 use dashcore::secp256k1::Secp256k1;
@@ -18,6 +18,7 @@ use key_wallet::account::ManagedAccountTrait;
 use key_wallet::bip32::{ChildNumber, ExtendedPrivKey};
 use key_wallet::gap_limit::DEFAULT_EXTERNAL_GAP_LIMIT;
 use key_wallet::mnemonic::Mnemonic;
+use key_wallet::wallet::balance::WalletCoreBalance;
 use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
 use key_wallet::wallet::managed_wallet_info::fee::FeeRate;
@@ -637,4 +638,97 @@ async fn test_drain_account_into_another() {
     assert_eq!(utxos(AccountTypePreference::BIP44), 1);
 
     client_handle.stop().await;
+}
+
+const COINBASE_MATURITY: u64 = 100;
+
+async fn mining_context() -> Option<TestContext> {
+    let ctx = TestContext::new(TestChain::Minimal).await?;
+    if !ctx.dashd.supports_mining {
+        eprintln!("Skipping test (dashd RPC miner not available)");
+        return None;
+    }
+    Some(ctx)
+}
+
+async fn wallet_balance(ctx: &TestContext) -> WalletCoreBalance {
+    ctx.wallet.read().await.get_wallet_balance(&ctx.wallet_id).expect("wallet balance")
+}
+
+/// Mine a coinbase to the wallet and bury it under `COINBASE_MATURITY` blocks
+/// paid to the separate mining wallet. Returns the balance before the coinbase
+/// and the immature balance carrying it.
+async fn bury_wallet_coinbase(ctx: &TestContext, handle: &mut ClientHandle) -> (u64, u64) {
+    let baseline = wallet_balance(ctx).await;
+
+    let reward_address = ctx.receive_address().await;
+    ctx.dashd.node.generate_blocks(1, &reward_address);
+    let reward_height = ctx.dashd.initial_height + 1;
+    wait_for_sync(&mut handle.progress_receiver, reward_height).await;
+
+    let immature = wallet_balance(ctx).await.immature();
+    assert!(
+        immature > baseline.immature(),
+        "coinbase should be immature at its own height: {} -> {}",
+        baseline.immature(),
+        immature
+    );
+
+    let miner_address = ctx.dashd.node.get_new_address_from_wallet("default");
+    ctx.dashd.node.generate_blocks(COINBASE_MATURITY, &miner_address);
+    let mature_height = reward_height + COINBASE_MATURITY as u32;
+    wait_for_sync(&mut handle.progress_receiver, mature_height).await;
+    wait_for_wallet_synced(&ctx.wallet, &ctx.wallet_id, mature_height).await;
+
+    (baseline.spendable(), immature)
+}
+
+/// A coinbase must mature once it is `COINBASE_MATURITY` blocks deep, even when
+/// none of those blocks touches the wallet (dashpay/rust-dashcore#995).
+#[tokio::test]
+async fn test_coinbase_matures_without_later_wallet_activity() {
+    let Some(ctx) = mining_context().await else {
+        return;
+    };
+    let mut handle = ctx.spawn_new_client().await;
+    wait_for_sync(&mut handle.progress_receiver, ctx.dashd.initial_height).await;
+
+    let (spendable_before, immature) = bury_wallet_coinbase(&ctx, &mut handle).await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while wallet_balance(&ctx).await.immature() != 0 && tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    let balance = wallet_balance(&ctx).await;
+    handle.stop().await;
+
+    assert_eq!(balance.immature(), 0, "buried coinbase is still immature");
+    assert_eq!(balance.spendable(), spendable_before + immature, "matured coinbase is unspendable");
+}
+
+/// The control: the same chain, plus a later block paying the wallet. It is the
+/// workaround reported in dashpay/rust-dashcore#995, and the only difference
+/// from the test above.
+#[tokio::test]
+async fn test_coinbase_matures_when_a_later_block_touches_the_wallet() {
+    let Some(ctx) = mining_context().await else {
+        return;
+    };
+    let mut handle = ctx.spawn_new_client().await;
+    wait_for_sync(&mut handle.progress_receiver, ctx.dashd.initial_height).await;
+
+    let (spendable_before, immature) = bury_wallet_coinbase(&ctx, &mut handle).await;
+
+    let address = ctx.receive_address().await;
+    ctx.dashd.node.generate_blocks(1, &address);
+    let height = ctx.dashd.initial_height + COINBASE_MATURITY as u32 + 2;
+    wait_for_sync(&mut handle.progress_receiver, height).await;
+    wait_for_wallet_synced(&ctx.wallet, &ctx.wallet_id, height).await;
+
+    let balance = wallet_balance(&ctx).await;
+    handle.stop().await;
+
+    assert!(balance.immature() > 0, "the newest coinbase is immature");
+    assert_eq!(balance.spendable(), spendable_before + immature, "matured coinbase is unspendable");
 }

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -826,6 +826,84 @@ async fn test_block_processed_carries_matured_coinbase_record() {
     }
 }
 
+#[tokio::test]
+async fn test_maturity_clock_advance_carries_matured_coinbase_record() {
+    // The clock can advance with no block of its own: dash-spv calls this at
+    // every committed filter batch, including ranges that match nothing
+    // (dashpay/rust-dashcore#995).
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    let coinbase_tx = make_coinbase_paying_to(&addr, 5_000_000_000);
+    let coinbase_block = make_block(vec![coinbase_tx.clone()], 0xc2, 4000);
+    let wallets = BTreeSet::from([wallet_id]);
+    manager
+        .process_block_for_wallets(&coinbase_block, coinbase_block.block_hash(), 100, &wallets)
+        .await;
+
+    let mut rx = manager.subscribe_events();
+    manager.update_wallet_last_processed_height(&wallet_id, 200);
+
+    let events = drain_events(&mut rx);
+    let block_event = events
+        .iter()
+        .find(|e| matches!(e, WalletEvent::BlockProcessed { .. }))
+        .unwrap_or_else(|| panic!("expected a BlockProcessed, got {:?}", events));
+
+    match block_event {
+        WalletEvent::BlockProcessed {
+            height,
+            matured,
+            balance,
+            ..
+        } => {
+            assert_eq!(*height, 200);
+            assert_eq!(matured.len(), 1);
+            assert_eq!(matured[0].txid, coinbase_tx.txid());
+            assert_eq!(balance.immature(), 0);
+            assert_eq!(balance.confirmed(), 5_000_000_000);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[tokio::test]
+async fn test_coinbase_found_below_the_maturity_clock_is_spendable_but_unannounced() {
+    // A rescan can surface a matched block the clock already passed. The
+    // coinbase in it is mature on arrival, so it counts as confirmed, but its
+    // maturity window is behind us and no `matured` record can name it.
+    let (mut manager, wallet_id, addr) = setup_manager_with_wallet();
+    manager.update_wallet_last_processed_height(&wallet_id, 300);
+
+    let mut rx = manager.subscribe_events();
+    let coinbase_tx = make_coinbase_paying_to(&addr, 5_000_000_000);
+    let late_block = make_block(vec![coinbase_tx.clone()], 0xc3, 4000);
+    let wallets = BTreeSet::from([wallet_id]);
+    manager.process_block_for_wallets(&late_block, late_block.block_hash(), 150, &wallets).await;
+
+    let events = drain_events(&mut rx);
+    let block_event = events
+        .iter()
+        .find(|e| matches!(e, WalletEvent::BlockProcessed { .. }))
+        .unwrap_or_else(|| panic!("expected a BlockProcessed, got {:?}", events));
+
+    match block_event {
+        WalletEvent::BlockProcessed {
+            height,
+            inserted,
+            matured,
+            balance,
+            ..
+        } => {
+            assert_eq!(*height, 150);
+            assert_eq!(inserted.len(), 1);
+            assert_eq!(inserted[0].txid, coinbase_tx.txid());
+            assert!(matured.is_empty());
+            assert_eq!(balance.immature(), 0);
+            assert_eq!(balance.confirmed(), 5_000_000_000);
+        }
+        _ => unreachable!(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // SyncHeightAdvanced
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes https://github.com/dashpay/rust-dashcore/issues/995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet synchronization now advances processing height consistently when scanned batches are committed.
  * Coinbase rewards correctly mature after the required number of confirmations, even when no later block directly affects the wallet.
  * Wallet balances and transaction events now accurately reflect matured and confirmed coinbase rewards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->