### PR TITLE
fix(key-wallet): keep a spend-first coin recognisable so its spend stays in history

### DIFF
--- a/key-wallet/src/managed_account/managed_core_funds_account.rs
+++ b/key-wallet/src/managed_account/managed_core_funds_account.rs
@@ -62,6 +62,9 @@ pub struct ManagedCoreFundsAccount {
     /// Rebuilt from `transactions` during deserialization.
     #[cfg_attr(feature = "serde", serde(skip_serializing))]
     spent_outpoints: HashSet<OutPoint>,
+    /// Ours, but spent before the funding arrived, so never in `utxos` (#649).
+    /// Input matching falls back to these.
+    pub(crate) spent_before_funded: BTreeMap<OutPoint, Utxo>,
     /// Outpoints reserved by in-flight transaction builds so concurrent builds
     /// do not select the same UTXO before the first build's transaction is
     /// processed. Empty after a restart, where chain and mempool sync
@@ -103,6 +106,7 @@ impl ManagedCoreFundsAccount {
             balance: WalletCoreBalance::default(),
             utxos: BTreeMap::new(),
             spent_outpoints: HashSet::new(),
+            spent_before_funded: BTreeMap::new(),
             reservations: ReservationSet::default(),
         }
     }
@@ -130,6 +134,7 @@ impl ManagedCoreFundsAccount {
             balance: WalletCoreBalance::default(),
             utxos: BTreeMap::new(),
             spent_outpoints: HashSet::new(),
+            spent_before_funded: BTreeMap::new(),
             reservations: ReservationSet::default(),
         }
     }
@@ -336,6 +341,16 @@ impl ManagedCoreFundsAccount {
                                     outpoint = %outpoint,
                                     "Skipping UTXO already observed spent in an earlier-processed block (#649)"
                                 );
+                                self.spent_before_funded.insert(
+                                    outpoint,
+                                    Utxo::new(
+                                        outpoint,
+                                        output.clone(),
+                                        addr.clone(),
+                                        context.block_info().map_or(0, |i| i.height),
+                                        tx.is_coin_base(),
+                                    ),
+                                );
                                 continue;
                             }
 
@@ -383,6 +398,7 @@ impl ManagedCoreFundsAccount {
                 self.reservations.release(tx.input.iter().map(|input| &input.previous_output));
                 for input in &tx.input {
                     self.spent_outpoints.insert(input.previous_output);
+                    self.spent_before_funded.remove(&input.previous_output);
 
                     if self.utxos.remove(&input.previous_output).is_some() {
                         tracing::debug!(
@@ -468,6 +484,7 @@ impl ManagedCoreFundsAccount {
         for outpoint in doomed {
             self.utxos.remove(&outpoint);
         }
+        self.spent_before_funded.retain(|outpoint, _| !abandoned.contains(&outpoint.txid));
 
         let mut records = 0;
         let mut freed: HashSet<OutPoint> = HashSet::new();
@@ -635,6 +652,7 @@ impl ManagedCoreFundsAccount {
                 self.utxos.remove(&outpoint);
                 changed = true;
             }
+            self.spent_before_funded.retain(|outpoint, _| outpoint.txid != *loser);
             if let Some(record) = self.keys.transactions_mut().remove(loser) {
                 freed.extend(record.transaction.input.iter().map(|input| input.previous_output));
             }
@@ -809,10 +827,15 @@ impl ManagedCoreFundsAccount {
             .collect();
 
         // Input details must be built before `update_utxos` removes spent UTXOs
+        // and drops the `spent_before_funded` entry for the same outpoint.
         let mut input_details = Vec::new();
         if !tx.is_coin_base() {
             for (idx, input) in tx.input.iter().enumerate() {
-                if let Some(utxo) = self.utxos.get(&input.previous_output) {
+                if let Some(utxo) = self
+                    .utxos
+                    .get(&input.previous_output)
+                    .or_else(|| self.spent_before_funded.get(&input.previous_output))
+                {
                     input_details.push(InputDetail {
                         index: idx as u32,
                         value: utxo.txout.value,
@@ -824,10 +847,11 @@ impl ManagedCoreFundsAccount {
 
         // Marks a transaction that spends our coins. `input_details` (built
         // above) and `account_match.sent` (built in `check_transaction_with_index`)
-        // both derive from `self.utxos.get(&input.previous_output)` on this
-        // account, with no UTXO mutation between the two lookups, so they
-        // populate together; keeping both keeps this robust should the two
-        // call sites ever compute over different UTXO snapshots.
+        // both resolve each input against `self.utxos` and then
+        // `self.spent_before_funded` on this account, with no mutation of either
+        // between the two lookups, so they populate together; keeping both keeps
+        // this robust should the two call sites ever compute over different
+        // snapshots.
         let has_inputs = !input_details.is_empty() || account_match.sent > 0;
 
         let network = self.keys.network();
@@ -1296,6 +1320,8 @@ impl<'de> Deserialize<'de> for ManagedCoreFundsAccount {
             keys: ManagedCoreKeysAccount,
             balance: WalletCoreBalance,
             utxos: BTreeMap<OutPoint, Utxo>,
+            #[serde(default)]
+            spent_before_funded: BTreeMap<OutPoint, Utxo>,
         }
 
         let helper = Helper::deserialize(deserializer)?;
@@ -1307,6 +1333,7 @@ impl<'de> Deserialize<'de> for ManagedCoreFundsAccount {
             balance: helper.balance,
             utxos: helper.utxos,
             spent_outpoints,
+            spent_before_funded: helper.spent_before_funded,
             reservations: ReservationSet::default(),
         })
     }

--- a/key-wallet/src/tests/observed_spent_outpoints_tests.rs
+++ b/key-wallet/src/tests/observed_spent_outpoints_tests.rs
@@ -26,6 +26,7 @@ use dashcore::hashes::Hash;
 use dashcore::{BlockHash, TxIn, Txid};
 
 use crate::managed_account::managed_account_trait::ManagedAccountTrait;
+use crate::managed_account::transaction_record::TransactionDirection;
 use crate::test_utils::TestWalletContext;
 use crate::transaction_checking::{BlockInfo, TransactionContext};
 use crate::wallet::managed_wallet_info::managed_account_operations::ManagedAccountOperations;
@@ -306,6 +307,174 @@ async fn born_fully_spent_funding_tx_is_recorded_in_history() {
                 | crate::managed_account::transaction_record::OutputRole::Change
         )),
         "the received output detail is preserved in the born-fully-spent record's history"
+    );
+}
+
+/// Value of the coin the spend-first fixture funds and then spends.
+const SPEND_FIRST_FUNDING_VALUE: u64 = 1_000_000;
+
+fn in_block(height: u32, tag: u8) -> TransactionContext {
+    TransactionContext::InBlock(BlockInfo::new(
+        height,
+        BlockHash::from_slice(&[tag; 32]).expect("hash"),
+        1_650_000_000 + height,
+    ))
+}
+
+/// Drives the spend-first ordering: the spend of a coin arrives before the
+/// transaction that funds it, leaving the funding output in
+/// `spent_before_funded` rather than in `utxos`.
+async fn spend_first_context(
+    fund_ctx: TransactionContext,
+) -> (TestWalletContext, Transaction, Transaction) {
+    use dashcore::blockdata::script::ScriptBuf;
+    use dashcore::TxOut;
+
+    let mut ctx = TestWalletContext::new_random();
+
+    let funding_value = SPEND_FIRST_FUNDING_VALUE;
+    let funding = Transaction::dummy(&ctx.receive_address, 0..1, &[funding_value]);
+
+    let external = dashcore::Address::p2pkh(
+        &dashcore::PublicKey::from_slice(&[0x02; 33]).expect("pubkey"),
+        dashcore::Network::Testnet,
+    );
+    let spend = Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn {
+            previous_output: OutPoint::new(funding.txid(), 0),
+            script_sig: ScriptBuf::new(),
+            sequence: 0xffffffff,
+            witness: dashcore::Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: funding_value - 1_000,
+            script_pubkey: external.script_pubkey(),
+        }],
+        special_transaction_payload: None,
+    };
+
+    let spend_ctx = TransactionContext::InBlock(BlockInfo::new(
+        200,
+        BlockHash::from_slice(&[2u8; 32]).expect("hash"),
+        1_650_000_200,
+    ));
+    assert!(!ctx.check_transaction(&spend, spend_ctx).await.is_relevant);
+    assert!(ctx.check_transaction(&funding, fund_ctx).await.is_relevant);
+    assert_eq!(
+        ctx.managed_wallet
+            .first_bip44_managed_account()
+            .expect("BIP44 account")
+            .spent_before_funded
+            .len(),
+        1,
+        "the funding output is held as ours without entering the UTXO set"
+    );
+
+    (ctx, funding, spend)
+}
+
+/// The spending half of a spend-first pair: once the funding has arrived, a
+/// redelivered spend must be recognised and recorded.
+#[tokio::test]
+async fn spend_seen_before_its_funding_is_recorded_on_redelivery() {
+    let (mut ctx, _funding, spend) = spend_first_context(in_block(100, 1)).await;
+    let s_txid = spend.txid();
+
+    let spend_ctx = TransactionContext::InBlock(BlockInfo::new(
+        200,
+        BlockHash::from_slice(&[2u8; 32]).expect("hash"),
+        1_650_000_200,
+    ));
+    let redelivered = ctx.check_transaction(&spend, spend_ctx).await;
+    assert!(
+        redelivered.is_relevant,
+        "a spend of our coin must be recognised once the funding has arrived"
+    );
+
+    let account = ctx.managed_wallet.first_bip44_managed_account().expect("BIP44 account");
+    let record =
+        account.transactions().get(&s_txid).expect("the spending transaction must land in history");
+
+    // The record must be complete, not merely present: the held output is the
+    // only remaining source of the spent coin's value and address, so a
+    // `record_transaction` consulting `utxos` alone would file this spend with
+    // the right net amount and an empty input list (#897).
+    assert_eq!(
+        record.net_amount,
+        -(SPEND_FIRST_FUNDING_VALUE as i64),
+        "the whole coin leaves the wallet"
+    );
+    assert_eq!(
+        record.direction,
+        TransactionDirection::Outgoing,
+        "a spend paying a third party is outgoing"
+    );
+    assert_eq!(record.input_details.len(), 1, "the spent coin must be attributed to its input");
+    let input_detail = &record.input_details[0];
+    assert_eq!(input_detail.index, 0);
+    assert_eq!(input_detail.value, SPEND_FIRST_FUNDING_VALUE);
+    assert_eq!(
+        input_detail.address, ctx.receive_address,
+        "the input must carry the address the funding paid"
+    );
+
+    assert!(account.utxos.is_empty(), "the already-spent output must not become a UTXO");
+    assert_eq!(
+        ctx.managed_wallet.balance.total(),
+        0,
+        "recovering history must not move the balance"
+    );
+}
+
+/// Abandoning the funding transaction takes its held output with it: the coin
+/// was never ours, so a spend of it must stop being recognisable.
+#[tokio::test]
+async fn abandoning_the_funding_drops_the_held_output() {
+    let (mut ctx, funding, _spend) = spend_first_context(in_block(100, 1)).await;
+
+    let account = ctx.managed_wallet.first_bip44_managed_account_mut().expect("BIP44 account");
+    account.apply_abandon(&std::collections::BTreeSet::from([funding.txid()]));
+
+    assert!(
+        account.spent_before_funded.is_empty(),
+        "an abandoned funding transaction must not leave its output behind"
+    );
+}
+
+/// Same for a funding transaction that loses a conflict: the winner spends its
+/// input, so the loser and everything it contributed goes.
+#[tokio::test]
+async fn losing_a_conflict_drops_the_held_output() {
+    use dashcore::blockdata::script::ScriptBuf;
+
+    let (mut ctx, funding, _spend) = spend_first_context(TransactionContext::Mempool).await;
+
+    let winner = Transaction {
+        version: 2,
+        lock_time: 0,
+        input: vec![TxIn {
+            previous_output: funding.input[0].previous_output,
+            script_sig: ScriptBuf::new(),
+            sequence: 0xffffffff,
+            witness: dashcore::Witness::new(),
+        }],
+        output: Vec::new(),
+        special_transaction_payload: None,
+    };
+    let winner_ctx = TransactionContext::InBlock(BlockInfo::new(
+        300,
+        BlockHash::from_slice(&[3u8; 32]).expect("hash"),
+        1_650_000_300,
+    ));
+
+    let account = ctx.managed_wallet.first_bip44_managed_account_mut().expect("BIP44 account");
+    let sweep = account.drop_conflicted_transactions(&winner, &winner_ctx);
+    assert!(sweep.txids.contains(&funding.txid()), "the funding transaction is the loser here");
+    assert!(
+        account.spent_before_funded.is_empty(),
+        "a funding transaction dropped as a conflict loser must not leave its output behind"
     );
 }
 

--- a/key-wallet/src/transaction_checking/account_checker.rs
+++ b/key-wallet/src/transaction_checking/account_checker.rs
@@ -696,7 +696,11 @@ impl ManagedCoreFundsAccount {
         // Check inputs (sent) - rely on tracked UTXOs to determine spends
         if !tx.is_coin_base() {
             for input in &tx.input {
-                if let Some(utxo) = self.utxos.get(&input.previous_output) {
+                if let Some(utxo) = self
+                    .utxos
+                    .get(&input.previous_output)
+                    .or_else(|| self.spent_before_funded.get(&input.previous_output))
+                {
                     sent = sent.saturating_add(utxo.txout.value);
 
                     if let Some(address_info) = self.get_address_info(&utxo.address) {


### PR DESCRIPTION
Two syncs of the same wallet over the same chain ended with different sets of transactions while agreeing to the satoshi on the balance. Ten mainnet restores settled on three different answers — 6722, 6732 and 6745 transactions — and the divergence ran in both directions: each run knew transactions the others did not.

Relevance by input is computed over the live `utxos`, and #649 deliberately never inserts an output whose spend was already observed: the coin is genuinely spent on chain, so the balance must not count it. The two combine badly. When a block is applied before the block that funds one of the outpoints it spends — routine, since a rescan queues a funding block only once a later block derives the address it pays — the spend matches nothing on arrival, `update_utxos` then skips the funding output, and the account never learns the coin was ever its own. Every later delivery of the spending block asks the same question against the same empty `utxos` and gets the same answer, so the transaction drops out of history for good.

The balance stays right throughout, which is what made this invisible: `record_observed_spends` had already noted the outpoint, so the coin is treated as spent no matter which order the blocks arrive in. Only the record is lost.

Measured on one restore: 405 outputs skipped this way, 404 of them with the funding block below the spend in height, i.e. delivered after it. Blocks were seen to match on their first delivery and report nothing on every later one — 99 of them in a single run, with another 306 matching less than they first did.

`spent_before_funded` keeps such an output as ours without putting it back in `utxos`, and input matching falls back to it. The whole `Utxo` rather than the bare outpoint: matching needs the value and the address to compute `sent` and the involved addresses, or the recovered record carries empty amounts. Entries are dropped once the spend is recorded, so the map holds only what is still outstanding.

Eight consecutive mainnet restores now return the same 6787 transactions, where the same wallet previously split three ways. Against the best previous run: 65 transactions recovered, none lost — strictly a superset. The balance is unchanged at 14114383 sat across every run before and after. The #649 skips themselves still vary run to run (290 to 339), so block ordering is as non-deterministic as it ever was; what no longer depends on it is the result

Closes #897

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction tracking when a spend is received before its funding transaction.
  * Spends are now correctly recognized and recorded in transaction history without incorrectly adding funds to the wallet balance.
  * Improved handling of redelivered spend transactions for more accurate UTXO and balance reporting.
  * Removed stale transaction data after abandoning a funding transaction or losing a transaction conflict.
  * Ensured outgoing transaction records retain complete input details in these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->