### PR TITLE
feat(dash-spv-bench): report the client's peak RSS

### DIFF
--- a/dash-spv-bench/run.sh
+++ b/dash-spv-bench/run.sh
@@ -116,7 +116,7 @@ if [ -z "${BENCH_BATCH:-}" ]; then
   mkdir -p "${OUT_DIR}"
   TSV="${OUT_DIR}/results.tsv"
   REPORT="${OUT_DIR}/report.md"
-  printf 'scenario\tcompleted\ttotal_ms\tblock_headers_ms\tfilter_headers_ms\tfilters_ms\ttransactions\tconfirmed_sat\n' >"${TSV}"
+  printf 'scenario\tcompleted\ttotal_ms\tblock_headers_ms\tfilter_headers_ms\tfilters_ms\ttransactions\tconfirmed_sat\tpeak_rss_mib\n' >"${TSV}"
 
   child_flags=()
   [ "${FLAME}" -eq 1 ] && child_flags+=(--flame)
@@ -139,7 +139,7 @@ if [ -z "${BENCH_BATCH:-}" ]; then
     src="${log}"
     if [ -s "${OUT_DIR}/${name}.summary.txt" ]; then src="${OUT_DIR}/${name}.summary.txt"; fi
     wallet_line="$(grep -m1 -o 'confirmed_sat=[0-9]*' "${src}" || true)"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
       "${name}" \
       "$(metric "${src}" completed)" \
       "$(metric "${src}" total_ms)" \
@@ -148,15 +148,16 @@ if [ -z "${BENCH_BATCH:-}" ]; then
       "$(metric "${src}" filters_ms)" \
       "$(metric "${src}" transactions)" \
       "$(sed -n 's/.*confirmed_sat=\([0-9]*\).*/\1/p' <<<"${wallet_line}")" \
+      "$(metric "${src}" peak_rss_mib)" \
       >>"${TSV}"
   done
 
   {
     echo "# dash-spv bench — ${RUN_TS}"
     echo
-    echo "| scenario | completed | total_ms | headers_ms | filter_headers_ms | filters_ms | transactions | confirmed_sat |"
-    echo "|---|---|---|---|---|---|---|---|"
-    tail -n +2 "${TSV}" | awk -F'\t' '{printf "| %s | %s | %s | %s | %s | %s | %s | %s |\n", $1,$2,$3,$4,$5,$6,$7,$8}'
+    echo "| scenario | completed | total_ms | headers_ms | filter_headers_ms | filters_ms | transactions | confirmed_sat | peak_rss_mib |"
+    echo "|---|---|---|---|---|---|---|---|---|"
+    tail -n +2 "${TSV}" | awk -F'\t' '{printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1,$2,$3,$4,$5,$6,$7,$8,$9}'
   } >"${REPORT}"
 
   echo

--- a/dash-spv-bench/src/main.rs
+++ b/dash-spv-bench/src/main.rs
@@ -40,6 +40,17 @@ fn load_mnemonics() -> Vec<String> {
         .unwrap_or_default()
 }
 
+fn peak_rss_kb() -> Option<u64> {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("VmHWM:"))?
+        .split_whitespace()
+        .next()?
+        .parse()
+        .ok()
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let dashboard = Arc::new(Dashboard::new());
@@ -188,6 +199,9 @@ async fn main() -> Result<()> {
 
     use std::fmt::Write as _;
     let mut report = format!("{m}\n");
+    if let Some(kb) = peak_rss_kb() {
+        let _ = writeln!(report, "peak_rss_mib:         {}", kb / 1024);
+    }
 
     if !wallet_ids.is_empty() {
         use key_wallet_manager::WalletInterface;


### PR DESCRIPTION
At the end of a run the client reads `VmHWM` from `/proc/self/status`, one read with no sampling, and writes
`peak_rss_mib` to `summary.txt`. `run.sh` carries it into `results.tsv` and `report.md`. A 100 Mbit / 100 ms mainnet restore of the bench wallet peaks at 1488 MiB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark results now include peak memory usage.
  * Batch TSV output and generated Markdown reports include a `peak_rss_mib` column for each scenario.
  * Individual benchmark reports include peak resident memory when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->