### PR TITLE
fix(key-wallet): discover DashPay asset unlock receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Unreleased
+
+### Fixed
+
+- Discover AssetUnlock withdrawal receipts in DashPay and CoinJoin accounts.
+
 ## 0.44.0 - 2026-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## Unreleased
-
-### Fixed
-
-- Discover AssetUnlock withdrawal receipts in DashPay and CoinJoin accounts.
-
 ## 0.44.0 - 2026-07-01
 
 ### Added

--- a/key-wallet/src/transaction_checking/transaction_router/mod.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/mod.rs
@@ -157,7 +157,9 @@ impl TransactionRouter {
                 accounts
             }
             TransactionType::AssetUnlock => {
-                vec![AccountTypeToCheck::StandardBIP44, AccountTypeToCheck::StandardBIP32]
+                // Withdrawal outputs may pay any owned script, including DIP-15 contact
+                // addresses. Restricting discovery to standard accounts loses those receipts.
+                Self::fund_bearing_account_types()
             }
             TransactionType::Coinbase => vec![
                 // Check all account types for unknown special transactions

--- a/key-wallet/src/transaction_checking/transaction_router/tests/asset_unlock.rs
+++ b/key-wallet/src/transaction_checking/transaction_router/tests/asset_unlock.rs
@@ -21,8 +21,11 @@ fn test_asset_unlock_routing() {
     let tx_type = TransactionType::AssetUnlock;
     let accounts = TransactionRouter::get_relevant_account_types(&tx_type);
 
-    // Asset unlock only goes to standard accounts
-    assert_eq!(accounts.len(), 2);
+    // Withdrawals can pay any fund-bearing account.
+    assert_eq!(accounts.len(), 5);
+    assert!(accounts.contains(&AccountTypeToCheck::CoinJoin));
+    assert!(accounts.contains(&AccountTypeToCheck::DashpayReceivingFunds));
+    assert!(accounts.contains(&AccountTypeToCheck::DashpayExternalAccount));
     assert!(accounts.contains(&AccountTypeToCheck::StandardBIP44));
     assert!(accounts.contains(&AccountTypeToCheck::StandardBIP32));
 
@@ -62,7 +65,7 @@ fn test_asset_unlock_classification() {
 
     // Verify routing for AssetUnlock
     let accounts = TransactionRouter::get_relevant_account_types(&tx_type);
-    assert_eq!(accounts.len(), 2, "AssetUnlock should route to exactly 2 account types");
+    assert_eq!(accounts.len(), 5, "AssetUnlock must check every fund-bearing account");
     assert!(accounts.contains(&AccountTypeToCheck::StandardBIP44));
     assert!(accounts.contains(&AccountTypeToCheck::StandardBIP32));
 }
@@ -194,4 +197,65 @@ async fn test_asset_unlock_routing_to_bip32_account() {
         )),
         "Asset unlock should have affected the BIP44 account"
     );
+}
+
+/// A Platform withdrawal has no Core inputs and can pay a DIP-15 contact address.
+#[tokio::test]
+async fn test_asset_unlock_credits_dashpay_contact() {
+    use crate::account::AccountType;
+    use crate::managed_account::managed_account_trait::ManagedAccountTrait;
+    use crate::wallet::managed_wallet_info::managed_account_operations::ManagedAccountOperations;
+    use crate::{KeySource, ManagedAccountType};
+
+    let mut ctx = TestWalletContext::new_random();
+    let account_type = AccountType::DashpayReceivingFunds {
+        index: 0,
+        user_identity_id: [0xaa; 32],
+        friend_identity_id: [0xbb; 32],
+    };
+    ctx.wallet.add_account(account_type, None).unwrap();
+    ctx.managed_wallet.add_managed_account(&ctx.wallet, account_type).unwrap();
+    let xpub = ctx.wallet.accounts.account_of_type(account_type).unwrap().account_xpub;
+    let account = ctx.managed_wallet.accounts.funds_account_mut(&account_type).unwrap();
+    let ManagedAccountType::DashpayReceivingFunds {
+        addresses,
+        ..
+    } = account.managed_account_type_mut()
+    else {
+        panic!("expected contact account");
+    };
+    let address = addresses.next_unused(&KeySource::Public(xpub), true).unwrap();
+    let mut tx = Transaction::dummy(&address, 0..0, &[2_000_000]);
+    tx.version = 3;
+    tx.special_transaction_payload =
+        Some(TransactionPayload::AssetUnlockPayloadType(AssetUnlockPayload {
+            base: AssetUnlockBasePayload {
+                version: 1,
+                index: 42,
+                fee: 1000,
+            },
+            request_info: AssetUnlockRequestInfo {
+                request_height: 500000,
+                quorum_hash: [5u8; 32].into(),
+            },
+            quorum_sig: BLSSignature::from([6u8; 96]),
+        }));
+    let context = TransactionContext::InBlock(BlockInfo::new(
+        500100,
+        BlockHash::from_byte_array([7; 32]),
+        1234567890,
+    ));
+    let result = ctx.check_transaction(&tx, context.clone()).await;
+    assert!(result.is_relevant, "withdrawal to a contact must be discovered");
+    assert_eq!(result.total_received, 2_000_000);
+    let outpoint = OutPoint {
+        txid: tx.txid(),
+        vout: 0,
+    };
+    let account = ctx.managed_wallet.accounts.funds_account_mut(&account_type).unwrap();
+    assert_eq!(account.utxos.get(&outpoint).unwrap().txout.value, 2_000_000);
+    assert!(account.transactions().contains_key(&tx.txid()));
+    ctx.check_transaction(&tx, context).await;
+    let account = ctx.managed_wallet.accounts.funds_account_mut(&account_type).unwrap();
+    assert_eq!(account.utxos.len(), 1, "block replay must not duplicate funds");
 }


### PR DESCRIPTION
## Issue

Platform and Shielded withdrawals can pay any Core address, including a DashPay contact's DIP-15 address. The transaction router only checked BIP44/BIP32 accounts for AssetUnlock, so a confirmed payout to a contact was silently omitted from the recipient wallet's UTXOs and transaction history.

This was reproduced with two registered testnet contacts while testing dashpay/dashwallet-ios#1117: confirmed AssetUnlock payouts of 0.02 and 0.1 DASH were present on Core at watched contact addresses, while the recipient wallet only recorded the earlier standard payment.

## Change

Use the existing fund-bearing account set for AssetUnlock discovery. Ownership checks remain unchanged; standard accounts remain included, and DashPay/CoinJoin accounts now receive matching outputs.

## Validation

- New inputless AssetUnlock-to-DIP-15 test fails before the fix and passes after. It verifies relevance, exact UTXO value, transaction storage, and replay without duplicate funds.
- Full workspace build with all features, repository hook `cargo check --workspace`, key-wallet clippy (all targets/features, warnings denied), and workspace formatting passed.
- `cargo test --workspace --all-features --lib -- --skip tests::performance_tests::`: **2,324 passed, 41 ignored**, no failures. The full run hit two timing assertions under concurrent build load; serialization and address-generation tests each passed when rerun in isolation.
- The broader integration run stopped at 10 masternode tests because `DASHD_PATH` was unset. Those network integration tests are not claimed as passed.
- Minimal backport onto the SDK's existing393b612 revision: all5 AssetUnlock tests passed, with no unrelated dependency changes.

Normal recipient relaunch with SDK `2c17d85` recovered both real AssetUnlock payouts. The 0.02 DASH Platform payment and user-submitted 0.1 DASH Shielded payment each have one persisted DashPay receipt and a confirmed, unspent, unlocked output for the exact transaction ID and amount. Both receipt screens show `Pasta-dashpay-send-0907`; the recipient transparent balance is 1.09999737 DASH. Wallet data was preserved, with no database edits or mock data. Recovery used the Platform SDK’s existing contact backfill mechanism on relaunch; this router change does not itself rewind the wallet. [Screenshots and provenance](https://github.com/PastaPastaPasta/dash-ui-artifacts/blob/d1f33a977c8165c171832117c20c975c0904528a/dashwallet-ios/pr-1117/README.md).

This pull request was created by Codex.
