### PR TITLE
fix(dash-spv): make backward coverage durable by rewinding synced_height instead of sweeping in memory

### DIFF
--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -110,6 +110,11 @@ pub(super) struct CallbackTracker {
 
     // Completion tracking
     pub(super) last_sync_cycle: AtomicU32,
+    /// Cycle number of the FIRST `on_sync_complete`. A wallet that derives
+    /// scripts while scanning is followed by a backward-coverage re-walk,
+    /// which completes as a further cycle, so `last_sync_cycle` is not the
+    /// initial one for such wallets.
+    pub(super) first_sync_cycle: AtomicU32,
 
     // Baseline for `wait_for_sync`: captured before the client starts so that
     // a SyncComplete firing between client start and `wait_for_sync` entry is
@@ -346,7 +351,9 @@ extern "C" fn on_sync_complete(header_tip: u32, cycle: u32, user_data: *mut c_vo
     tracker.last_sync_cycle.store(cycle, Ordering::SeqCst);
     let seq = tracker.sequence_counter.fetch_add(1, Ordering::SeqCst);
     tracker.sync_complete_seq.store(seq, Ordering::SeqCst);
-    tracker.sync_complete_count.fetch_add(1, Ordering::SeqCst);
+    if tracker.sync_complete_count.fetch_add(1, Ordering::SeqCst) == 0 {
+        tracker.first_sync_cycle.store(cycle, Ordering::SeqCst);
+    }
     tracing::info!("on_sync_complete: header_tip={}, cycle={}, seq={}", header_tip, cycle, seq);
 }
 

--- a/dash-spv-ffi/tests/dashd_sync/callbacks.rs
+++ b/dash-spv-ffi/tests/dashd_sync/callbacks.rs
@@ -3,7 +3,7 @@
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 use std::slice;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -42,8 +42,13 @@ pub(super) struct CallbackTracker {
     pub(super) block_processed_wallet_count: AtomicU32,
     pub(super) block_processed_wallet_record_count: AtomicU32,
     pub(super) synced_height_updated_count: AtomicU32,
-    /// Highest synced-height value observed from any `SyncedHeightUpdated`.
+    /// The most recent synced-height value from `SyncedHeightUpdated`. Not
+    /// monotonic: backward coverage rewinds a wallet's checkpoint and reports
+    /// the lower value through this same callback.
     pub(super) last_synced_height: AtomicU32,
+    /// Set the first time a `SyncedHeightUpdated` reports a height BELOW one
+    /// already reported — the observable signature of that rewind.
+    pub(super) synced_height_rewound: AtomicBool,
 
     // Data from callbacks
     pub(super) last_header_tip: AtomicU32,
@@ -574,7 +579,10 @@ extern "C" fn on_sync_height_advanced(
     // Store the height before bumping the counter so a test that waits on the
     // counter and then reads `last_synced_height` is guaranteed to observe the
     // height for the same callback invocation.
-    tracker.last_synced_height.store(height, Ordering::SeqCst);
+    let previous = tracker.last_synced_height.swap(height, Ordering::SeqCst);
+    if height < previous {
+        tracker.synced_height_rewound.store(true, Ordering::SeqCst);
+    }
     tracker.synced_height_updated_count.fetch_add(1, Ordering::SeqCst);
     let wallet_str = unsafe { cstr_or_unknown(wallet_id) };
     tracing::info!("on_sync_height_advanced: wallet={}, height={}", wallet_str, height);

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -146,16 +146,33 @@ fn test_all_callbacks_during_sync() {
         // so observing block-processed records does not guarantee it has fired yet.
         tracker.wait_for_callback(&tracker.synced_height_updated_count, 0, "synced_height_updated");
         let synced_height_fired = tracker.synced_height_updated_count.load(Ordering::SeqCst);
-        let last_synced_height = tracker.last_synced_height.load(Ordering::SeqCst);
         assert!(
             synced_height_fired > 0,
             "on_synced_height_updated should fire at least once during sync"
         );
-        assert!(
-            last_synced_height >= dashd.initial_height,
-            "last_synced_height ({}) should be at least initial_height ({}) after sync",
-            last_synced_height,
-            dashd.initial_height
+        // The callback is not monotonic: scripts derived during the scan are
+        // covered by rewinding the wallet's checkpoint and re-walking
+        // committed history (backward coverage), and the rewind is reported
+        // through this same callback. Wait for the re-walk to bring the
+        // reported height back to the tip instead of sampling it once.
+        let synced_deadline = std::time::Instant::now() + Duration::from_secs(60);
+        let last_synced_height = loop {
+            let h = tracker.last_synced_height.load(Ordering::SeqCst);
+            if h >= dashd.initial_height {
+                break h;
+            }
+            assert!(
+                std::time::Instant::now() < synced_deadline,
+                "last_synced_height ({}) did not reach initial_height ({}) within 60s",
+                h,
+                dashd.initial_height
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        };
+        tracing::info!(
+            "SyncedHeightUpdated: fired {} time(s), last {}",
+            synced_height_fired,
+            last_synced_height
         );
 
         // Validate sync cycle (initial sync is cycle 0)

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -175,9 +175,21 @@ fn test_all_callbacks_during_sync() {
             last_synced_height
         );
 
-        // Validate sync cycle (initial sync is cycle 0)
-        let last_sync_cycle = tracker.last_sync_cycle.load(Ordering::SeqCst);
-        assert_eq!(last_sync_cycle, 0, "Initial sync should be cycle 0");
+        // Validate sync cycle (initial sync is cycle 0). This wallet has
+        // transactions, so the scan derives scripts and a backward-coverage
+        // re-walk follows, completing as a later cycle — check the first
+        // completion, not the last.
+        assert!(
+            tracker.sync_complete_count.load(Ordering::SeqCst) > 0,
+            "on_sync_complete should have fired"
+        );
+        let first_sync_cycle = tracker.first_sync_cycle.load(Ordering::SeqCst);
+        assert_eq!(first_sync_cycle, 0, "Initial sync should be cycle 0");
+        tracing::info!(
+            "Sync cycles: first={}, last={}",
+            first_sync_cycle,
+            tracker.last_sync_cycle.load(Ordering::SeqCst)
+        );
 
         // Validate callback lifecycle ordering
         let sync_start_seq = tracker.sync_start_seq.load(Ordering::SeqCst);

--- a/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
+++ b/dash-spv-ffi/tests/dashd_sync/tests_callback.rs
@@ -155,15 +155,24 @@ fn test_all_callbacks_during_sync() {
         // committed history (backward coverage), and the rewind is reported
         // through this same callback. Wait for the re-walk to bring the
         // reported height back to the tip instead of sampling it once.
+        // Two conditions, not one: the checkpoint must be seen going DOWN
+        // (the rewind itself) and then coming back to the tip (the re-walk
+        // that follows it). Waiting only for the tip would be satisfied by
+        // the value already stored before the rewind ever happened, so the
+        // whole backward-coverage path could be dead and this test would
+        // still pass.
         let synced_deadline = std::time::Instant::now() + Duration::from_secs(60);
         let last_synced_height = loop {
             let h = tracker.last_synced_height.load(Ordering::SeqCst);
-            if h >= dashd.initial_height {
+            let rewound = tracker.synced_height_rewound.load(Ordering::SeqCst);
+            if rewound && h >= dashd.initial_height {
                 break h;
             }
             assert!(
                 std::time::Instant::now() < synced_deadline,
-                "last_synced_height ({}) did not reach initial_height ({}) within 60s",
+                "backward coverage did not complete within 60s: rewind observed={}, \
+                 last_synced_height={} (initial_height={})",
+                rewound,
                 h,
                 dashd.initial_height
             );

--- a/dash-spv/src/sync/filters/coinjoin_gap_discovery_tests.rs
+++ b/dash-spv/src/sync/filters/coinjoin_gap_discovery_tests.rs
@@ -345,6 +345,11 @@ async fn coinjoin_gap_limit_inversion_within_batch_recovers() {
 /// flow through the `track_for_new_scripts` re-download path to the same
 /// commit-time fixpoint. `highest_used` reaches G+21.
 #[tokio::test]
+#[ignore = "LOCAL DIAGNOSTIC BUILD: backward coverage now happens through a \
+synced_height rewind picked up by the sync-manager tick (durable re-walk), \
+not the in-manager sweep this harness can observe — the tick never runs \
+here, so recovery cannot complete inside this test. Field-verified instead; \
+un-ignore when reverting to the sweep."]
 async fn coinjoin_gap_limit_stall_across_committed_batch() {
     let (mut manager, wallet, wallet_id) = setup().await;
     let addresses = coinjoin_external_addresses(&wallet, &wallet_id, (G + 22) as u32).await;
@@ -436,6 +441,10 @@ async fn coinjoin_gap_limit_stall_across_committed_batch() {
 /// applied. `committed_range_sweeps` counts sweeps that reach the chunk walk
 /// in `rescan_committed_range`.
 #[tokio::test]
+#[ignore = "LOCAL DIAGNOSTIC BUILD: the tail batch now commits before the \
+sweep's blocks drain (see try_commit_batches), so the 'sweep completes before \
+FiltersSyncComplete' invariant this test asserts is deliberately relaxed on \
+this branch. Upstream keeps the invariant; un-ignore when reverting."]
 async fn committed_range_sweep_coalesces_across_batch_commits() {
     let (mut manager, wallet, wallet_id) = setup().await;
     let addresses = coinjoin_external_addresses(&wallet, &wallet_id, (G + 22) as u32).await;

--- a/dash-spv/src/sync/filters/coinjoin_gap_discovery_tests.rs
+++ b/dash-spv/src/sync/filters/coinjoin_gap_discovery_tests.rs
@@ -50,6 +50,7 @@ use key_wallet::account::ManagedAccountTrait;
 use key_wallet::gap_limit::DEFAULT_COINJOIN_GAP_LIMIT;
 use key_wallet::managed_account::address_pool::{AddressPool, AddressPoolType, KeySource};
 use key_wallet::wallet::initialization::WalletAccountCreationOptions;
+use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet_manager::WalletManager;
 use tokio::sync::mpsc::unbounded_channel;
@@ -325,32 +326,25 @@ async fn coinjoin_gap_limit_inversion_within_batch_recovers() {
     );
 }
 
-/// Gap-window outputs in an already-COMMITTED batch (#846).
+/// Backward coverage across a committed batch is a durable rewind, not an
+/// in-memory sweep.
 ///
-/// Same funding shape as the within-batch inversion test, but the early
-/// block (indices G+10..=G+21, height 10) sits in batch 0..=99 while the
-/// in-window block (indices 0..=29) sits at height 110 in batch 100..=199.
-/// Batch 0 scans clean (nothing watched matches) and commits. Processing the
-/// height-110 block extends the window past G+21, and those scripts DO match
-/// block 10's filter — but `rescan_batch` only reaches `active_batches`, and
-/// committed batches are gone (`try_commit_batches` removes them; the
-/// tracker prunes at-or-below the committed height). Indices G+10..=G+21 —
-/// squarely inside the BIP-44/CoinJoin gap-limit recovery contract
-/// (G+21 < 29 + 1 + G) — used to stay invisible forever, along with their
-/// funds; a fresh re-sync from genesis hit the same wall deterministically.
+/// Block A (height 10, batch 0) funds CoinJoin External indices G+10..=G+21,
+/// beyond the initial gap window; block B (height 110, batch 1) funds
+/// 0..=29 and its processing derives the scripts that would have matched
+/// block A — after batch 0 has already committed. At the forward drain the
+/// manager must not sweep the committed range in memory (an iOS suspension
+/// drops such a sweep whole) but rewind the wallet's `synced_height` so the
+/// sync-manager tick re-walks committed history in persisted batches, and
+/// it must NOT declare the filters complete while that re-walk is pending:
+/// one "synced" cycle with the walk still to run is exactly what the host
+/// would mistake for a caught-up wallet. Once the wallet is back at the
+/// committed frontier, completion is emitted.
 ///
-/// GREEN since `rescan_committed_range`: newly derived scripts are re-tested
-/// against the persisted filters below the committing batch (BIP-158 filters
-/// are address-independent, so re-matching needs no re-download), and hits
-/// flow through the `track_for_new_scripts` re-download path to the same
-/// commit-time fixpoint. `highest_used` reaches G+21.
+/// The tick itself does not run in this harness, so the re-walk is
+/// represented by advancing the wallet's checkpoint by hand.
 #[tokio::test]
-#[ignore = "LOCAL DIAGNOSTIC BUILD: backward coverage now happens through a \
-synced_height rewind picked up by the sync-manager tick (durable re-walk), \
-not the in-manager sweep this harness can observe — the tick never runs \
-here, so recovery cannot complete inside this test. Field-verified instead; \
-un-ignore when reverting to the sweep."]
-async fn coinjoin_gap_limit_stall_across_committed_batch() {
+async fn backward_coverage_rewinds_and_holds_completion_until_rewalked() {
     let (mut manager, wallet, wallet_id) = setup().await;
     let addresses = coinjoin_external_addresses(&wallet, &wallet_id, (G + 22) as u32).await;
 
@@ -397,29 +391,42 @@ async fn coinjoin_gap_limit_stall_across_committed_batch() {
     let initial_events = manager.try_process_batch().await.unwrap();
     drive_to_quiescence(&mut manager, &wallet, &blocks, initial_events).await;
 
-    let (highest_used, highest_generated, used_count) =
-        coinjoin_pool_state(&wallet, &wallet_id).await;
-    // Sanity: the in-window block was found and the gap window extended past
-    // index G+21, so the missed indices ARE inside the watched range by now.
+    let (_, highest_generated, _) = coinjoin_pool_state(&wallet, &wallet_id).await;
     assert!(
         highest_generated >= Some((G + 21) as u32),
         "gap maintenance must have extended the watch window past index G+21 \
          (got {highest_generated:?})"
     );
+
+    // The drain rewound the wallet to its own floor instead of sweeping.
+    let (synced_height, birth_height) = {
+        let reader = wallet.read().await;
+        let info = reader.get_wallet_info(&wallet_id).expect("wallet info");
+        (info.synced_height(), info.birth_height())
+    };
     assert_eq!(
-        highest_used,
-        Some((G + 21) as u32),
-        "CoinJoin External indices G+10..=G+21 were funded at height 10 in a batch that \
-         committed before their scripts were derived, and the new-script rescan never \
-         looks below the committed boundary (rescan_batch only reaches active_batches; \
-         BlockMatchTracker/commit pruning drops the range). The addresses are within \
-         the gap-limit recovery contract and are watched now (highest_generated = \
-         {highest_generated:?}), yet their outputs stay invisible: highest_used stalls \
-         at {highest_used:?}, used_count={used_count}. Fix direction: key re-scan \
-         suppression by (wallet, address/script) instead of block/commit progress, or \
-         trigger a below-committed-height rescan for a wallet whose gap maintenance \
-         derives scripts mid-sync."
+        synced_height,
+        birth_height.saturating_sub(1),
+        "wallet synced_height must be rewound to birth_height - 1 for the durable re-walk"
     );
+    assert!(manager.rewalk_pending().await, "a re-walk must be pending after the rewind");
+    assert_eq!(
+        manager.state(),
+        SyncState::Syncing,
+        "filters must not be declared complete while a rewound wallet is below the frontier"
+    );
+
+    // Stand in for the tick's re-walk: the wallet catches up to the
+    // committed frontier. Only now may the filters complete.
+    let committed = manager.progress.committed_height();
+    wallet.write().await.update_wallet_synced_height(&wallet_id, committed);
+    assert!(!manager.rewalk_pending().await);
+    let events = manager.try_process_batch().await.unwrap();
+    assert!(
+        events.iter().any(|e| matches!(e, SyncEvent::FiltersSyncComplete { .. })),
+        "FiltersSyncComplete must be emitted once the rewound wallet has caught up"
+    );
+    assert_eq!(manager.state(), SyncState::Synced);
 }
 
 /// Committed-range sweeps coalesce across batch commits.
@@ -441,10 +448,11 @@ async fn coinjoin_gap_limit_stall_across_committed_batch() {
 /// applied. `committed_range_sweeps` counts sweeps that reach the chunk walk
 /// in `rescan_committed_range`.
 #[tokio::test]
-#[ignore = "LOCAL DIAGNOSTIC BUILD: the tail batch now commits before the \
-sweep's blocks drain (see try_commit_batches), so the 'sweep completes before \
-FiltersSyncComplete' invariant this test asserts is deliberately relaxed on \
-this branch. Upstream keeps the invariant; un-ignore when reverting."]
+#[ignore = "backward coverage no longer sweeps the committed range in the \
+manager; it rewinds the wallet and the sync-manager tick re-walks, which this \
+harness cannot drive. The coalescing this test measured has no counterpart \
+now — see backward_coverage_rewinds_and_holds_completion_until_rewalked for \
+the contract that replaced it. Remove together with rescan_committed_range."]
 async fn committed_range_sweep_coalesces_across_batch_commits() {
     let (mut manager, wallet, wallet_id) = setup().await;
     let addresses = coinjoin_external_addresses(&wallet, &wallet_id, (G + 22) as u32).await;

--- a/dash-spv/src/sync/filters/coinjoin_gap_discovery_tests.rs
+++ b/dash-spv/src/sync/filters/coinjoin_gap_discovery_tests.rs
@@ -202,11 +202,14 @@ async fn drive_to_quiescence(
     wallet: &Arc<RwLock<WalletManager<ManagedWalletInfo>>>,
     blocks: &HashMap<BlockHash, Block>,
     initial_events: Vec<SyncEvent>,
-) {
+) -> Vec<SyncEvent> {
     let (tx, _rx) = unbounded_channel();
     let requests = RequestSender::new(tx);
 
     let mut events = initial_events;
+    // Everything the run emitted that was not a block request — the caller's
+    // window into completion, which is otherwise consumed here.
+    let mut observed = Vec::new();
     for _round in 0..64 {
         let mut pending: BTreeMap<(u32, BlockHash), BTreeSet<WalletId>> = BTreeMap::new();
         for event in events.drain(..) {
@@ -217,10 +220,12 @@ async fn drive_to_quiescence(
                 for (key, wallets) in needed {
                     pending.entry((key.height(), *key.hash())).or_default().extend(wallets);
                 }
+            } else {
+                observed.push(event);
             }
         }
         if pending.is_empty() {
-            return;
+            return observed;
         }
 
         let mut next_events = Vec::new();
@@ -361,9 +366,11 @@ async fn backward_coverage_rewinds_and_holds_completion_until_rewalked() {
     {
         let mut header_storage = manager.header_storage.write().await;
         let mut filter_storage = manager.filter_storage.write().await;
-        for height in 0..=99u32 {
+        for height in 0..=199u32 {
             let (header, filter_bytes) = if height == 10 {
                 (block_a.header, filter_a.content.clone())
+            } else if height == 110 {
+                (block_b.header, filter_b.content.clone())
             } else {
                 let filler = Block::dummy(height, vec![]);
                 let filter = BlockFilter::dummy(&filler);
@@ -387,6 +394,12 @@ async fn backward_coverage_rewinds_and_holds_completion_until_rewalked() {
     batch_1.mark_verified();
     manager.active_batches.insert(100, batch_1);
     manager.progress.update_stored_height(199);
+    // The re-walk below re-enters `start_download`, which scans against the
+    // filter-header frontier rather than the injected batches. Without a tip
+    // it takes the "nothing to download" early return and the rescan is a
+    // silent no-op — which is precisely the failure this test must not miss.
+    manager.progress.update_filter_header_tip_height(199);
+    manager.progress.update_target_height(199);
 
     let initial_events = manager.try_process_batch().await.unwrap();
     drive_to_quiescence(&mut manager, &wallet, &blocks, initial_events).await;
@@ -416,15 +429,60 @@ async fn backward_coverage_rewinds_and_holds_completion_until_rewalked() {
         "filters must not be declared complete while a rewound wallet is below the frontier"
     );
 
-    // Stand in for the tick's re-walk: the wallet catches up to the
-    // committed frontier. Only now may the filters complete.
-    let committed = manager.progress.committed_height();
-    wallet.write().await.update_wallet_synced_height(&wallet_id, committed);
-    assert!(!manager.rewalk_pending().await);
-    let events = manager.try_process_batch().await.unwrap();
+    // Block A's outputs are still missing at this point — the rewind exists
+    // to recover them, so the re-walk below has real work to do.
+    let (highest_used_before, _, _) = coinjoin_pool_state(&wallet, &wallet_id).await;
     assert!(
-        events.iter().any(|e| matches!(e, SyncEvent::FiltersSyncComplete { .. })),
-        "FiltersSyncComplete must be emitted once the rewound wallet has caught up"
+        highest_used_before < Some((G + 10) as u32),
+        "block A's beyond-window outputs must still be unapplied before the re-walk \
+         (highest_used={highest_used_before:?})"
+    );
+
+    // Drive the real re-walk, not a stand-in: the tick is what notices a
+    // wallet below the committed frontier, restarts the scan at its rewound
+    // checkpoint, and re-requests the blocks whose filters match the scripts
+    // derived since. Feeding those blocks back through the wallet is the
+    // blocks-manager's job, which `drive_to_quiescence` performs.
+    let (tx, _rx) = unbounded_channel();
+    let requests = RequestSender::new(tx);
+    let mut sync_complete_seen = false;
+    for _round in 0..64 {
+        let events = manager.tick(&requests).await.expect("tick");
+        let quiesced = events.is_empty();
+        let observed = drive_to_quiescence(&mut manager, &wallet, &blocks, events).await;
+        for event in observed {
+            if let SyncEvent::FiltersSyncComplete {
+                ..
+            } = event
+            {
+                // Completion is only honest once the re-walk has applied what
+                // it was rewound to find.
+                let (highest_used, _, _) = coinjoin_pool_state(&wallet, &wallet_id).await;
+                assert_eq!(
+                    highest_used,
+                    Some((G + 21) as u32),
+                    "FiltersSyncComplete was emitted before the re-walk recovered block A"
+                );
+                sync_complete_seen = true;
+            }
+        }
+        if !manager.rewalk_pending().await && quiesced {
+            break;
+        }
+    }
+
+    let (highest_used, _, used_count) = coinjoin_pool_state(&wallet, &wallet_id).await;
+    assert_eq!(
+        highest_used,
+        Some((G + 21) as u32),
+        "the re-walk must recover block A's beyond-window outputs (used_count={used_count})"
+    );
+    assert_eq!(used_count, 30 + 12, "indices 0..=29 and G+10..=G+21 must all be marked used");
+
+    assert!(!manager.rewalk_pending().await, "the re-walk must have completed");
+    assert!(
+        sync_complete_seen,
+        "FiltersSyncComplete must be emitted once the rewound wallet has been re-walked"
     );
     assert_eq!(manager.state(), SyncState::Synced);
 }
@@ -449,10 +507,11 @@ async fn backward_coverage_rewinds_and_holds_completion_until_rewalked() {
 /// in `rescan_committed_range`.
 #[tokio::test]
 #[ignore = "backward coverage no longer sweeps the committed range in the \
-manager; it rewinds the wallet and the sync-manager tick re-walks, which this \
-harness cannot drive. The coalescing this test measured has no counterpart \
-now — see backward_coverage_rewinds_and_holds_completion_until_rewalked for \
-the contract that replaced it. Remove together with rescan_committed_range."]
+manager; it rewinds the wallet and the sync-manager tick re-walks it. The \
+per-commit coalescing this test measured has no counterpart now — see \
+backward_coverage_rewinds_and_holds_completion_until_rewalked, which drives \
+that re-walk through the tick and asserts the same recovery. Remove together \
+with rescan_committed_range."]
 async fn committed_range_sweep_coalesces_across_batch_commits() {
     let (mut manager, wallet, wallet_id) = setup().await;
     let addresses = coinjoin_external_addresses(&wallet, &wallet_id, (G + 22) as u32).await;

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -594,6 +594,14 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
     async fn try_commit_batches(&mut self) -> SyncResult<Vec<SyncEvent>> {
         let mut events = Vec::new();
 
+        // Wallets whose synced_height was rewound this pass for backward
+        // coverage (see the forward-drained branch). Their commit-time
+        // advance below is skipped: advancing them to the batch end would
+        // both undo the in-memory rewind and race the persisted checkpoint
+        // back up to tip, losing the re-walk across a restart.
+        let mut rewound_wallets: std::collections::HashSet<WalletId> =
+            std::collections::HashSet::new();
+
         // Lowest height any scan can ever reach. Read once, before the wallet
         // write lock below, so header storage is never locked underneath it.
         let scan_floor = self.header_storage.read().await.get_start_height().await.unwrap_or(0);
@@ -670,15 +678,55 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                     });
                 if forward_drained && !self.backward_scripts.is_empty() {
                     let backward_scripts = std::mem::take(&mut self.backward_scripts);
-                    events
-                        .extend(self.rescan_committed_range(batch_start, &backward_scripts).await?);
 
-                    // Check if the backward sweep found more blocks
-                    if let Some(batch) = self.active_batches.get(&batch_start) {
-                        if batch.pending_blocks() > 0 {
-                            // Found more blocks, can't commit yet
-                            break;
+                    // LOCAL BUILD: durable backward coverage via a persisted
+                    // checkpoint rewind, replacing the in-memory monolithic
+                    // sweep (`rescan_committed_range`).
+                    //
+                    // The sweep held three losing properties on a large
+                    // restored wallet: it ran minutes of silent compute
+                    // inside this task, it charged tens of thousands of
+                    // BIP-158 false-positive downloads to this batch's
+                    // commit gate, and every bit of it lived in memory — an
+                    // iOS suspension eight seconds after "synced" was
+                    // observed to drop 28,616 queued blocks irrecoverably.
+                    //
+                    // The scripts are already in the wallet's watch set
+                    // (deriving them is what put them in `backward_scripts`),
+                    // so backward coverage is exactly "re-walk committed
+                    // history with the enlarged set". The existing
+                    // wallet-behind restart does that durably: rewinding the
+                    // wallet's synced_height makes the next tick restart the
+                    // batch scan, which re-commits (and re-persists) progress
+                    // every BATCH_PROCESSING_SIZE filters. The persisted
+                    // checkpoint applies verbatim on the app side, so a
+                    // suspension mid-walk resumes from the last committed
+                    // batch instead of losing the debt. Already-stored blocks
+                    // are served from storage on the re-walk, so completed
+                    // work is not re-downloaded.
+                    let script_count: usize =
+                        backward_scripts.values().map(|scripts| scripts.len()).sum();
+                    // One floor for every wallet: the earliest height any of
+                    // them requires. The restart tick clamps its actual
+                    // resume point to the birth/storage floor anyway, so a
+                    // conservative target here only ever means "re-walk from
+                    // the beginning of what is locally scannable".
+                    let wallet_base = self.wallet.read().await.earliest_required_height().await;
+                    let target = wallet_base.saturating_sub(1);
+                    let mut wallet = self.wallet.write().await;
+                    for wallet_id in backward_scripts.keys() {
+                        if target < wallet.wallet_synced_height(wallet_id) {
+                            wallet.rewind_wallet_synced_height(wallet_id, target);
+                            rewound_wallets.insert(*wallet_id);
                         }
+                    }
+                    drop(wallet);
+                    if !rewound_wallets.is_empty() {
+                        tracing::info!(
+                            "Backward coverage: {} new script(s) across {} wallet(s) — rewound their synced_height for a durable re-walk of committed history",
+                            script_count,
+                            rewound_wallets.len()
+                        );
                     }
                 }
                 // Mark rescan as complete
@@ -729,6 +777,15 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                         let effective_synced = wallet
                             .wallet_synced_height(wallet_id)
                             .max(scan_floor.saturating_sub(1));
+                        // A wallet rewound this pass for backward coverage
+                        // must not be re-advanced by the very commit that
+                        // triggered the rewind. The contiguity guard below
+                        // already refuses (its synced_height now sits far
+                        // under `batch_start`), but the intent deserves to
+                        // be explicit rather than a side effect.
+                        if rewound_wallets.contains(wallet_id) {
+                            continue;
+                        }
                         if effective_synced.saturating_add(1) >= batch_start {
                             wallet.update_wallet_synced_height(wallet_id, end);
                             // A committed batch certifies the whole range for
@@ -1182,6 +1239,11 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
     /// filter elements — since those were already watched when the range
     /// was originally scanned; including them would re-download previously
     /// processed blocks across the whole history.
+    // LOCAL BUILD: unused — the forward-drained branch now rewinds the
+    // wallets' synced_height instead (durable re-walk through the existing
+    // batch pipeline). Kept, with its chunk-progress logging, as the
+    // reference implementation for the upstream discussion.
+    #[allow(dead_code)]
     pub(super) async fn rescan_committed_range(
         &mut self,
         batch_start: u32,
@@ -1211,11 +1273,19 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
             return Ok(vec![]);
         }
 
+        // The script count is what makes a sweep's block count readable: these
+        // scripts are the raw accumulated set, so a large count here is the
+        // expected cause of a BIP-158 false-positive block count far above the
+        // wallet's real history. Without it the two are indistinguishable in a
+        // log.
+        let script_count: usize = wallet_queries.iter().map(|(_, scripts)| scripts.len()).sum();
+
         self.committed_range_sweeps += 1;
         tracing::info!(
-            "Rescan committed filters ({}-{}) for new scripts across {} wallets (sweep #{})",
+            "Rescan committed filters ({}-{}) for {} new scripts across {} wallets (sweep #{})",
             range_start,
             range_end,
+            script_count,
             wallet_queries.len(),
             self.committed_range_sweeps
         );
@@ -1248,6 +1318,21 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                 }
             }
             chunk_start = chunk_end + 1;
+
+            // The sweep over a large committed range runs for minutes; without
+            // a heartbeat it is indistinguishable from a hang (and gets the
+            // app killed, losing the whole pass). Log roughly every 250k
+            // filters, and yield so this long-running turn does not pin its
+            // runtime worker.
+            if (chunk_start - range_start) % 250_000 < BATCH_PROCESSING_SIZE {
+                tracing::info!(
+                    "Committed-range rescan progress: {}/{} filters checked, {} matched so far",
+                    chunk_start - range_start,
+                    range_end - range_start + 1,
+                    block_to_wallets.len()
+                );
+            }
+            tokio::task::yield_now().await;
         }
 
         Ok(self.queue_new_script_matches(batch_start, block_to_wallets, "Committed-range rescan"))

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -561,7 +561,18 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         // If no active batches and all filters downloaded, emit FiltersSyncComplete.
         // This handles both initial sync (Syncing → Synced transition) and incremental
         // updates (already Synced, signal BlocksManager that no more blocks are coming).
+        //
+        // Not while a wallet sits below the committed frontier: a wallet
+        // rewound for backward coverage at the last commit (or one added
+        // behind the scan) still has committed history to re-walk, and the
+        // tick restarts the scan for it. Declaring the filters complete here
+        // would report one "synced" cycle with that walk still pending — the
+        // host would treat the wallet as caught up, and a transaction in the
+        // tip block would land only once the walk reaches it. Holding the
+        // state at Syncing means a single completion, after the re-walk.
+        let wallet_behind_frontier = self.rewalk_pending().await;
         if self.active_batches.is_empty()
+            && !wallet_behind_frontier
             && matches!(self.state(), SyncState::Syncing | SyncState::Synced)
             && self.progress.committed_height() >= self.progress.filter_header_tip_height()
             && self.progress.committed_height() >= self.progress.target_height()
@@ -588,6 +599,28 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
         }
 
         Ok(events)
+    }
+
+    /// Whether the sync-manager tick will restart the scan for a wallet that
+    /// sits below the committed frontier. Mirrors that tick's test exactly
+    /// (`FilterSyncManager::tick`: the lowest stale `synced_height` + 1,
+    /// floored at the wallets' birth height and the stored headers' start,
+    /// must reach the committed frontier) so that a wallet which reports a
+    /// low checkpoint yet needs nothing below the floor neither restarts
+    /// the scan there nor holds completion here.
+    pub(super) async fn rewalk_pending(&self) -> bool {
+        let committed = self.progress.committed_height();
+        let wallet_read = self.wallet.read().await;
+        let behind = wallet_read.wallets_behind(committed);
+        let stale_min_synced = behind.iter().map(|id| wallet_read.wallet_synced_height(id)).min();
+        let birth_height = wallet_read.earliest_required_height().await;
+        drop(wallet_read);
+        let Some(stale_min_synced) = stale_min_synced else {
+            return false;
+        };
+        let scan_floor = birth_height
+            .max(self.header_storage.read().await.get_start_height().await.unwrap_or(0));
+        stale_min_synced.saturating_add(1).max(scan_floor) <= committed
     }
 
     /// Commit completed batches in order (lowest batch_start first).

--- a/dash-spv/src/sync/filters/manager.rs
+++ b/dash-spv/src/sync/filters/manager.rs
@@ -748,9 +748,31 @@ impl<H: BlockHeaderStorage, FH: FilterHeaderStorage, F: FilterStorage, W: Wallet
                     let target = wallet_base.saturating_sub(1);
                     let mut wallet = self.wallet.write().await;
                     for wallet_id in backward_scripts.keys() {
-                        if target < wallet.wallet_synced_height(wallet_id) {
-                            wallet.rewind_wallet_synced_height(wallet_id, target);
+                        let before = wallet.wallet_synced_height(wallet_id);
+                        if target >= before {
+                            continue;
+                        }
+                        wallet.rewind_wallet_synced_height(wallet_id, target);
+                        // Read the checkpoint back instead of assuming the
+                        // rewind landed. `rewind_wallet_synced_height` returns
+                        // nothing and defaults to a no-op, so an implementation
+                        // that predates backward coverage would otherwise have
+                        // its commit-time advance skipped below on the strength
+                        // of a call that did nothing — stranding this batch's
+                        // certified coverage with no re-walk to replace it. A
+                        // rewind clamped up to the wallet's own floor still
+                        // sits under `before`, so it counts as what it is.
+                        if wallet.wallet_synced_height(wallet_id) < before {
                             rewound_wallets.insert(*wallet_id);
+                        } else {
+                            tracing::warn!(
+                                "Backward coverage: wallet {} did not honor the rewind to {} (still at {}); \
+                                 committing its coverage forward instead — scripts derived after this range \
+                                 committed stay untested against it",
+                                hex::encode(wallet_id),
+                                target,
+                                before
+                            );
                         }
                     }
                     drop(wallet);

--- a/dash-spv/tests/dashd_sync/tests_multi_wallet.rs
+++ b/dash-spv/tests/dashd_sync/tests_multi_wallet.rs
@@ -425,6 +425,8 @@ async fn test_runtime_add_during_initial_sync() {
     }
 
     let (w1_synced_at_add, w1_processed_at_add) = wallet_heights(&wallet, &w1_id).await;
+    let w1_birth_height =
+        wallet.read().await.get_wallet_info(&w1_id).expect("wallet info").birth_height();
     assert!(
         w1_synced_at_add < initial_height,
         "W1 must be in mid-flight at the moment W2 is added (synced_height={}, tip={})",
@@ -443,11 +445,17 @@ async fn test_runtime_add_during_initial_sync() {
     loop {
         let (w1_synced_now, w1_processed_now) = wallet_heights(&wallet, &w1_id).await;
         let (w2_synced_now, _) = wallet_heights(&wallet, &w2_id).await;
+        // W1's synced_height may legitimately drop below its add-time value:
+        // scripts W1 derives while scanning are covered by rewinding its
+        // checkpoint and re-walking committed history (backward coverage),
+        // and that rewind is persisted. What must hold is that it never goes
+        // under W1's own start — W2's lower birth height must not drag it
+        // there — and that it converges to the tip below.
         assert!(
-            w1_synced_now >= w1_synced_at_add,
-            "W1 synced_height regressed during mid-flight rescan: {} -> {}",
-            w1_synced_at_add,
+            w1_synced_now + 1 >= w1_birth_height,
+            "W1 synced_height rewound below its own birth height: {} (birth {})",
             w1_synced_now,
+            w1_birth_height,
         );
         assert!(
             w1_processed_now >= w1_processed_at_add,

--- a/key-wallet-manager/src/event_tests.rs
+++ b/key-wallet-manager/src/event_tests.rs
@@ -1270,6 +1270,81 @@ async fn test_update_wallet_synced_height_does_not_re_emit_when_unchanged() {
     );
 }
 
+#[tokio::test]
+async fn test_rewind_wallet_synced_height_lowers_and_emits() {
+    let (mut manager, wallet_id, _addr) = setup_manager_with_wallet();
+    let mut rx = manager.subscribe_events();
+    manager.update_wallet_synced_height(&wallet_id, 2000);
+    drain_events(&mut rx);
+
+    // A rewind lowers the checkpoint and is reported through the same event
+    // an advance emits, so persisters store it verbatim and the rewind
+    // survives a restart.
+    manager.rewind_wallet_synced_height(&wallet_id, 1200);
+    assert_eq!(manager.wallet_synced_height(&wallet_id), 1200);
+    let synced_events: Vec<_> = drain_events(&mut rx)
+        .into_iter()
+        .filter_map(|e| match e {
+            WalletEvent::SyncHeightAdvanced {
+                wallet_id,
+                height,
+            } => Some((wallet_id, height)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(synced_events, vec![(wallet_id, 1200)]);
+
+    // At or above the current checkpoint is ignored — no change, no event.
+    manager.rewind_wallet_synced_height(&wallet_id, 1200);
+    manager.rewind_wallet_synced_height(&wallet_id, 5000);
+    assert_eq!(manager.wallet_synced_height(&wallet_id), 1200);
+    let events = drain_events(&mut rx);
+    assert!(
+        !events.iter().any(|e| matches!(e, WalletEvent::SyncHeightAdvanced { .. })),
+        "no SyncHeightAdvanced for a non-lowering rewind, got {:?}",
+        events
+    );
+
+    // An unknown wallet is a no-op.
+    manager.rewind_wallet_synced_height(&[9u8; 32], 0);
+    assert!(drain_events(&mut rx).is_empty());
+}
+
+#[tokio::test]
+async fn test_rewind_wallet_synced_height_clamps_to_own_birth_height() {
+    // The caller passes one floor for every wallet it rewinds; a wallet must
+    // never be dragged below its own start by another wallet's lower birth.
+    let mut manager = WalletManager::<ManagedWalletInfo>::new(Network::Testnet);
+    let wallet_id = manager
+        .create_wallet_from_mnemonic(
+            TEST_MNEMONIC,
+            500,
+            key_wallet::wallet::initialization::WalletAccountCreationOptions::Default,
+        )
+        .unwrap();
+    manager.update_wallet_synced_height(&wallet_id, 3000);
+    let mut rx = manager.subscribe_events();
+
+    manager.rewind_wallet_synced_height(&wallet_id, 0);
+    assert_eq!(manager.wallet_synced_height(&wallet_id), 499);
+    let synced_events: Vec<_> = drain_events(&mut rx)
+        .into_iter()
+        .filter_map(|e| match e {
+            WalletEvent::SyncHeightAdvanced {
+                height,
+                ..
+            } => Some(height),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(synced_events, vec![499]);
+
+    // Already at the floor: a second rewind changes nothing.
+    manager.rewind_wallet_synced_height(&wallet_id, 0);
+    assert_eq!(manager.wallet_synced_height(&wallet_id), 499);
+    assert!(drain_events(&mut rx).is_empty());
+}
+
 // ---------------------------------------------------------------------------
 // Dry run and irrelevant paths
 // ---------------------------------------------------------------------------

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -363,6 +363,25 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
         }
     }
 
+    fn rewind_wallet_synced_height(&mut self, wallet_id: &WalletId, height: CoreBlockHeight) {
+        if let Some(info) = self.wallet_infos.get_mut(wallet_id) {
+            if height < info.synced_height() {
+                info.update_synced_height(height);
+                // Deliberately the same event an advance emits: the
+                // persisters apply `synced_height` verbatim (no monotonic
+                // clamp at the row), so this is what makes the rewind
+                // durable across a restart. Only the in-batch changeset
+                // merge is monotonic-max; the caller keeps the rewind out
+                // of a batch that also carries a higher advance by not
+                // advancing a rewound wallet at the same commit.
+                self.emit_event(WalletEvent::SyncHeightAdvanced {
+                    wallet_id: *wallet_id,
+                    height,
+                });
+            }
+        }
+    }
+
     fn update_wallet_last_processed_height(
         &mut self,
         wallet_id: &WalletId,

--- a/key-wallet-manager/src/process_block.rs
+++ b/key-wallet-manager/src/process_block.rs
@@ -365,6 +365,14 @@ impl<T: WalletInfoInterface + Send + Sync + 'static> WalletInterface for WalletM
 
     fn rewind_wallet_synced_height(&mut self, wallet_id: &WalletId, height: CoreBlockHeight) {
         if let Some(info) = self.wallet_infos.get_mut(wallet_id) {
+            // Never below this wallet's own start: the caller passes one
+            // floor for every wallet it rewinds (the earliest height any of
+            // them requires), and a wallet added at runtime with a lower
+            // birth height must not drag an older wallet's checkpoint under
+            // its own birth — that re-walks history the wallet cannot have
+            // touched, and on a persisted store it looks like the wallet
+            // was reset.
+            let height = height.max(info.birth_height().saturating_sub(1));
             if height < info.synced_height() {
                 info.update_synced_height(height);
                 // Deliberately the same event an advance emits: the

--- a/key-wallet-manager/src/test_utils/mock_wallet.rs
+++ b/key-wallet-manager/src/test_utils/mock_wallet.rs
@@ -223,6 +223,12 @@ impl WalletInterface for MockWallet {
         }
     }
 
+    fn rewind_wallet_synced_height(&mut self, wallet_id: &WalletId, height: CoreBlockHeight) {
+        if wallet_id == &self.wallet_id && height < self.synced_height {
+            self.synced_height = height;
+        }
+    }
+
     fn update_wallet_last_processed_height(
         &mut self,
         wallet_id: &WalletId,
@@ -347,6 +353,12 @@ impl WalletInterface for NonMatchingMockWallet {
 
     fn update_wallet_synced_height(&mut self, wallet_id: &WalletId, height: CoreBlockHeight) {
         if wallet_id == &self.wallet_id && height > self.synced_height {
+            self.synced_height = height;
+        }
+    }
+
+    fn rewind_wallet_synced_height(&mut self, wallet_id: &WalletId, height: CoreBlockHeight) {
+        if wallet_id == &self.wallet_id && height < self.synced_height {
             self.synced_height = height;
         }
     }

--- a/key-wallet-manager/src/test_utils/mock_wallet.rs
+++ b/key-wallet-manager/src/test_utils/mock_wallet.rs
@@ -538,6 +538,14 @@ impl WalletInterface for MultiMockWallet {
         }
     }
 
+    fn rewind_wallet_synced_height(&mut self, wallet_id: &WalletId, height: CoreBlockHeight) {
+        if let Some(state) = self.wallets.get_mut(wallet_id) {
+            if height < state.synced_height {
+                state.synced_height = height;
+            }
+        }
+    }
+
     fn update_wallet_last_processed_height(
         &mut self,
         wallet_id: &WalletId,

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -165,6 +165,16 @@ pub trait WalletInterface: Send + Sync + 'static {
     /// only advance forward (a value below the current is silently ignored).
     fn update_wallet_synced_height(&mut self, wallet_id: &WalletId, height: CoreBlockHeight);
 
+    /// Rewind one wallet's committed sync checkpoint below its current value,
+    /// so the filter sync re-walks committed history — used when scripts
+    /// derived after a range committed must still be tested against it.
+    /// Implementations must only lower (a value at or above the current is
+    /// silently ignored) and must emit the same persistence signal an advance
+    /// emits, so the rewound checkpoint survives a restart and the re-walk
+    /// resumes from its own committed progress. The default is a no-op for
+    /// implementations that predate backward coverage.
+    fn rewind_wallet_synced_height(&mut self, _wallet_id: &WalletId, _height: CoreBlockHeight) {}
+
     /// Advance one wallet's last-processed height after a block has been applied
     /// to its state. Implementations must only advance forward.
     fn update_wallet_last_processed_height(

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -169,10 +169,12 @@ pub trait WalletInterface: Send + Sync + 'static {
     /// so the filter sync re-walks committed history — used when scripts
     /// derived after a range committed must still be tested against it.
     /// Implementations must only lower (a value at or above the current is
-    /// silently ignored) and must emit the same persistence signal an advance
-    /// emits, so the rewound checkpoint survives a restart and the re-walk
-    /// resumes from its own committed progress. The default is a no-op for
-    /// implementations that predate backward coverage.
+    /// silently ignored), must clamp `height` to the wallet's own earliest
+    /// required height so a floor computed across several wallets never
+    /// drags one below its birth, and must emit the same persistence signal
+    /// an advance emits, so the rewound checkpoint survives a restart and the
+    /// re-walk resumes from its own committed progress. The default is a
+    /// no-op for implementations that predate backward coverage.
     fn rewind_wallet_synced_height(&mut self, _wallet_id: &WalletId, _height: CoreBlockHeight) {}
 
     /// Advance one wallet's last-processed height after a block has been applied

--- a/key-wallet-manager/src/wallet_interface.rs
+++ b/key-wallet-manager/src/wallet_interface.rs
@@ -173,8 +173,14 @@ pub trait WalletInterface: Send + Sync + 'static {
     /// required height so a floor computed across several wallets never
     /// drags one below its birth, and must emit the same persistence signal
     /// an advance emits, so the rewound checkpoint survives a restart and the
-    /// re-walk resumes from its own committed progress. The default is a
-    /// no-op for implementations that predate backward coverage.
+    /// re-walk resumes from its own committed progress.
+    ///
+    /// The default is a no-op, for implementations that predate backward
+    /// coverage. Opting out that way costs backward coverage itself, not
+    /// correctness of the forward scan: the caller reads the checkpoint back
+    /// and, seeing it unmoved, commits the range forward as it always did
+    /// (and warns), rather than skipping the advance for a re-walk that will
+    /// never happen.
     fn rewind_wallet_synced_height(&mut self, _wallet_id: &WalletId, _height: CoreBlockHeight) {}
 
     /// Advance one wallet's last-processed height after a block has been applied


### PR DESCRIPTION
## Issue being fixed or feature implemented

Since #866/#974 the filter sync covers scripts derived after a range committed by rescanning the committed range at the forward drain (`rescan_committed_range`). On a mixing-heavy wallet (~6.7k transactions, ~13k CoinJoin scripts derived during the scan) that is one silent multi-minute pass over ~2.3M filters matching ~41k blocks, with no persisted progress:

- the sweep's block requests are charged to the tail batch's commit gate, so an iOS suspension a few seconds after the client reports "synced" drops the whole sweep — the user sees a synced wallet missing the newly derived scripts' transactions until a manual rescan;
- on a relaunch with those blocks already in storage, the matched blocks drain through the `SyncEvent` broadcast channel faster than the monitor consumes them, `spawn_broadcast_monitor` hits `Lagged`, treats it as fatal, and the client shuts down (`SyncEvent monitor lagged, missed 1462 events` → `Storage shutdown completed`; the host's run loop only logs it).

This is the dash-spv half of the large-wallet "sync finished but transactions are missing" reports. Companion changes: dashpay/platform#4595 (linear persistence round) and dashpay/dashwallet-ios#1112 (UI gate on the durable watermark).

**Draft because it changes an invariant** (`synced_height` may now be lowered by the sync layer) and needs the dash-spv owner's view on that before it is polished further.

## What was done?

- `WalletInterface::rewind_wallet_synced_height(wallet_id, height)` (key-wallet-manager): new hook that lowers one wallet's committed sync checkpoint. Emits the same `SyncHeightAdvanced` persistence event an advance emits, so persisters store the lowered height verbatim and the rewind survives a restart. Only lowers; a value at or above the current is ignored. Default no-op; implemented for `WalletManager` (`process_block.rs`) and `MockWallet`.
- `FilterSyncManager` (`sync/filters/manager.rs`): at the forward drain, when backward scripts exist, rewind the affected wallets to `earliest_required_height - 1` instead of sweeping. The existing wallet-behind path ("Wallet synced_height fell below committed_height, restarting scan") re-walks committed history in the normal 5,000-height batches, each persisting its own progress. The commit-time advance skips a wallet rewound at the same drain so the batch's own `SyncHeightAdvanced` does not clobber the rewind.
- `FilterSyncManager::try_process_batch` holds `FiltersSyncComplete` while `rewalk_pending()` — a wallet below the committed frontier that the tick will restart the scan for (tested exactly as the tick tests it). The state stays `Syncing` through the re-walk and `SyncComplete` fires once, after it; hosts never see a "synced" cycle with a re-walk still pending.
- `WalletManager::rewind_wallet_synced_height` clamps to the wallet's own `birth_height - 1`: the drain passes one floor for every wallet it rewinds, and a wallet added at runtime with a lower birth height must not drag an older wallet below its own start.
- `rescan_committed_range` is kept but unused (`#[allow(dead_code)]`), with progress logging and a `yield_now` per batch; to be removed once the re-walk has soaked.
- Tests: `backward_coverage_rewinds_and_holds_completion_until_rewalked` (dash-spv) replaces the first sweep-shaped test in `coinjoin_gap_discovery_tests` — the committed-batch shape now asserts the rewind, `rewalk_pending()`, no completion while behind, completion once caught up; two `WalletManager` unit tests cover lowering + event, the non-lowering no-op, and the birth-height clamp. The second sweep test (sweep coalescing) stays `#[ignore]`d — it measured a mechanism that no longer exists; remove with `rescan_committed_range`. Two dashd integration tests asserted the old monotonic `synced_height` (`test_runtime_add_during_initial_sync`, `test_all_callbacks_during_sync`) and now check "never below own birth height, converges to the tip" / the first completed cycle.

## How Has This Been Tested?

`cargo test -p dash-spv --lib` (569 passed, 3 ignored) and `cargo test -p key-wallet-manager --lib` (66 passed) on this branch; dashd integration tests via CI.

Manual, same seed throughout, built into the iOS wallet via platform's swift-sdk:
- iOS Simulator, fresh restore: rewind of 13,034 scripts at the drain; re-walk in 5,000-height batches with `BlocksNeeded` ≤ 343 per batch; reached the tip; store audited with `gettxout` over every unspent row matched the chain, whereas the previous build's store carried 0.128 DASH of CoinJoin outputs that are spent on-chain.
- iPhone 13 Pro, relaunch on an existing store and a full rescan: both reached the tip with the persisted watermark at the tip, zero `Lagged`.
- Simulator kill test: process killed mid re-walk (store watermark 1,780,000), relaunch resumed from there and reached the tip 3 minutes later; the store matched the chain and contained 62 previously missed CoinJoin spends, none lost.
- Field log of the previous build (same wallet, relaunch): `Committed-range rescan found 41546 additional blocks` → `SyncEvent monitor lagged, missed 1462 events` → client shutdown.

Known cost: the re-walk starts at birth height and re-delivers already-known transactions through the persistence channel, so it is slower than the targeted sweep (about +7 minutes for this wallet from a fresh restore in the simulator; more on device). Follow-ups: rewind to the lowest matched height for the new scripts; persist deltas only (rs-platform-wallet); treat `Lagged` as recoverable in the event monitor and restart the run loop.

## Breaking Changes

None in the public API (`rewind_wallet_synced_height` has a default no-op). Behavioural: a wallet's `synced_height` is no longer monotonic across a sync cycle — it can be lowered at the forward drain and then re-advanced by the re-walk. Persisters that clamp the watermark to max would silently break the re-walk's resume; the two in-tree persisters apply it verbatim.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved wallet synchronization when newly discovered scripts require checking previously processed filter ranges.
  - Wallet sync checkpoints can now safely rewind to each wallet’s earliest valid height, ensuring missed history is reprocessed.
  - Sync completion is now delayed until required backward reprocessing finishes.
  - Improved handling of wallets added during an active initial synchronization.
  - Enhanced synchronization progress tracking and validation for more reliable status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->