### PR TITLE
build!: adopt GroveDB bincode across the workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Unreleased
+
+### Changed
+
+- **Breaking:** the `bincode` feature and binary serialization dependencies now use
+  `grovedb-bincode` 2.0.2 and its derive macros, sharing the same pinned GroveDB
+  revision as Platform. Existing bincode encodings and C interfaces are unchanged,
+  but Rust consumers must use the fork for compatible `Encode`/`Decode` traits.
+  The dependency switch does not automatically opt types into `DecodeUntrusted`.
+
 ## 0.44.0 - 2026-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - **Breaking:** the `bincode` feature and binary serialization dependencies now use
-  `grovedb-bincode` 2.0.2 and its derive macros, sharing the same pinned GroveDB
-  revision as Platform. Existing bincode encodings and C interfaces are unchanged,
-  but Rust consumers must use the fork for compatible `Encode`/`Decode` traits.
+  `grovedb-bincode` 2.1.0 and its derive macros from crates.io, sharing the same
+  serialization traits as Platform. Existing bincode encodings and C interfaces
+  are unchanged, but Rust consumers must use the fork for compatible `Encode`/`Decode` traits.
   The dependency switch does not automatically opt types into `DecodeUntrusted`.
 
 ## 0.44.0 - 2026-07-01

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 members = ["dash", "dash-network", "hashes", "internals", "fuzz", "rpc-client", "rpc-json", "rpc-integration-test", "key-wallet", "key-wallet-manager", "key-wallet-ffi", "dash-spv", "dash-spv-ffi", "git-state", "dash-network-seeds", "masternode-seeds-fetcher", "dash-spv-bench"]
 resolver = "2"
 
+[workspace.dependencies]
+bincode = { package = "grovedb-bincode", git = "https://github.com/dashpay/grovedb", rev = "2b9c7ba9a794bfab1a03fa1d0b3f5496b63175ae" }
+bincode_derive = { package = "grovedb-bincode-derive", git = "https://github.com/dashpay/grovedb", rev = "2b9c7ba9a794bfab1a03fa1d0b3f5496b63175ae" }
+
 [workspace.package]
 version = "0.45.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ members = ["dash", "dash-network", "hashes", "internals", "fuzz", "rpc-client", 
 resolver = "2"
 
 [workspace.dependencies]
-bincode = { package = "grovedb-bincode", git = "https://github.com/dashpay/grovedb", rev = "2b9c7ba9a794bfab1a03fa1d0b3f5496b63175ae" }
-bincode_derive = { package = "grovedb-bincode-derive", git = "https://github.com/dashpay/grovedb", rev = "2b9c7ba9a794bfab1a03fa1d0b3f5496b63175ae" }
+bincode = { package = "grovedb-bincode", version = "=2.1.0" }
+bincode_derive = { package = "grovedb-bincode-derive", version = "=2.1.0" }
 
 [workspace.package]
 version = "0.45.0"

--- a/dash-network/Cargo.toml
+++ b/dash-network/Cargo.toml
@@ -22,8 +22,8 @@ ffi = []
 
 [dependencies]
 serde = { version = "1.0.219", default-features = false, features = ["derive"], optional = true }
-bincode = { version = "2.0.1", optional = true }
-bincode_derive = { version = "2.0.1", optional = true }
+bincode = { workspace = true, optional = true }
+bincode_derive = { workspace = true, optional = true }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/dash/Cargo.toml
+++ b/dash/Cargo.toml
@@ -54,8 +54,8 @@ bitcoinconsensus = { version = "0.20.2-0.5.0", default-features = false, optiona
 hex_lit = "0.1.1"
 anyhow = { version= "1.0" }
 hex = { version= "0.4" }
-bincode = { version = "2.0.1", optional = true }
-bincode_derive = { version = "2.0.1", optional = true }
+bincode = { workspace = true, optional = true }
+bincode_derive = { workspace = true, optional = true }
 blsful = { git = "https://github.com/dashpay/agora-blsful", rev = "0c34a7a488a0bd1c9a9a2196e793b303ad35c900", optional = true }
 ed25519-dalek = { version = "2.1", features = ["rand_core"], optional = true }
 blake3 = "1.8.1"
@@ -68,7 +68,7 @@ serde_json = "1.0.140"
 serde_test = "1.0.177"
 serde_derive = "1.0.219"
 secp256k1 = { features = [ "recovery", "rand", "hashes" ], version="0.30.0" }
-bincode = { version = "2.0.1", features = ["serde"] }
+bincode = { workspace = true, features = ["serde"] }
 assert_matches = "1.5.0"
 dashcore = { path = ".", features = ["core-block-hash-use-x11", "message_verification", "quorum_validation", "signer"] }
 criterion = "0.5"

--- a/hashes/Cargo.toml
+++ b/hashes/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0.219", default-features = false, optional = true }
 actual-schemars = { package = "schemars", version = "1.0", optional = true }
 
 rs-x11-hash = { version = "0.1.8", optional = true }
-bincode = { version = "2.0.1", optional = true }
+bincode = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/key-wallet-manager/Cargo.toml
+++ b/key-wallet-manager/Cargo.toml
@@ -36,7 +36,7 @@ tokio = { version = "1", features = ["macros", "rt", "sync"] }
 tracing = "0.1"
 zeroize = { version = "1.8", features = ["derive"] }
 rayon = { version = "1.11", optional = true }
-bincode = { version = "2.0.1", optional = true }
+bincode = { workspace = true, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/key-wallet/Cargo.toml
+++ b/key-wallet/Cargo.toml
@@ -48,8 +48,8 @@ sha2 = { version = "0.10", default-features = false }
 bs58 = { version = "0.5", default-features = false, features = ["check", "alloc"], optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
 # Serialization
-bincode = { version = "2.0.1", optional = true }
-bincode_derive = { version = "2.0.1", optional = true }
+bincode = { workspace = true, optional = true }
+bincode_derive = { workspace = true, optional = true }
 base64 = { version = "0.22", optional = true }
 serde_json = { version = "1.0", optional = true }
 hex = { version = "0.4"}

--- a/rpc-json/Cargo.toml
+++ b/rpc-json/Cargo.toml
@@ -28,4 +28,4 @@ hex = { version="0.4", features=["serde"]}
 key-wallet = { path = "../key-wallet", default-features = false, features=["serde", "getrandom"] }
 dashcore = { path = "../dash", features=["secp-recovery", "rand-std", "signer", "serde"] }
 
-bincode = { version = "2.0.1", features = ["serde"] }
+bincode = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[GroveDB #938](https://github.com/dashpay/grovedb/pull/938) introduces the `grovedb-bincode` fork. Platform is adopting it in [Platform #4625](https://github.com/dashpay/platform/pull/4625), but its `Encode`/`Decode` traits are distinct from crates.io bincode's traits. Moving rust-dashcore to the same fork lets Core, wallet, GroveDB, and Platform types share those traits directly, without a compatibility package or downstream Cargo patch.

## What was done?
<!--- Describe your changes in detail -->

- Pin workspace dependencies `bincode` and `bincode_derive` to `grovedb-bincode` / `grovedb-bincode-derive` 2.1.0 from crates.io.
- Use those dependencies in dashcore, dash-network, hashes, key-wallet, key-wallet-manager, and RPC JSON, preserving existing feature names, optional dependencies, and Serde features.
- Document the Rust compatibility change in the changelog. Existing codec implementations, C/Swift interfaces, and build scripts are unchanged. This dependency migration does not automatically opt types into `DecodeUntrusted` or change ordinary decoding behavior.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Passed locally on macOS. Workspace compilation, unit tests, and strict Clippy were rerun with the published 2.1.0 packages; their Rust source matches the previously tested fork revision:

- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `cargo test --workspace --lib --all-features`: 2,332 passed, 41 ignored.
- `cargo test -p dash-network -p dashcore_hashes -p dashcore -p key-wallet -p key-wallet-manager -p dashcore-rpc-json --all-features`, including existing wallet serialization integration tests and documentation tests.

The dependency graph resolves only the fork's bincode runtime and derives. Live-node integration and device builds were not run locally; native FFI targets are covered by workspace compilation and unit tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

Rust consumers serializing these types must use the published `grovedb-bincode` 2.1.0 crate for compatible `Encode`/`Decode` traits. Existing serialized bytes and the C ABI are unchanged.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Rust consumers must use compatible `Encode` and `Decode` traits from `grovedb-bincode` 2.1.0 and its matching derive macros.
  * Existing serialized encodings and C interfaces remain unchanged.
  * Types are not automatically configured for `DecodeUntrusted`.

* **Documentation**
  * Updated the Unreleased changelog with serialization compatibility requirements and migration guidance.
  * Clarified that the compatible serialization traits and derive macros are available through crates.io.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->